### PR TITLE
drivers: rf: RFCC26X2_multiMode: regression due to prior race fix

### DIFF
--- a/simplelink/source/ti/drivers/rf/RFCC26X2_multiMode.c
+++ b/simplelink/source/ti/drivers/rf/RFCC26X2_multiMode.c
@@ -3531,15 +3531,15 @@ static void RF_fsmActiveState(RF_Object *pObj, RF_FsmEvent e)
         /* Enter critical section. */
         key = HwiP_disable();
 
+        /* Verify if the decision has not been reverted in the meantime. */
+        transitionAllowed = RF_isStateTransitionAllowed();
+
         /* Store the previous status in case the transition will be rejected */
         previousStatus = RF_core.status;
 
         /* Indicate that the RF core is being powered down from now.
            This must be done early on to avoid nesting. */
         RF_core.status = RF_CoreStatusPoweringDown;
-
-        /* Verify if the decision has not been reverted in the meantime. */
-        transitionAllowed = RF_isStateTransitionAllowed();
 
         /* If possible, put the running RAT channels into pending state allowing to
            power down the RF core. */


### PR DESCRIPTION
The fix of a race condition in the previous commit introduced a regression in power management which disallowed transitions to power-down state. This fixes the regression.

@vaishnavachath Sorry for that. :-( It's just a two-liner so probably a quick review.

@cfriedt Could you maybe do a second review? This is a quick one.