### PR TITLE
zephyr: remove usage of deprecated zephyr/zephyr.h header

### DIFF
--- a/simplelink/kernel/zephyr/dpl/stubs.h
+++ b/simplelink/kernel/zephyr/dpl/stubs.h
@@ -1,7 +1,7 @@
 #ifndef STUBS_H_
 #define STUBS_H_
 
-#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 #define STUB(fmt, args...) printk("%s(): %d: STUB: " fmt "\n", __func__, __LINE__, ##args)
 

--- a/simplelink/source/ti/drivers/dpl/ClockP.h
+++ b/simplelink/source/ti/drivers/dpl/ClockP.h
@@ -61,7 +61,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Use zephyr/kernel.h instead. stubs.h only required zephyr/sys/printk.h.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>