### PR TITLE
Fix: Several TI clock issues

### DIFF
--- a/simplelink/kernel/zephyr/dpl/ClockP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/ClockP_zephyr.c
@@ -69,7 +69,19 @@ ClockP_Handle ClockP_construct(ClockP_Struct *handle, ClockP_Fxn clockFxn,
 }
 
 /*
+ *  ======== ClockP_getSystemTickFreq ========
+ */
+inline uint32_t ClockP_getSystemTickFreq()
+{
+   return CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+}
+
+/*
  *  ======== ClockP_getSystemTickPeriod ========
+ *
+ *  This implementation rounds the system tick period down by ~17250ppm
+ *  which makes it useless for any precision timing. Use
+ *  (timeUs * ClockP_getSystemTickFreq() for these purposes instead.
  */
 inline uint32_t ClockP_getSystemTickPeriod()
 {

--- a/simplelink/kernel/zephyr/dpl/ClockP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/ClockP_zephyr.c
@@ -9,7 +9,6 @@
 #include <kernel/zephyr/dpl/dpl.h>
 #include <ti/drivers/dpl/ClockP.h>
 
-#include "stubs.h"
 
 /* 
  * ClockP_STRUCT_SIZE in ClockP.h must be updated to match the size of this

--- a/simplelink/kernel/zephyr/dpl/HwiP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/HwiP_zephyr.c
@@ -18,8 +18,6 @@
 #endif
 #include <driverlib/interrupt.h>
 
-#include "stubs.h"
-
 /*
  * IRQ_CONNECT requires we know the ISR signature and argument
  * at build time; whereas SimpleLink plugs the interrupts

--- a/simplelink/kernel/zephyr/dpl/SemaphoreP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/SemaphoreP_zephyr.c
@@ -9,8 +9,6 @@
 #include <kernel/zephyr/dpl/dpl.h>
 #include <ti/drivers/dpl/SemaphoreP.h>
 
-#include "stubs.h"
-
 /*
  * Zephyr kernel object pools:
  *

--- a/simplelink/kernel/zephyr/dpl/SemaphoreP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/SemaphoreP_zephyr.c
@@ -45,7 +45,7 @@ static SemaphoreP_Status dpl_sem_pool_free(struct k_sem *sem)
 	return SemaphoreP_OK;
 }
 
-/* timeout comes in and out as milliSeconds: */
+/* timeout comes in and out in ticks */
 static k_timeout_t dpl_convert_timeout(uint32_t timeout)
 {
 	switch(timeout) {
@@ -54,7 +54,7 @@ static k_timeout_t dpl_convert_timeout(uint32_t timeout)
 	case SemaphoreP_WAIT_FOREVER:
 		return K_FOREVER;
 	default:
-		return K_MSEC(timeout);
+		return K_TICKS(timeout);
 	}
 }
 

--- a/simplelink/kernel/zephyr/dpl/config.c
+++ b/simplelink/kernel/zephyr/dpl/config.c
@@ -3,7 +3,6 @@
 
 #include <zephyr/kernel.h>
 
-#include "stubs.h"
 
 #if defined(CONFIG_HAS_CC13X2_CC26X2_SDK) || defined(CONFIG_HAS_CC13X2X7_CC26X2X7_SDK)
 #include "ti/devices/cc13x2_cc26x2/driverlib/interrupt.h"

--- a/simplelink/kernel/zephyr/dpl/stubs.h
+++ b/simplelink/kernel/zephyr/dpl/stubs.h
@@ -1,8 +1,0 @@
-#ifndef STUBS_H_
-#define STUBS_H_
-
-#include <zephyr/kernel.h>
-
-#define STUB(fmt, args...) printk("%s(): %d: STUB: " fmt "\n", __func__, __LINE__, ##args)
-
-#endif /* STUBS_H_ */

--- a/simplelink/source/ti/drivers/apps/Button.c
+++ b/simplelink/source/ti/drivers/apps/Button.c
@@ -55,25 +55,6 @@ extern Button_Config Button_config[];
 /* Local functions */
 
 /*
- *  ======== ticksToMs ========
- * Convert system ticks to milliseconds(ms). If the value cannot be represented
- * with 32 bits, ~0 is returned.
- */
-static uint32_t ticksToMs(uint32_t ticks)
-{
-    uint64_t ms = (ticks * ClockP_getSystemTickPeriod()) / 1000;
-
-    if((uint64_t)ms > (uint32_t)ms)
-    {
-        return((uint32_t)~0);
-    }
-    else
-    {
-        return((uint32_t)ms);
-    }
-}
-
-/*
  *  ======== timediff ========
  *  Calculates time difference between input system tick and current system
  *  tick value. If more than 32 bits of ticks have passed, this function is
@@ -91,27 +72,6 @@ static uint32_t timediff(uint32_t startTick)
         /* System tick value overflowed */
         return(currentTick + ((uint32_t)(~0) - startTick));
     }
