### PR TITLE
simplelink: Fix clang-llvm compiler errors/warnings

### DIFF
--- a/simplelink/source/ti/devices/cc13x2_cc26x2/driverlib/cpu.c
+++ b/simplelink/source/ti/devices/cc13x2_cc26x2/driverlib/cpu.c
@@ -108,6 +108,16 @@ CPUcpsid(void)
     // you expect in R0.
     return(0);
 }
+#elif defined(__clang__)
+uint32_t __attribute__((naked))
+CPUcpsid(void)
+{
+    // Read PRIMASK and disable interrupts
+    __asm volatile ("    mrs     r0, PRIMASK\n"
+                    "    cpsid   i\n"
+                    "    bx      lr\n"
+                   );
+}
 #else
 uint32_t __attribute__((naked))
 CPUcpsid(void)
@@ -175,6 +185,15 @@ CPUprimask(void)
     // return(0) is never executed and the function returns with the value
     // you expect in R0.
     return(0);
+}
+#elif defined(__clang__)
+uint32_t __attribute__((naked))
+CPUprimask(void)
+{
+    // Read PRIMASK
+    __asm volatile ("    mrs     r0, PRIMASK\n"
+                    "    bx      lr\n"
+                   );
 }
 #else
 uint32_t __attribute__((naked))
@@ -246,6 +265,16 @@ CPUcpsie(void)
     // you expect in R0.
     return(0);
 }
+#elif defined(__clang__)
+uint32_t __attribute__((naked))
+CPUcpsie(void)
+{
+    // Read PRIMASK and enable interrupts.
+    __asm volatile ("    mrs     r0, PRIMASK\n"
+                    "    cpsie   i\n"
+                    "    bx      lr\n"
+                   );
+}
 #else
 uint32_t __attribute__((naked))
 CPUcpsie(void)
@@ -313,6 +342,15 @@ CPUbasepriGet(void)
     // return(0) is never executed and the function returns with the value
     // you expect in R0.
     return(0);
+}
+#elif defined(__clang__)
+uint32_t __attribute__((naked))
+CPUbasepriGet(void)
+{
+    // Read BASEPRI.
+    __asm volatile ("    mrs     r0, BASEPRI\n"
+                    "    bx      lr\n"
+                   );
 }
 #else
 uint32_t __attribute__((naked))
@@ -386,11 +424,9 @@ void __attribute__((naked))
 CPUdelay(uint32_t ui32Count)
 {
     // Loop the specified number of times
-    __asm volatile ("%=:  subs  %0, #1\n"
-                    "     bne   %=b\n"
-                    "     bx    lr\n"
-                    : /* No output */
-                    : "r" (ui32Count)
+    __asm volatile ("CPUdel:  subs  r0, #1\n"
+                    "         bne   CPUdel\n"
+                    "         bx    lr\n"
                    );
 }
 #endif

--- a/simplelink/source/ti/devices/cc13x2_cc26x2/driverlib/cpu.h
+++ b/simplelink/source/ti/devices/cc13x2_cc26x2/driverlib/cpu.h
@@ -367,10 +367,8 @@ __STATIC_INLINE void __attribute__ ((naked))
 CPUbasepriSet(uint32_t ui32NewBasepri)
 {
     // Set the BASEPRI register.
-    __asm volatile ("    msr     BASEPRI, %0\n"
+    __asm volatile ("    msr     BASEPRI, r0\n"
                     "    bx      lr\n"
-                    : /* No output */
-                    : "r" (ui32NewBasepri)
                    );
 }
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Fix inline assembly issues related to clang/llvm.  Mostly related
errors of the form:

driverlib/cpu.h:373:28: error: parameter references not allowed in
                        naked functions

or
driverlib/cpu.c:253:5: error: non-ASM statement in naked function is
                       not supported

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>