### PR TITLE
zephyr: remove posix prefix on time.h standard include

### DIFF
--- a/simplelink/source/ti/drivers/net/wifi/porting/cc_pal.h
+++ b/simplelink/source/ti/drivers/net/wifi/porting/cc_pal.h
@@ -50,7 +50,7 @@ extern "C" {
 #include <ti/drivers/dpl/ClockP.h>
 #if defined(SL_PLATFORM_MULTI_THREADED)
 /* Use Zephyr posix headers */
-#include <posix/time.h>
+#include <time.h>
 #include <posix/pthread.h>
 #include <posix/semaphore.h>
 #include <posix/unistd.h>

--- a/simplelink/source/ti/net/slnetsock.h
+++ b/simplelink/source/ti/net/slnetsock.h
@@ -196,7 +196,8 @@ interface.  Some are mandatory, others are optional (but recommended).
  * Can remove this if support for CONFIG_NET_SOCKETS_POSIX_NAMES
  * is dropped someday
  */
-#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES
+#if defined(CONFIG_NET_SOCKETS_POSIX_NAMES) || defined(CONFIG_POSIX_CLOCK) \
+    || defined(CONFIG_POSIX_API)
 #include <sys/time.h>
 #endif
 


### PR DESCRIPTION
Instead of using `#include <posix/time.h>`, just use `#include <time.h>`.

Required-by zephyrproject-rtos/zephyr#43998