### PR TITLE
zephyr: update include paths to use <zephyr/...>

### DIFF
--- a/simplelink/kernel/zephyr/dpl/ClockP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/ClockP_zephyr.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>
 #include <kernel/zephyr/dpl/dpl.h>
 #include <ti/drivers/dpl/ClockP.h>

--- a/simplelink/kernel/zephyr/dpl/ClockP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/ClockP_zephyr.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/__assert.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/__assert.h>
 #include <kernel/zephyr/dpl/dpl.h>
 #include <ti/drivers/dpl/ClockP.h>
 

--- a/simplelink/kernel/zephyr/dpl/HwiP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/HwiP_zephyr.c
@@ -5,8 +5,8 @@
  */
 
 
-#include <zephyr.h>
-#include <sys/__assert.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/__assert.h>
 #include <kernel/zephyr/dpl/dpl.h>
 #include <ti/drivers/dpl/HwiP.h>
 

--- a/simplelink/kernel/zephyr/dpl/HwiP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/HwiP_zephyr.c
@@ -5,7 +5,7 @@
  */
 
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>
 #include <kernel/zephyr/dpl/dpl.h>
 #include <ti/drivers/dpl/HwiP.h>

--- a/simplelink/kernel/zephyr/dpl/MutexP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/MutexP_zephyr.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>
 #include <kernel/zephyr/dpl/dpl.h>
 #include <ti/drivers/dpl/MutexP.h>

--- a/simplelink/kernel/zephyr/dpl/MutexP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/MutexP_zephyr.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/__assert.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/__assert.h>
 #include <kernel/zephyr/dpl/dpl.h>
 #include <ti/drivers/dpl/MutexP.h>
 

--- a/simplelink/kernel/zephyr/dpl/SemaphoreP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/SemaphoreP_zephyr.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/__assert.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/__assert.h>
 #include <kernel/zephyr/dpl/dpl.h>
 #include <ti/drivers/dpl/SemaphoreP.h>
 

--- a/simplelink/kernel/zephyr/dpl/SemaphoreP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/SemaphoreP_zephyr.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>
 #include <kernel/zephyr/dpl/dpl.h>
 #include <ti/drivers/dpl/SemaphoreP.h>

--- a/simplelink/kernel/zephyr/dpl/SwiP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/SwiP_zephyr.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include <ti/drivers/dpl/HwiP.h>
 #include <ti/drivers/dpl/SwiP.h>

--- a/simplelink/kernel/zephyr/dpl/SwiP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/SwiP_zephyr.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #include <ti/drivers/dpl/HwiP.h>
 #include <ti/drivers/dpl/SwiP.h>

--- a/simplelink/kernel/zephyr/dpl/config.c
+++ b/simplelink/kernel/zephyr/dpl/config.c
@@ -1,7 +1,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #include "stubs.h"
 

--- a/simplelink/kernel/zephyr/dpl/config.c
+++ b/simplelink/kernel/zephyr/dpl/config.c
@@ -1,7 +1,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include "stubs.h"
 

--- a/simplelink/kernel/zephyr/dpl/dpl.c
+++ b/simplelink/kernel/zephyr/dpl/dpl.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/util.h>

--- a/simplelink/kernel/zephyr/dpl/dpl.c
+++ b/simplelink/kernel/zephyr/dpl/dpl.c
@@ -8,11 +8,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <zephyr.h>
-#include <device.h>
-#include <init.h>
-#include <sys/util.h>
-#include <sys/__assert.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/__assert.h>
 
 #include <inc/hw_types.h>
 #include <inc/hw_ints.h>

--- a/simplelink/kernel/zephyr/dpl/stubs.h
+++ b/simplelink/kernel/zephyr/dpl/stubs.h
@@ -1,7 +1,7 @@
 #ifndef STUBS_H_
 #define STUBS_H_
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #define STUB(fmt, args...) printk("%s(): %d: STUB: " fmt "\n", __func__, __LINE__, ##args)
 

