### PR TITLE
cc13x2: kconfig conditions for P variant support & custom RF hwattrs

### DIFF
--- a/simplelink/CMakeLists.txt
+++ b/simplelink/CMakeLists.txt
@@ -81,7 +81,7 @@ elseif(CONFIG_HAS_CC13X2_CC26X2_SDK)
     kernel/zephyr/dpl/QueueP_zephyr.c
     )
 
-  if(CONFIG_SOC_CC1352R)
+  if(CONFIG_SOC_CC1352R OR CONFIG_SOC_CC1352P)
     set_source_files_properties(source/ti/drivers/power/PowerCC26X2.c
       PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC13X2;${COMPILER}" )
     set_source_files_properties(source/ti/drivers/power/PowerCC26X2_calibrateRCOSC.c
@@ -90,7 +90,7 @@ elseif(CONFIG_HAS_CC13X2_CC26X2_SDK)
       PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC13X2;${COMPILER}" )
     set_source_files_properties(source/ti/drivers/temperature/TemperatureCC26X2.c
       PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC13X2;${COMPILER}" )
-  elseif(CONFIG_SOC_CC2652R)
+  elseif(CONFIG_SOC_CC2652R OR CONFIG_SOC_CC2652P)
     set_source_files_properties(source/ti/drivers/power/PowerCC26X2.c
       PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC26X2;${COMPILER}" )
     set_source_files_properties(source/ti/drivers/power/PowerCC26X2_calibrateRCOSC.c

--- a/simplelink/kernel/zephyr/dpl/config.c
+++ b/simplelink/kernel/zephyr/dpl/config.c
@@ -10,11 +10,11 @@
 #include "ti/drivers/power/PowerCC26X2.h"
 #endif /* CONFIG_HAS_CC13X2_CC26X2_SDK */
 
-#ifdef CONFIG_SOC_CC1352R
+#if defined(CONFIG_SOC_CC1352R) || defined(CONFIG_SOC_CC1352P)
 #define DeviceFamily_CC13X2
 #endif /* CONFIG_SOC_CC1352R */
 
-#ifdef CONFIG_SOC_CC2652R
+#if defined(CONFIG_SOC_CC2652R) || defined(CONFIG_SOC_CC2652P)
 #define DeviceFamily_CC26X2
 #endif /* CONFIG_SOC_CC2652R */
 

--- a/simplelink/kernel/zephyr/dpl/config.c
+++ b/simplelink/kernel/zephyr/dpl/config.c
@@ -20,7 +20,8 @@
 
 #include "ti/drivers/rf/RF.h"
 
-#ifdef CONFIG_HAS_CC13X2_CC26X2_SDK
+#if defined(CONFIG_HAS_CC13X2_CC26X2_SDK) && !defined(CONFIG_CC13X2_CC26X2_HAS_CUSTOM_RF_HWATTRS)
+
 const RFCC26XX_HWAttrsV2 RFCC26XX_hwAttrs = {
     .hwiPriority        = INT_PRI_LEVEL7,  // Lowest HWI priority:  INT_PRI_LEVEL7
                                            // Highest HWI priority: INT_PRI_LEVEL1
@@ -31,4 +32,5 @@ const RFCC26XX_HWAttrsV2 RFCC26XX_hwAttrs = {
     .xoscHfAlwaysNeeded = true             // Power driver always starts XOSC-HF:       true
                                            // RF driver will request XOSC-HF if needed: false
 };
-#endif /* CONFIG_HAS_CC13X2_CC26X2_SDK */
+
+#endif /* CONFIG_HAS_CC13X2_CC26X2_SDK && !CONFIG_CC13X2_CC26X2_HAS_CUSTOM_RF_HWATTRS */

--- a/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
+++ b/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
@@ -44,11 +44,11 @@ zephyr_library_sources_ifdef(CONFIG_BLE_CC13XX_CC26XX driverlib/rfc.c)
 # Required for on-chip flash support
 zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_CC13XX_CC26XX driverlib/flash.c)
 
-if(CONFIG_SOC_CC1352R)
+if(CONFIG_SOC_CC1352R OR CONFIG_SOC_CC1352P)
   # Required for RFCDoorbellSendTo which is not in ROM
   set_source_files_properties(driverlib/rfc.c
     PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC13X2;${COMPILER}" )
-elseif(CONFIG_SOC_CC2652R)
+elseif(CONFIG_SOC_CC2652R OR CONFIG_SOC_CC2652P)
   # Required for RFCDoorbellSendTo which is not in ROM
   set_source_files_properties(driverlib/rfc.c
     PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC26X2;${COMPILER}" )


### PR DESCRIPTION
Required for supporting CC13x2P / CC26x2P (with high power amplifier) variants:

- conditions for new `SOC_CC1352P` / `SOC_CC2652P` kconfig defines;
- new condition to be able to supply a custom `RFCC26XX_hwAttrs` (to be able to add event callback required for board-specific antenna switching).

Will come with pull req using these to support CC1352P Launchpad board with power amplifier (for IEEE802152 Sub-GHz driver).