### PR TITLE
simplelink: slnetsock: fix sys/time.h include when sockets are enabled

### DIFF
--- a/simplelink/source/ti/net/slnetsock.h
+++ b/simplelink/source/ti/net/slnetsock.h
@@ -196,8 +196,8 @@ interface.  Some are mandatory, others are optional (but recommended).
  * Can remove this if support for CONFIG_NET_SOCKETS_POSIX_NAMES
  * is dropped someday
  */
-#if defined(CONFIG_NET_SOCKETS_POSIX_NAMES) || defined(CONFIG_POSIX_CLOCK) \
-    || defined(CONFIG_POSIX_API)
+#if !(defined(CONFIG_NET_SOCKETS_POSIX_NAMES) || defined(CONFIG_POSIX_CLOCK) \
+    || defined(CONFIG_POSIX_API))
 #include <sys/time.h>
 #endif
 


### PR DESCRIPTION
This include is causing a nemspace collision between the picolibc and the Zephyr select definitions. Looks like this was originally a '#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES' but got inverted as a positive condition at some stage, which is now causing a build fail.