### PR TITLE
simplelink: use 'errno' instead of '*__errno()' for picolibc compat

### DIFF
--- a/simplelink/kernel/zephyr/dpl/dpl.c
+++ b/simplelink/kernel/zephyr/dpl/dpl.c
@@ -110,7 +110,7 @@ int dpl_set_errno(int err)
 	 * __errno() is a Zephyr function returning a pointer to the
 	 * current thread's errno variable.
 	 */
-	*__errno() = (err < 0? -err : err);
+	errno = (err < 0? -err : err);
 	return -1;
 }
 #endif


### PR DESCRIPTION
Picolibc doesn't always use an __errno function, preferring to use TLS errno variable instead as that's more efficient. But, that means applications shouldn't dig through the original errno abstraction to use the underlying implementation directly.

Signed-off-by: Keith Packard <keithp@keithp.com>