--- a/simplelink/source/ti/devices/cc13x2_cc26x2/startup_files/ccfg.c
+++ b/simplelink/source/ti/devices/cc13x2_cc26x2/startup_files/ccfg.c
@@ -47,7 +47,7 @@
 #include "../inc/hw_ccfg_simple_struct.h"
 
 /* Required for Zephyr __ti_ccfg_section macro */
-#include <linker/sections.h>
+#include <zephyr/linker/sections.h>
 
 //*****************************************************************************
 //

--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p401m.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p401m.c
@@ -44,7 +44,7 @@
 
 #include <stdint.h>
 #include <ti/devices/msp432p4xx/inc/msp.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /*--------------------- Configuration Instructions ----------------------------
    1. If you prefer to halt the Watchdog Timer, set __HALT_WDT to 1:

--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p401r.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p401r.c
@@ -44,7 +44,7 @@
 
 #include <stdint.h>
 #include <ti/devices/msp432p4xx/inc/msp.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /*--------------------- Configuration Instructions ----------------------------
    1. If you prefer to halt the Watchdog Timer, set __HALT_WDT to 1:

--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p4111.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p4111.c
@@ -44,7 +44,7 @@
 
 #include <stdint.h>
 #include <ti/devices/msp432p4xx/inc/msp.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /*--------------------- Configuration Instructions ----------------------------
    1. If you prefer to halt the Watchdog Timer, set __HALT_WDT to 1:

--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p411v.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p411v.c
@@ -44,7 +44,7 @@
 
 #include <stdint.h>
 #include <ti/devices/msp432p4xx/inc/msp.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /*--------------------- Configuration Instructions ----------------------------
    1. If you prefer to halt the Watchdog Timer, set __HALT_WDT to 1:

--- a/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p411y.c
+++ b/simplelink/source/ti/devices/msp432p4xx/startup_system_files/system_msp432p411y.c
@@ -44,7 +44,7 @@
 
 #include <stdint.h>
 #include <ti/devices/msp432p4xx/inc/msp.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /*--------------------- Configuration Instructions ----------------------------
    1. If you prefer to halt the Watchdog Timer, set __HALT_WDT to 1:

--- a/simplelink/source/ti/drivers/dpl/ClockP.h
+++ b/simplelink/source/ti/drivers/dpl/ClockP.h
@@ -61,7 +61,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/simplelink/source/ti/drivers/net/wifi/porting/cc_pal.h
+++ b/simplelink/source/ti/drivers/net/wifi/porting/cc_pal.h
@@ -51,9 +51,9 @@ extern "C" {
 #if defined(SL_PLATFORM_MULTI_THREADED)
 /* Use Zephyr posix headers */
 #include <time.h>
-#include <posix/pthread.h>
-#include <posix/semaphore.h>
-#include <posix/unistd.h>
+#include <zephyr/posix/pthread.h>
+#include <zephyr/posix/semaphore.h>
+#include <zephyr/posix/unistd.h>
 #else //SL_PLATFORM_MULTI_THREADED
 #include <ti/drivers/dpl/SemaphoreP.h>
 #include <ti/drivers/dpl/MutexP.h>

--- a/simplelink/source/ti/net/slnetsock.c
+++ b/simplelink/source/ti/net/slnetsock.c
@@ -47,7 +47,7 @@
 
 /* POSIX Header files */
 /* Changed include path to match Zephyr posix */
-#include <posix/semaphore.h>
+#include <zephyr/posix/semaphore.h>
 
 /*****************************************************************************/
 /* Macro declarations                                                        */


### PR DESCRIPTION
Zephyr has prefixed all of its includes with <zephyr/...>. While the old
mode can still be used (CONFIG_LEGACY_INCLUDE_PATH) and is still enabled
by default, it's better to be prepared for its removal in the future.