### PR TITLE
Add files necessary to rebuild Zephyr's IEEE 802.15.4 driver

### DIFF
--- a/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
+++ b/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
@@ -19,6 +19,9 @@ zephyr_library_sources(
   driverlib/driverlib_release.c
   )
 
+# Required for IEEE 802.15.4 support
+zephyr_sources_ifdef(CONFIG_IEEE802154_CC13XX_CC26XX
+	rf_patches/rf_patch_cpe_ieee_802_15_4.c)
 # Required for RFCDoorbellSendTo which is not in ROM
 zephyr_sources_ifdef(CONFIG_IEEE802154_CC13XX_CC26XX driverlib/rfc.c)
 

--- a/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
+++ b/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
@@ -19,6 +19,9 @@ zephyr_library_sources(
   driverlib/driverlib_release.c
   )
 
+# Required for RFCDoorbellSendTo which is not in ROM
+zephyr_sources_ifdef(CONFIG_IEEE802154_CC13XX_CC26XX driverlib/rfc.c)
+
 if(CONFIG_SOC_CC1352R)
   # Required for RFCDoorbellSendTo which is not in ROM
   set_source_files_properties(driverlib/rfc.c


### PR DESCRIPTION
Adding some files to the build that are necessary in order to rebuild the IEEE 802.15.4 driver. rfc.c was inadvertently left out during the update to SimpleLink SDK 4.10, and a new patch file has also been introduced.