### PR TITLE
ext: simplelink: Use monothonic time

### DIFF
--- a/simplelink/source/ti/drivers/net/wifi/porting/cc_pal.c
+++ b/simplelink/source/ti/drivers/net/wifi/porting/cc_pal.c
@@ -410,8 +410,9 @@ int Semaphore_pend_handle(sem_t* pSemHandle,  uint32_t timeout)
         abstime.tv_sec = 0;
 
         /* Since POSIX timeout are relative and not absolute,
-         * take the current timestamp. */
-        clock_gettime(CLOCK_REALTIME, &abstime);
+         * take the current timestamp.
+         * Zephyr sem_timedwait uses uptime */
+        clock_gettime(CLOCK_MONOTONIC, &abstime);
         if(abstime.tv_nsec < 0)
         {
             abstime.tv_sec = timeout;


### PR DESCRIPTION
Rationale: In case if 

> clock_gettime(CLOCK_REALTIME, &abstime);

 derives RTC time system will hang on bootup

Zephyr sem_timedwait uses uptime, thus user must use mothonic time instead of realtime.