-}
-
-/*
- *  ======== msToTicks ========
- * Convert milliseconds to system ticks
- */
-static uint32_t msToTicks(uint32_t ms)
-{
-    uint32_t ticks;
-
-    if(ms == 0)
-    {
-        return(0);
-    }
-
-    ticks = (ms * 1000)/ClockP_getSystemTickPeriod();
-    if(ticks == 0)
-    {
-        ticks = 1;
-    }
-    return(ticks);
 }
 
 /*
@@ -451,10 +411,10 @@ Button_Handle Button_open(uint_least8_t buttonIndex,
     }
 
     /* Set internal variables */
-    obj->debounceDuration            = msToTicks(params->debounceDuration);
-    obj->longPressDuration           = msToTicks(params->longPressDuration);
-    obj->doublePressDetectiontimeout = msToTicks(params->
-                                                 doublePressDetectiontimeout);
+    obj->debounceDuration = ClockP_convertMsToSystemTicksRound(params->debounceDuration);
+    obj->longPressDuration = ClockP_convertMsToSystemTicksRound(params->longPressDuration);
+    obj->doublePressDetectiontimeout =
+        ClockP_convertMsToSystemTicksRound(params->doublePressDetectiontimeout);
     obj->buttonCallback              = buttonCallback;
     obj->buttonEventMask             = params->buttonEventMask;
 
@@ -540,5 +500,5 @@ extern uint32_t Button_getLastPressedDuration(Button_Handle handle)
 {
     uint32_t ticks = ((Button_Object *)(handle->object))->
         buttonStateVariables.lastPressedDuration;
-    return(ticksToMs(ticks));
+    return(ClockP_convertSystemTicksToMsRound(ticks));
 }

--- a/simplelink/source/ti/drivers/apps/LED.c
+++ b/simplelink/source/ti/drivers/apps/LED.c
@@ -83,29 +83,6 @@ static void clockTimeoutHandler(uintptr_t arg)
     }
 }
 
-/*
- *  ======== msToTicks ========
- * Convert milliseconds to system ticks.
- * If passed zero, returns zero. If passed a ms value that converts to less
- * than one system tick, returns one.
- */
-static uint32_t msToTicks(uint32_t ms)
-{
-    uint32_t ticks;
-
-    if(ms == 0)
-    {
-        return(0);
-    }
-
-    ticks = (ms * 1000)/ClockP_getSystemTickPeriod();
-    if(ticks == 0)
-    {
-        ticks = 1;
-    }
-    return(ticks);
-}
-
 /* API functions: */
 
 /*
@@ -440,7 +417,7 @@ void LED_startBlinking(LED_Handle ledHandle,
             obj->blinkCount = 2 * blinkCount;
         }
 
-        obj->togglePeriod = msToTicks(blinkPeriod/2);
+        obj->togglePeriod = ClockP_convertMsToSystemTicksRound(blinkPeriod/2);
         ClockP_setTimeout(obj->clockHandle, obj->togglePeriod);
         ClockP_start(obj->clockHandle);
         obj->state = LED_STATE_BLINKING;

--- a/simplelink/source/ti/drivers/dpl/ClockP.h
+++ b/simplelink/source/ti/drivers/dpl/ClockP.h
@@ -67,6 +67,8 @@
 extern "C" {
 #endif
 
+#define US_PER_S 1000000UL
+
 /*!
  *  @brief  Prototype for a ClockP function.
  */

