### PR TITLE
hal: inject required definitions

### DIFF
--- a/simplelink/CMakeLists.txt
+++ b/simplelink/CMakeLists.txt
@@ -59,6 +59,13 @@ if(CONFIG_HAS_CC3220SDK)
   endif()
 
 elseif(CONFIG_HAS_CC13X2_CC26X2_SDK)
+
+  if(CONFIG_SOC_CC1352R OR CONFIG_SOC_CC1352P)
+    zephyr_compile_definitions(DeviceFamily_CC13X2 ${COMPILER})
+  elseif(CONFIG_SOC_CC2652R OR CONFIG_SOC_CC2652P)
+    zephyr_compile_definitions(DeviceFamily_CC26X2 ${COMPILER})
+  endif()
+
   zephyr_include_directories(
     .
     source
@@ -80,26 +87,6 @@ elseif(CONFIG_HAS_CC13X2_CC26X2_SDK)
     kernel/zephyr/dpl/SemaphoreP_zephyr.c
     kernel/zephyr/dpl/QueueP_zephyr.c
     )
-
-  if(CONFIG_SOC_CC1352R OR CONFIG_SOC_CC1352P)
-    set_source_files_properties(source/ti/drivers/power/PowerCC26X2.c
-      PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC13X2;${COMPILER}" )
-    set_source_files_properties(source/ti/drivers/power/PowerCC26X2_calibrateRCOSC.c
-      PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC13X2;${COMPILER}" )
-    set_source_files_properties(source/ti/drivers/rf/RFCC26X2_multiMode.c
-      PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC13X2;${COMPILER}" )
-    set_source_files_properties(source/ti/drivers/temperature/TemperatureCC26X2.c
-      PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC13X2;${COMPILER}" )
-  elseif(CONFIG_SOC_CC2652R OR CONFIG_SOC_CC2652P)
-    set_source_files_properties(source/ti/drivers/power/PowerCC26X2.c
-      PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC26X2;${COMPILER}" )
-    set_source_files_properties(source/ti/drivers/power/PowerCC26X2_calibrateRCOSC.c
-      PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC26X2;${COMPILER}" )
-    set_source_files_properties(source/ti/drivers/rf/RFCC26X2_multiMode.c
-      PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC26X2;${COMPILER}" )
-    set_source_files_properties(source/ti/drivers/temperature/TemperatureCC26X2.c
-      PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC26X2;${COMPILER}" )
-  endif()
 
 elseif(CONFIG_HAS_MSP432P4XXSDK)
   zephyr_include_directories(

--- a/simplelink/kernel/zephyr/dpl/config.c
+++ b/simplelink/kernel/zephyr/dpl/config.c
@@ -10,14 +10,6 @@
 #include "ti/drivers/power/PowerCC26X2.h"
 #endif /* CONFIG_HAS_CC13X2_CC26X2_SDK */
 
-#if defined(CONFIG_SOC_CC1352R) || defined(CONFIG_SOC_CC1352P)
-#define DeviceFamily_CC13X2
-#endif /* CONFIG_SOC_CC1352R */
-
-#if defined(CONFIG_SOC_CC2652R) || defined(CONFIG_SOC_CC2652P)
-#define DeviceFamily_CC26X2
-#endif /* CONFIG_SOC_CC2652R */
-
 #include "ti/drivers/rf/RF.h"
 
 #if defined(CONFIG_HAS_CC13X2_CC26X2_SDK) && !defined(CONFIG_CC13X2_CC26X2_HAS_CUSTOM_RF_HWATTRS)

--- a/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
+++ b/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
@@ -5,7 +5,7 @@ zephyr_include_directories(
   )
 
 zephyr_library()
-zephyr_library_compile_definitions(${COMPILER})
+
 zephyr_library_sources(
   # Required for SystemTrimDevice which is not in ROM
   driverlib/setup.c
@@ -45,13 +45,3 @@ zephyr_library_sources_ifdef(CONFIG_BLE_CC13XX_CC26XX driverlib/rfc.c)
 
 # Required for on-chip flash support
 zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_CC13XX_CC26XX driverlib/flash.c)
-
-if(CONFIG_SOC_CC1352R OR CONFIG_SOC_CC1352P)
-  # Required for RFCDoorbellSendTo which is not in ROM
-  set_source_files_properties(driverlib/rfc.c
-    PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC13X2;${COMPILER}" )
-elseif(CONFIG_SOC_CC2652R OR CONFIG_SOC_CC2652P)
-  # Required for RFCDoorbellSendTo which is not in ROM
-  set_source_files_properties(driverlib/rfc.c
-    PROPERTIES COMPILE_DEFINITIONS "DeviceFamily_CC26X2;${COMPILER}" )
-endif()


### PR DESCRIPTION
The TI HAL requires certain definitions, e.g. DeviceFamily_XYZ to be
present when compiling, as some public headers require them. Instead of
manually injecting them to every file because one of its includes
requires it, just insert global level definitions. This makes sure
they'll be made available where necessary without the need of individual
hacks.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>