### PR TITLE
simplelink: dpl: Fix SemaphoreP initialization

### DIFF
--- a/simplelink/kernel/zephyr/dpl/SemaphoreP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/SemaphoreP_zephyr.c
@@ -79,7 +79,7 @@ SemaphoreP_Handle SemaphoreP_create(unsigned int count,
 
 	sem = dpl_sem_pool_alloc();
 	if (sem) {
-		k_sem_init(sem, 0, limit);
+		k_sem_init(sem, count, limit);
 	}
 
 	return (SemaphoreP_Handle)sem;
@@ -154,7 +154,7 @@ SemaphoreP_Handle SemaphoreP_construct(SemaphoreP_Struct *handle,
 
     sem = (struct k_sem *)handle;
     if (sem) {
-        k_sem_init(sem, 0, limit);
+        k_sem_init(sem, count, limit);
     }
 
     return (SemaphoreP_Handle)sem;


### PR DESCRIPTION
When creating or constructing a semaphore, the count passed in is
incorrectly being ignored. We need to fix SemaphoreP_create/construct
to pass the initial count to k_sem_init().

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>