### PR TITLE
dts: Include devicetree.h instead of generated_dts_board.h

### DIFF
--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p401m.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p401m.c
@@ -44,7 +44,7 @@
 
 #include <stdint.h>
 #include <ti/devices/msp432p4xx/inc/msp.h>
-#include <generated_dts_board.h>
+#include <devicetree.h>
 
 /*--------------------- Configuration Instructions ----------------------------
    1. If you prefer to halt the Watchdog Timer, set __HALT_WDT to 1:

--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p401r.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p401r.c
@@ -44,7 +44,7 @@
 
 #include <stdint.h>
 #include <ti/devices/msp432p4xx/inc/msp.h>
-#include <generated_dts_board.h>
+#include <devicetree.h>
 
 /*--------------------- Configuration Instructions ----------------------------
    1. If you prefer to halt the Watchdog Timer, set __HALT_WDT to 1:

--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p4111.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p4111.c
@@ -44,7 +44,7 @@
 
 #include <stdint.h>
 #include <ti/devices/msp432p4xx/inc/msp.h>
-#include <generated_dts_board.h>
+#include <devicetree.h>
 
 /*--------------------- Configuration Instructions ----------------------------
    1. If you prefer to halt the Watchdog Timer, set __HALT_WDT to 1:

--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p411v.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p411v.c
@@ -44,7 +44,7 @@
 
 #include <stdint.h>
 #include <ti/devices/msp432p4xx/inc/msp.h>
-#include <generated_dts_board.h>
+#include <devicetree.h>
 
 /*--------------------- Configuration Instructions ----------------------------
    1. If you prefer to halt the Watchdog Timer, set __HALT_WDT to 1:

--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p411y.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p411y.c
@@ -44,7 +44,7 @@
 
 #include <stdint.h>
 #include <ti/devices/msp432p4xx/inc/msp.h>
-#include <generated_dts_board.h>
+#include <devicetree.h>
 
 /*--------------------- Configuration Instructions ----------------------------
    1. If you prefer to halt the Watchdog Timer, set __HALT_WDT to 1:


### PR DESCRIPTION
Needed for https://github.com/zephyrproject-rtos/zephyr/pull/20757, to
avoid a warning-turned-error.