### PR TITLE
simplelink: wifi: avoid re-declaring pthread_self()

### DIFF
--- a/simplelink/source/ti/drivers/net/wifi/source/driver.h
+++ b/simplelink/source/ti/drivers/net/wifi/source/driver.h
@@ -460,7 +460,7 @@ extern void _SlDrvSleep(_u16 DurationInMsec);
 #endif
 
 #if defined(SL_PLATFORM_MULTI_THREADED)
-extern void * pthread_self(void);
+/* Note: pthread_self() previously declared here */
 #endif
 
 extern _SlReturnVal_t _SlNetAppHandleAsync_DnsGetHostByName(void *pVoidBuf);


### PR DESCRIPTION
The normative spec says this returns `pthread_t`, not `void *`.

It's probably better to simply `#include <pthread.h>` outside of this file explicitly (due to current non-standard prefixed path in Zerphy) than to re-declare it with a potentially conflicting signature.
