### PR TITLE
simplelink: cc13x2_cc26x2: include ADC driverlib sources

### DIFF
--- a/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
+++ b/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
@@ -45,3 +45,6 @@ zephyr_library_sources_ifdef(CONFIG_BLE_CC13XX_CC26XX driverlib/rfc.c)
 
 # Required for on-chip flash support
 zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_CC13XX_CC26XX driverlib/flash.c)
+
+# Required for AUX ADC support
+zephyr_library_sources_ifdef(CONFIG_ADC_CC13XX_CC26XX driverlib/aux_adc.c)


### PR DESCRIPTION
To be used by upcoming TI CC13xx/CC26xx Zephyr ADC driver (PR incoming).