--- a/simplelink/source/ti/drivers/net/wifi/porting/user.h
+++ b/simplelink/source/ti/drivers/net/wifi/porting/user.h
@@ -1228,9 +1228,10 @@ extern  _i16 os_Spawn(P_OS_SPAWN_ENTRY pEntry, void *pValue, unsigned long flags
 
     \return Number of ticks in 10ms
     \note
-    \warning
+    \warning This calculation is not precise as rounding takes place in the
+             order of 1000 ppm if the system tick is the LF clock (32768 Hz).
 */
-#define SL_TIMESTAMP_TICKS_IN_10_MILLISECONDS     (10000/ClockP_getSystemTickPeriod())
+#define SL_TIMESTAMP_TICKS_IN_10_MILLISECONDS     DIV_ROUND_UP(ClockP_getSystemTickFreq(), 100)
 /*!
  *
  Close the Doxygen group.

--- a/simplelink/source/ti/drivers/power/PowerCC26X2.c
+++ b/simplelink/source/ti/drivers/power/PowerCC26X2.c
@@ -296,7 +296,7 @@ int_fast16_t Power_init()
          */
         ClockP_construct(&PowerCC26X2_module.tcxoEnableClock,
                          (ClockP_Fxn)&switchToTCXO,
-                         (CCFGRead_TCXO_MAX_START()*100)/ClockP_getSystemTickPeriod(),
+                         (CCFGRead_TCXO_MAX_START() * ClockP_getSystemTickFreq()) / 10000UL,
                          NULL);
 
         HWREG(AUX_DDI0_OSC_BASE + DDI_O_CLR + DDI_0_OSC_O_CTL0) = DDI_0_OSC_CTL0_XTAL_IS_24M;

--- a/simplelink/source/ti/drivers/sd/SDSPI.c
+++ b/simplelink/source/ti/drivers/sd/SDSPI.c
@@ -273,7 +273,7 @@ int_fast16_t SDSPI_initialize(SD_Handle handle)
                  * completed.
                  */
                 status = SD_STATUS_ERROR;
-                timeout = 1000000/ClockP_getSystemTickPeriod();
+                timeout = ClockP_getSystemTickFreq();
                 startTime = ClockP_getSystemTicks();
 
                 do {
@@ -320,7 +320,7 @@ int_fast16_t SDSPI_initialize(SD_Handle handle)
          * completed.
          */
         status = SD_STATUS_ERROR;
-        timeout = 1000000/ClockP_getSystemTickPeriod();
+        timeout = ClockP_getSystemTickFreq();
         startTime = ClockP_getSystemTicks();
         do {
             if (cardType == SD_SDSC) {
@@ -610,7 +610,7 @@ static bool recvDataBlock(SPI_Handle handle, void *buf, uint32_t count)
      * Wait for SD card to be ready up to 1s.  SD card is ready when the
      * START_BLOCK_TOKEN is received.
      */
-    timeout = 1000000/ClockP_getSystemTickPeriod();
+    timeout = ClockP_getSystemTickFreq();
     startTime = ClockP_getSystemTicks();
     do {
         status = spiTransfer(handle, &rxBuf, &txBuf, 1);
@@ -788,7 +788,7 @@ static bool waitUntilReady(SPI_Handle handle)
     uint32_t     timeout;
 
     /* Wait up to 1s for data packet */
-    timeout = 1000000/ClockP_getSystemTickPeriod();
+    timeout = ClockP_getSystemTickFreq();
     startTime = ClockP_getSystemTicks();
     do {
         status = spiTransfer(handle, &rxDummy, &txDummy, 1);

--- a/simplelink/source/ti/drivers/uart/UARTCC32XXDMA.c
+++ b/simplelink/source/ti/drivers/uart/UARTCC32XXDMA.c
@@ -1088,7 +1088,7 @@ static void startTxFifoEmptyClk(UART_Handle handle, unsigned int numData)
      *       - 8 - for maximum data length
      *       - 3 - for one start bit and maximum of two stop bits
      */
-    ticksPerSec = 1000000 / ClockP_getSystemTickPeriod();
+    ticksPerSec = ClockP_getSystemTickFreq();
     writeTimeout = ((numData * (8 + 3) * ticksPerSec) + object->baudRate - 1)
                            / object->baudRate;
 


### PR DESCRIPTION
This change set contains fixes for several issues discovered in Zephyr's ClockP API implementation:
* the unused stubs.h header was removed.
* the ClockP implementation contained some cruft due to an incomplete migration from the ms based to the tick based kernel timer API.
* the ClockP implementation assumed timeouts and periods to be given in ms although TI's API always expected ticks.

This change set contains a fix for a major conversion bug in TI's own usage of the ClockP API throughout the SimpleLink framework:

* The TI clock subsystem has a method ClockP_getSystemTickPeriod()  that is used in many places as a multipler to convert ticks from/to microseconds or milliseconds. This function returns integer us-precision values. OSes like Zephyr but also the original nortos, FreeRTOS and TI RTOS implementations may use the AON timer at ~32k frequency as a tick source. This has a period of ~30.5 us. Rounding this value to 30us (as the current implementation does) amounts to a systematic timing error of ~17253 ppm which is way worse than what a typical oscillator can do. Even in the ns domain the LF tick period cannot be represented as an integer w/o rounding and the ppm error would still be unacceptably high IMO (~19 ppm). So the approach of calculating with periods will systematically not work in combination with the LF crystal oscillator. This is especially problematic in the RF area where precise timing is crucial. To fix this, an alternative approach is proposed that bases calculations on precise tick frequencies and rounds off as late as possible.
* The fix has been tested in the TSCH context. Without the fix an error of ~25ms accumulates over a period of about 1.5 seconds which means that the timer will systematically oversleep which renders the power saving feature (RF_yield & Co.) virtually useless. With the fix, an error of +/- 1ns nominally can be observed which amounts to RAT tick precision.
