### PR TITLE
power: migrate PM includes to <zephyr/...>

### DIFF
--- a/simplelink/source/ti/drivers/power/PowerCC26X2.c
+++ b/simplelink/source/ti/drivers/power/PowerCC26X2.c
@@ -71,7 +71,7 @@
 #include DeviceFamily_constructPath(driverlib/setup.h)
 #include DeviceFamily_constructPath(driverlib/ccfgread.h)
 
-#include <pm/policy.h>
+#include <zephyr/pm/policy.h>
 
 static unsigned int configureXOSCHF(unsigned int action);
 static unsigned int nopResourceHandler(unsigned int action);


### PR DESCRIPTION
Zephyr has prefixed all of its includes with <zephyr/...>. While the old
mode can still be used (CONFIG_LEGACY_INCLUDE_PATH) and is still enabled
by default, it's better to be prepared for its removal in the future.