### PR TITLE
simplelink: cc13x2_cc26x2: include flash driverlib sources

### DIFF
--- a/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
+++ b/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
@@ -41,6 +41,9 @@ zephyr_library_sources_ifdef(CONFIG_BLE_CC13XX_CC26XX
 # Required for RFCDoorbellSendTo which is not in ROM
 zephyr_library_sources_ifdef(CONFIG_BLE_CC13XX_CC26XX driverlib/rfc.c)
 
+# Required for on-chip flash support
+zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_CC13XX_CC26XX driverlib/flash.c)
+
 if(CONFIG_SOC_CC1352R)
   # Required for RFCDoorbellSendTo which is not in ROM
   set_source_files_properties(driverlib/rfc.c


### PR DESCRIPTION
These sources are required for CC13xx/CC26xx on-chip flash driver which makes use of TI's HAL functions and some of them are not inside ROM.