### PR TITLE
simplelink: add RFC driverlib sources

### DIFF
--- a/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
+++ b/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
@@ -13,4 +13,6 @@ zephyr_library_sources(
   driverlib/aux_sysif.c
   # Required for CPUdelay which is not in ROM
   driverlib/cpu.c
+  # Required for RFCDoorbellSendTo which is not in ROM
+  driverlib/rfc.c
   )


### PR DESCRIPTION
Required for RFCDoorbellSendTo used in 802.15.4 driver.

See zephyrproject-rtos/zephyr#16263

Signed-off-by: Brett Witherspoon <spoonb@cdspooner.com>