### PR TITLE
msp432p4xx: replace DT_ARM_CORTEX_*_CLOCK_FREQUENCY with new dt macros

### DIFF
--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p401m.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p401m.c
@@ -69,7 +69,7 @@
 //     <12000000> 12 MHz
 //     <24000000> 24 MHz
 //     <48000000> 48 MHz
-#define  __SYSTEM_CLOCK    DT_ARM_CORTEX_M4F_0_CLOCK_FREQUENCY
+#define  __SYSTEM_CLOCK    DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
 
 /*--------------------- Power Regulator Configuration -----------------------*/
 //  Power Regulator Mode

--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p401r.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p401r.c
@@ -69,7 +69,7 @@
 //     <12000000> 12 MHz
 //     <24000000> 24 MHz
 //     <48000000> 48 MHz
-#define  __SYSTEM_CLOCK    DT_ARM_CORTEX_M4F_0_CLOCK_FREQUENCY
+#define  __SYSTEM_CLOCK    DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
 
 /*--------------------- Power Regulator Configuration -----------------------*/
 //  Power Regulator Mode

--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p4111.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p4111.c
@@ -69,7 +69,7 @@
 //     <12000000> 12 MHz
 //     <24000000> 24 MHz
 //     <48000000> 48 MHz
-#define  __SYSTEM_CLOCK    DT_ARM_CORTEX_M4F_0_CLOCK_FREQUENCY
+#define  __SYSTEM_CLOCK    DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
 
 /*--------------------- Power Regulator Configuration -----------------------*/
 //  Power Regulator Mode

--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p411v.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p411v.c
@@ -69,7 +69,7 @@
 //     <12000000> 12 MHz
 //     <24000000> 24 MHz
 //     <48000000> 48 MHz
-#define  __SYSTEM_CLOCK    DT_ARM_CORTEX_M4F_0_CLOCK_FREQUENCY
+#define  __SYSTEM_CLOCK    DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
 
 /*--------------------- Power Regulator Configuration -----------------------*/
 //  Power Regulator Mode

--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p411y.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p411y.c
@@ -69,7 +69,7 @@
 //     <12000000> 12 MHz
 //     <24000000> 24 MHz
 //     <48000000> 48 MHz
-#define  __SYSTEM_CLOCK    DT_ARM_CORTEX_M4F_0_CLOCK_FREQUENCY
+#define  __SYSTEM_CLOCK    DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
 
 /*--------------------- Power Regulator Configuration -----------------------*/
 //  Power Regulator Mode


### PR DESCRIPTION
Replace DT_ARM_CORTEX_*_0_CLOCK_FREQUENCY with a PATH based reference
to cpu@0 (DT_PATH(cpus, cpu_0)) and than getting the clock_frequency
property:

    DT_ARM_CORTEX_*_CLOCK_FREQUENCY ->
        DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>