### PR TITLE
fixup! cc13x2_cc26x2: update to TI SimpleLink SDK 4.10.00.78

### DIFF
--- a/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
+++ b/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
@@ -21,10 +21,12 @@ zephyr_library_sources(
 
 if(CONFIG_SOC_CC1352R)
   # Required for RFCDoorbellSendTo which is not in ROM
+  zephyr_library_sources(driverlib/rfc.c)
   set_source_files_properties(driverlib/rfc.c
     PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC13X2;${COMPILER}" )
 elseif(CONFIG_SOC_CC2652R)
   # Required for RFCDoorbellSendTo which is not in ROM
+  zephyr_library_sources(driverlib/rfc.c)
   set_source_files_properties(driverlib/rfc.c
     PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC26X2;${COMPILER}" )
 endif()


### PR DESCRIPTION
Commit 73a56862dd32ea400f0acda4673505d47d67e2ea by @vanti actually removed rfc.c from the final link (effectively removed @bwitherspoon's previous commit ccee61e5bdb5309a273b19b2beb6aea654218375).

The changes I've made should be a reasonable compromise.