### PR TITLE
simplelink: drivers: resolve symbol Temperature_getTemperature

### DIFF
--- a/simplelink/CMakeLists.txt
+++ b/simplelink/CMakeLists.txt
@@ -67,6 +67,7 @@ elseif(CONFIG_HAS_CC13X2_CC26X2_SDK)
     source/ti/drivers/power/PowerCC26X2_calibrateRCOSC.c
     source/ti/drivers/utils/List.c
     source/ti/drivers/rf/RFCC26X2_multiMode.c
+    source/ti/drivers/temperature/TemperatureCC26X2.c
 
     kernel/zephyr/dpl/config.c
     kernel/zephyr/dpl/ClockP_zephyr.c
@@ -83,12 +84,16 @@ elseif(CONFIG_HAS_CC13X2_CC26X2_SDK)
       PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC13X2;${COMPILER}" )
     set_source_files_properties(source/ti/drivers/rf/RFCC26X2_multiMode.c
       PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC13X2;${COMPILER}" )
+    set_source_files_properties(source/ti/drivers/temperature/TemperatureCC26X2.c
+      PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC13X2;${COMPILER}" )
   elseif(CONFIG_SOC_CC2652R)
     set_source_files_properties(source/ti/drivers/power/PowerCC26X2.c
       PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC26X2;${COMPILER}" )
     set_source_files_properties(source/ti/drivers/power/PowerCC26X2_calibrateRCOSC.c
       PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC26X2;${COMPILER}" )
     set_source_files_properties(source/ti/drivers/rf/RFCC26X2_multiMode.c
+      PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC26X2;${COMPILER}" )
+    set_source_files_properties(source/ti/drivers/temperature/TemperatureCC26X2.c
       PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC26X2;${COMPILER}" )
   endif()
 


### PR DESCRIPTION
CC: @vanti 
RFCC26X2_multiMode.c references Temperature_getTemperature() but source/ti/drivers/temperature/TemperatureCC26X2.c was not previously linked in.
    
