### PR TITLE
hal: drivers: use Zephyr PM constraints API

### DIFF
--- a/simplelink/source/ti/drivers/power/PowerCC26X2.c
+++ b/simplelink/source/ti/drivers/power/PowerCC26X2.c
@@ -71,6 +71,8 @@
 #include DeviceFamily_constructPath(driverlib/setup.h)
 #include DeviceFamily_constructPath(driverlib/ccfgread.h)
 
+#include <pm/pm.h>
+
 static unsigned int configureXOSCHF(unsigned int action);
 static unsigned int nopResourceHandler(unsigned int action);
 static unsigned int configureRFCoreClocks(unsigned int action);
@@ -456,6 +458,18 @@ int_fast16_t Power_releaseConstraint(uint_fast16_t constraintId)
     /* assert constraintId is valid */
     DebugP_assert(constraintId < PowerCC26X2_NUMCONSTRAINTS);
 
+    /* forward constraint release to Zephyr */
+    switch (constraintId) {
+    case PowerCC26XX_DISALLOW_STANDBY:
+        pm_constraint_release(PM_STATE_STANDBY);
+        break;
+    case PowerCC26XX_DISALLOW_IDLE:
+        pm_constraint_release(PM_STATE_RUNTIME_IDLE);
+        break;
+    default:
+        break;
+    }
+
     key = HwiP_disable();
 
     /* get the count of the constraint */
@@ -560,6 +574,18 @@ int_fast16_t Power_setConstraint(uint_fast16_t constraintId)
 
     /* assert constraint id is valid */
     DebugP_assert(constraintId < PowerCC26X2_NUMCONSTRAINTS);
+
+    /* forward constraint set to Zephyr */
+    switch (constraintId) {
+    case PowerCC26XX_DISALLOW_STANDBY:
+        pm_constraint_set(PM_STATE_STANDBY);
+        break;
+    case PowerCC26XX_DISALLOW_IDLE:
+        pm_constraint_set(PM_STATE_RUNTIME_IDLE);
+        break;
+    default:
+        break;
+    }
 
     /* disable interrupts */
     key = HwiP_disable();


### PR DESCRIPTION
The constraints API offered by TI HAL is meant to be used externally,
for example, when implementing a policy using their policy mechanism
(not used on Zephyr). The API is likely designed for systems where a
thin RTOS is used (e.g., FreeRTOS, TI-RTOS?), places where you basically
get a Kernel and a few services around, but not a system like Zephyr
where you also get, for example, a power management subsystem. This
means that it gets difficult for an RTOS like Zephyr to use such HAL
APIs while using its own constraints API. The first question is why we
allowed such kind of HAL code to be part of upstream Zephyr. It
certainly does useful things, but it is also uses a HAL infrastructure
which is hardly exportable to an RTOS like Zephyr. Part of the
Power_init() code, for example, should likely be part of a clock
controller driver, where Zephyr APIs can be used.

This patch replaces constraints API usage with the Zephyr API, so that
we don't need hacks on the Zephyr side like allowing re-implementations
of the constraints API.