### PR TITLE
simplelink: Use <errno.h> to get definition of errno

### DIFF
--- a/simplelink/kernel/zephyr/dpl/dpl.h
+++ b/simplelink/kernel/zephyr/dpl/dpl.h
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define MEM_ALIGN (sizeof(uint32_t))
+#include <errno.h>
 
-extern int *__errno(void);
+#define MEM_ALIGN (sizeof(uint32_t))


### PR DESCRIPTION
Use the C library errno header instead of assuming a particular
implementation. This allows the use of picolibc with projects
using this module.

Signed-off-by: Keith Packard <keithp@keithp.com>