### PR TITLE
simplelink: include needed headers

### DIFF
--- a/simplelink/CMakeLists.txt
+++ b/simplelink/CMakeLists.txt
@@ -5,6 +5,7 @@ if(CONFIG_SIMPLELINK_HOST_DRIVER)
     .
     source
     kernel/zephyr/dpl
+    source/ti/drivers/net/wifi/porting
     )
   zephyr_compile_definitions(
     SL_SUPPORT_IPV6


### PR DESCRIPTION
Originall this was included directly in the driver (from ext/), fix this
to allow inclusion from the module.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>