### PR TITLE
mspm0: Add MSPM0 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(simplelink)
+add_subdirectory(mspm0)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,246 @@
+This file provides licensing information on the code provided in this repository.
+
+Two licenses are in use in this repository: Apache-2.0 and BSD-3-Clause.
+They are applied according to the following scheme:
+- All files imported from official TI repositories are subject to their
+  original license: BSD-3-Clause
+- All other files, which are put in place for adaptation to Zephyr RTOS
+  (CMakeLists.txt, ...) or available as utilities (scripts/) are subject to
+  usual Zephyr project license: Apache-2.0
+- Files missing explicit license information fall under the Apache-2.0
+
+
+For these two licenses, full length texts are available hereafter:
+
+
+                             BSD 3-Clause License
+                      Copyright (c) 2023, Texas Instruments
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+   Neither the name of STMicroelectronics nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Texas Instruments
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,6 @@
+This module addes additional hardware abstractions for several TI devices.
+
+Drivers and other improvements that are TI-specific will be updated periodically.
+These may change with new SDK releases as additional changes occur. 
+
+Please notify a TI Zephyr representative if additional changes are needed.

--- a/mspm0/CMakeLists.txt
+++ b/mspm0/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_subdirectory(source/ti/devices)
+
+if(CONFIG_HAS_MSPM0_SDK)
+  zephyr_include_directories(
+	.
+	source
+	source/ti
+	source/ti/driverlib
+	source/ti/driverlib/m0p
+	source/ti/driverlib/m0p/sysctl
+	)
+
+  file(GLOB driverlib source/ti/driverlib/*.c)
+  file(GLOB sysctl source/ti/driverlib/m0p/sysctl/*.c)
+
+  zephyr_library()
+  zephyr_library_compile_definitions(${COMPILER})
+  zephyr_library_sources(
+	${driverlib}
+	${sysctl}
+	)
+endif()

--- a/mspm0/source/ti/devices/CMakeLists.txt
+++ b/mspm0/source/ti/devices/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(msp)

--- a/mspm0/source/ti/devices/DeviceFamily.h
+++ b/mspm0/source/ti/devices/DeviceFamily.h
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2017-2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/** ============================================================================
+ *  @file       DeviceFamily.h
+ *
+ *  @brief      Infrastructure to select correct driverlib path and identify devices
+ *
+ *  This module enables the selection of the correct driverlib path for the current
+ *  device. It also facilitates the use of per-device conditional compilation
+ *  to enable minor variations in drivers between devices.
+ *
+ *  In order to use this functionality, DeviceFamily_XYZ must be defined as one of
+ *  the supported values. The DeviceFamily_ID and DeviceFamily_DIRECTORY defines
+ *  are set based on DeviceFamily_XYZ.
+ */
+
+#ifndef ti_devices_DeviceFamily__include
+#define ti_devices_DeviceFamily__include
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/*
+ * DeviceFamily_ID_XYZ values.
+ *
+ * DeviceFamily_ID may be used in the preprocessor for conditional compilation.
+ * DeviceFamily_ID is set to one of these values based on the top level
+ * DeviceFamily_XYZ define.
+ */
+#define DeviceFamily_ID_MSPM0L130X      1
+#define DeviceFamily_ID_MSPM0L134X      2
+#define DeviceFamily_ID_MSPM0L110X      3
+#define DeviceFamily_ID_MSPM0G110X      4
+#define DeviceFamily_ID_MSPM0G150X      5
+#define DeviceFamily_ID_MSPM0G310X      6
+#define DeviceFamily_ID_MSPM0G350X      7
+#define DeviceFamily_ID_MSPM0C110X      8
+#define DeviceFamily_ID_MSPS003FX       9
+#define DeviceFamily_ID_MSPM0L122X      10
+#define DeviceFamily_ID_MSPM0L222X      11
+
+/*
+ * DeviceFamily_PARENT_XYZ values.
+ *
+ * DeviceFamily_PARENT may be used in the preprocessor for conditional
+ * compilation. DeviceFamily_PARENT is set to one of these values based
+ * on the top-level DeviceFamily_XYZ define.
+ */
+#define DeviceFamily_PARENT_MSPM0L11XX_L13XX    1
+#define DeviceFamily_PARENT_MSPM0G1X0X_G3X0X    2
+#define DeviceFamily_PARENT_MSPM0C110X          3
+#define DeviceFamily_PARENT_MSPS003FX           4
+#define DeviceFamily_PARENT_MSPM0L122X_L222X    5
+
+/*
+ * Lookup table that sets DeviceFamily_ID, DeviceFamily_DIRECTORY, and
+ * DeviceFamily_PARENT based on the DeviceFamily_XYZ define.
+ * If DeviceFamily_XYZ is undefined, a compiler error is thrown. If
+ * multiple DeviceFamily_XYZ are defined, the first one encountered is used.
+ */
+#if defined(DeviceFamily_MSPM0L130X) || defined(__MSPM0L1306__) \
+     || defined(__MSPM0L1305__) || defined(__MSPM0L1304__) \
+     || defined(__MSPM0L1303__)
+    #define DeviceFamily_ID             DeviceFamily_ID_MSPM0L130X
+    #define DeviceFamily_DIRECTORY      msp
+    #define DeviceFamily_PARENT         DeviceFamily_PARENT_MSPM0L11XX_L13XX
+
+#elif defined(DeviceFamily_MSPM0L134X) || defined(__MSPM0L1346__) \
+    || defined(__MSPM0L1345__) || defined(__MSPM0L1344__) \
+    || defined(__MSPM0L1343__)
+    #define DeviceFamily_ID             DeviceFamily_ID_MSPM0L134X
+    #define DeviceFamily_DIRECTORY      msp
+    #define DeviceFamily_PARENT         DeviceFamily_PARENT_MSPM0L11XX_L13XX
+
+#elif defined(DeviceFamily_MSPM0L110X) || defined(__MSPM0L1106__) \
+    || defined(__MSPM0L1105__)
+    #define DeviceFamily_ID             DeviceFamily_ID_MSPM0L110X
+    #define DeviceFamily_DIRECTORY      msp
+    #define DeviceFamily_PARENT         DeviceFamily_PARENT_MSPM0L11XX_L13XX
+
+#elif defined(DeviceFamily_MSPM0G110X) || defined(__MSPM0G1107__) \
+    || defined(__MSPM0G1106__) || defined(__MSPM0G1105__)
+    #define DeviceFamily_ID             DeviceFamily_ID_MSPM0G110X
+    #define DeviceFamily_DIRECTORY      msp
+    #define DeviceFamily_PARENT         DeviceFamily_PARENT_MSPM0G1X0X_G3X0X
+
+#elif defined(DeviceFamily_MSPM0G150X) || defined(__MSPM0G1507__) \
+    || defined(__MSPM0G1506__) || defined(__MSPM0G1505__)
+    #define DeviceFamily_ID             DeviceFamily_ID_MSPM0G150X
+    #define DeviceFamily_DIRECTORY      msp
+    #define DeviceFamily_PARENT         DeviceFamily_PARENT_MSPM0G1X0X_G3X0X
+
+#elif defined(DeviceFamily_MSPM0G310X) || defined(__MSPM0G3107__) \
+    || defined(__MSPM0G3106__) || defined(__MSPM0G3105__)
+    #define DeviceFamily_ID             DeviceFamily_ID_MSPM0G310X
+    #define DeviceFamily_DIRECTORY      msp
+    #define DeviceFamily_PARENT         DeviceFamily_PARENT_MSPM0G1X0X_G3X0X
+
+#elif defined(DeviceFamily_MSPM0G350X) || defined(__MSPM0G3507__) \
+    || defined(__MSPM0G3506__) || defined(__MSPM0G3505__)
+    #define DeviceFamily_ID             DeviceFamily_ID_MSPM0G350X
+    #define DeviceFamily_DIRECTORY      msp
+    #define DeviceFamily_PARENT         DeviceFamily_PARENT_MSPM0G1X0X_G3X0X
+#elif defined(DeviceFamily_MSPM0C110X) || defined(__MSPM0C1104__) \
+    || defined(__MSPM0C1103__)
+    #define DeviceFamily_ID             DeviceFamily_ID_MSPM0C110X
+    #define DeviceFamily_DIRECTORY      msp
+    #define DeviceFamily_PARENT         DeviceFamily_PARENT_MSPM0C110X
+
+#elif defined(DeviceFamily_MSPS003FX) || defined(__MSPS003F4__) \
+    || defined(__MSPS003F3__)
+    #define DeviceFamily_ID             DeviceFamily_ID_MSPS003FX
+    #define DeviceFamily_DIRECTORY      msp
+    #define DeviceFamily_PARENT         DeviceFamily_PARENT_MSPS003FX
+
+#elif defined(DeviceFamily_MSPM0L122X) || defined(__MSPM0L1228__) \
+    || defined(__MSPM0L1227__) || defined(__MSPM0L1226__)
+    #define DeviceFamily_ID             DeviceFamily_ID_MSPM0L122X
+    #define DeviceFamily_DIRECTORY      msp
+    #define DeviceFamily_PARENT         DeviceFamily_PARENT_MSPM0L122X_L222X
+
+#elif defined(DeviceFamily_MSPM0L222X) || defined(__MSPM0L2228__) \
+    || defined(__MSPM0L2227__) || defined(__MSPM0L2226__)
+    #define DeviceFamily_ID             DeviceFamily_ID_MSPM0L222X
+    #define DeviceFamily_DIRECTORY      msp
+    #define DeviceFamily_PARENT         DeviceFamily_PARENT_MSPM0L122X_L222X
+
+
+#else
+    #error "DeviceFamily_XYZ undefined. You must define a DeviceFamily_XYZ!"
+#endif
+
+/* Ensure that only one DeviceFamily was specified */
+#if (defined(DeviceFamily_MSPM0L130X) \
+    + defined(DeviceFamily_MSPM0L134X) \
+    + defined(DeviceFamily_MSPM0L110X) \
+    + defined(DeviceFamily_MSPM0G110X) \
+    + defined(DeviceFamily_MSPM0G150X) \
+    + defined(DeviceFamily_MSPM0G310X) \
+    + defined(DeviceFamily_MSPM0G350X) \
+    + defined(DeviceFamily_MSPM0C110X) \
+    + defined(DeviceFamily_MSPS003FX) \
+    + defined(DeviceFamily_MSPM0L122X) \
+    + defined(DeviceFamily_MSPM0L222X) \
+    ) > 1
+    #error More then one DeviceFamily has been defined!
+#endif
+
+/*!
+ *  @brief  Macro to include correct driverlib path.
+ *
+ *  @pre    DeviceFamily_XYZ which sets DeviceFamily_DIRECTORY must be defined
+ *          first.
+ *
+ *  @param  x   A token containing the path of the file to include based on
+ *              the root device folder. The preceding forward slash must be
+ *              omitted. For example:
+ *                  - #include DeviceFamily_constructPath(inc/hw_memmap.h)
+ *                  - #include DeviceFamily_constructPath(driverlib/ssi.h)
+ *
+ *  @return Returns an include path.
+ *
+ */
+#define DeviceFamily_constructPath(x) <ti/devices/DeviceFamily_DIRECTORY/x>
+
+    /* clang-format on */
+
+#ifdef __cplusplus
+    }
+#endif
+
+#endif /* ti_devices_DeviceFamily__include */

--- a/mspm0/source/ti/devices/msp/CMakeLists.txt
+++ b/mspm0/source/ti/devices/msp/CMakeLists.txt
@@ -1,0 +1,7 @@
+zephyr_include_directories(
+  .
+  m0p
+  peripherals
+  peripherals/m0p
+  peripherals/m0p/sysctl
+  )

--- a/mspm0/source/ti/devices/msp/m0p/mspm0g110x.h
+++ b/mspm0/source/ti/devices/msp/m0p/mspm0g110x.h
@@ -1,0 +1,1011 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/ 
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+   Redistributions of source code must retain the above copyright 
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the   
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_m0p_mspm0g110x__include
+#define ti_devices_msp_m0p_mspm0g110x__include
+
+/* Filename: mspm0g110x.h */
+/* Revised: 2023-02-03 08:37:25 */
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** @addtogroup MSPM0G110X_Definitions MSPM0G110X Definitions
+  This file defines all structures and symbols for MSPM0G110X
+  @{
+*/
+
+/** @addtogroup MSPM0G110X_CMSIS Device CMSIS Definitions
+  Configuration of the Processor and Core Peripherals
+  @{
+*/
+/******************************************************************************
+* Interrupt Definitions                                                       *
+******************************************************************************/
+typedef enum IRQn
+{
+  NonMaskableInt_IRQn         = -14,    /* 2  Non Maskable Interrupt */
+  HardFault_IRQn              = -13,    /* 3  Hard Fault Interrupt */
+  SVCall_IRQn                 = -5,     /* 11 SV Call Interrupt */
+  PendSV_IRQn                 = -2,     /* 14 Pend SV Interrupt */
+  SysTick_IRQn                = -1,     /* 15 System Tick Interrupt */
+  SYSCTL_INT_IRQn             = 0,      /* 16 SYSCTL_INT Interrupt */
+  WWDT1_INT_IRQn              = 0,      /* 16 WWDT1_INT Interrupt */
+  WWDT0_INT_IRQn              = 0,      /* 16 WWDT0_INT Interrupt */
+  FLASHCTL_INT_IRQn           = 0,      /* 16 FLASHCTL_INT Interrupt */
+  DEBUGSS_INT_IRQn            = 0,      /* 16 DEBUGSS_INT Interrupt */
+  GPIOB_INT_IRQn              = 1,      /* 17 GPIOB_INT Interrupt */
+  GPIOA_INT_IRQn              = 1,      /* 17 GPIOA_INT Interrupt */
+  TIMG8_INT_IRQn              = 2,      /* 18 TIMG8_INT Interrupt */
+  UART3_INT_IRQn              = 3,      /* 19 UART3_INT Interrupt */
+  ADC0_INT_IRQn               = 4,      /* 20 ADC0_INT Interrupt */
+  ADC1_INT_IRQn               = 5,      /* 21 ADC1_INT Interrupt */
+  SPI0_INT_IRQn               = 9,      /* 25 SPI0_INT Interrupt */
+  SPI1_INT_IRQn               = 10,     /* 26 SPI1_INT Interrupt */
+  UART1_INT_IRQn              = 13,     /* 29 UART1_INT Interrupt */
+  UART2_INT_IRQn              = 14,     /* 30 UART2_INT Interrupt */
+  UART0_INT_IRQn              = 15,     /* 31 UART0_INT Interrupt */
+  TIMG0_INT_IRQn              = 16,     /* 32 TIMG0_INT Interrupt */
+  TIMG6_INT_IRQn              = 17,     /* 33 TIMG6_INT Interrupt */
+  TIMA0_INT_IRQn              = 18,     /* 34 TIMA0_INT Interrupt */
+  TIMA1_INT_IRQn              = 19,     /* 35 TIMA1_INT Interrupt */
+  TIMG7_INT_IRQn              = 20,     /* 36 TIMG7_INT Interrupt */
+  TIMG12_INT_IRQn             = 21,     /* 37 TIMG12_INT Interrupt */
+  I2C0_INT_IRQn               = 24,     /* 40 I2C0_INT Interrupt */
+  I2C1_INT_IRQn               = 25,     /* 41 I2C1_INT Interrupt */
+  RTC_INT_IRQn                = 30,     /* 46 RTC_INT Interrupt */
+  DMA_INT_IRQn                = 31,     /* 47 DMA_INT Interrupt */
+} IRQn_Type;
+
+#define NonMaskableInt_VECn     2     /* Non Maskable Interrupt */
+#define HardFault_VECn          3     /* Hard Fault Interrupt */
+#define SVCall_VECn             11    /* SV Call Interrupt */
+#define PendSV_VECn             14    /* Pend SV Interrupt */
+#define SysTick_VECn            15    /* System Tick Interrupt */
+#define SYSCTL_INT_VECn         16    /* SYSCTL_INT Interrupt */
+#define WWDT1_INT_VECn          16    /* WWDT1_INT Interrupt */
+#define WWDT0_INT_VECn          16    /* WWDT0_INT Interrupt */
+#define FLASHCTL_INT_VECn       16    /* FLASHCTL_INT Interrupt */
+#define DEBUGSS_INT_VECn        16    /* DEBUGSS_INT Interrupt */
+#define GPIOB_INT_VECn          17    /* GPIOB_INT Interrupt */
+#define GPIOA_INT_VECn          17    /* GPIOA_INT Interrupt */
+#define TIMG8_INT_VECn          18    /* TIMG8_INT Interrupt */
+#define UART3_INT_VECn          19    /* UART3_INT Interrupt */
+#define ADC0_INT_VECn           20    /* ADC0_INT Interrupt */
+#define ADC1_INT_VECn           21    /* ADC1_INT Interrupt */
+#define SPI0_INT_VECn           25    /* SPI0_INT Interrupt */
+#define SPI1_INT_VECn           26    /* SPI1_INT Interrupt */
+#define UART1_INT_VECn          29    /* UART1_INT Interrupt */
+#define UART2_INT_VECn          30    /* UART2_INT Interrupt */
+#define UART0_INT_VECn          31    /* UART0_INT Interrupt */
+#define TIMG0_INT_VECn          32    /* TIMG0_INT Interrupt */
+#define TIMG6_INT_VECn          33    /* TIMG6_INT Interrupt */
+#define TIMA0_INT_VECn          34    /* TIMA0_INT Interrupt */
+#define TIMA1_INT_VECn          35    /* TIMA1_INT Interrupt */
+#define TIMG7_INT_VECn          36    /* TIMG7_INT Interrupt */
+#define TIMG12_INT_VECn         37    /* TIMG12_INT Interrupt */
+#define I2C0_INT_VECn           40    /* I2C0_INT Interrupt */
+#define I2C1_INT_VECn           41    /* I2C1_INT Interrupt */
+#define RTC_INT_VECn            46    /* RTC_INT Interrupt */
+#define DMA_INT_VECn            47    /* DMA_INT Interrupt */
+
+
+/******************************************************************************
+* Ignore unused variables                                                     *
+******************************************************************************/
+
+#if   defined (__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined (__ICCARM__)
+  #pragma language=extended
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wc11-extensions"
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning 586
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+/******************************************************************************
+* Processor and Core Peripheral Section                                       *
+******************************************************************************/
+
+#define __CM0PLUS_REV           0x0001U    /* Core revision r0p1 */
+#define __MPU_PRESENT           0x0001U    /* MPU present */
+#define __VTOR_PRESENT          0x0001U    /* VTOR present */
+#define __NVIC_PRIO_BITS        0x0002U    /* Number of bits used for Priority Levels */
+#define __Vendor_SysTickConfig  0x0000U    /* Set to 1 if different SysTick Config is used */
+
+#include "core_cm0plus.h"                  /* Processor and core peripherals */
+
+/******************************************************************************
+* Peripheral headers                                                          *
+******************************************************************************/
+/** @addtogroup MSPM0G110X_Peripherals MSPM0G110X Peripherals
+  MSPM0G110X Peripheral registers structures
+  @{
+*/
+
+#include <ti/devices/msp/peripherals/hw_adc12.h>
+#include <ti/devices/msp/peripherals/hw_crc.h>
+#include <ti/devices/msp/peripherals/hw_dma.h>
+#include <ti/devices/msp/peripherals/hw_flashctl.h>
+#include <ti/devices/msp/peripherals/hw_gpio.h>
+#include <ti/devices/msp/peripherals/hw_gptimer.h>
+#include <ti/devices/msp/peripherals/hw_i2c.h>
+#include <ti/devices/msp/peripherals/hw_iomux.h>
+#include <ti/devices/msp/peripherals/hw_rtc.h>
+#include <ti/devices/msp/peripherals/hw_spi.h>
+#include <ti/devices/msp/peripherals/hw_uart.h>
+#include <ti/devices/msp/peripherals/hw_vref.h>
+#include <ti/devices/msp/peripherals/hw_wuc.h>
+#include <ti/devices/msp/peripherals/hw_wwdt.h>
+#include <ti/devices/msp/peripherals/m0p/hw_factoryregion.h>
+#include <ti/devices/msp/peripherals/m0p/hw_cpuss.h>
+#include <ti/devices/msp/peripherals/m0p/hw_debugss.h>
+#include <ti/devices/msp/peripherals/m0p/hw_sysctl.h>
+
+#define __MSPM0_HAS_ADC12__
+#define __MSPM0_HAS_CRC__
+#define __MSPM0_HAS_GPAMP__
+#define __MSPM0_HAS_GPIO__
+#define __MSPM0_HAS_TIMER_A__
+#define __MSPM0_HAS_TIMER_G__
+#define __MSPM0_HAS_I2C__
+#define __MSPM0_HAS_RTC__
+#define __MSPM0_HAS_SPI__
+#define __MSPM0_HAS_UART_EXTD__
+#define __MSPM0_HAS_UART_MAIN__
+#define __MSPM0_HAS_VREF__
+#define __MSPM0_HAS_WWDT__
+
+#define __MSPM0_HAS_ECC__
+
+/*@}*/ /* end of group MSPM0G110X_Peripherals */
+
+/******************************************************************************
+* Device and peripheral memory map                                            *
+******************************************************************************/
+/** @addtogroup MSPM0G110X_MemoryMap MSPM0G110X Memory Mapping
+  @{
+*/
+
+#define I2C0_BASE                      (0x400F0000U)     /*!< Base address of module I2C0 */
+#define SYSCTL_BASE                    (0x400AF000U)     /*!< Base address of module SYSCTL */
+#define WWDT1_BASE                     (0x40082000U)     /*!< Base address of module WWDT1 */
+#define CPUSS_BASE                     (0x40400000U)     /*!< Base address of module CPUSS */
+#define IOMUX_BASE                     (0x40428000U)     /*!< Base address of module IOMUX */
+#define GPIOB_BASE                     (0x400A2000U)     /*!< Base address of module GPIOB */
+#define CRC_BASE                       (0x40440000U)     /*!< Base address of module CRC */
+#define WWDT0_BASE                     (0x40080000U)     /*!< Base address of module WWDT0 */
+#define SPI1_BASE                      (0x4046A000U)     /*!< Base address of module SPI1 */
+#define I2C1_BASE                      (0x400F2000U)     /*!< Base address of module I2C1 */
+#define GPIOA_BASE                     (0x400A0000U)     /*!< Base address of module GPIOA */
+#define FLASHCTL_BASE                  (0x400CD000U)     /*!< Base address of module FLASHCTL */
+#define RTC_BASE                       (0x40094000U)     /*!< Base address of module RTC */
+#define SPI0_BASE                      (0x40468000U)     /*!< Base address of module SPI0 */
+#define DMA_BASE                       (0x4042A000U)     /*!< Base address of module DMA */
+#define TIMA0_BASE                     (0x40860000U)     /*!< Base address of module TIMA0 */
+#define TIMA1_BASE                     (0x40862000U)     /*!< Base address of module TIMA1 */
+#define UART3_BASE                     (0x40500000U)     /*!< Base address of module UART3 */
+#define UART0_BASE                     (0x40108000U)     /*!< Base address of module UART0 */
+#define UART1_BASE                     (0x40100000U)     /*!< Base address of module UART1 */
+#define UART2_BASE                     (0x40102000U)     /*!< Base address of module UART2 */
+#define WUC_BASE                       (0x40424000U)     /*!< Base address of module WUC */
+#define FACTORYREGION_BASE             (0x41C40000U)     /*!< Base address of module FACTORYREGION */
+#define ADC0_BASE                      (0x40000000U)     /*!< Base address of module ADC0 */
+#define ADC0_PERIPHERALREGIONSVT_BASE  (0x40556000U)     /*!< Base address of module ADC0_PERIPHERALREGIONSVT */
+#define ADC1_BASE                      (0x40002000U)     /*!< Base address of module ADC1 */
+#define ADC1_PERIPHERALREGIONSVT_BASE  (0x40558000U)     /*!< Base address of module ADC1_PERIPHERALREGIONSVT */
+#define TIMG0_BASE                     (0x40084000U)     /*!< Base address of module TIMG0 */
+#define VREF_BASE                      (0x40030000U)     /*!< Base address of module VREF */
+#define TIMG12_BASE                    (0x40870000U)     /*!< Base address of module TIMG12 */
+#define TIMG6_BASE                     (0x40868000U)     /*!< Base address of module TIMG6 */
+#define TIMG7_BASE                     (0x4086A000U)     /*!< Base address of module TIMG7 */
+#define TIMG8_BASE                     (0x40090000U)     /*!< Base address of module TIMG8 */
+#define DEBUGSS_BASE                   (0x400C7000U)     /*!< Base address of module DEBUGSS */
+
+
+/*@}*/ /* end of group MSPM0G110X_MemoryMap */
+
+/******************************************************************************
+* Peripheral declarations                                                     *
+******************************************************************************/
+/** @addtogroup MSPM0G110X_PeripheralDecl MSPM0G110X Peripheral Declaration
+  @{
+*/
+
+static I2C_Regs                                 * const I2C0                           = ((I2C_Regs *) I2C0_BASE);
+static SYSCTL_Regs                              * const SYSCTL                         = ((SYSCTL_Regs *) SYSCTL_BASE);
+static WWDT_Regs                                * const WWDT1                          = ((WWDT_Regs *) WWDT1_BASE);
+static CPUSS_Regs                               * const CPUSS                          = ((CPUSS_Regs *) CPUSS_BASE);
+static IOMUX_Regs                               * const IOMUX                          = ((IOMUX_Regs *) IOMUX_BASE);
+static GPIO_Regs                                * const GPIOB                          = ((GPIO_Regs *) GPIOB_BASE);
+static CRC_Regs                                 * const CRC                            = ((CRC_Regs *) CRC_BASE);
+static WWDT_Regs                                * const WWDT0                          = ((WWDT_Regs *) WWDT0_BASE);
+static SPI_Regs                                 * const SPI1                           = ((SPI_Regs *) SPI1_BASE);
+static I2C_Regs                                 * const I2C1                           = ((I2C_Regs *) I2C1_BASE);
+static GPIO_Regs                                * const GPIOA                          = ((GPIO_Regs *) GPIOA_BASE);
+static FLASHCTL_Regs                            * const FLASHCTL                       = ((FLASHCTL_Regs *) FLASHCTL_BASE);
+static RTC_Regs                                 * const RTC                            = ((RTC_Regs *) RTC_BASE);
+static SPI_Regs                                 * const SPI0                           = ((SPI_Regs *) SPI0_BASE);
+static DMA_Regs                                 * const DMA                            = ((DMA_Regs *) DMA_BASE);
+static GPTIMER_Regs                             * const TIMA0                          = ((GPTIMER_Regs *) TIMA0_BASE);
+static GPTIMER_Regs                             * const TIMA1                          = ((GPTIMER_Regs *) TIMA1_BASE);
+static UART_Regs                                * const UART3                          = ((UART_Regs *) UART3_BASE);
+static UART_Regs                                * const UART0                          = ((UART_Regs *) UART0_BASE);
+static UART_Regs                                * const UART1                          = ((UART_Regs *) UART1_BASE);
+static UART_Regs                                * const UART2                          = ((UART_Regs *) UART2_BASE);
+static WUC_Regs                                 * const WUC                            = ((WUC_Regs *) WUC_BASE);
+static FACTORYREGION_OPEN_Regs                  * const FACTORYREGION                  = ((FACTORYREGION_OPEN_Regs *) FACTORYREGION_BASE);
+static ADC12_Regs                               * const ADC0                           = ((ADC12_Regs *) ADC0_BASE);
+static ADC12_PERIPHERALREGIONSVT_Regs           * const ADC0_PERIPHERALREGIONSVT       = ((ADC12_PERIPHERALREGIONSVT_Regs *) ADC0_PERIPHERALREGIONSVT_BASE);
+static ADC12_Regs                               * const ADC1                           = ((ADC12_Regs *) ADC1_BASE);
+static ADC12_PERIPHERALREGIONSVT_Regs           * const ADC1_PERIPHERALREGIONSVT       = ((ADC12_PERIPHERALREGIONSVT_Regs *) ADC1_PERIPHERALREGIONSVT_BASE);
+static GPTIMER_Regs                             * const TIMG0                          = ((GPTIMER_Regs *) TIMG0_BASE);
+static VREF_Regs                                * const VREF                           = ((VREF_Regs *) VREF_BASE);
+static GPTIMER_Regs                             * const TIMG12                         = ((GPTIMER_Regs *) TIMG12_BASE);
+static GPTIMER_Regs                             * const TIMG6                          = ((GPTIMER_Regs *) TIMG6_BASE);
+static GPTIMER_Regs                             * const TIMG7                          = ((GPTIMER_Regs *) TIMG7_BASE);
+static GPTIMER_Regs                             * const TIMG8                          = ((GPTIMER_Regs *) TIMG8_BASE);
+static DEBUGSS_Regs                             * const DEBUGSS                        = ((DEBUGSS_Regs *) DEBUGSS_BASE);
+
+
+/******************************************************************************
+* SYS parameters                                                              *
+******************************************************************************/
+
+#define DMA_SYS_N_DMA_CHANNEL                         (7)       /* !< Number of DMA channels implemented in DMA. */
+#define DMA_SYS_N_DMA_FULL_CHANNEL                    (3)       /* !< Number of FULL-DMA channels implemented in DMA. */
+#define CRC_SYS_CRC32_ENABLE                          (1)       /* !< Parameter to exclude or include 32-bit CRC. */
+#define FLASHCTL_SYS_DATAWIDTH                        (64)      /* !< Data bit width of a single flash word. */
+#define ADC_SYS_NUM_ANALOG_CHAN                       (16)      /* !< Number of analog channels. */
+#define I2C_SYS_FENTRIES                              (8)       /* !< Number of FIFO entries */
+#define FLASHCTL_SYS_WEPROTAWIDTH                     (32)      /* !< Bit width of WEPROTA register */
+#define FLASHCTL_SYS_WEPROTBWIDTH                     (12)      /* !< Bit width of WEPROTB register */
+#define FLASHCTL_SYS_WEPROTCWIDTH                     (0)       /* !< Bit width of WEPROTC register */
+
+/******************************************************************************
+* DMA Triggers                                                                *
+******************************************************************************/
+
+/* External DMA Triggers */
+#define DMA_SOFTWARE_TRIG                             (0)
+#define DMA_GENERIC_SUB0_TRIG                         (1)
+#define DMA_GENERIC_SUB1_TRIG                         (2)
+#define DMA_I2C0_TX_TRIG                              (7)
+#define DMA_I2C0_RX_TRIG                              (8)
+#define DMA_I2C1_TX_TRIG                              (9)
+#define DMA_I2C1_RX_TRIG                              (10)
+#define DMA_SPI0_RX_TRIG                              (11)
+#define DMA_SPI0_TX_TRIG                              (12)
+#define DMA_SPI1_RX_TRIG                              (13)
+#define DMA_SPI1_TX_TRIG                              (14)
+#define DMA_UART3_RX_TRIG                             (15)
+#define DMA_UART3_TX_TRIG                             (16)
+#define DMA_UART0_RX_TRIG                             (17)
+#define DMA_UART0_TX_TRIG                             (18)
+#define DMA_UART1_RX_TRIG                             (19)
+#define DMA_UART1_TX_TRIG                             (20)
+#define DMA_UART2_RX_TRIG                             (21)
+#define DMA_UART2_TX_TRIG                             (22)
+#define DMA_ADC0_EVT_GEN_BD_TRIG                      (23)
+#define DMA_ADC1_EVT_GEN_BD_TRIG                      (24)
+
+/* Internal DMA Triggers */
+#define DMA_CH_0_TRIG                                 (0)
+#define DMA_CH_1_TRIG                                 (1)
+#define DMA_CH_2_TRIG                                 (2)
+#define DMA_CH_3_TRIG                                 (3)
+#define DMA_CH_4_TRIG                                 (4)
+#define DMA_CH_5_TRIG                                 (5)
+#define DMA_CH_6_TRIG                                 (6)
+
+
+/******************************************************************************
+* IOMUX Pin Definitions                                                       *
+******************************************************************************/
+
+typedef enum IOMUX_PINCM
+{
+  IOMUX_PINCM1         = (0),
+  IOMUX_PINCM2         = (1),
+  IOMUX_PINCM3         = (2),
+  IOMUX_PINCM4         = (3),
+  IOMUX_PINCM5         = (4),
+  IOMUX_PINCM6         = (5),
+  IOMUX_PINCM7         = (6),
+  IOMUX_PINCM8         = (7),
+  IOMUX_PINCM9         = (8),
+  IOMUX_PINCM10        = (9),
+  IOMUX_PINCM11        = (10),
+  IOMUX_PINCM12        = (11),
+  IOMUX_PINCM13        = (12),
+  IOMUX_PINCM14        = (13),
+  IOMUX_PINCM15        = (14),
+  IOMUX_PINCM16        = (15),
+  IOMUX_PINCM17        = (16),
+  IOMUX_PINCM18        = (17),
+  IOMUX_PINCM19        = (18),
+  IOMUX_PINCM20        = (19),
+  IOMUX_PINCM21        = (20),
+  IOMUX_PINCM22        = (21),
+  IOMUX_PINCM23        = (22),
+  IOMUX_PINCM24        = (23),
+  IOMUX_PINCM25        = (24),
+  IOMUX_PINCM26        = (25),
+  IOMUX_PINCM27        = (26),
+  IOMUX_PINCM28        = (27),
+  IOMUX_PINCM29        = (28),
+  IOMUX_PINCM30        = (29),
+  IOMUX_PINCM31        = (30),
+  IOMUX_PINCM32        = (31),
+  IOMUX_PINCM33        = (32),
+  IOMUX_PINCM34        = (33),
+  IOMUX_PINCM35        = (34),
+  IOMUX_PINCM36        = (35),
+  IOMUX_PINCM37        = (36),
+  IOMUX_PINCM38        = (37),
+  IOMUX_PINCM39        = (38),
+  IOMUX_PINCM40        = (39),
+  IOMUX_PINCM41        = (40),
+  IOMUX_PINCM42        = (41),
+  IOMUX_PINCM43        = (42),
+  IOMUX_PINCM44        = (43),
+  IOMUX_PINCM45        = (44),
+  IOMUX_PINCM46        = (45),
+  IOMUX_PINCM47        = (46),
+  IOMUX_PINCM48        = (47),
+  IOMUX_PINCM49        = (48),
+  IOMUX_PINCM50        = (49),
+  IOMUX_PINCM51        = (50),
+  IOMUX_PINCM52        = (51),
+  IOMUX_PINCM53        = (52),
+  IOMUX_PINCM54        = (53),
+  IOMUX_PINCM55        = (54),
+  IOMUX_PINCM56        = (55),
+  IOMUX_PINCM57        = (56),
+  IOMUX_PINCM58        = (57),
+  IOMUX_PINCM59        = (58),
+  IOMUX_PINCM60        = (59),
+} IOMUX_PINCM;
+
+
+/* IOMUX_PINCM1[PF] Bits */
+#define IOMUX_PINCM1_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM1_PF_GPIOA_DIO00                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM1_PF_UART0_TX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM1_PF_I2C0_SDA                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM1_PF_TIMA0_CCP0                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM1_PF_TIMA_FAULT1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM1_PF_TIMG8_CCP1                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM1_PF_SYSCTL_FCC_IN                 ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM2[PF] Bits */
+#define IOMUX_PINCM2_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM2_PF_GPIOA_DIO01                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM2_PF_UART0_RX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM2_PF_I2C0_SCL                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM2_PF_TIMA0_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM2_PF_TIMA_FAULT2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM2_PF_TIMG8_IDX                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM2_PF_TIMG8_CCP0                    ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM3[PF] Bits */
+#define IOMUX_PINCM3_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM3_PF_GPIOA_DIO28                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM3_PF_UART0_TX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM3_PF_I2C0_SDA                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM3_PF_TIMA0_CCP3                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM3_PF_TIMA_FAULT0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM3_PF_TIMG7_CCP0                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM3_PF_TIMA1_CCP0                    ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM4[PF] Bits */
+#define IOMUX_PINCM4_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM4_PF_GPIOA_DIO29                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM4_PF_I2C1_SCL                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM4_PF_UART2_RTS                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM4_PF_TIMG8_CCP0                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM4_PF_TIMG6_CCP0                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM5[PF] Bits */
+#define IOMUX_PINCM5_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM5_PF_GPIOA_DIO30                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM5_PF_I2C1_SDA                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM5_PF_UART2_CTS                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM5_PF_TIMG8_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM5_PF_TIMG6_CCP1                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM6[PF] Bits */
+#define IOMUX_PINCM6_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM6_PF_GPIOA_DIO31                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM6_PF_UART0_RX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM6_PF_I2C0_SCL                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM6_PF_TIMA0_CCP3_CMPL               ((uint32_t)0X00000004)
+#define IOMUX_PINCM6_PF_TIMG12_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM6_PF_SYSCTL_CLK_OUT                ((uint32_t)0X00000006)
+#define IOMUX_PINCM6_PF_TIMG7_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM6_PF_TIMA1_CCP1                    ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM7[PF] Bits */
+#define IOMUX_PINCM7_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM7_PF_GPIOA_DIO02                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM7_PF_TIMG8_CCP1                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM7_PF_SPI0_CS0                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM7_PF_TIMG7_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM7_PF_SPI1_CS0                      ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM8[PF] Bits */
+#define IOMUX_PINCM8_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM8_PF_GPIOA_DIO03                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM8_PF_TIMG8_CCP0                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM8_PF_SPI0_CS1_POCI1                ((uint32_t)0X00000003)
+#define IOMUX_PINCM8_PF_UART2_CTS                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM8_PF_TIMA0_CCP2                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM8_PF_COMP1_OUT                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM8_PF_TIMG7_CCP0                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM8_PF_TIMA0_CCP1                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM8_PF_I2C1_SDA                      ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM9[PF] Bits */
+#define IOMUX_PINCM9_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM9_PF_GPIOA_DIO04                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM9_PF_TIMG8_CCP1                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM9_PF_SPI0_POCI                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM9_PF_UART2_RTS                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM9_PF_TIMA0_CCP3                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM9_PF_SYSCTL_LFCLKIN                ((uint32_t)0X00000006)
+#define IOMUX_PINCM9_PF_TIMG7_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM9_PF_TIMA0_CCP1_CMPL               ((uint32_t)0X00000008)
+#define IOMUX_PINCM9_PF_I2C1_SCL                      ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM10[PF] Bits */
+#define IOMUX_PINCM10_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM10_PF_GPIOA_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM10_PF_TIMG8_CCP0                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM10_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM10_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM10_PF_TIMG0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM10_PF_TIMG6_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM10_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM11[PF] Bits */
+#define IOMUX_PINCM11_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM11_PF_GPIOA_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM11_PF_TIMG8_CCP1                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM11_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM11_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM11_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM11_PF_SYSCTL_HFCLKIN               ((uint32_t)0X00000006)
+#define IOMUX_PINCM11_PF_TIMG6_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM11_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM12[PF] Bits */
+#define IOMUX_PINCM12_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM12_PF_GPIOB_DIO00                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM12_PF_UART0_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM12_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM12_PF_TIMA1_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM12_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM13[PF] Bits */
+#define IOMUX_PINCM13_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM13_PF_GPIOB_DIO01                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM13_PF_UART0_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM13_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM13_PF_TIMA1_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM13_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM14[PF] Bits */
+#define IOMUX_PINCM14_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM14_PF_GPIOA_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM14_PF_COMP0_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM14_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000003)
+#define IOMUX_PINCM14_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM14_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM14_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM14_PF_TIMG7_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM14_PF_TIMA0_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM15[PF] Bits */
+#define IOMUX_PINCM15_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM15_PF_GPIOB_DIO02                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM15_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM15_PF_UART2_CTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM15_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM15_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM15_PF_UART1_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM15_PF_TIMG6_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM15_PF_TIMA1_CCP0                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM16[PF] Bits */
+#define IOMUX_PINCM16_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM16_PF_GPIOB_DIO03                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM16_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM16_PF_UART2_RTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM16_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM16_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM16_PF_UART1_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM16_PF_TIMG6_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM16_PF_TIMA1_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM17[PF] Bits */
+#define IOMUX_PINCM17_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM17_PF_GPIOB_DIO04                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM17_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM17_PF_UART3_CTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM17_PF_TIMA1_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM17_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM17_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM18[PF] Bits */
+#define IOMUX_PINCM18_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM18_PF_GPIOB_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM18_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM18_PF_UART3_RTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM18_PF_TIMA1_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM18_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM18_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM19[PF] Bits */
+#define IOMUX_PINCM19_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM19_PF_GPIOA_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM19_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM19_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM19_PF_UART0_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM19_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM19_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM20[PF] Bits */
+#define IOMUX_PINCM20_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM20_PF_GPIOA_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM20_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM20_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM20_PF_UART0_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM20_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM20_PF_RTC_RTC_OUT                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM20_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM20_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000008)
+#define IOMUX_PINCM20_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM21[PF] Bits */
+#define IOMUX_PINCM21_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM21_PF_GPIOA_DIO10                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM21_PF_UART0_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM21_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM21_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM21_PF_TIMA1_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM21_PF_TIMG12_CCP0                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM21_PF_TIMA0_CCP2                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM21_PF_I2C1_SDA                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM21_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM22[PF] Bits */
+#define IOMUX_PINCM22_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM22_PF_GPIOA_DIO11                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM22_PF_UART0_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM22_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM22_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM22_PF_TIMA1_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM22_PF_COMP0_OUT                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM22_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM22_PF_I2C1_SCL                     ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM23[PF] Bits */
+#define IOMUX_PINCM23_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM23_PF_GPIOB_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM23_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM23_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM23_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000004)
+#define IOMUX_PINCM23_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM23_PF_UART2_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM23_PF_TIMG6_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM23_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM24[PF] Bits */
+#define IOMUX_PINCM24_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM24_PF_GPIOB_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM24_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM24_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM24_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000004)
+#define IOMUX_PINCM24_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM24_PF_UART2_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM24_PF_TIMG6_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM24_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM25[PF] Bits */
+#define IOMUX_PINCM25_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM25_PF_GPIOB_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM25_PF_UART1_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM25_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM25_PF_TIMA0_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM25_PF_COMP1_OUT                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM26[PF] Bits */
+#define IOMUX_PINCM26_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM26_PF_GPIOB_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM26_PF_UART1_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM26_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM26_PF_TIMA0_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM26_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM27[PF] Bits */
+#define IOMUX_PINCM27_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM27_PF_GPIOB_DIO10                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM27_PF_TIMG0_CCP0                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM27_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM27_PF_COMP1_OUT                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM27_PF_TIMG6_CCP0                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM28[PF] Bits */
+#define IOMUX_PINCM28_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM28_PF_GPIOB_DIO11                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM28_PF_TIMG0_CCP1                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM28_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM28_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000004)
+#define IOMUX_PINCM28_PF_TIMG6_CCP1                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM29[PF] Bits */
+#define IOMUX_PINCM29_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM29_PF_GPIOB_DIO12                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM29_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM29_PF_TIMA0_CCP2                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM29_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM29_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM30[PF] Bits */
+#define IOMUX_PINCM30_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM30_PF_GPIOB_DIO13                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM30_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM30_PF_TIMA0_CCP3                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM30_PF_TIMG12_CCP0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM30_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM31[PF] Bits */
+#define IOMUX_PINCM31_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM31_PF_GPIOB_DIO14                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM31_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000002)
+#define IOMUX_PINCM31_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM31_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000004)
+#define IOMUX_PINCM31_PF_TIMG12_CCP1                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM31_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM31_PF_TIMA0_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM32[PF] Bits */
+#define IOMUX_PINCM32_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM32_PF_GPIOB_DIO15                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM32_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM32_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM32_PF_UART3_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM32_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM32_PF_TIMG7_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM33[PF] Bits */
+#define IOMUX_PINCM33_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM33_PF_GPIOB_DIO16                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM33_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM33_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM33_PF_UART3_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM33_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM33_PF_TIMG7_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM34[PF] Bits */
+#define IOMUX_PINCM34_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM34_PF_GPIOA_DIO12                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM34_PF_UART3_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM34_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM34_PF_TIMG0_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM34_PF_CANFD0_CANTX                 ((uint32_t)0X00000005)
+#define IOMUX_PINCM34_PF_TIMA0_CCP3                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM34_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM35[PF] Bits */
+#define IOMUX_PINCM35_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM35_PF_GPIOA_DIO13                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM35_PF_UART3_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM35_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM35_PF_UART3_RX                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM35_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM35_PF_CANFD0_CANRX                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM35_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM36[PF] Bits */
+#define IOMUX_PINCM36_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM36_PF_GPIOA_DIO14                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM36_PF_UART0_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM36_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM36_PF_UART3_TX                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM36_PF_TIMG12_CCP0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM36_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM37[PF] Bits */
+#define IOMUX_PINCM37_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM37_PF_GPIOA_DIO15                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM37_PF_UART0_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM37_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM37_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM37_PF_TIMA1_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM37_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM37_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM37_PF_TIMA0_CCP2                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM38[PF] Bits */
+#define IOMUX_PINCM38_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM38_PF_GPIOA_DIO16                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM38_PF_COMP2_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM38_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM38_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM38_PF_TIMA1_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM38_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM38_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM38_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM39[PF] Bits */
+#define IOMUX_PINCM39_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM39_PF_GPIOA_DIO17                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM39_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM39_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM39_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM39_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM39_PF_TIMG7_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM39_PF_TIMA1_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM40[PF] Bits */
+#define IOMUX_PINCM40_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM40_PF_GPIOA_DIO18                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM40_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM40_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM40_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM40_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM40_PF_TIMG7_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM40_PF_TIMA1_CCP1                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM41[PF] Bits */
+#define IOMUX_PINCM41_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM41_PF_GPIOA_DIO19                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM41_PF_DEBUGSS_SWDIO                ((uint32_t)0X00000002)
+
+/* IOMUX_PINCM42[PF] Bits */
+#define IOMUX_PINCM42_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM42_PF_GPIOA_DIO20                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM42_PF_DEBUGSS_SWCLK                ((uint32_t)0X00000002)
+
+/* IOMUX_PINCM43[PF] Bits */
+#define IOMUX_PINCM43_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM43_PF_GPIOB_DIO17                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM43_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM43_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM43_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000004)
+#define IOMUX_PINCM43_PF_TIMA1_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM43_PF_TIMA0_CCP2                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM44[PF] Bits */
+#define IOMUX_PINCM44_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM44_PF_GPIOB_DIO18                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM44_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM44_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM44_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000004)
+#define IOMUX_PINCM44_PF_TIMA1_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM44_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM45[PF] Bits */
+#define IOMUX_PINCM45_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM45_PF_GPIOB_DIO19                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM45_PF_COMP2_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM45_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM45_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM45_PF_UART0_CTS                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM45_PF_TIMG7_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM46[PF] Bits */
+#define IOMUX_PINCM46_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM46_PF_GPIOA_DIO21                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM46_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM46_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM46_PF_UART1_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM46_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM46_PF_TIMG6_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM47[PF] Bits */
+#define IOMUX_PINCM47_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM47_PF_GPIOA_DIO22                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM47_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM47_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM47_PF_UART1_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM47_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM47_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+#define IOMUX_PINCM47_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM47_PF_TIMG6_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM48[PF] Bits */
+#define IOMUX_PINCM48_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM48_PF_GPIOB_DIO20                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM48_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000002)
+#define IOMUX_PINCM48_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM48_PF_TIMA0_CCP2                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM48_PF_TIMG12_CCP0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM48_PF_TIMA_FAULT1                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM48_PF_TIMA0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM48_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM49[PF] Bits */
+#define IOMUX_PINCM49_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM49_PF_GPIOB_DIO21                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM49_PF_SPI1_POCI                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM49_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+
+/* IOMUX_PINCM50[PF] Bits */
+#define IOMUX_PINCM50_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM50_PF_GPIOB_DIO22                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM50_PF_SPI1_PICO                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM50_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+
+/* IOMUX_PINCM51[PF] Bits */
+#define IOMUX_PINCM51_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM51_PF_GPIOB_DIO23                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM51_PF_SPI1_SCLK                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM51_PF_COMP0_OUT                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM51_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+
+/* IOMUX_PINCM52[PF] Bits */
+#define IOMUX_PINCM52_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM52_PF_GPIOB_DIO24                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM52_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000002)
+#define IOMUX_PINCM52_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM52_PF_TIMA0_CCP3                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM52_PF_TIMG12_CCP1                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM52_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM52_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM53[PF] Bits */
+#define IOMUX_PINCM53_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM53_PF_GPIOA_DIO23                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM53_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM53_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM53_PF_TIMA0_CCP3                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM53_PF_TIMG0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM53_PF_UART3_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM53_PF_TIMG7_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM53_PF_TIMG8_CCP0                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM54[PF] Bits */
+#define IOMUX_PINCM54_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM54_PF_GPIOA_DIO24                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM54_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM54_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM54_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000004)
+#define IOMUX_PINCM54_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM54_PF_UART3_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM54_PF_TIMG7_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM54_PF_TIMA1_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM55[PF] Bits */
+#define IOMUX_PINCM55_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM55_PF_GPIOA_DIO25                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM55_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM55_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM55_PF_TIMG12_CCP1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM55_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM55_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM56[PF] Bits */
+#define IOMUX_PINCM56_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM56_PF_GPIOB_DIO25                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM56_PF_UART0_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM56_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM56_PF_TIMA_FAULT2                  ((uint32_t)0X00000004)
+
+/* IOMUX_PINCM57[PF] Bits */
+#define IOMUX_PINCM57_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM57_PF_GPIOB_DIO26                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM57_PF_UART0_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM57_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM57_PF_TIMA0_CCP3                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM57_PF_TIMG6_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM57_PF_TIMA1_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM58[PF] Bits */
+#define IOMUX_PINCM58_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM58_PF_GPIOB_DIO27                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM58_PF_COMP2_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM58_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM58_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000004)
+#define IOMUX_PINCM58_PF_TIMG6_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM58_PF_TIMA1_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM59[PF] Bits */
+#define IOMUX_PINCM59_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM59_PF_GPIOA_DIO26                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM59_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM59_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM59_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM59_PF_TIMA_FAULT0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM59_PF_CANFD0_CANTX                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM59_PF_TIMG7_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM60[PF] Bits */
+#define IOMUX_PINCM60_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM60_PF_GPIOA_DIO27                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM60_PF_RTC_RTC_OUT                  ((uint32_t)0X00000002)
+#define IOMUX_PINCM60_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM60_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM60_PF_TIMA_FAULT2                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM60_PF_CANFD0_CANRX                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM60_PF_TIMG7_CCP1                   ((uint32_t)0X00000007)
+
+
+#if   defined (__CC_ARM)
+  #pragma pop
+#elif defined (__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+  #pragma clang diagnostic pop
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning restore
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+/*@}*/ /* end of group MSPM0G110X_PeripheralDecl */
+
+/*@}*/ /* end of group MSPM0G110X_Definitions */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_m0p_mspm0g110x__include */
+

--- a/mspm0/source/ti/devices/msp/m0p/mspm0g150x.h
+++ b/mspm0/source/ti/devices/msp/m0p/mspm0g150x.h
@@ -1,0 +1,1057 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/ 
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+   Redistributions of source code must retain the above copyright 
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the   
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_m0p_mspm0g150x__include
+#define ti_devices_msp_m0p_mspm0g150x__include
+
+/* Filename: mspm0g150x.h */
+/* Revised: 2023-02-03 08:37:25 */
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** @addtogroup MSPM0G150X_Definitions MSPM0G150X Definitions
+  This file defines all structures and symbols for MSPM0G150X
+  @{
+*/
+
+/** @addtogroup MSPM0G150X_CMSIS Device CMSIS Definitions
+  Configuration of the Processor and Core Peripherals
+  @{
+*/
+/******************************************************************************
+* Interrupt Definitions                                                       *
+******************************************************************************/
+typedef enum IRQn
+{
+  NonMaskableInt_IRQn         = -14,    /* 2  Non Maskable Interrupt */
+  HardFault_IRQn              = -13,    /* 3  Hard Fault Interrupt */
+  SVCall_IRQn                 = -5,     /* 11 SV Call Interrupt */
+  PendSV_IRQn                 = -2,     /* 14 Pend SV Interrupt */
+  SysTick_IRQn                = -1,     /* 15 System Tick Interrupt */
+  SYSCTL_INT_IRQn             = 0,      /* 16 SYSCTL_INT Interrupt */
+  WWDT1_INT_IRQn              = 0,      /* 16 WWDT1_INT Interrupt */
+  WWDT0_INT_IRQn              = 0,      /* 16 WWDT0_INT Interrupt */
+  FLASHCTL_INT_IRQn           = 0,      /* 16 FLASHCTL_INT Interrupt */
+  DEBUGSS_INT_IRQn            = 0,      /* 16 DEBUGSS_INT Interrupt */
+  GPIOB_INT_IRQn              = 1,      /* 17 GPIOB_INT Interrupt */
+  GPIOA_INT_IRQn              = 1,      /* 17 GPIOA_INT Interrupt */
+  TRNG_INT_IRQn               = 1,      /* 17 TRNG_INT Interrupt */
+  COMP0_INT_IRQn              = 1,      /* 17 COMP0_INT Interrupt */
+  COMP1_INT_IRQn              = 1,      /* 17 COMP1_INT Interrupt */
+  COMP2_INT_IRQn              = 1,      /* 17 COMP2_INT Interrupt */
+  TIMG8_INT_IRQn              = 2,      /* 18 TIMG8_INT Interrupt */
+  UART3_INT_IRQn              = 3,      /* 19 UART3_INT Interrupt */
+  ADC0_INT_IRQn               = 4,      /* 20 ADC0_INT Interrupt */
+  ADC1_INT_IRQn               = 5,      /* 21 ADC1_INT Interrupt */
+  DAC0_INT_IRQn               = 7,      /* 23 DAC0_INT Interrupt */
+  SPI0_INT_IRQn               = 9,      /* 25 SPI0_INT Interrupt */
+  SPI1_INT_IRQn               = 10,     /* 26 SPI1_INT Interrupt */
+  UART1_INT_IRQn              = 13,     /* 29 UART1_INT Interrupt */
+  UART2_INT_IRQn              = 14,     /* 30 UART2_INT Interrupt */
+  UART0_INT_IRQn              = 15,     /* 31 UART0_INT Interrupt */
+  TIMG0_INT_IRQn              = 16,     /* 32 TIMG0_INT Interrupt */
+  TIMG6_INT_IRQn              = 17,     /* 33 TIMG6_INT Interrupt */
+  TIMA0_INT_IRQn              = 18,     /* 34 TIMA0_INT Interrupt */
+  TIMA1_INT_IRQn              = 19,     /* 35 TIMA1_INT Interrupt */
+  TIMG7_INT_IRQn              = 20,     /* 36 TIMG7_INT Interrupt */
+  TIMG12_INT_IRQn             = 21,     /* 37 TIMG12_INT Interrupt */
+  I2C0_INT_IRQn               = 24,     /* 40 I2C0_INT Interrupt */
+  I2C1_INT_IRQn               = 25,     /* 41 I2C1_INT Interrupt */
+  AES_INT_IRQn                = 28,     /* 44 AES_INT Interrupt */
+  RTC_INT_IRQn                = 30,     /* 46 RTC_INT Interrupt */
+  DMA_INT_IRQn                = 31,     /* 47 DMA_INT Interrupt */
+} IRQn_Type;
+
+#define NonMaskableInt_VECn     2     /* Non Maskable Interrupt */
+#define HardFault_VECn          3     /* Hard Fault Interrupt */
+#define SVCall_VECn             11    /* SV Call Interrupt */
+#define PendSV_VECn             14    /* Pend SV Interrupt */
+#define SysTick_VECn            15    /* System Tick Interrupt */
+#define SYSCTL_INT_VECn         16    /* SYSCTL_INT Interrupt */
+#define WWDT1_INT_VECn          16    /* WWDT1_INT Interrupt */
+#define WWDT0_INT_VECn          16    /* WWDT0_INT Interrupt */
+#define FLASHCTL_INT_VECn       16    /* FLASHCTL_INT Interrupt */
+#define DEBUGSS_INT_VECn        16    /* DEBUGSS_INT Interrupt */
+#define GPIOB_INT_VECn          17    /* GPIOB_INT Interrupt */
+#define GPIOA_INT_VECn          17    /* GPIOA_INT Interrupt */
+#define TRNG_INT_VECn           17    /* TRNG_INT Interrupt */
+#define COMP0_INT_VECn          17    /* COMP0_INT Interrupt */
+#define COMP1_INT_VECn          17    /* COMP1_INT Interrupt */
+#define COMP2_INT_VECn          17    /* COMP2_INT Interrupt */
+#define TIMG8_INT_VECn          18    /* TIMG8_INT Interrupt */
+#define UART3_INT_VECn          19    /* UART3_INT Interrupt */
+#define ADC0_INT_VECn           20    /* ADC0_INT Interrupt */
+#define ADC1_INT_VECn           21    /* ADC1_INT Interrupt */
+#define DAC0_INT_VECn           23    /* DAC0_INT Interrupt */
+#define SPI0_INT_VECn           25    /* SPI0_INT Interrupt */
+#define SPI1_INT_VECn           26    /* SPI1_INT Interrupt */
+#define UART1_INT_VECn          29    /* UART1_INT Interrupt */
+#define UART2_INT_VECn          30    /* UART2_INT Interrupt */
+#define UART0_INT_VECn          31    /* UART0_INT Interrupt */
+#define TIMG0_INT_VECn          32    /* TIMG0_INT Interrupt */
+#define TIMG6_INT_VECn          33    /* TIMG6_INT Interrupt */
+#define TIMA0_INT_VECn          34    /* TIMA0_INT Interrupt */
+#define TIMA1_INT_VECn          35    /* TIMA1_INT Interrupt */
+#define TIMG7_INT_VECn          36    /* TIMG7_INT Interrupt */
+#define TIMG12_INT_VECn         37    /* TIMG12_INT Interrupt */
+#define I2C0_INT_VECn           40    /* I2C0_INT Interrupt */
+#define I2C1_INT_VECn           41    /* I2C1_INT Interrupt */
+#define AES_INT_VECn            44    /* AES_INT Interrupt */
+#define RTC_INT_VECn            46    /* RTC_INT Interrupt */
+#define DMA_INT_VECn            47    /* DMA_INT Interrupt */
+
+
+/******************************************************************************
+* Ignore unused variables                                                     *
+******************************************************************************/
+
+#if   defined (__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined (__ICCARM__)
+  #pragma language=extended
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wc11-extensions"
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning 586
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+/******************************************************************************
+* Processor and Core Peripheral Section                                       *
+******************************************************************************/
+
+#define __CM0PLUS_REV           0x0001U    /* Core revision r0p1 */
+#define __MPU_PRESENT           0x0001U    /* MPU present */
+#define __VTOR_PRESENT          0x0001U    /* VTOR present */
+#define __NVIC_PRIO_BITS        0x0002U    /* Number of bits used for Priority Levels */
+#define __Vendor_SysTickConfig  0x0000U    /* Set to 1 if different SysTick Config is used */
+
+#include "core_cm0plus.h"                  /* Processor and core peripherals */
+
+/******************************************************************************
+* Peripheral headers                                                          *
+******************************************************************************/
+/** @addtogroup MSPM0G150X_Peripherals MSPM0G150X Peripherals
+  MSPM0G150X Peripheral registers structures
+  @{
+*/
+
+#include <ti/devices/msp/peripherals/hw_adc12.h>
+#include <ti/devices/msp/peripherals/hw_aes.h>
+#include <ti/devices/msp/peripherals/hw_comp.h>
+#include <ti/devices/msp/peripherals/hw_crc.h>
+#include <ti/devices/msp/peripherals/hw_dac12.h>
+#include <ti/devices/msp/peripherals/hw_dma.h>
+#include <ti/devices/msp/peripherals/hw_flashctl.h>
+#include <ti/devices/msp/peripherals/hw_gpio.h>
+#include <ti/devices/msp/peripherals/hw_gptimer.h>
+#include <ti/devices/msp/peripherals/hw_i2c.h>
+#include <ti/devices/msp/peripherals/hw_iomux.h>
+#include <ti/devices/msp/peripherals/hw_mathacl.h>
+#include <ti/devices/msp/peripherals/hw_oa.h>
+#include <ti/devices/msp/peripherals/hw_rtc.h>
+#include <ti/devices/msp/peripherals/hw_spi.h>
+#include <ti/devices/msp/peripherals/hw_trng.h>
+#include <ti/devices/msp/peripherals/hw_uart.h>
+#include <ti/devices/msp/peripherals/hw_vref.h>
+#include <ti/devices/msp/peripherals/hw_wuc.h>
+#include <ti/devices/msp/peripherals/hw_wwdt.h>
+#include <ti/devices/msp/peripherals/m0p/hw_factoryregion.h>
+#include <ti/devices/msp/peripherals/m0p/hw_cpuss.h>
+#include <ti/devices/msp/peripherals/m0p/hw_debugss.h>
+#include <ti/devices/msp/peripherals/m0p/hw_sysctl.h>
+
+#define __MSPM0_HAS_ADC12__
+#define __MSPM0_HAS_AES__
+#define __MSPM0_HAS_COMP__
+#define __MSPM0_HAS_CRC__
+#define __MSPM0_HAS_DAC12__
+#define __MSPM0_HAS_GPAMP__
+#define __MSPM0_HAS_GPIO__
+#define __MSPM0_HAS_TIMER_A__
+#define __MSPM0_HAS_TIMER_G__
+#define __MSPM0_HAS_I2C__
+#define __MSPM0_HAS_MATHACL__
+#define __MSPM0_HAS_OA__
+#define __MSPM0_HAS_RTC__
+#define __MSPM0_HAS_SPI__
+#define __MSPM0_HAS_TRNG__
+#define __MSPM0_HAS_UART_EXTD__
+#define __MSPM0_HAS_UART_MAIN__
+#define __MSPM0_HAS_VREF__
+#define __MSPM0_HAS_WWDT__
+
+#define __MSPM0_HAS_ECC__
+
+/*@}*/ /* end of group MSPM0G150X_Peripherals */
+
+/******************************************************************************
+* Device and peripheral memory map                                            *
+******************************************************************************/
+/** @addtogroup MSPM0G150X_MemoryMap MSPM0G150X Memory Mapping
+  @{
+*/
+
+#define I2C0_BASE                      (0x400F0000U)     /*!< Base address of module I2C0 */
+#define SYSCTL_BASE                    (0x400AF000U)     /*!< Base address of module SYSCTL */
+#define WWDT1_BASE                     (0x40082000U)     /*!< Base address of module WWDT1 */
+#define CPUSS_BASE                     (0x40400000U)     /*!< Base address of module CPUSS */
+#define IOMUX_BASE                     (0x40428000U)     /*!< Base address of module IOMUX */
+#define GPIOB_BASE                     (0x400A2000U)     /*!< Base address of module GPIOB */
+#define CRC_BASE                       (0x40440000U)     /*!< Base address of module CRC */
+#define WWDT0_BASE                     (0x40080000U)     /*!< Base address of module WWDT0 */
+#define SPI1_BASE                      (0x4046A000U)     /*!< Base address of module SPI1 */
+#define DAC0_BASE                      (0x40018000U)     /*!< Base address of module DAC0 */
+#define I2C1_BASE                      (0x400F2000U)     /*!< Base address of module I2C1 */
+#define GPIOA_BASE                     (0x400A0000U)     /*!< Base address of module GPIOA */
+#define FLASHCTL_BASE                  (0x400CD000U)     /*!< Base address of module FLASHCTL */
+#define TRNG_BASE                      (0x40444000U)     /*!< Base address of module TRNG */
+#define RTC_BASE                       (0x40094000U)     /*!< Base address of module RTC */
+#define SPI0_BASE                      (0x40468000U)     /*!< Base address of module SPI0 */
+#define AES_BASE                       (0x40442000U)     /*!< Base address of module AES */
+#define DMA_BASE                       (0x4042A000U)     /*!< Base address of module DMA */
+#define OPA0_BASE                      (0x40020000U)     /*!< Base address of module OPA0 */
+#define OPA1_BASE                      (0x40022000U)     /*!< Base address of module OPA1 */
+#define TIMA0_BASE                     (0x40860000U)     /*!< Base address of module TIMA0 */
+#define TIMA1_BASE                     (0x40862000U)     /*!< Base address of module TIMA1 */
+#define UART3_BASE                     (0x40500000U)     /*!< Base address of module UART3 */
+#define UART0_BASE                     (0x40108000U)     /*!< Base address of module UART0 */
+#define UART1_BASE                     (0x40100000U)     /*!< Base address of module UART1 */
+#define UART2_BASE                     (0x40102000U)     /*!< Base address of module UART2 */
+#define COMP0_BASE                     (0x40008000U)     /*!< Base address of module COMP0 */
+#define COMP1_BASE                     (0x4000A000U)     /*!< Base address of module COMP1 */
+#define COMP2_BASE                     (0x4000C000U)     /*!< Base address of module COMP2 */
+#define WUC_BASE                       (0x40424000U)     /*!< Base address of module WUC */
+#define FACTORYREGION_BASE             (0x41C40000U)     /*!< Base address of module FACTORYREGION */
+#define ADC0_BASE                      (0x40000000U)     /*!< Base address of module ADC0 */
+#define ADC0_PERIPHERALREGIONSVT_BASE  (0x40556000U)     /*!< Base address of module ADC0_PERIPHERALREGIONSVT */
+#define ADC1_BASE                      (0x40002000U)     /*!< Base address of module ADC1 */
+#define ADC1_PERIPHERALREGIONSVT_BASE  (0x40558000U)     /*!< Base address of module ADC1_PERIPHERALREGIONSVT */
+#define TIMG0_BASE                     (0x40084000U)     /*!< Base address of module TIMG0 */
+#define VREF_BASE                      (0x40030000U)     /*!< Base address of module VREF */
+#define MATHACL_BASE                   (0x40410000U)     /*!< Base address of module MATHACL */
+#define TIMG12_BASE                    (0x40870000U)     /*!< Base address of module TIMG12 */
+#define TIMG6_BASE                     (0x40868000U)     /*!< Base address of module TIMG6 */
+#define TIMG7_BASE                     (0x4086A000U)     /*!< Base address of module TIMG7 */
+#define TIMG8_BASE                     (0x40090000U)     /*!< Base address of module TIMG8 */
+#define DEBUGSS_BASE                   (0x400C7000U)     /*!< Base address of module DEBUGSS */
+
+
+/*@}*/ /* end of group MSPM0G150X_MemoryMap */
+
+/******************************************************************************
+* Peripheral declarations                                                     *
+******************************************************************************/
+/** @addtogroup MSPM0G150X_PeripheralDecl MSPM0G150X Peripheral Declaration
+  @{
+*/
+
+static I2C_Regs                                 * const I2C0                           = ((I2C_Regs *) I2C0_BASE);
+static SYSCTL_Regs                              * const SYSCTL                         = ((SYSCTL_Regs *) SYSCTL_BASE);
+static WWDT_Regs                                * const WWDT1                          = ((WWDT_Regs *) WWDT1_BASE);
+static CPUSS_Regs                               * const CPUSS                          = ((CPUSS_Regs *) CPUSS_BASE);
+static IOMUX_Regs                               * const IOMUX                          = ((IOMUX_Regs *) IOMUX_BASE);
+static GPIO_Regs                                * const GPIOB                          = ((GPIO_Regs *) GPIOB_BASE);
+static CRC_Regs                                 * const CRC                            = ((CRC_Regs *) CRC_BASE);
+static WWDT_Regs                                * const WWDT0                          = ((WWDT_Regs *) WWDT0_BASE);
+static SPI_Regs                                 * const SPI1                           = ((SPI_Regs *) SPI1_BASE);
+static DAC12_Regs                               * const DAC0                           = ((DAC12_Regs *) DAC0_BASE);
+static I2C_Regs                                 * const I2C1                           = ((I2C_Regs *) I2C1_BASE);
+static GPIO_Regs                                * const GPIOA                          = ((GPIO_Regs *) GPIOA_BASE);
+static FLASHCTL_Regs                            * const FLASHCTL                       = ((FLASHCTL_Regs *) FLASHCTL_BASE);
+static TRNG_Regs                                * const TRNG                           = ((TRNG_Regs *) TRNG_BASE);
+static RTC_Regs                                 * const RTC                            = ((RTC_Regs *) RTC_BASE);
+static SPI_Regs                                 * const SPI0                           = ((SPI_Regs *) SPI0_BASE);
+static AES_Regs                                 * const AES                            = ((AES_Regs *) AES_BASE);
+static DMA_Regs                                 * const DMA                            = ((DMA_Regs *) DMA_BASE);
+static OA_Regs                                  * const OPA0                           = ((OA_Regs *) OPA0_BASE);
+static OA_Regs                                  * const OPA1                           = ((OA_Regs *) OPA1_BASE);
+static GPTIMER_Regs                             * const TIMA0                          = ((GPTIMER_Regs *) TIMA0_BASE);
+static GPTIMER_Regs                             * const TIMA1                          = ((GPTIMER_Regs *) TIMA1_BASE);
+static UART_Regs                                * const UART3                          = ((UART_Regs *) UART3_BASE);
+static UART_Regs                                * const UART0                          = ((UART_Regs *) UART0_BASE);
+static UART_Regs                                * const UART1                          = ((UART_Regs *) UART1_BASE);
+static UART_Regs                                * const UART2                          = ((UART_Regs *) UART2_BASE);
+static COMP_Regs                                * const COMP0                          = ((COMP_Regs *) COMP0_BASE);
+static COMP_Regs                                * const COMP1                          = ((COMP_Regs *) COMP1_BASE);
+static COMP_Regs                                * const COMP2                          = ((COMP_Regs *) COMP2_BASE);
+static WUC_Regs                                 * const WUC                            = ((WUC_Regs *) WUC_BASE);
+static FACTORYREGION_OPEN_Regs                  * const FACTORYREGION                  = ((FACTORYREGION_OPEN_Regs *) FACTORYREGION_BASE);
+static ADC12_Regs                               * const ADC0                           = ((ADC12_Regs *) ADC0_BASE);
+static ADC12_PERIPHERALREGIONSVT_Regs           * const ADC0_PERIPHERALREGIONSVT       = ((ADC12_PERIPHERALREGIONSVT_Regs *) ADC0_PERIPHERALREGIONSVT_BASE);
+static ADC12_Regs                               * const ADC1                           = ((ADC12_Regs *) ADC1_BASE);
+static ADC12_PERIPHERALREGIONSVT_Regs           * const ADC1_PERIPHERALREGIONSVT       = ((ADC12_PERIPHERALREGIONSVT_Regs *) ADC1_PERIPHERALREGIONSVT_BASE);
+static GPTIMER_Regs                             * const TIMG0                          = ((GPTIMER_Regs *) TIMG0_BASE);
+static VREF_Regs                                * const VREF                           = ((VREF_Regs *) VREF_BASE);
+static MATHACL_Regs                             * const MATHACL                        = ((MATHACL_Regs *) MATHACL_BASE);
+static GPTIMER_Regs                             * const TIMG12                         = ((GPTIMER_Regs *) TIMG12_BASE);
+static GPTIMER_Regs                             * const TIMG6                          = ((GPTIMER_Regs *) TIMG6_BASE);
+static GPTIMER_Regs                             * const TIMG7                          = ((GPTIMER_Regs *) TIMG7_BASE);
+static GPTIMER_Regs                             * const TIMG8                          = ((GPTIMER_Regs *) TIMG8_BASE);
+static DEBUGSS_Regs                             * const DEBUGSS                        = ((DEBUGSS_Regs *) DEBUGSS_BASE);
+
+
+/******************************************************************************
+* SYS parameters                                                              *
+******************************************************************************/
+
+#define DMA_SYS_N_DMA_CHANNEL                         (7)       /* !< Number of DMA channels implemented in DMA. */
+#define DMA_SYS_N_DMA_FULL_CHANNEL                    (3)       /* !< Number of FULL-DMA channels implemented in DMA. */
+#define CRC_SYS_CRC32_ENABLE                          (1)       /* !< Parameter to exclude or include 32-bit CRC. */
+#define FLASHCTL_SYS_DATAWIDTH                        (64)      /* !< Data bit width of a single flash word. */
+#define ADC_SYS_NUM_ANALOG_CHAN                       (16)      /* !< Number of analog channels. */
+#define I2C_SYS_FENTRIES                              (8)       /* !< Number of FIFO entries */
+#define FLASHCTL_SYS_WEPROTAWIDTH                     (32)      /* !< Bit width of WEPROTA register */
+#define FLASHCTL_SYS_WEPROTBWIDTH                     (12)      /* !< Bit width of WEPROTB register */
+#define FLASHCTL_SYS_WEPROTCWIDTH                     (0)       /* !< Bit width of WEPROTC register */
+
+/******************************************************************************
+* DMA Triggers                                                                *
+******************************************************************************/
+
+/* External DMA Triggers */
+#define DMA_SOFTWARE_TRIG                             (0)
+#define DMA_GENERIC_SUB0_TRIG                         (1)
+#define DMA_GENERIC_SUB1_TRIG                         (2)
+#define DMA_AES_AES_0_TRIG                            (3)
+#define DMA_AES_AES_1_TRIG                            (4)
+#define DMA_AES_AES_2_TRIG                            (5)
+#define DMA_DAC0_EVT_BD_1_TRIG                        (6)
+#define DMA_I2C0_TX_TRIG                              (7)
+#define DMA_I2C0_RX_TRIG                              (8)
+#define DMA_I2C1_TX_TRIG                              (9)
+#define DMA_I2C1_RX_TRIG                              (10)
+#define DMA_SPI0_RX_TRIG                              (11)
+#define DMA_SPI0_TX_TRIG                              (12)
+#define DMA_SPI1_RX_TRIG                              (13)
+#define DMA_SPI1_TX_TRIG                              (14)
+#define DMA_UART3_RX_TRIG                             (15)
+#define DMA_UART3_TX_TRIG                             (16)
+#define DMA_UART0_RX_TRIG                             (17)
+#define DMA_UART0_TX_TRIG                             (18)
+#define DMA_UART1_RX_TRIG                             (19)
+#define DMA_UART1_TX_TRIG                             (20)
+#define DMA_UART2_RX_TRIG                             (21)
+#define DMA_UART2_TX_TRIG                             (22)
+#define DMA_ADC0_EVT_GEN_BD_TRIG                      (23)
+#define DMA_ADC1_EVT_GEN_BD_TRIG                      (24)
+
+/* Internal DMA Triggers */
+#define DMA_CH_0_TRIG                                 (0)
+#define DMA_CH_1_TRIG                                 (1)
+#define DMA_CH_2_TRIG                                 (2)
+#define DMA_CH_3_TRIG                                 (3)
+#define DMA_CH_4_TRIG                                 (4)
+#define DMA_CH_5_TRIG                                 (5)
+#define DMA_CH_6_TRIG                                 (6)
+
+
+/******************************************************************************
+* IOMUX Pin Definitions                                                       *
+******************************************************************************/
+
+typedef enum IOMUX_PINCM
+{
+  IOMUX_PINCM1         = (0),
+  IOMUX_PINCM2         = (1),
+  IOMUX_PINCM3         = (2),
+  IOMUX_PINCM4         = (3),
+  IOMUX_PINCM5         = (4),
+  IOMUX_PINCM6         = (5),
+  IOMUX_PINCM7         = (6),
+  IOMUX_PINCM8         = (7),
+  IOMUX_PINCM9         = (8),
+  IOMUX_PINCM10        = (9),
+  IOMUX_PINCM11        = (10),
+  IOMUX_PINCM12        = (11),
+  IOMUX_PINCM13        = (12),
+  IOMUX_PINCM14        = (13),
+  IOMUX_PINCM15        = (14),
+  IOMUX_PINCM16        = (15),
+  IOMUX_PINCM17        = (16),
+  IOMUX_PINCM18        = (17),
+  IOMUX_PINCM19        = (18),
+  IOMUX_PINCM20        = (19),
+  IOMUX_PINCM21        = (20),
+  IOMUX_PINCM22        = (21),
+  IOMUX_PINCM23        = (22),
+  IOMUX_PINCM24        = (23),
+  IOMUX_PINCM25        = (24),
+  IOMUX_PINCM26        = (25),
+  IOMUX_PINCM27        = (26),
+  IOMUX_PINCM28        = (27),
+  IOMUX_PINCM29        = (28),
+  IOMUX_PINCM30        = (29),
+  IOMUX_PINCM31        = (30),
+  IOMUX_PINCM32        = (31),
+  IOMUX_PINCM33        = (32),
+  IOMUX_PINCM34        = (33),
+  IOMUX_PINCM35        = (34),
+  IOMUX_PINCM36        = (35),
+  IOMUX_PINCM37        = (36),
+  IOMUX_PINCM38        = (37),
+  IOMUX_PINCM39        = (38),
+  IOMUX_PINCM40        = (39),
+  IOMUX_PINCM41        = (40),
+  IOMUX_PINCM42        = (41),
+  IOMUX_PINCM43        = (42),
+  IOMUX_PINCM44        = (43),
+  IOMUX_PINCM45        = (44),
+  IOMUX_PINCM46        = (45),
+  IOMUX_PINCM47        = (46),
+  IOMUX_PINCM48        = (47),
+  IOMUX_PINCM49        = (48),
+  IOMUX_PINCM50        = (49),
+  IOMUX_PINCM51        = (50),
+  IOMUX_PINCM52        = (51),
+  IOMUX_PINCM53        = (52),
+  IOMUX_PINCM54        = (53),
+  IOMUX_PINCM55        = (54),
+  IOMUX_PINCM56        = (55),
+  IOMUX_PINCM57        = (56),
+  IOMUX_PINCM58        = (57),
+  IOMUX_PINCM59        = (58),
+  IOMUX_PINCM60        = (59),
+} IOMUX_PINCM;
+
+
+/* IOMUX_PINCM1[PF] Bits */
+#define IOMUX_PINCM1_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM1_PF_GPIOA_DIO00                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM1_PF_UART0_TX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM1_PF_I2C0_SDA                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM1_PF_TIMA0_CCP0                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM1_PF_TIMA_FAULT1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM1_PF_TIMG8_CCP1                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM1_PF_SYSCTL_FCC_IN                 ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM2[PF] Bits */
+#define IOMUX_PINCM2_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM2_PF_GPIOA_DIO01                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM2_PF_UART0_RX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM2_PF_I2C0_SCL                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM2_PF_TIMA0_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM2_PF_TIMA_FAULT2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM2_PF_TIMG8_IDX                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM2_PF_TIMG8_CCP0                    ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM3[PF] Bits */
+#define IOMUX_PINCM3_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM3_PF_GPIOA_DIO28                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM3_PF_UART0_TX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM3_PF_I2C0_SDA                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM3_PF_TIMA0_CCP3                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM3_PF_TIMA_FAULT0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM3_PF_TIMG7_CCP0                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM3_PF_TIMA1_CCP0                    ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM4[PF] Bits */
+#define IOMUX_PINCM4_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM4_PF_GPIOA_DIO29                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM4_PF_I2C1_SCL                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM4_PF_UART2_RTS                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM4_PF_TIMG8_CCP0                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM4_PF_TIMG6_CCP0                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM5[PF] Bits */
+#define IOMUX_PINCM5_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM5_PF_GPIOA_DIO30                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM5_PF_I2C1_SDA                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM5_PF_UART2_CTS                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM5_PF_TIMG8_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM5_PF_TIMG6_CCP1                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM6[PF] Bits */
+#define IOMUX_PINCM6_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM6_PF_GPIOA_DIO31                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM6_PF_UART0_RX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM6_PF_I2C0_SCL                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM6_PF_TIMA0_CCP3_CMPL               ((uint32_t)0X00000004)
+#define IOMUX_PINCM6_PF_TIMG12_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM6_PF_SYSCTL_CLK_OUT                ((uint32_t)0X00000006)
+#define IOMUX_PINCM6_PF_TIMG7_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM6_PF_TIMA1_CCP1                    ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM7[PF] Bits */
+#define IOMUX_PINCM7_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM7_PF_GPIOA_DIO02                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM7_PF_TIMG8_CCP1                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM7_PF_SPI0_CS0                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM7_PF_TIMG7_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM7_PF_SPI1_CS0                      ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM8[PF] Bits */
+#define IOMUX_PINCM8_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM8_PF_GPIOA_DIO03                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM8_PF_TIMG8_CCP0                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM8_PF_SPI0_CS1_POCI1                ((uint32_t)0X00000003)
+#define IOMUX_PINCM8_PF_UART2_CTS                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM8_PF_TIMA0_CCP2                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM8_PF_COMP1_OUT                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM8_PF_TIMG7_CCP0                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM8_PF_TIMA0_CCP1                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM8_PF_I2C1_SDA                      ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM9[PF] Bits */
+#define IOMUX_PINCM9_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM9_PF_GPIOA_DIO04                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM9_PF_TIMG8_CCP1                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM9_PF_SPI0_POCI                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM9_PF_UART2_RTS                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM9_PF_TIMA0_CCP3                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM9_PF_SYSCTL_LFCLKIN                ((uint32_t)0X00000006)
+#define IOMUX_PINCM9_PF_TIMG7_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM9_PF_TIMA0_CCP1_CMPL               ((uint32_t)0X00000008)
+#define IOMUX_PINCM9_PF_I2C1_SCL                      ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM10[PF] Bits */
+#define IOMUX_PINCM10_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM10_PF_GPIOA_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM10_PF_TIMG8_CCP0                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM10_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM10_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM10_PF_TIMG0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM10_PF_TIMG6_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM10_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM11[PF] Bits */
+#define IOMUX_PINCM11_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM11_PF_GPIOA_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM11_PF_TIMG8_CCP1                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM11_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM11_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM11_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM11_PF_SYSCTL_HFCLKIN               ((uint32_t)0X00000006)
+#define IOMUX_PINCM11_PF_TIMG6_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM11_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM12[PF] Bits */
+#define IOMUX_PINCM12_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM12_PF_GPIOB_DIO00                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM12_PF_UART0_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM12_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM12_PF_TIMA1_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM12_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM13[PF] Bits */
+#define IOMUX_PINCM13_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM13_PF_GPIOB_DIO01                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM13_PF_UART0_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM13_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM13_PF_TIMA1_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM13_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM14[PF] Bits */
+#define IOMUX_PINCM14_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM14_PF_GPIOA_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM14_PF_COMP0_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM14_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000003)
+#define IOMUX_PINCM14_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM14_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM14_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM14_PF_TIMG7_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM14_PF_TIMA0_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM15[PF] Bits */
+#define IOMUX_PINCM15_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM15_PF_GPIOB_DIO02                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM15_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM15_PF_UART2_CTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM15_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM15_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM15_PF_UART1_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM15_PF_TIMG6_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM15_PF_TIMA1_CCP0                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM16[PF] Bits */
+#define IOMUX_PINCM16_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM16_PF_GPIOB_DIO03                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM16_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM16_PF_UART2_RTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM16_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM16_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM16_PF_UART1_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM16_PF_TIMG6_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM16_PF_TIMA1_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM17[PF] Bits */
+#define IOMUX_PINCM17_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM17_PF_GPIOB_DIO04                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM17_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM17_PF_UART3_CTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM17_PF_TIMA1_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM17_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM17_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM18[PF] Bits */
+#define IOMUX_PINCM18_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM18_PF_GPIOB_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM18_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM18_PF_UART3_RTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM18_PF_TIMA1_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM18_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM18_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM19[PF] Bits */
+#define IOMUX_PINCM19_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM19_PF_GPIOA_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM19_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM19_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM19_PF_UART0_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM19_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM19_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM20[PF] Bits */
+#define IOMUX_PINCM20_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM20_PF_GPIOA_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM20_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM20_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM20_PF_UART0_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM20_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM20_PF_RTC_RTC_OUT                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM20_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM20_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000008)
+#define IOMUX_PINCM20_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM21[PF] Bits */
+#define IOMUX_PINCM21_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM21_PF_GPIOA_DIO10                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM21_PF_UART0_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM21_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM21_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM21_PF_TIMA1_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM21_PF_TIMG12_CCP0                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM21_PF_TIMA0_CCP2                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM21_PF_I2C1_SDA                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM21_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM22[PF] Bits */
+#define IOMUX_PINCM22_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM22_PF_GPIOA_DIO11                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM22_PF_UART0_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM22_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM22_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM22_PF_TIMA1_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM22_PF_COMP0_OUT                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM22_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM22_PF_I2C1_SCL                     ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM23[PF] Bits */
+#define IOMUX_PINCM23_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM23_PF_GPIOB_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM23_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM23_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM23_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000004)
+#define IOMUX_PINCM23_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM23_PF_UART2_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM23_PF_TIMG6_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM23_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM24[PF] Bits */
+#define IOMUX_PINCM24_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM24_PF_GPIOB_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM24_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM24_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM24_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000004)
+#define IOMUX_PINCM24_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM24_PF_UART2_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM24_PF_TIMG6_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM24_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM25[PF] Bits */
+#define IOMUX_PINCM25_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM25_PF_GPIOB_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM25_PF_UART1_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM25_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM25_PF_TIMA0_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM25_PF_COMP1_OUT                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM26[PF] Bits */
+#define IOMUX_PINCM26_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM26_PF_GPIOB_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM26_PF_UART1_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM26_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM26_PF_TIMA0_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM26_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM27[PF] Bits */
+#define IOMUX_PINCM27_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM27_PF_GPIOB_DIO10                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM27_PF_TIMG0_CCP0                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM27_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM27_PF_COMP1_OUT                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM27_PF_TIMG6_CCP0                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM28[PF] Bits */
+#define IOMUX_PINCM28_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM28_PF_GPIOB_DIO11                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM28_PF_TIMG0_CCP1                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM28_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM28_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000004)
+#define IOMUX_PINCM28_PF_TIMG6_CCP1                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM29[PF] Bits */
+#define IOMUX_PINCM29_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM29_PF_GPIOB_DIO12                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM29_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM29_PF_TIMA0_CCP2                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM29_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM29_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM30[PF] Bits */
+#define IOMUX_PINCM30_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM30_PF_GPIOB_DIO13                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM30_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM30_PF_TIMA0_CCP3                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM30_PF_TIMG12_CCP0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM30_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM31[PF] Bits */
+#define IOMUX_PINCM31_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM31_PF_GPIOB_DIO14                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM31_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000002)
+#define IOMUX_PINCM31_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM31_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000004)
+#define IOMUX_PINCM31_PF_TIMG12_CCP1                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM31_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM31_PF_TIMA0_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM32[PF] Bits */
+#define IOMUX_PINCM32_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM32_PF_GPIOB_DIO15                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM32_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM32_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM32_PF_UART3_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM32_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM32_PF_TIMG7_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM33[PF] Bits */
+#define IOMUX_PINCM33_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM33_PF_GPIOB_DIO16                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM33_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM33_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM33_PF_UART3_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM33_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM33_PF_TIMG7_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM34[PF] Bits */
+#define IOMUX_PINCM34_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM34_PF_GPIOA_DIO12                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM34_PF_UART3_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM34_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM34_PF_TIMG0_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM34_PF_CANFD0_CANTX                 ((uint32_t)0X00000005)
+#define IOMUX_PINCM34_PF_TIMA0_CCP3                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM34_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM35[PF] Bits */
+#define IOMUX_PINCM35_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM35_PF_GPIOA_DIO13                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM35_PF_UART3_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM35_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM35_PF_UART3_RX                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM35_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM35_PF_CANFD0_CANRX                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM35_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM36[PF] Bits */
+#define IOMUX_PINCM36_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM36_PF_GPIOA_DIO14                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM36_PF_UART0_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM36_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM36_PF_UART3_TX                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM36_PF_TIMG12_CCP0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM36_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM37[PF] Bits */
+#define IOMUX_PINCM37_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM37_PF_GPIOA_DIO15                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM37_PF_UART0_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM37_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM37_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM37_PF_TIMA1_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM37_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM37_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM37_PF_TIMA0_CCP2                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM38[PF] Bits */
+#define IOMUX_PINCM38_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM38_PF_GPIOA_DIO16                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM38_PF_COMP2_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM38_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM38_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM38_PF_TIMA1_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM38_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM38_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM38_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM39[PF] Bits */
+#define IOMUX_PINCM39_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM39_PF_GPIOA_DIO17                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM39_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM39_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM39_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM39_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM39_PF_TIMG7_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM39_PF_TIMA1_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM40[PF] Bits */
+#define IOMUX_PINCM40_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM40_PF_GPIOA_DIO18                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM40_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM40_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM40_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM40_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM40_PF_TIMG7_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM40_PF_TIMA1_CCP1                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM41[PF] Bits */
+#define IOMUX_PINCM41_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM41_PF_GPIOA_DIO19                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM41_PF_DEBUGSS_SWDIO                ((uint32_t)0X00000002)
+
+/* IOMUX_PINCM42[PF] Bits */
+#define IOMUX_PINCM42_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM42_PF_GPIOA_DIO20                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM42_PF_DEBUGSS_SWCLK                ((uint32_t)0X00000002)
+
+/* IOMUX_PINCM43[PF] Bits */
+#define IOMUX_PINCM43_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM43_PF_GPIOB_DIO17                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM43_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM43_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM43_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000004)
+#define IOMUX_PINCM43_PF_TIMA1_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM43_PF_TIMA0_CCP2                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM44[PF] Bits */
+#define IOMUX_PINCM44_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM44_PF_GPIOB_DIO18                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM44_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM44_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM44_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000004)
+#define IOMUX_PINCM44_PF_TIMA1_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM44_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM45[PF] Bits */
+#define IOMUX_PINCM45_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM45_PF_GPIOB_DIO19                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM45_PF_COMP2_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM45_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM45_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM45_PF_UART0_CTS                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM45_PF_TIMG7_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM46[PF] Bits */
+#define IOMUX_PINCM46_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM46_PF_GPIOA_DIO21                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM46_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM46_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM46_PF_UART1_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM46_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM46_PF_TIMG6_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM47[PF] Bits */
+#define IOMUX_PINCM47_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM47_PF_GPIOA_DIO22                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM47_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM47_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM47_PF_UART1_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM47_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM47_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+#define IOMUX_PINCM47_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM47_PF_TIMG6_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM48[PF] Bits */
+#define IOMUX_PINCM48_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM48_PF_GPIOB_DIO20                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM48_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000002)
+#define IOMUX_PINCM48_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM48_PF_TIMA0_CCP2                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM48_PF_TIMG12_CCP0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM48_PF_TIMA_FAULT1                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM48_PF_TIMA0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM48_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM49[PF] Bits */
+#define IOMUX_PINCM49_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM49_PF_GPIOB_DIO21                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM49_PF_SPI1_POCI                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM49_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+
+/* IOMUX_PINCM50[PF] Bits */
+#define IOMUX_PINCM50_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM50_PF_GPIOB_DIO22                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM50_PF_SPI1_PICO                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM50_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+
+/* IOMUX_PINCM51[PF] Bits */
+#define IOMUX_PINCM51_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM51_PF_GPIOB_DIO23                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM51_PF_SPI1_SCLK                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM51_PF_COMP0_OUT                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM51_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+
+/* IOMUX_PINCM52[PF] Bits */
+#define IOMUX_PINCM52_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM52_PF_GPIOB_DIO24                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM52_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000002)
+#define IOMUX_PINCM52_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM52_PF_TIMA0_CCP3                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM52_PF_TIMG12_CCP1                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM52_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM52_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM53[PF] Bits */
+#define IOMUX_PINCM53_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM53_PF_GPIOA_DIO23                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM53_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM53_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM53_PF_TIMA0_CCP3                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM53_PF_TIMG0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM53_PF_UART3_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM53_PF_TIMG7_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM53_PF_TIMG8_CCP0                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM54[PF] Bits */
+#define IOMUX_PINCM54_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM54_PF_GPIOA_DIO24                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM54_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM54_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM54_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000004)
+#define IOMUX_PINCM54_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM54_PF_UART3_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM54_PF_TIMG7_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM54_PF_TIMA1_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM55[PF] Bits */
+#define IOMUX_PINCM55_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM55_PF_GPIOA_DIO25                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM55_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM55_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM55_PF_TIMG12_CCP1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM55_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM55_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM56[PF] Bits */
+#define IOMUX_PINCM56_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM56_PF_GPIOB_DIO25                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM56_PF_UART0_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM56_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM56_PF_TIMA_FAULT2                  ((uint32_t)0X00000004)
+
+/* IOMUX_PINCM57[PF] Bits */
+#define IOMUX_PINCM57_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM57_PF_GPIOB_DIO26                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM57_PF_UART0_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM57_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM57_PF_TIMA0_CCP3                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM57_PF_TIMG6_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM57_PF_TIMA1_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM58[PF] Bits */
+#define IOMUX_PINCM58_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM58_PF_GPIOB_DIO27                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM58_PF_COMP2_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM58_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM58_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000004)
+#define IOMUX_PINCM58_PF_TIMG6_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM58_PF_TIMA1_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM59[PF] Bits */
+#define IOMUX_PINCM59_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM59_PF_GPIOA_DIO26                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM59_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM59_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM59_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM59_PF_TIMA_FAULT0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM59_PF_CANFD0_CANTX                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM59_PF_TIMG7_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM60[PF] Bits */
+#define IOMUX_PINCM60_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM60_PF_GPIOA_DIO27                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM60_PF_RTC_RTC_OUT                  ((uint32_t)0X00000002)
+#define IOMUX_PINCM60_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM60_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM60_PF_TIMA_FAULT2                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM60_PF_CANFD0_CANRX                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM60_PF_TIMG7_CCP1                   ((uint32_t)0X00000007)
+
+
+#if   defined (__CC_ARM)
+  #pragma pop
+#elif defined (__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+  #pragma clang diagnostic pop
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning restore
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+/*@}*/ /* end of group MSPM0G150X_PeripheralDecl */
+
+/*@}*/ /* end of group MSPM0G150X_Definitions */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_m0p_mspm0g150x__include */
+

--- a/mspm0/source/ti/devices/msp/m0p/mspm0g310x.h
+++ b/mspm0/source/ti/devices/msp/m0p/mspm0g310x.h
@@ -1,0 +1,1033 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/ 
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+   Redistributions of source code must retain the above copyright 
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the   
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_m0p_mspm0g310x__include
+#define ti_devices_msp_m0p_mspm0g310x__include
+
+/* Filename: mspm0g310x.h */
+/* Revised: 2023-02-03 08:37:25 */
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** @addtogroup MSPM0G310X_Definitions MSPM0G310X Definitions
+  This file defines all structures and symbols for MSPM0G310X
+  @{
+*/
+
+/** @addtogroup MSPM0G310X_CMSIS Device CMSIS Definitions
+  Configuration of the Processor and Core Peripherals
+  @{
+*/
+/******************************************************************************
+* Interrupt Definitions                                                       *
+******************************************************************************/
+typedef enum IRQn
+{
+  NonMaskableInt_IRQn         = -14,    /* 2  Non Maskable Interrupt */
+  HardFault_IRQn              = -13,    /* 3  Hard Fault Interrupt */
+  SVCall_IRQn                 = -5,     /* 11 SV Call Interrupt */
+  PendSV_IRQn                 = -2,     /* 14 Pend SV Interrupt */
+  SysTick_IRQn                = -1,     /* 15 System Tick Interrupt */
+  SYSCTL_INT_IRQn             = 0,      /* 16 SYSCTL_INT Interrupt */
+  WWDT1_INT_IRQn              = 0,      /* 16 WWDT1_INT Interrupt */
+  WWDT0_INT_IRQn              = 0,      /* 16 WWDT0_INT Interrupt */
+  FLASHCTL_INT_IRQn           = 0,      /* 16 FLASHCTL_INT Interrupt */
+  DEBUGSS_INT_IRQn            = 0,      /* 16 DEBUGSS_INT Interrupt */
+  GPIOB_INT_IRQn              = 1,      /* 17 GPIOB_INT Interrupt */
+  GPIOA_INT_IRQn              = 1,      /* 17 GPIOA_INT Interrupt */
+  TRNG_INT_IRQn               = 1,      /* 17 TRNG_INT Interrupt */
+  TIMG8_INT_IRQn              = 2,      /* 18 TIMG8_INT Interrupt */
+  UART3_INT_IRQn              = 3,      /* 19 UART3_INT Interrupt */
+  ADC0_INT_IRQn               = 4,      /* 20 ADC0_INT Interrupt */
+  ADC1_INT_IRQn               = 5,      /* 21 ADC1_INT Interrupt */
+  CANFD0_INT_IRQn             = 6,      /* 22 CANFD0_INT Interrupt */
+  SPI0_INT_IRQn               = 9,      /* 25 SPI0_INT Interrupt */
+  SPI1_INT_IRQn               = 10,     /* 26 SPI1_INT Interrupt */
+  UART1_INT_IRQn              = 13,     /* 29 UART1_INT Interrupt */
+  UART2_INT_IRQn              = 14,     /* 30 UART2_INT Interrupt */
+  UART0_INT_IRQn              = 15,     /* 31 UART0_INT Interrupt */
+  TIMG0_INT_IRQn              = 16,     /* 32 TIMG0_INT Interrupt */
+  TIMG6_INT_IRQn              = 17,     /* 33 TIMG6_INT Interrupt */
+  TIMA0_INT_IRQn              = 18,     /* 34 TIMA0_INT Interrupt */
+  TIMA1_INT_IRQn              = 19,     /* 35 TIMA1_INT Interrupt */
+  TIMG7_INT_IRQn              = 20,     /* 36 TIMG7_INT Interrupt */
+  TIMG12_INT_IRQn             = 21,     /* 37 TIMG12_INT Interrupt */
+  I2C0_INT_IRQn               = 24,     /* 40 I2C0_INT Interrupt */
+  I2C1_INT_IRQn               = 25,     /* 41 I2C1_INT Interrupt */
+  AES_INT_IRQn                = 28,     /* 44 AES_INT Interrupt */
+  RTC_INT_IRQn                = 30,     /* 46 RTC_INT Interrupt */
+  DMA_INT_IRQn                = 31,     /* 47 DMA_INT Interrupt */
+} IRQn_Type;
+
+#define NonMaskableInt_VECn     2     /* Non Maskable Interrupt */
+#define HardFault_VECn          3     /* Hard Fault Interrupt */
+#define SVCall_VECn             11    /* SV Call Interrupt */
+#define PendSV_VECn             14    /* Pend SV Interrupt */
+#define SysTick_VECn            15    /* System Tick Interrupt */
+#define SYSCTL_INT_VECn         16    /* SYSCTL_INT Interrupt */
+#define WWDT1_INT_VECn          16    /* WWDT1_INT Interrupt */
+#define WWDT0_INT_VECn          16    /* WWDT0_INT Interrupt */
+#define FLASHCTL_INT_VECn       16    /* FLASHCTL_INT Interrupt */
+#define DEBUGSS_INT_VECn        16    /* DEBUGSS_INT Interrupt */
+#define GPIOB_INT_VECn          17    /* GPIOB_INT Interrupt */
+#define GPIOA_INT_VECn          17    /* GPIOA_INT Interrupt */
+#define TRNG_INT_VECn           17    /* TRNG_INT Interrupt */
+#define TIMG8_INT_VECn          18    /* TIMG8_INT Interrupt */
+#define UART3_INT_VECn          19    /* UART3_INT Interrupt */
+#define ADC0_INT_VECn           20    /* ADC0_INT Interrupt */
+#define ADC1_INT_VECn           21    /* ADC1_INT Interrupt */
+#define CANFD0_INT_VECn         22    /* CANFD0_INT Interrupt */
+#define SPI0_INT_VECn           25    /* SPI0_INT Interrupt */
+#define SPI1_INT_VECn           26    /* SPI1_INT Interrupt */
+#define UART1_INT_VECn          29    /* UART1_INT Interrupt */
+#define UART2_INT_VECn          30    /* UART2_INT Interrupt */
+#define UART0_INT_VECn          31    /* UART0_INT Interrupt */
+#define TIMG0_INT_VECn          32    /* TIMG0_INT Interrupt */
+#define TIMG6_INT_VECn          33    /* TIMG6_INT Interrupt */
+#define TIMA0_INT_VECn          34    /* TIMA0_INT Interrupt */
+#define TIMA1_INT_VECn          35    /* TIMA1_INT Interrupt */
+#define TIMG7_INT_VECn          36    /* TIMG7_INT Interrupt */
+#define TIMG12_INT_VECn         37    /* TIMG12_INT Interrupt */
+#define I2C0_INT_VECn           40    /* I2C0_INT Interrupt */
+#define I2C1_INT_VECn           41    /* I2C1_INT Interrupt */
+#define AES_INT_VECn            44    /* AES_INT Interrupt */
+#define RTC_INT_VECn            46    /* RTC_INT Interrupt */
+#define DMA_INT_VECn            47    /* DMA_INT Interrupt */
+
+
+/******************************************************************************
+* Ignore unused variables                                                     *
+******************************************************************************/
+
+#if   defined (__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined (__ICCARM__)
+  #pragma language=extended
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wc11-extensions"
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning 586
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+/******************************************************************************
+* Processor and Core Peripheral Section                                       *
+******************************************************************************/
+
+#define __CM0PLUS_REV           0x0001U    /* Core revision r0p1 */
+#define __MPU_PRESENT           0x0001U    /* MPU present */
+#define __VTOR_PRESENT          0x0001U    /* VTOR present */
+#define __NVIC_PRIO_BITS        0x0002U    /* Number of bits used for Priority Levels */
+#define __Vendor_SysTickConfig  0x0000U    /* Set to 1 if different SysTick Config is used */
+
+#include "core_cm0plus.h"                  /* Processor and core peripherals */
+
+/******************************************************************************
+* Peripheral headers                                                          *
+******************************************************************************/
+/** @addtogroup MSPM0G310X_Peripherals MSPM0G310X Peripherals
+  MSPM0G310X Peripheral registers structures
+  @{
+*/
+
+#include <ti/devices/msp/peripherals/hw_adc12.h>
+#include <ti/devices/msp/peripherals/hw_aes.h>
+#include <ti/devices/msp/peripherals/hw_crc.h>
+#include <ti/devices/msp/peripherals/hw_dma.h>
+#include <ti/devices/msp/peripherals/hw_flashctl.h>
+#include <ti/devices/msp/peripherals/hw_gpio.h>
+#include <ti/devices/msp/peripherals/hw_gptimer.h>
+#include <ti/devices/msp/peripherals/hw_i2c.h>
+#include <ti/devices/msp/peripherals/hw_iomux.h>
+#include <ti/devices/msp/peripherals/hw_mcan.h>
+#include <ti/devices/msp/peripherals/hw_rtc.h>
+#include <ti/devices/msp/peripherals/hw_spi.h>
+#include <ti/devices/msp/peripherals/hw_trng.h>
+#include <ti/devices/msp/peripherals/hw_uart.h>
+#include <ti/devices/msp/peripherals/hw_vref.h>
+#include <ti/devices/msp/peripherals/hw_wuc.h>
+#include <ti/devices/msp/peripherals/hw_wwdt.h>
+#include <ti/devices/msp/peripherals/m0p/hw_factoryregion.h>
+#include <ti/devices/msp/peripherals/m0p/hw_cpuss.h>
+#include <ti/devices/msp/peripherals/m0p/hw_debugss.h>
+#include <ti/devices/msp/peripherals/m0p/hw_sysctl.h>
+
+#define __MSPM0_HAS_ADC12__
+#define __MSPM0_HAS_AES__
+#define __MSPM0_HAS_CRC__
+#define __MSPM0_HAS_GPAMP__
+#define __MSPM0_HAS_GPIO__
+#define __MSPM0_HAS_TIMER_A__
+#define __MSPM0_HAS_TIMER_G__
+#define __MSPM0_HAS_I2C__
+#define __MSPM0_HAS_MCAN__
+#define __MSPM0_HAS_RTC__
+#define __MSPM0_HAS_SPI__
+#define __MSPM0_HAS_TRNG__
+#define __MSPM0_HAS_UART_EXTD__
+#define __MSPM0_HAS_UART_MAIN__
+#define __MSPM0_HAS_VREF__
+#define __MSPM0_HAS_WWDT__
+
+#define __MSPM0_HAS_ECC__
+
+/*@}*/ /* end of group MSPM0G310X_Peripherals */
+
+/******************************************************************************
+* Device and peripheral memory map                                            *
+******************************************************************************/
+/** @addtogroup MSPM0G310X_MemoryMap MSPM0G310X Memory Mapping
+  @{
+*/
+
+#define I2C0_BASE                      (0x400F0000U)     /*!< Base address of module I2C0 */
+#define SYSCTL_BASE                    (0x400AF000U)     /*!< Base address of module SYSCTL */
+#define WWDT1_BASE                     (0x40082000U)     /*!< Base address of module WWDT1 */
+#define CPUSS_BASE                     (0x40400000U)     /*!< Base address of module CPUSS */
+#define CANFD0_BASE                    (0x40508000U)     /*!< Base address of module CANFD0 */
+#define CANFD0_SRAM_BASE               (0x40508000U)     /*!< Base address of memory CANFD0_SRAM */
+#define IOMUX_BASE                     (0x40428000U)     /*!< Base address of module IOMUX */
+#define GPIOB_BASE                     (0x400A2000U)     /*!< Base address of module GPIOB */
+#define CRC_BASE                       (0x40440000U)     /*!< Base address of module CRC */
+#define WWDT0_BASE                     (0x40080000U)     /*!< Base address of module WWDT0 */
+#define SPI1_BASE                      (0x4046A000U)     /*!< Base address of module SPI1 */
+#define I2C1_BASE                      (0x400F2000U)     /*!< Base address of module I2C1 */
+#define GPIOA_BASE                     (0x400A0000U)     /*!< Base address of module GPIOA */
+#define FLASHCTL_BASE                  (0x400CD000U)     /*!< Base address of module FLASHCTL */
+#define TRNG_BASE                      (0x40444000U)     /*!< Base address of module TRNG */
+#define RTC_BASE                       (0x40094000U)     /*!< Base address of module RTC */
+#define SPI0_BASE                      (0x40468000U)     /*!< Base address of module SPI0 */
+#define AES_BASE                       (0x40442000U)     /*!< Base address of module AES */
+#define DMA_BASE                       (0x4042A000U)     /*!< Base address of module DMA */
+#define TIMA0_BASE                     (0x40860000U)     /*!< Base address of module TIMA0 */
+#define TIMA1_BASE                     (0x40862000U)     /*!< Base address of module TIMA1 */
+#define UART3_BASE                     (0x40500000U)     /*!< Base address of module UART3 */
+#define UART0_BASE                     (0x40108000U)     /*!< Base address of module UART0 */
+#define UART1_BASE                     (0x40100000U)     /*!< Base address of module UART1 */
+#define UART2_BASE                     (0x40102000U)     /*!< Base address of module UART2 */
+#define WUC_BASE                       (0x40424000U)     /*!< Base address of module WUC */
+#define FACTORYREGION_BASE             (0x41C40000U)     /*!< Base address of module FACTORYREGION */
+#define ADC0_BASE                      (0x40000000U)     /*!< Base address of module ADC0 */
+#define ADC0_PERIPHERALREGIONSVT_BASE  (0x40556000U)     /*!< Base address of module ADC0_PERIPHERALREGIONSVT */
+#define ADC1_BASE                      (0x40002000U)     /*!< Base address of module ADC1 */
+#define ADC1_PERIPHERALREGIONSVT_BASE  (0x40558000U)     /*!< Base address of module ADC1_PERIPHERALREGIONSVT */
+#define TIMG0_BASE                     (0x40084000U)     /*!< Base address of module TIMG0 */
+#define VREF_BASE                      (0x40030000U)     /*!< Base address of module VREF */
+#define TIMG12_BASE                    (0x40870000U)     /*!< Base address of module TIMG12 */
+#define TIMG6_BASE                     (0x40868000U)     /*!< Base address of module TIMG6 */
+#define TIMG7_BASE                     (0x4086A000U)     /*!< Base address of module TIMG7 */
+#define TIMG8_BASE                     (0x40090000U)     /*!< Base address of module TIMG8 */
+#define DEBUGSS_BASE                   (0x400C7000U)     /*!< Base address of module DEBUGSS */
+
+
+/*@}*/ /* end of group MSPM0G310X_MemoryMap */
+
+/******************************************************************************
+* Peripheral declarations                                                     *
+******************************************************************************/
+/** @addtogroup MSPM0G310X_PeripheralDecl MSPM0G310X Peripheral Declaration
+  @{
+*/
+
+static I2C_Regs                                 * const I2C0                           = ((I2C_Regs *) I2C0_BASE);
+static SYSCTL_Regs                              * const SYSCTL                         = ((SYSCTL_Regs *) SYSCTL_BASE);
+static WWDT_Regs                                * const WWDT1                          = ((WWDT_Regs *) WWDT1_BASE);
+static CPUSS_Regs                               * const CPUSS                          = ((CPUSS_Regs *) CPUSS_BASE);
+static MCAN_Regs                                * const CANFD0                         = ((MCAN_Regs *) CANFD0_BASE);
+static IOMUX_Regs                               * const IOMUX                          = ((IOMUX_Regs *) IOMUX_BASE);
+static GPIO_Regs                                * const GPIOB                          = ((GPIO_Regs *) GPIOB_BASE);
+static CRC_Regs                                 * const CRC                            = ((CRC_Regs *) CRC_BASE);
+static WWDT_Regs                                * const WWDT0                          = ((WWDT_Regs *) WWDT0_BASE);
+static SPI_Regs                                 * const SPI1                           = ((SPI_Regs *) SPI1_BASE);
+static I2C_Regs                                 * const I2C1                           = ((I2C_Regs *) I2C1_BASE);
+static GPIO_Regs                                * const GPIOA                          = ((GPIO_Regs *) GPIOA_BASE);
+static FLASHCTL_Regs                            * const FLASHCTL                       = ((FLASHCTL_Regs *) FLASHCTL_BASE);
+static TRNG_Regs                                * const TRNG                           = ((TRNG_Regs *) TRNG_BASE);
+static RTC_Regs                                 * const RTC                            = ((RTC_Regs *) RTC_BASE);
+static SPI_Regs                                 * const SPI0                           = ((SPI_Regs *) SPI0_BASE);
+static AES_Regs                                 * const AES                            = ((AES_Regs *) AES_BASE);
+static DMA_Regs                                 * const DMA                            = ((DMA_Regs *) DMA_BASE);
+static GPTIMER_Regs                             * const TIMA0                          = ((GPTIMER_Regs *) TIMA0_BASE);
+static GPTIMER_Regs                             * const TIMA1                          = ((GPTIMER_Regs *) TIMA1_BASE);
+static UART_Regs                                * const UART3                          = ((UART_Regs *) UART3_BASE);
+static UART_Regs                                * const UART0                          = ((UART_Regs *) UART0_BASE);
+static UART_Regs                                * const UART1                          = ((UART_Regs *) UART1_BASE);
+static UART_Regs                                * const UART2                          = ((UART_Regs *) UART2_BASE);
+static WUC_Regs                                 * const WUC                            = ((WUC_Regs *) WUC_BASE);
+static FACTORYREGION_OPEN_Regs                  * const FACTORYREGION                  = ((FACTORYREGION_OPEN_Regs *) FACTORYREGION_BASE);
+static ADC12_Regs                               * const ADC0                           = ((ADC12_Regs *) ADC0_BASE);
+static ADC12_PERIPHERALREGIONSVT_Regs           * const ADC0_PERIPHERALREGIONSVT       = ((ADC12_PERIPHERALREGIONSVT_Regs *) ADC0_PERIPHERALREGIONSVT_BASE);
+static ADC12_Regs                               * const ADC1                           = ((ADC12_Regs *) ADC1_BASE);
+static ADC12_PERIPHERALREGIONSVT_Regs           * const ADC1_PERIPHERALREGIONSVT       = ((ADC12_PERIPHERALREGIONSVT_Regs *) ADC1_PERIPHERALREGIONSVT_BASE);
+static GPTIMER_Regs                             * const TIMG0                          = ((GPTIMER_Regs *) TIMG0_BASE);
+static VREF_Regs                                * const VREF                           = ((VREF_Regs *) VREF_BASE);
+static GPTIMER_Regs                             * const TIMG12                         = ((GPTIMER_Regs *) TIMG12_BASE);
+static GPTIMER_Regs                             * const TIMG6                          = ((GPTIMER_Regs *) TIMG6_BASE);
+static GPTIMER_Regs                             * const TIMG7                          = ((GPTIMER_Regs *) TIMG7_BASE);
+static GPTIMER_Regs                             * const TIMG8                          = ((GPTIMER_Regs *) TIMG8_BASE);
+static DEBUGSS_Regs                             * const DEBUGSS                        = ((DEBUGSS_Regs *) DEBUGSS_BASE);
+
+
+/******************************************************************************
+* SYS parameters                                                              *
+******************************************************************************/
+
+#define DMA_SYS_N_DMA_CHANNEL                         (7)       /* !< Number of DMA channels implemented in DMA. */
+#define DMA_SYS_N_DMA_FULL_CHANNEL                    (3)       /* !< Number of FULL-DMA channels implemented in DMA. */
+#define CRC_SYS_CRC32_ENABLE                          (1)       /* !< Parameter to exclude or include 32-bit CRC. */
+#define FLASHCTL_SYS_DATAWIDTH                        (64)      /* !< Data bit width of a single flash word. */
+#define ADC_SYS_NUM_ANALOG_CHAN                       (16)      /* !< Number of analog channels. */
+#define I2C_SYS_FENTRIES                              (8)       /* !< Number of FIFO entries */
+#define FLASHCTL_SYS_WEPROTAWIDTH                     (32)      /* !< Bit width of WEPROTA register */
+#define FLASHCTL_SYS_WEPROTBWIDTH                     (12)      /* !< Bit width of WEPROTB register */
+#define FLASHCTL_SYS_WEPROTCWIDTH                     (0)       /* !< Bit width of WEPROTC register */
+
+/******************************************************************************
+* DMA Triggers                                                                *
+******************************************************************************/
+
+/* External DMA Triggers */
+#define DMA_SOFTWARE_TRIG                             (0)
+#define DMA_GENERIC_SUB0_TRIG                         (1)
+#define DMA_GENERIC_SUB1_TRIG                         (2)
+#define DMA_AES_AES_0_TRIG                            (3)
+#define DMA_AES_AES_1_TRIG                            (4)
+#define DMA_AES_AES_2_TRIG                            (5)
+#define DMA_I2C0_TX_TRIG                              (7)
+#define DMA_I2C0_RX_TRIG                              (8)
+#define DMA_I2C1_TX_TRIG                              (9)
+#define DMA_I2C1_RX_TRIG                              (10)
+#define DMA_SPI0_RX_TRIG                              (11)
+#define DMA_SPI0_TX_TRIG                              (12)
+#define DMA_SPI1_RX_TRIG                              (13)
+#define DMA_SPI1_TX_TRIG                              (14)
+#define DMA_UART3_RX_TRIG                             (15)
+#define DMA_UART3_TX_TRIG                             (16)
+#define DMA_UART0_RX_TRIG                             (17)
+#define DMA_UART0_TX_TRIG                             (18)
+#define DMA_UART1_RX_TRIG                             (19)
+#define DMA_UART1_TX_TRIG                             (20)
+#define DMA_UART2_RX_TRIG                             (21)
+#define DMA_UART2_TX_TRIG                             (22)
+#define DMA_ADC0_EVT_GEN_BD_TRIG                      (23)
+#define DMA_ADC1_EVT_GEN_BD_TRIG                      (24)
+
+/* Internal DMA Triggers */
+#define DMA_CH_0_TRIG                                 (0)
+#define DMA_CH_1_TRIG                                 (1)
+#define DMA_CH_2_TRIG                                 (2)
+#define DMA_CH_3_TRIG                                 (3)
+#define DMA_CH_4_TRIG                                 (4)
+#define DMA_CH_5_TRIG                                 (5)
+#define DMA_CH_6_TRIG                                 (6)
+
+
+/******************************************************************************
+* IOMUX Pin Definitions                                                       *
+******************************************************************************/
+
+typedef enum IOMUX_PINCM
+{
+  IOMUX_PINCM1         = (0),
+  IOMUX_PINCM2         = (1),
+  IOMUX_PINCM3         = (2),
+  IOMUX_PINCM4         = (3),
+  IOMUX_PINCM5         = (4),
+  IOMUX_PINCM6         = (5),
+  IOMUX_PINCM7         = (6),
+  IOMUX_PINCM8         = (7),
+  IOMUX_PINCM9         = (8),
+  IOMUX_PINCM10        = (9),
+  IOMUX_PINCM11        = (10),
+  IOMUX_PINCM12        = (11),
+  IOMUX_PINCM13        = (12),
+  IOMUX_PINCM14        = (13),
+  IOMUX_PINCM15        = (14),
+  IOMUX_PINCM16        = (15),
+  IOMUX_PINCM17        = (16),
+  IOMUX_PINCM18        = (17),
+  IOMUX_PINCM19        = (18),
+  IOMUX_PINCM20        = (19),
+  IOMUX_PINCM21        = (20),
+  IOMUX_PINCM22        = (21),
+  IOMUX_PINCM23        = (22),
+  IOMUX_PINCM24        = (23),
+  IOMUX_PINCM25        = (24),
+  IOMUX_PINCM26        = (25),
+  IOMUX_PINCM27        = (26),
+  IOMUX_PINCM28        = (27),
+  IOMUX_PINCM29        = (28),
+  IOMUX_PINCM30        = (29),
+  IOMUX_PINCM31        = (30),
+  IOMUX_PINCM32        = (31),
+  IOMUX_PINCM33        = (32),
+  IOMUX_PINCM34        = (33),
+  IOMUX_PINCM35        = (34),
+  IOMUX_PINCM36        = (35),
+  IOMUX_PINCM37        = (36),
+  IOMUX_PINCM38        = (37),
+  IOMUX_PINCM39        = (38),
+  IOMUX_PINCM40        = (39),
+  IOMUX_PINCM41        = (40),
+  IOMUX_PINCM42        = (41),
+  IOMUX_PINCM43        = (42),
+  IOMUX_PINCM44        = (43),
+  IOMUX_PINCM45        = (44),
+  IOMUX_PINCM46        = (45),
+  IOMUX_PINCM47        = (46),
+  IOMUX_PINCM48        = (47),
+  IOMUX_PINCM49        = (48),
+  IOMUX_PINCM50        = (49),
+  IOMUX_PINCM51        = (50),
+  IOMUX_PINCM52        = (51),
+  IOMUX_PINCM53        = (52),
+  IOMUX_PINCM54        = (53),
+  IOMUX_PINCM55        = (54),
+  IOMUX_PINCM56        = (55),
+  IOMUX_PINCM57        = (56),
+  IOMUX_PINCM58        = (57),
+  IOMUX_PINCM59        = (58),
+  IOMUX_PINCM60        = (59),
+} IOMUX_PINCM;
+
+
+/* IOMUX_PINCM1[PF] Bits */
+#define IOMUX_PINCM1_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM1_PF_GPIOA_DIO00                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM1_PF_UART0_TX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM1_PF_I2C0_SDA                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM1_PF_TIMA0_CCP0                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM1_PF_TIMA_FAULT1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM1_PF_TIMG8_CCP1                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM1_PF_SYSCTL_FCC_IN                 ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM2[PF] Bits */
+#define IOMUX_PINCM2_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM2_PF_GPIOA_DIO01                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM2_PF_UART0_RX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM2_PF_I2C0_SCL                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM2_PF_TIMA0_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM2_PF_TIMA_FAULT2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM2_PF_TIMG8_IDX                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM2_PF_TIMG8_CCP0                    ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM3[PF] Bits */
+#define IOMUX_PINCM3_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM3_PF_GPIOA_DIO28                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM3_PF_UART0_TX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM3_PF_I2C0_SDA                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM3_PF_TIMA0_CCP3                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM3_PF_TIMA_FAULT0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM3_PF_TIMG7_CCP0                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM3_PF_TIMA1_CCP0                    ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM4[PF] Bits */
+#define IOMUX_PINCM4_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM4_PF_GPIOA_DIO29                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM4_PF_I2C1_SCL                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM4_PF_UART2_RTS                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM4_PF_TIMG8_CCP0                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM4_PF_TIMG6_CCP0                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM5[PF] Bits */
+#define IOMUX_PINCM5_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM5_PF_GPIOA_DIO30                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM5_PF_I2C1_SDA                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM5_PF_UART2_CTS                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM5_PF_TIMG8_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM5_PF_TIMG6_CCP1                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM6[PF] Bits */
+#define IOMUX_PINCM6_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM6_PF_GPIOA_DIO31                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM6_PF_UART0_RX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM6_PF_I2C0_SCL                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM6_PF_TIMA0_CCP3_CMPL               ((uint32_t)0X00000004)
+#define IOMUX_PINCM6_PF_TIMG12_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM6_PF_SYSCTL_CLK_OUT                ((uint32_t)0X00000006)
+#define IOMUX_PINCM6_PF_TIMG7_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM6_PF_TIMA1_CCP1                    ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM7[PF] Bits */
+#define IOMUX_PINCM7_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM7_PF_GPIOA_DIO02                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM7_PF_TIMG8_CCP1                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM7_PF_SPI0_CS0                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM7_PF_TIMG7_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM7_PF_SPI1_CS0                      ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM8[PF] Bits */
+#define IOMUX_PINCM8_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM8_PF_GPIOA_DIO03                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM8_PF_TIMG8_CCP0                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM8_PF_SPI0_CS1_POCI1                ((uint32_t)0X00000003)
+#define IOMUX_PINCM8_PF_UART2_CTS                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM8_PF_TIMA0_CCP2                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM8_PF_COMP1_OUT                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM8_PF_TIMG7_CCP0                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM8_PF_TIMA0_CCP1                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM8_PF_I2C1_SDA                      ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM9[PF] Bits */
+#define IOMUX_PINCM9_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM9_PF_GPIOA_DIO04                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM9_PF_TIMG8_CCP1                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM9_PF_SPI0_POCI                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM9_PF_UART2_RTS                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM9_PF_TIMA0_CCP3                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM9_PF_SYSCTL_LFCLKIN                ((uint32_t)0X00000006)
+#define IOMUX_PINCM9_PF_TIMG7_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM9_PF_TIMA0_CCP1_CMPL               ((uint32_t)0X00000008)
+#define IOMUX_PINCM9_PF_I2C1_SCL                      ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM10[PF] Bits */
+#define IOMUX_PINCM10_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM10_PF_GPIOA_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM10_PF_TIMG8_CCP0                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM10_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM10_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM10_PF_TIMG0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM10_PF_TIMG6_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM10_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM11[PF] Bits */
+#define IOMUX_PINCM11_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM11_PF_GPIOA_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM11_PF_TIMG8_CCP1                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM11_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM11_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM11_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM11_PF_SYSCTL_HFCLKIN               ((uint32_t)0X00000006)
+#define IOMUX_PINCM11_PF_TIMG6_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM11_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM12[PF] Bits */
+#define IOMUX_PINCM12_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM12_PF_GPIOB_DIO00                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM12_PF_UART0_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM12_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM12_PF_TIMA1_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM12_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM13[PF] Bits */
+#define IOMUX_PINCM13_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM13_PF_GPIOB_DIO01                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM13_PF_UART0_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM13_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM13_PF_TIMA1_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM13_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM14[PF] Bits */
+#define IOMUX_PINCM14_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM14_PF_GPIOA_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM14_PF_COMP0_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM14_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000003)
+#define IOMUX_PINCM14_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM14_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM14_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM14_PF_TIMG7_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM14_PF_TIMA0_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM15[PF] Bits */
+#define IOMUX_PINCM15_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM15_PF_GPIOB_DIO02                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM15_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM15_PF_UART2_CTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM15_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM15_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM15_PF_UART1_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM15_PF_TIMG6_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM15_PF_TIMA1_CCP0                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM16[PF] Bits */
+#define IOMUX_PINCM16_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM16_PF_GPIOB_DIO03                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM16_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM16_PF_UART2_RTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM16_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM16_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM16_PF_UART1_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM16_PF_TIMG6_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM16_PF_TIMA1_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM17[PF] Bits */
+#define IOMUX_PINCM17_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM17_PF_GPIOB_DIO04                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM17_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM17_PF_UART3_CTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM17_PF_TIMA1_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM17_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM17_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM18[PF] Bits */
+#define IOMUX_PINCM18_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM18_PF_GPIOB_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM18_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM18_PF_UART3_RTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM18_PF_TIMA1_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM18_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM18_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM19[PF] Bits */
+#define IOMUX_PINCM19_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM19_PF_GPIOA_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM19_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM19_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM19_PF_UART0_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM19_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM19_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM20[PF] Bits */
+#define IOMUX_PINCM20_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM20_PF_GPIOA_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM20_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM20_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM20_PF_UART0_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM20_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM20_PF_RTC_RTC_OUT                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM20_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM20_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000008)
+#define IOMUX_PINCM20_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM21[PF] Bits */
+#define IOMUX_PINCM21_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM21_PF_GPIOA_DIO10                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM21_PF_UART0_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM21_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM21_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM21_PF_TIMA1_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM21_PF_TIMG12_CCP0                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM21_PF_TIMA0_CCP2                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM21_PF_I2C1_SDA                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM21_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM22[PF] Bits */
+#define IOMUX_PINCM22_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM22_PF_GPIOA_DIO11                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM22_PF_UART0_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM22_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM22_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM22_PF_TIMA1_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM22_PF_COMP0_OUT                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM22_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM22_PF_I2C1_SCL                     ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM23[PF] Bits */
+#define IOMUX_PINCM23_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM23_PF_GPIOB_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM23_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM23_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM23_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000004)
+#define IOMUX_PINCM23_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM23_PF_UART2_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM23_PF_TIMG6_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM23_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM24[PF] Bits */
+#define IOMUX_PINCM24_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM24_PF_GPIOB_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM24_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM24_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM24_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000004)
+#define IOMUX_PINCM24_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM24_PF_UART2_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM24_PF_TIMG6_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM24_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM25[PF] Bits */
+#define IOMUX_PINCM25_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM25_PF_GPIOB_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM25_PF_UART1_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM25_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM25_PF_TIMA0_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM25_PF_COMP1_OUT                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM26[PF] Bits */
+#define IOMUX_PINCM26_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM26_PF_GPIOB_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM26_PF_UART1_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM26_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM26_PF_TIMA0_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM26_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM27[PF] Bits */
+#define IOMUX_PINCM27_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM27_PF_GPIOB_DIO10                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM27_PF_TIMG0_CCP0                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM27_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM27_PF_COMP1_OUT                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM27_PF_TIMG6_CCP0                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM28[PF] Bits */
+#define IOMUX_PINCM28_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM28_PF_GPIOB_DIO11                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM28_PF_TIMG0_CCP1                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM28_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM28_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000004)
+#define IOMUX_PINCM28_PF_TIMG6_CCP1                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM29[PF] Bits */
+#define IOMUX_PINCM29_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM29_PF_GPIOB_DIO12                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM29_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM29_PF_TIMA0_CCP2                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM29_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM29_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM30[PF] Bits */
+#define IOMUX_PINCM30_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM30_PF_GPIOB_DIO13                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM30_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM30_PF_TIMA0_CCP3                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM30_PF_TIMG12_CCP0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM30_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM31[PF] Bits */
+#define IOMUX_PINCM31_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM31_PF_GPIOB_DIO14                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM31_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000002)
+#define IOMUX_PINCM31_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM31_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000004)
+#define IOMUX_PINCM31_PF_TIMG12_CCP1                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM31_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM31_PF_TIMA0_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM32[PF] Bits */
+#define IOMUX_PINCM32_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM32_PF_GPIOB_DIO15                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM32_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM32_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM32_PF_UART3_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM32_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM32_PF_TIMG7_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM33[PF] Bits */
+#define IOMUX_PINCM33_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM33_PF_GPIOB_DIO16                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM33_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM33_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM33_PF_UART3_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM33_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM33_PF_TIMG7_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM34[PF] Bits */
+#define IOMUX_PINCM34_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM34_PF_GPIOA_DIO12                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM34_PF_UART3_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM34_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM34_PF_TIMG0_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM34_PF_CANFD0_CANTX                 ((uint32_t)0X00000005)
+#define IOMUX_PINCM34_PF_TIMA0_CCP3                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM34_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM35[PF] Bits */
+#define IOMUX_PINCM35_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM35_PF_GPIOA_DIO13                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM35_PF_UART3_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM35_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM35_PF_UART3_RX                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM35_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM35_PF_CANFD0_CANRX                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM35_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM36[PF] Bits */
+#define IOMUX_PINCM36_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM36_PF_GPIOA_DIO14                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM36_PF_UART0_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM36_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM36_PF_UART3_TX                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM36_PF_TIMG12_CCP0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM36_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM37[PF] Bits */
+#define IOMUX_PINCM37_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM37_PF_GPIOA_DIO15                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM37_PF_UART0_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM37_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM37_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM37_PF_TIMA1_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM37_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM37_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM37_PF_TIMA0_CCP2                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM38[PF] Bits */
+#define IOMUX_PINCM38_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM38_PF_GPIOA_DIO16                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM38_PF_COMP2_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM38_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM38_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM38_PF_TIMA1_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM38_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM38_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM38_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM39[PF] Bits */
+#define IOMUX_PINCM39_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM39_PF_GPIOA_DIO17                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM39_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM39_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM39_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM39_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM39_PF_TIMG7_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM39_PF_TIMA1_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM40[PF] Bits */
+#define IOMUX_PINCM40_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM40_PF_GPIOA_DIO18                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM40_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM40_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM40_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM40_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM40_PF_TIMG7_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM40_PF_TIMA1_CCP1                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM41[PF] Bits */
+#define IOMUX_PINCM41_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM41_PF_GPIOA_DIO19                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM41_PF_DEBUGSS_SWDIO                ((uint32_t)0X00000002)
+
+/* IOMUX_PINCM42[PF] Bits */
+#define IOMUX_PINCM42_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM42_PF_GPIOA_DIO20                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM42_PF_DEBUGSS_SWCLK                ((uint32_t)0X00000002)
+
+/* IOMUX_PINCM43[PF] Bits */
+#define IOMUX_PINCM43_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM43_PF_GPIOB_DIO17                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM43_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM43_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM43_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000004)
+#define IOMUX_PINCM43_PF_TIMA1_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM43_PF_TIMA0_CCP2                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM44[PF] Bits */
+#define IOMUX_PINCM44_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM44_PF_GPIOB_DIO18                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM44_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM44_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM44_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000004)
+#define IOMUX_PINCM44_PF_TIMA1_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM44_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM45[PF] Bits */
+#define IOMUX_PINCM45_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM45_PF_GPIOB_DIO19                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM45_PF_COMP2_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM45_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM45_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM45_PF_UART0_CTS                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM45_PF_TIMG7_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM46[PF] Bits */
+#define IOMUX_PINCM46_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM46_PF_GPIOA_DIO21                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM46_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM46_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM46_PF_UART1_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM46_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM46_PF_TIMG6_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM47[PF] Bits */
+#define IOMUX_PINCM47_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM47_PF_GPIOA_DIO22                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM47_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM47_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM47_PF_UART1_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM47_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM47_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+#define IOMUX_PINCM47_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM47_PF_TIMG6_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM48[PF] Bits */
+#define IOMUX_PINCM48_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM48_PF_GPIOB_DIO20                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM48_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000002)
+#define IOMUX_PINCM48_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM48_PF_TIMA0_CCP2                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM48_PF_TIMG12_CCP0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM48_PF_TIMA_FAULT1                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM48_PF_TIMA0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM48_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM49[PF] Bits */
+#define IOMUX_PINCM49_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM49_PF_GPIOB_DIO21                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM49_PF_SPI1_POCI                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM49_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+
+/* IOMUX_PINCM50[PF] Bits */
+#define IOMUX_PINCM50_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM50_PF_GPIOB_DIO22                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM50_PF_SPI1_PICO                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM50_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+
+/* IOMUX_PINCM51[PF] Bits */
+#define IOMUX_PINCM51_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM51_PF_GPIOB_DIO23                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM51_PF_SPI1_SCLK                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM51_PF_COMP0_OUT                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM51_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+
+/* IOMUX_PINCM52[PF] Bits */
+#define IOMUX_PINCM52_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM52_PF_GPIOB_DIO24                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM52_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000002)
+#define IOMUX_PINCM52_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM52_PF_TIMA0_CCP3                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM52_PF_TIMG12_CCP1                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM52_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM52_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM53[PF] Bits */
+#define IOMUX_PINCM53_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM53_PF_GPIOA_DIO23                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM53_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM53_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM53_PF_TIMA0_CCP3                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM53_PF_TIMG0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM53_PF_UART3_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM53_PF_TIMG7_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM53_PF_TIMG8_CCP0                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM54[PF] Bits */
+#define IOMUX_PINCM54_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM54_PF_GPIOA_DIO24                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM54_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM54_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM54_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000004)
+#define IOMUX_PINCM54_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM54_PF_UART3_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM54_PF_TIMG7_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM54_PF_TIMA1_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM55[PF] Bits */
+#define IOMUX_PINCM55_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM55_PF_GPIOA_DIO25                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM55_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM55_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM55_PF_TIMG12_CCP1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM55_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM55_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM56[PF] Bits */
+#define IOMUX_PINCM56_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM56_PF_GPIOB_DIO25                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM56_PF_UART0_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM56_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM56_PF_TIMA_FAULT2                  ((uint32_t)0X00000004)
+
+/* IOMUX_PINCM57[PF] Bits */
+#define IOMUX_PINCM57_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM57_PF_GPIOB_DIO26                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM57_PF_UART0_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM57_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM57_PF_TIMA0_CCP3                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM57_PF_TIMG6_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM57_PF_TIMA1_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM58[PF] Bits */
+#define IOMUX_PINCM58_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM58_PF_GPIOB_DIO27                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM58_PF_COMP2_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM58_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM58_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000004)
+#define IOMUX_PINCM58_PF_TIMG6_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM58_PF_TIMA1_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM59[PF] Bits */
+#define IOMUX_PINCM59_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM59_PF_GPIOA_DIO26                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM59_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM59_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM59_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM59_PF_TIMA_FAULT0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM59_PF_CANFD0_CANTX                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM59_PF_TIMG7_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM60[PF] Bits */
+#define IOMUX_PINCM60_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM60_PF_GPIOA_DIO27                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM60_PF_RTC_RTC_OUT                  ((uint32_t)0X00000002)
+#define IOMUX_PINCM60_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM60_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM60_PF_TIMA_FAULT2                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM60_PF_CANFD0_CANRX                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM60_PF_TIMG7_CCP1                   ((uint32_t)0X00000007)
+
+
+#if   defined (__CC_ARM)
+  #pragma pop
+#elif defined (__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+  #pragma clang diagnostic pop
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning restore
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+/*@}*/ /* end of group MSPM0G310X_PeripheralDecl */
+
+/*@}*/ /* end of group MSPM0G310X_Definitions */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_m0p_mspm0g310x__include */
+

--- a/mspm0/source/ti/devices/msp/m0p/mspm0g350x.h
+++ b/mspm0/source/ti/devices/msp/m0p/mspm0g350x.h
@@ -1,0 +1,1067 @@
+/*****************************************************************************
+
+  Copyright (C) 2020 Texas Instruments Incorporated - http://www.ti.com/ 
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+   Redistributions of source code must retain the above copyright 
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the   
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_m0p_mspm0g350x__include
+#define ti_devices_msp_m0p_mspm0g350x__include
+
+/* Filename: mspm0g350x.h */
+/* Revised: 2023-02-03 08:37:25 */
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** @addtogroup MSPM0G350X_Definitions MSPM0G350X Definitions
+  This file defines all structures and symbols for MSPM0G350X
+  @{
+*/
+
+/** @addtogroup MSPM0G350X_Device_Family MSPM0G350X Device Family Definitions
+  MSPM0G350X device family definitions
+  @{
+*/
+#define __MSPM0G__
+/*@}*/ /* end of group MSPM0G350X_Device_Family */
+
+/** @addtogroup MSPM0G350X_CMSIS Device CMSIS Definitions
+  Configuration of the Processor and Core Peripherals
+  @{
+*/
+/******************************************************************************
+* Interrupt Definitions                                                       *
+******************************************************************************/
+typedef enum IRQn
+{
+  NonMaskableInt_IRQn         = -14,    /* 2  Non Maskable Interrupt */
+  HardFault_IRQn              = -13,    /* 3  Hard Fault Interrupt */
+  SVCall_IRQn                 = -5,     /* 11 SV Call Interrupt */
+  PendSV_IRQn                 = -2,     /* 14 Pend SV Interrupt */
+  SysTick_IRQn                = -1,     /* 15 System Tick Interrupt */
+  SYSCTL_INT_IRQn             = 0,      /* 16 SYSCTL_INT Interrupt */
+  WWDT1_INT_IRQn              = 0,      /* 16 WWDT1_INT Interrupt */
+  WWDT0_INT_IRQn              = 0,      /* 16 WWDT0_INT Interrupt */
+  FLASHCTL_INT_IRQn           = 0,      /* 16 FLASHCTL_INT Interrupt */
+  DEBUGSS_INT_IRQn            = 0,      /* 16 DEBUGSS_INT Interrupt */
+  GPIOB_INT_IRQn              = 1,      /* 17 GPIOB_INT Interrupt */
+  GPIOA_INT_IRQn              = 1,      /* 17 GPIOA_INT Interrupt */
+  TRNG_INT_IRQn               = 1,      /* 17 TRNG_INT Interrupt */
+  COMP0_INT_IRQn              = 1,      /* 17 COMP0_INT Interrupt */
+  COMP1_INT_IRQn              = 1,      /* 17 COMP1_INT Interrupt */
+  COMP2_INT_IRQn              = 1,      /* 17 COMP2_INT Interrupt */
+  TIMG8_INT_IRQn              = 2,      /* 18 TIMG8_INT Interrupt */
+  UART3_INT_IRQn              = 3,      /* 19 UART3_INT Interrupt */
+  ADC0_INT_IRQn               = 4,      /* 20 ADC0_INT Interrupt */
+  ADC1_INT_IRQn               = 5,      /* 21 ADC1_INT Interrupt */
+  CANFD0_INT_IRQn             = 6,      /* 22 CANFD0_INT Interrupt */
+  DAC0_INT_IRQn               = 7,      /* 23 DAC0_INT Interrupt */
+  SPI0_INT_IRQn               = 9,      /* 25 SPI0_INT Interrupt */
+  SPI1_INT_IRQn               = 10,     /* 26 SPI1_INT Interrupt */
+  UART1_INT_IRQn              = 13,     /* 29 UART1_INT Interrupt */
+  UART2_INT_IRQn              = 14,     /* 30 UART2_INT Interrupt */
+  UART0_INT_IRQn              = 15,     /* 31 UART0_INT Interrupt */
+  TIMG0_INT_IRQn              = 16,     /* 32 TIMG0_INT Interrupt */
+  TIMG6_INT_IRQn              = 17,     /* 33 TIMG6_INT Interrupt */
+  TIMA0_INT_IRQn              = 18,     /* 34 TIMA0_INT Interrupt */
+  TIMA1_INT_IRQn              = 19,     /* 35 TIMA1_INT Interrupt */
+  TIMG7_INT_IRQn              = 20,     /* 36 TIMG7_INT Interrupt */
+  TIMG12_INT_IRQn             = 21,     /* 37 TIMG12_INT Interrupt */
+  I2C0_INT_IRQn               = 24,     /* 40 I2C0_INT Interrupt */
+  I2C1_INT_IRQn               = 25,     /* 41 I2C1_INT Interrupt */
+  AES_INT_IRQn                = 28,     /* 44 AES_INT Interrupt */
+  RTC_INT_IRQn                = 30,     /* 46 RTC_INT Interrupt */
+  DMA_INT_IRQn                = 31,     /* 47 DMA_INT Interrupt */
+} IRQn_Type;
+
+#define NonMaskableInt_VECn     2     /* Non Maskable Interrupt */
+#define HardFault_VECn          3     /* Hard Fault Interrupt */
+#define SVCall_VECn             11    /* SV Call Interrupt */
+#define PendSV_VECn             14    /* Pend SV Interrupt */
+#define SysTick_VECn            15    /* System Tick Interrupt */
+#define SYSCTL_INT_VECn         16    /* SYSCTL_INT Interrupt */
+#define WWDT1_INT_VECn          16    /* WWDT1_INT Interrupt */
+#define WWDT0_INT_VECn          16    /* WWDT0_INT Interrupt */
+#define FLASHCTL_INT_VECn       16    /* FLASHCTL_INT Interrupt */
+#define DEBUGSS_INT_VECn        16    /* DEBUGSS_INT Interrupt */
+#define GPIOB_INT_VECn          17    /* GPIOB_INT Interrupt */
+#define GPIOA_INT_VECn          17    /* GPIOA_INT Interrupt */
+#define TRNG_INT_VECn           17    /* TRNG_INT Interrupt */
+#define COMP0_INT_VECn          17    /* COMP0_INT Interrupt */
+#define COMP1_INT_VECn          17    /* COMP1_INT Interrupt */
+#define COMP2_INT_VECn          17    /* COMP2_INT Interrupt */
+#define TIMG8_INT_VECn          18    /* TIMG8_INT Interrupt */
+#define UART3_INT_VECn          19    /* UART3_INT Interrupt */
+#define ADC0_INT_VECn           20    /* ADC0_INT Interrupt */
+#define ADC1_INT_VECn           21    /* ADC1_INT Interrupt */
+#define CANFD0_INT_VECn         22    /* CANFD0_INT Interrupt */
+#define DAC0_INT_VECn           23    /* DAC0_INT Interrupt */
+#define SPI0_INT_VECn           25    /* SPI0_INT Interrupt */
+#define SPI1_INT_VECn           26    /* SPI1_INT Interrupt */
+#define UART1_INT_VECn          29    /* UART1_INT Interrupt */
+#define UART2_INT_VECn          30    /* UART2_INT Interrupt */
+#define UART0_INT_VECn          31    /* UART0_INT Interrupt */
+#define TIMG0_INT_VECn          32    /* TIMG0_INT Interrupt */
+#define TIMG6_INT_VECn          33    /* TIMG6_INT Interrupt */
+#define TIMA0_INT_VECn          34    /* TIMA0_INT Interrupt */
+#define TIMA1_INT_VECn          35    /* TIMA1_INT Interrupt */
+#define TIMG7_INT_VECn          36    /* TIMG7_INT Interrupt */
+#define TIMG12_INT_VECn         37    /* TIMG12_INT Interrupt */
+#define I2C0_INT_VECn           40    /* I2C0_INT Interrupt */
+#define I2C1_INT_VECn           41    /* I2C1_INT Interrupt */
+#define AES_INT_VECn            44    /* AES_INT Interrupt */
+#define RTC_INT_VECn            46    /* RTC_INT Interrupt */
+#define DMA_INT_VECn            47    /* DMA_INT Interrupt */
+
+
+/******************************************************************************
+* Ignore unused variables                                                     *
+******************************************************************************/
+
+#if   defined (__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined (__ICCARM__)
+  #pragma language=extended
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wc11-extensions"
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning 586
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+/******************************************************************************
+* Processor and Core Peripheral Section                                       *
+******************************************************************************/
+
+#define __CM0PLUS_REV           0x0001U    /* Core revision r0p1 */
+#define __MPU_PRESENT           0x0001U    /* MPU present */
+#define __VTOR_PRESENT          0x0001U    /* VTOR present */
+#define __NVIC_PRIO_BITS        0x0002U    /* Number of bits used for Priority Levels */
+#define __Vendor_SysTickConfig  0x0000U    /* Set to 1 if different SysTick Config is used */
+
+#include "core_cm0plus.h"                  /* Processor and core peripherals */
+
+/******************************************************************************
+* Peripheral headers                                                          *
+******************************************************************************/
+/** @addtogroup MSPM0G350X_Peripherals MSPM0G350X Peripherals
+  MSPM0G350X Peripheral registers structures
+  @{
+*/
+
+#include <ti/devices/msp/peripherals/hw_adc12.h>
+#include <ti/devices/msp/peripherals/hw_aes.h>
+#include <ti/devices/msp/peripherals/hw_comp.h>
+#include <ti/devices/msp/peripherals/hw_crc.h>
+#include <ti/devices/msp/peripherals/hw_dac12.h>
+#include <ti/devices/msp/peripherals/hw_dma.h>
+#include <ti/devices/msp/peripherals/hw_flashctl.h>
+#include <ti/devices/msp/peripherals/hw_gpio.h>
+#include <ti/devices/msp/peripherals/hw_gptimer.h>
+#include <ti/devices/msp/peripherals/hw_i2c.h>
+#include <ti/devices/msp/peripherals/hw_iomux.h>
+#include <ti/devices/msp/peripherals/hw_mathacl.h>
+#include <ti/devices/msp/peripherals/hw_mcan.h>
+#include <ti/devices/msp/peripherals/hw_oa.h>
+#include <ti/devices/msp/peripherals/hw_rtc.h>
+#include <ti/devices/msp/peripherals/hw_spi.h>
+#include <ti/devices/msp/peripherals/hw_trng.h>
+#include <ti/devices/msp/peripherals/hw_uart.h>
+#include <ti/devices/msp/peripherals/hw_vref.h>
+#include <ti/devices/msp/peripherals/hw_wuc.h>
+#include <ti/devices/msp/peripherals/hw_wwdt.h>
+#include <ti/devices/msp/peripherals/m0p/hw_factoryregion.h>
+#include <ti/devices/msp/peripherals/m0p/hw_cpuss.h>
+#include <ti/devices/msp/peripherals/m0p/hw_debugss.h>
+#include <ti/devices/msp/peripherals/m0p/hw_sysctl.h>
+
+#define __MSPM0_HAS_ADC12__
+#define __MSPM0_HAS_AES__
+#define __MSPM0_HAS_COMP__
+#define __MSPM0_HAS_CRC__
+#define __MSPM0_HAS_DAC12__
+#define __MSPM0_HAS_GPAMP__
+#define __MSPM0_HAS_GPIO__
+#define __MSPM0_HAS_TIMER_A__
+#define __MSPM0_HAS_TIMER_G__
+#define __MSPM0_HAS_I2C__
+#define __MSPM0_HAS_MATHACL__
+#define __MSPM0_HAS_MCAN__
+#define __MSPM0_HAS_OA__
+#define __MSPM0_HAS_RTC__
+#define __MSPM0_HAS_SPI__
+#define __MSPM0_HAS_TRNG__
+#define __MSPM0_HAS_UART_EXTD__
+#define __MSPM0_HAS_UART_MAIN__
+#define __MSPM0_HAS_VREF__
+#define __MSPM0_HAS_WWDT__
+
+#define __MSPM0_HAS_ECC__
+
+/*@}*/ /* end of group MSPM0G350X_Peripherals */
+
+/******************************************************************************
+* Device and peripheral memory map                                            *
+******************************************************************************/
+/** @addtogroup MSPM0G350X_MemoryMap MSPM0G350X Memory Mapping
+  @{
+*/
+
+#define I2C0_BASE                      (0x400F0000U)     /*!< Base address of module I2C0 */
+#define SYSCTL_BASE                    (0x400AF000U)     /*!< Base address of module SYSCTL */
+#define WWDT1_BASE                     (0x40082000U)     /*!< Base address of module WWDT1 */
+#define CPUSS_BASE                     (0x40400000U)     /*!< Base address of module CPUSS */
+#define CANFD0_BASE                    (0x40508000U)     /*!< Base address of module CANFD0 */
+#define CANFD0_SRAM_BASE               (0x40508000U)     /*!< Base address of memory CANFD0_SRAM */
+#define IOMUX_BASE                     (0x40428000U)     /*!< Base address of module IOMUX */
+#define GPIOB_BASE                     (0x400A2000U)     /*!< Base address of module GPIOB */
+#define CRC_BASE                       (0x40440000U)     /*!< Base address of module CRC */
+#define WWDT0_BASE                     (0x40080000U)     /*!< Base address of module WWDT0 */
+#define SPI1_BASE                      (0x4046A000U)     /*!< Base address of module SPI1 */
+#define DAC0_BASE                      (0x40018000U)     /*!< Base address of module DAC0 */
+#define I2C1_BASE                      (0x400F2000U)     /*!< Base address of module I2C1 */
+#define GPIOA_BASE                     (0x400A0000U)     /*!< Base address of module GPIOA */
+#define FLASHCTL_BASE                  (0x400CD000U)     /*!< Base address of module FLASHCTL */
+#define TRNG_BASE                      (0x40444000U)     /*!< Base address of module TRNG */
+#define RTC_BASE                       (0x40094000U)     /*!< Base address of module RTC */
+#define SPI0_BASE                      (0x40468000U)     /*!< Base address of module SPI0 */
+#define AES_BASE                       (0x40442000U)     /*!< Base address of module AES */
+#define DMA_BASE                       (0x4042A000U)     /*!< Base address of module DMA */
+#define OPA0_BASE                      (0x40020000U)     /*!< Base address of module OPA0 */
+#define OPA1_BASE                      (0x40022000U)     /*!< Base address of module OPA1 */
+#define TIMA0_BASE                     (0x40860000U)     /*!< Base address of module TIMA0 */
+#define TIMA1_BASE                     (0x40862000U)     /*!< Base address of module TIMA1 */
+#define UART3_BASE                     (0x40500000U)     /*!< Base address of module UART3 */
+#define UART0_BASE                     (0x40108000U)     /*!< Base address of module UART0 */
+#define UART1_BASE                     (0x40100000U)     /*!< Base address of module UART1 */
+#define UART2_BASE                     (0x40102000U)     /*!< Base address of module UART2 */
+#define COMP0_BASE                     (0x40008000U)     /*!< Base address of module COMP0 */
+#define COMP1_BASE                     (0x4000A000U)     /*!< Base address of module COMP1 */
+#define COMP2_BASE                     (0x4000C000U)     /*!< Base address of module COMP2 */
+#define WUC_BASE                       (0x40424000U)     /*!< Base address of module WUC */
+#define FACTORYREGION_BASE             (0x41C40000U)     /*!< Base address of module FACTORYREGION */
+#define ADC0_BASE                      (0x40000000U)     /*!< Base address of module ADC0 */
+#define ADC0_PERIPHERALREGIONSVT_BASE  (0x40556000U)     /*!< Base address of module ADC0_PERIPHERALREGIONSVT */
+#define ADC1_BASE                      (0x40002000U)     /*!< Base address of module ADC1 */
+#define ADC1_PERIPHERALREGIONSVT_BASE  (0x40558000U)     /*!< Base address of module ADC1_PERIPHERALREGIONSVT */
+#define TIMG0_BASE                     (0x40084000U)     /*!< Base address of module TIMG0 */
+#define VREF_BASE                      (0x40030000U)     /*!< Base address of module VREF */
+#define MATHACL_BASE                   (0x40410000U)     /*!< Base address of module MATHACL */
+#define TIMG12_BASE                    (0x40870000U)     /*!< Base address of module TIMG12 */
+#define TIMG6_BASE                     (0x40868000U)     /*!< Base address of module TIMG6 */
+#define TIMG7_BASE                     (0x4086A000U)     /*!< Base address of module TIMG7 */
+#define TIMG8_BASE                     (0x40090000U)     /*!< Base address of module TIMG8 */
+#define DEBUGSS_BASE                   (0x400C7000U)     /*!< Base address of module DEBUGSS */
+
+/*@}*/ /* end of group MSPM0G350X_MemoryMap */
+
+/******************************************************************************
+* Peripheral declarations                                                     *
+******************************************************************************/
+/** @addtogroup MSPM0G350X_PeripheralDecl MSPM0G350X Peripheral Declaration
+  @{
+*/
+
+static I2C_Regs                                 * const I2C0                           = ((I2C_Regs *) I2C0_BASE);
+static SYSCTL_Regs                              * const SYSCTL                         = ((SYSCTL_Regs *) SYSCTL_BASE);
+static WWDT_Regs                                * const WWDT1                          = ((WWDT_Regs *) WWDT1_BASE);
+static CPUSS_Regs                               * const CPUSS                          = ((CPUSS_Regs *) CPUSS_BASE);
+static MCAN_Regs                                * const CANFD0                         = ((MCAN_Regs *) CANFD0_BASE);
+static IOMUX_Regs                               * const IOMUX                          = ((IOMUX_Regs *) IOMUX_BASE);
+static GPIO_Regs                                * const GPIOB                          = ((GPIO_Regs *) GPIOB_BASE);
+static CRC_Regs                                 * const CRC                            = ((CRC_Regs *) CRC_BASE);
+static WWDT_Regs                                * const WWDT0                          = ((WWDT_Regs *) WWDT0_BASE);
+static SPI_Regs                                 * const SPI1                           = ((SPI_Regs *) SPI1_BASE);
+static DAC12_Regs                               * const DAC0                           = ((DAC12_Regs *) DAC0_BASE);
+static I2C_Regs                                 * const I2C1                           = ((I2C_Regs *) I2C1_BASE);
+static GPIO_Regs                                * const GPIOA                          = ((GPIO_Regs *) GPIOA_BASE);
+static FLASHCTL_Regs                            * const FLASHCTL                       = ((FLASHCTL_Regs *) FLASHCTL_BASE);
+static TRNG_Regs                                * const TRNG                           = ((TRNG_Regs *) TRNG_BASE);
+static RTC_Regs                                 * const RTC                            = ((RTC_Regs *) RTC_BASE);
+static SPI_Regs                                 * const SPI0                           = ((SPI_Regs *) SPI0_BASE);
+static AES_Regs                                 * const AES                            = ((AES_Regs *) AES_BASE);
+static DMA_Regs                                 * const DMA                            = ((DMA_Regs *) DMA_BASE);
+static OA_Regs                                  * const OPA0                           = ((OA_Regs *) OPA0_BASE);
+static OA_Regs                                  * const OPA1                           = ((OA_Regs *) OPA1_BASE);
+static GPTIMER_Regs                             * const TIMA0                          = ((GPTIMER_Regs *) TIMA0_BASE);
+static GPTIMER_Regs                             * const TIMA1                          = ((GPTIMER_Regs *) TIMA1_BASE);
+static UART_Regs                                * const UART3                          = ((UART_Regs *) UART3_BASE);
+static UART_Regs                                * const UART0                          = ((UART_Regs *) UART0_BASE);
+static UART_Regs                                * const UART1                          = ((UART_Regs *) UART1_BASE);
+static UART_Regs                                * const UART2                          = ((UART_Regs *) UART2_BASE);
+static COMP_Regs                                * const COMP0                          = ((COMP_Regs *) COMP0_BASE);
+static COMP_Regs                                * const COMP1                          = ((COMP_Regs *) COMP1_BASE);
+static COMP_Regs                                * const COMP2                          = ((COMP_Regs *) COMP2_BASE);
+static WUC_Regs                                 * const WUC                            = ((WUC_Regs *) WUC_BASE);
+static FACTORYREGION_OPEN_Regs                  * const FACTORYREGION                  = ((FACTORYREGION_OPEN_Regs *) FACTORYREGION_BASE);
+static ADC12_Regs                               * const ADC0                           = ((ADC12_Regs *) ADC0_BASE);
+static ADC12_PERIPHERALREGIONSVT_Regs           * const ADC0_PERIPHERALREGIONSVT       = ((ADC12_PERIPHERALREGIONSVT_Regs *) ADC0_PERIPHERALREGIONSVT_BASE);
+static ADC12_Regs                               * const ADC1                           = ((ADC12_Regs *) ADC1_BASE);
+static ADC12_PERIPHERALREGIONSVT_Regs           * const ADC1_PERIPHERALREGIONSVT       = ((ADC12_PERIPHERALREGIONSVT_Regs *) ADC1_PERIPHERALREGIONSVT_BASE);
+static GPTIMER_Regs                             * const TIMG0                          = ((GPTIMER_Regs *) TIMG0_BASE);
+static VREF_Regs                                * const VREF                           = ((VREF_Regs *) VREF_BASE);
+static MATHACL_Regs                             * const MATHACL                        = ((MATHACL_Regs *) MATHACL_BASE);
+static GPTIMER_Regs                             * const TIMG12                         = ((GPTIMER_Regs *) TIMG12_BASE);
+static GPTIMER_Regs                             * const TIMG6                          = ((GPTIMER_Regs *) TIMG6_BASE);
+static GPTIMER_Regs                             * const TIMG7                          = ((GPTIMER_Regs *) TIMG7_BASE);
+static GPTIMER_Regs                             * const TIMG8                          = ((GPTIMER_Regs *) TIMG8_BASE);
+static DEBUGSS_Regs                             * const DEBUGSS                        = ((DEBUGSS_Regs *) DEBUGSS_BASE);
+
+/******************************************************************************
+* SYS parameters                                                              *
+******************************************************************************/
+
+#define DMA_SYS_N_DMA_CHANNEL                         (7)       /* !< Number of DMA channels implemented in DMA. */
+#define DMA_SYS_N_DMA_FULL_CHANNEL                    (3)       /* !< Number of FULL-DMA channels implemented in DMA. */
+#define CRC_SYS_CRC32_ENABLE                          (1)       /* !< Parameter to exclude or include 32-bit CRC. */
+#define FLASHCTL_SYS_DATAWIDTH                        (64)      /* !< Data bit width of a single flash word. */
+#define ADC_SYS_NUM_ANALOG_CHAN                       (16)      /* !< Number of analog channels. */
+#define I2C_SYS_FENTRIES                              (8)       /* !< Number of FIFO entries */
+#define FLASHCTL_SYS_WEPROTAWIDTH                     (32)      /* !< Bit width of WEPROTA register */
+#define FLASHCTL_SYS_WEPROTBWIDTH                     (12)      /* !< Bit width of WEPROTB register */
+#define FLASHCTL_SYS_WEPROTCWIDTH                     (0)       /* !< Bit width of WEPROTC register */
+
+/******************************************************************************
+* DMA Triggers                                                                *
+******************************************************************************/
+
+/* External DMA Triggers */
+#define DMA_SOFTWARE_TRIG                             (0)
+#define DMA_GENERIC_SUB0_TRIG                         (1)
+#define DMA_GENERIC_SUB1_TRIG                         (2)
+#define DMA_AES_AES_0_TRIG                            (3)
+#define DMA_AES_AES_1_TRIG                            (4)
+#define DMA_AES_AES_2_TRIG                            (5)
+#define DMA_DAC0_EVT_BD_1_TRIG                        (6)
+#define DMA_I2C0_TX_TRIG                              (7)
+#define DMA_I2C0_RX_TRIG                              (8)
+#define DMA_I2C1_TX_TRIG                              (9)
+#define DMA_I2C1_RX_TRIG                              (10)
+#define DMA_SPI0_RX_TRIG                              (11)
+#define DMA_SPI0_TX_TRIG                              (12)
+#define DMA_SPI1_RX_TRIG                              (13)
+#define DMA_SPI1_TX_TRIG                              (14)
+#define DMA_UART3_RX_TRIG                             (15)
+#define DMA_UART3_TX_TRIG                             (16)
+#define DMA_UART0_RX_TRIG                             (17)
+#define DMA_UART0_TX_TRIG                             (18)
+#define DMA_UART1_RX_TRIG                             (19)
+#define DMA_UART1_TX_TRIG                             (20)
+#define DMA_UART2_RX_TRIG                             (21)
+#define DMA_UART2_TX_TRIG                             (22)
+#define DMA_ADC0_EVT_GEN_BD_TRIG                      (23)
+#define DMA_ADC1_EVT_GEN_BD_TRIG                      (24)
+
+/* Internal DMA Triggers */
+#define DMA_CH_0_TRIG                                 (0)
+#define DMA_CH_1_TRIG                                 (1)
+#define DMA_CH_2_TRIG                                 (2)
+#define DMA_CH_3_TRIG                                 (3)
+#define DMA_CH_4_TRIG                                 (4)
+#define DMA_CH_5_TRIG                                 (5)
+#define DMA_CH_6_TRIG                                 (6)
+
+
+/******************************************************************************
+* IOMUX Pin Definitions                                                       *
+******************************************************************************/
+
+typedef enum IOMUX_PINCM
+{
+  IOMUX_PINCM1         = (0),
+  IOMUX_PINCM2         = (1),
+  IOMUX_PINCM3         = (2),
+  IOMUX_PINCM4         = (3),
+  IOMUX_PINCM5         = (4),
+  IOMUX_PINCM6         = (5),
+  IOMUX_PINCM7         = (6),
+  IOMUX_PINCM8         = (7),
+  IOMUX_PINCM9         = (8),
+  IOMUX_PINCM10        = (9),
+  IOMUX_PINCM11        = (10),
+  IOMUX_PINCM12        = (11),
+  IOMUX_PINCM13        = (12),
+  IOMUX_PINCM14        = (13),
+  IOMUX_PINCM15        = (14),
+  IOMUX_PINCM16        = (15),
+  IOMUX_PINCM17        = (16),
+  IOMUX_PINCM18        = (17),
+  IOMUX_PINCM19        = (18),
+  IOMUX_PINCM20        = (19),
+  IOMUX_PINCM21        = (20),
+  IOMUX_PINCM22        = (21),
+  IOMUX_PINCM23        = (22),
+  IOMUX_PINCM24        = (23),
+  IOMUX_PINCM25        = (24),
+  IOMUX_PINCM26        = (25),
+  IOMUX_PINCM27        = (26),
+  IOMUX_PINCM28        = (27),
+  IOMUX_PINCM29        = (28),
+  IOMUX_PINCM30        = (29),
+  IOMUX_PINCM31        = (30),
+  IOMUX_PINCM32        = (31),
+  IOMUX_PINCM33        = (32),
+  IOMUX_PINCM34        = (33),
+  IOMUX_PINCM35        = (34),
+  IOMUX_PINCM36        = (35),
+  IOMUX_PINCM37        = (36),
+  IOMUX_PINCM38        = (37),
+  IOMUX_PINCM39        = (38),
+  IOMUX_PINCM40        = (39),
+  IOMUX_PINCM41        = (40),
+  IOMUX_PINCM42        = (41),
+  IOMUX_PINCM43        = (42),
+  IOMUX_PINCM44        = (43),
+  IOMUX_PINCM45        = (44),
+  IOMUX_PINCM46        = (45),
+  IOMUX_PINCM47        = (46),
+  IOMUX_PINCM48        = (47),
+  IOMUX_PINCM49        = (48),
+  IOMUX_PINCM50        = (49),
+  IOMUX_PINCM51        = (50),
+  IOMUX_PINCM52        = (51),
+  IOMUX_PINCM53        = (52),
+  IOMUX_PINCM54        = (53),
+  IOMUX_PINCM55        = (54),
+  IOMUX_PINCM56        = (55),
+  IOMUX_PINCM57        = (56),
+  IOMUX_PINCM58        = (57),
+  IOMUX_PINCM59        = (58),
+  IOMUX_PINCM60        = (59),
+} IOMUX_PINCM;
+
+
+/* IOMUX_PINCM1[PF] Bits */
+#define IOMUX_PINCM1_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM1_PF_GPIOA_DIO00                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM1_PF_UART0_TX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM1_PF_I2C0_SDA                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM1_PF_TIMA0_CCP0                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM1_PF_TIMA_FAULT1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM1_PF_TIMG8_CCP1                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM1_PF_SYSCTL_FCC_IN                 ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM2[PF] Bits */
+#define IOMUX_PINCM2_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM2_PF_GPIOA_DIO01                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM2_PF_UART0_RX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM2_PF_I2C0_SCL                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM2_PF_TIMA0_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM2_PF_TIMA_FAULT2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM2_PF_TIMG8_IDX                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM2_PF_TIMG8_CCP0                    ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM3[PF] Bits */
+#define IOMUX_PINCM3_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM3_PF_GPIOA_DIO28                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM3_PF_UART0_TX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM3_PF_I2C0_SDA                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM3_PF_TIMA0_CCP3                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM3_PF_TIMA_FAULT0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM3_PF_TIMG7_CCP0                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM3_PF_TIMA1_CCP0                    ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM4[PF] Bits */
+#define IOMUX_PINCM4_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM4_PF_GPIOA_DIO29                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM4_PF_I2C1_SCL                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM4_PF_UART2_RTS                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM4_PF_TIMG8_CCP0                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM4_PF_TIMG6_CCP0                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM5[PF] Bits */
+#define IOMUX_PINCM5_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM5_PF_GPIOA_DIO30                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM5_PF_I2C1_SDA                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM5_PF_UART2_CTS                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM5_PF_TIMG8_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM5_PF_TIMG6_CCP1                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM6[PF] Bits */
+#define IOMUX_PINCM6_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM6_PF_GPIOA_DIO31                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM6_PF_UART0_RX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM6_PF_I2C0_SCL                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM6_PF_TIMA0_CCP3_CMPL               ((uint32_t)0X00000004)
+#define IOMUX_PINCM6_PF_TIMG12_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM6_PF_SYSCTL_CLK_OUT                ((uint32_t)0X00000006)
+#define IOMUX_PINCM6_PF_TIMG7_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM6_PF_TIMA1_CCP1                    ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM7[PF] Bits */
+#define IOMUX_PINCM7_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM7_PF_GPIOA_DIO02                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM7_PF_TIMG8_CCP1                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM7_PF_SPI0_CS0                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM7_PF_TIMG7_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM7_PF_SPI1_CS0                      ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM8[PF] Bits */
+#define IOMUX_PINCM8_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM8_PF_GPIOA_DIO03                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM8_PF_TIMG8_CCP0                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM8_PF_SPI0_CS1_POCI1                ((uint32_t)0X00000003)
+#define IOMUX_PINCM8_PF_UART2_CTS                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM8_PF_TIMA0_CCP2                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM8_PF_COMP1_OUT                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM8_PF_TIMG7_CCP0                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM8_PF_TIMA0_CCP1                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM8_PF_I2C1_SDA                      ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM9[PF] Bits */
+#define IOMUX_PINCM9_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM9_PF_GPIOA_DIO04                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM9_PF_TIMG8_CCP1                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM9_PF_SPI0_POCI                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM9_PF_UART2_RTS                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM9_PF_TIMA0_CCP3                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM9_PF_SYSCTL_LFCLKIN                ((uint32_t)0X00000006)
+#define IOMUX_PINCM9_PF_TIMG7_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM9_PF_TIMA0_CCP1_CMPL               ((uint32_t)0X00000008)
+#define IOMUX_PINCM9_PF_I2C1_SCL                      ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM10[PF] Bits */
+#define IOMUX_PINCM10_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM10_PF_GPIOA_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM10_PF_TIMG8_CCP0                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM10_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM10_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM10_PF_TIMG0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM10_PF_TIMG6_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM10_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM11[PF] Bits */
+#define IOMUX_PINCM11_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM11_PF_GPIOA_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM11_PF_TIMG8_CCP1                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM11_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM11_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM11_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM11_PF_SYSCTL_HFCLKIN               ((uint32_t)0X00000006)
+#define IOMUX_PINCM11_PF_TIMG6_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM11_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM12[PF] Bits */
+#define IOMUX_PINCM12_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM12_PF_GPIOB_DIO00                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM12_PF_UART0_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM12_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM12_PF_TIMA1_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM12_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM13[PF] Bits */
+#define IOMUX_PINCM13_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM13_PF_GPIOB_DIO01                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM13_PF_UART0_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM13_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM13_PF_TIMA1_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM13_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM14[PF] Bits */
+#define IOMUX_PINCM14_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM14_PF_GPIOA_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM14_PF_COMP0_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM14_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000003)
+#define IOMUX_PINCM14_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM14_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM14_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM14_PF_TIMG7_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM14_PF_TIMA0_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM15[PF] Bits */
+#define IOMUX_PINCM15_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM15_PF_GPIOB_DIO02                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM15_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM15_PF_UART2_CTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM15_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM15_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM15_PF_UART1_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM15_PF_TIMG6_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM15_PF_TIMA1_CCP0                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM16[PF] Bits */
+#define IOMUX_PINCM16_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM16_PF_GPIOB_DIO03                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM16_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM16_PF_UART2_RTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM16_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM16_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM16_PF_UART1_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM16_PF_TIMG6_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM16_PF_TIMA1_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM17[PF] Bits */
+#define IOMUX_PINCM17_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM17_PF_GPIOB_DIO04                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM17_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM17_PF_UART3_CTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM17_PF_TIMA1_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM17_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM17_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM18[PF] Bits */
+#define IOMUX_PINCM18_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM18_PF_GPIOB_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM18_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM18_PF_UART3_RTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM18_PF_TIMA1_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM18_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM18_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM19[PF] Bits */
+#define IOMUX_PINCM19_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM19_PF_GPIOA_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM19_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM19_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM19_PF_UART0_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM19_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM19_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM20[PF] Bits */
+#define IOMUX_PINCM20_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM20_PF_GPIOA_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM20_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM20_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM20_PF_UART0_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM20_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM20_PF_RTC_RTC_OUT                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM20_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM20_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000008)
+#define IOMUX_PINCM20_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM21[PF] Bits */
+#define IOMUX_PINCM21_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM21_PF_GPIOA_DIO10                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM21_PF_UART0_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM21_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM21_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM21_PF_TIMA1_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM21_PF_TIMG12_CCP0                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM21_PF_TIMA0_CCP2                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM21_PF_I2C1_SDA                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM21_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM22[PF] Bits */
+#define IOMUX_PINCM22_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM22_PF_GPIOA_DIO11                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM22_PF_UART0_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM22_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM22_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM22_PF_TIMA1_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM22_PF_COMP0_OUT                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM22_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM22_PF_I2C1_SCL                     ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM23[PF] Bits */
+#define IOMUX_PINCM23_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM23_PF_GPIOB_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM23_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM23_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM23_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000004)
+#define IOMUX_PINCM23_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM23_PF_UART2_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM23_PF_TIMG6_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM23_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM24[PF] Bits */
+#define IOMUX_PINCM24_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM24_PF_GPIOB_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM24_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM24_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM24_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000004)
+#define IOMUX_PINCM24_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM24_PF_UART2_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM24_PF_TIMG6_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM24_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM25[PF] Bits */
+#define IOMUX_PINCM25_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM25_PF_GPIOB_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM25_PF_UART1_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM25_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM25_PF_TIMA0_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM25_PF_COMP1_OUT                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM26[PF] Bits */
+#define IOMUX_PINCM26_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM26_PF_GPIOB_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM26_PF_UART1_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM26_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM26_PF_TIMA0_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM26_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM27[PF] Bits */
+#define IOMUX_PINCM27_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM27_PF_GPIOB_DIO10                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM27_PF_TIMG0_CCP0                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM27_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM27_PF_COMP1_OUT                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM27_PF_TIMG6_CCP0                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM28[PF] Bits */
+#define IOMUX_PINCM28_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM28_PF_GPIOB_DIO11                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM28_PF_TIMG0_CCP1                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM28_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM28_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000004)
+#define IOMUX_PINCM28_PF_TIMG6_CCP1                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM29[PF] Bits */
+#define IOMUX_PINCM29_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM29_PF_GPIOB_DIO12                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM29_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM29_PF_TIMA0_CCP2                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM29_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM29_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM30[PF] Bits */
+#define IOMUX_PINCM30_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM30_PF_GPIOB_DIO13                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM30_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM30_PF_TIMA0_CCP3                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM30_PF_TIMG12_CCP0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM30_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM31[PF] Bits */
+#define IOMUX_PINCM31_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM31_PF_GPIOB_DIO14                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM31_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000002)
+#define IOMUX_PINCM31_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM31_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000004)
+#define IOMUX_PINCM31_PF_TIMG12_CCP1                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM31_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM31_PF_TIMA0_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM32[PF] Bits */
+#define IOMUX_PINCM32_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM32_PF_GPIOB_DIO15                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM32_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM32_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM32_PF_UART3_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM32_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM32_PF_TIMG7_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM33[PF] Bits */
+#define IOMUX_PINCM33_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM33_PF_GPIOB_DIO16                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM33_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM33_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM33_PF_UART3_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM33_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM33_PF_TIMG7_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM34[PF] Bits */
+#define IOMUX_PINCM34_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM34_PF_GPIOA_DIO12                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM34_PF_UART3_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM34_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM34_PF_TIMG0_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM34_PF_CANFD0_CANTX                 ((uint32_t)0X00000005)
+#define IOMUX_PINCM34_PF_TIMA0_CCP3                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM34_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM35[PF] Bits */
+#define IOMUX_PINCM35_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM35_PF_GPIOA_DIO13                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM35_PF_UART3_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM35_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM35_PF_UART3_RX                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM35_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM35_PF_CANFD0_CANRX                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM35_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM36[PF] Bits */
+#define IOMUX_PINCM36_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM36_PF_GPIOA_DIO14                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM36_PF_UART0_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM36_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM36_PF_UART3_TX                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM36_PF_TIMG12_CCP0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM36_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM37[PF] Bits */
+#define IOMUX_PINCM37_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM37_PF_GPIOA_DIO15                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM37_PF_UART0_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM37_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM37_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM37_PF_TIMA1_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM37_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM37_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM37_PF_TIMA0_CCP2                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM38[PF] Bits */
+#define IOMUX_PINCM38_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM38_PF_GPIOA_DIO16                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM38_PF_COMP2_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM38_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM38_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM38_PF_TIMA1_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM38_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM38_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM38_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM39[PF] Bits */
+#define IOMUX_PINCM39_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM39_PF_GPIOA_DIO17                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM39_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM39_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM39_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM39_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM39_PF_TIMG7_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM39_PF_TIMA1_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM40[PF] Bits */
+#define IOMUX_PINCM40_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM40_PF_GPIOA_DIO18                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM40_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM40_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM40_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM40_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM40_PF_TIMG7_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM40_PF_TIMA1_CCP1                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM41[PF] Bits */
+#define IOMUX_PINCM41_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM41_PF_GPIOA_DIO19                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM41_PF_DEBUGSS_SWDIO                ((uint32_t)0X00000002)
+
+/* IOMUX_PINCM42[PF] Bits */
+#define IOMUX_PINCM42_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM42_PF_GPIOA_DIO20                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM42_PF_DEBUGSS_SWCLK                ((uint32_t)0X00000002)
+
+/* IOMUX_PINCM43[PF] Bits */
+#define IOMUX_PINCM43_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM43_PF_GPIOB_DIO17                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM43_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM43_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM43_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000004)
+#define IOMUX_PINCM43_PF_TIMA1_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM43_PF_TIMA0_CCP2                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM44[PF] Bits */
+#define IOMUX_PINCM44_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM44_PF_GPIOB_DIO18                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM44_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM44_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM44_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000004)
+#define IOMUX_PINCM44_PF_TIMA1_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM44_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM45[PF] Bits */
+#define IOMUX_PINCM45_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM45_PF_GPIOB_DIO19                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM45_PF_COMP2_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM45_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM45_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM45_PF_UART0_CTS                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM45_PF_TIMG7_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM46[PF] Bits */
+#define IOMUX_PINCM46_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM46_PF_GPIOA_DIO21                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM46_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM46_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM46_PF_UART1_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM46_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM46_PF_TIMG6_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM47[PF] Bits */
+#define IOMUX_PINCM47_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM47_PF_GPIOA_DIO22                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM47_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM47_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM47_PF_UART1_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM47_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM47_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+#define IOMUX_PINCM47_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000007)
+#define IOMUX_PINCM47_PF_TIMG6_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM48[PF] Bits */
+#define IOMUX_PINCM48_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM48_PF_GPIOB_DIO20                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM48_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000002)
+#define IOMUX_PINCM48_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM48_PF_TIMA0_CCP2                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM48_PF_TIMG12_CCP0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM48_PF_TIMA_FAULT1                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM48_PF_TIMA0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM48_PF_TIMA1_CCP1_CMPL              ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM49[PF] Bits */
+#define IOMUX_PINCM49_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM49_PF_GPIOB_DIO21                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM49_PF_SPI1_POCI                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM49_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+
+/* IOMUX_PINCM50[PF] Bits */
+#define IOMUX_PINCM50_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM50_PF_GPIOB_DIO22                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM50_PF_SPI1_PICO                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM50_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+
+/* IOMUX_PINCM51[PF] Bits */
+#define IOMUX_PINCM51_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM51_PF_GPIOB_DIO23                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM51_PF_SPI1_SCLK                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM51_PF_COMP0_OUT                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM51_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+
+/* IOMUX_PINCM52[PF] Bits */
+#define IOMUX_PINCM52_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM52_PF_GPIOB_DIO24                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM52_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000002)
+#define IOMUX_PINCM52_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM52_PF_TIMA0_CCP3                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM52_PF_TIMG12_CCP1                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM52_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM52_PF_TIMA1_CCP0_CMPL              ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM53[PF] Bits */
+#define IOMUX_PINCM53_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM53_PF_GPIOA_DIO23                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM53_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM53_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM53_PF_TIMA0_CCP3                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM53_PF_TIMG0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM53_PF_UART3_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM53_PF_TIMG7_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM53_PF_TIMG8_CCP0                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM54[PF] Bits */
+#define IOMUX_PINCM54_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM54_PF_GPIOA_DIO24                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM54_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM54_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM54_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000004)
+#define IOMUX_PINCM54_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM54_PF_UART3_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM54_PF_TIMG7_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM54_PF_TIMA1_CCP1                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM55[PF] Bits */
+#define IOMUX_PINCM55_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM55_PF_GPIOA_DIO25                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM55_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM55_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM55_PF_TIMG12_CCP1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM55_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM55_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM56[PF] Bits */
+#define IOMUX_PINCM56_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM56_PF_GPIOB_DIO25                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM56_PF_UART0_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM56_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM56_PF_TIMA_FAULT2                  ((uint32_t)0X00000004)
+
+/* IOMUX_PINCM57[PF] Bits */
+#define IOMUX_PINCM57_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM57_PF_GPIOB_DIO26                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM57_PF_UART0_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM57_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM57_PF_TIMA0_CCP3                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM57_PF_TIMG6_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM57_PF_TIMA1_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM58[PF] Bits */
+#define IOMUX_PINCM58_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM58_PF_GPIOB_DIO27                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM58_PF_COMP2_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM58_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM58_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000004)
+#define IOMUX_PINCM58_PF_TIMG6_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM58_PF_TIMA1_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM59[PF] Bits */
+#define IOMUX_PINCM59_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM59_PF_GPIOA_DIO26                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM59_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM59_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM59_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM59_PF_TIMA_FAULT0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM59_PF_CANFD0_CANTX                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM59_PF_TIMG7_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM60[PF] Bits */
+#define IOMUX_PINCM60_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM60_PF_GPIOA_DIO27                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM60_PF_RTC_RTC_OUT                  ((uint32_t)0X00000002)
+#define IOMUX_PINCM60_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM60_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM60_PF_TIMA_FAULT2                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM60_PF_CANFD0_CANRX                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM60_PF_TIMG7_CCP1                   ((uint32_t)0X00000007)
+#if   defined (__CC_ARM)
+  #pragma pop
+#elif defined (__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+  #pragma clang diagnostic pop
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning restore
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+/*@}*/ /* end of group MSPM0G350X_PeripheralDecl */
+
+/*@}*/ /* end of group MSPM0G350X_Definitions */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_m0p_mspm0g350x__include */
+

--- a/mspm0/source/ti/devices/msp/m0p/mspm0l122x.h
+++ b/mspm0/source/ti/devices/msp/m0p/mspm0l122x.h
@@ -1,0 +1,1336 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/ 
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+   Redistributions of source code must retain the above copyright 
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the   
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_m0p_mspm0l122x__include
+#define ti_devices_msp_m0p_mspm0l122x__include
+
+/* Filename: mspm0l122x.h */
+/* Revised: 2023-11-15 16:54:18*/
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** @addtogroup MSPM0L122X_Definitions MSPM0L122X Definitions
+  This file defines all structures and symbols for MSPM0L122X
+  @{
+*/
+
+/** @addtogroup MSPM0L122X_CMSIS Device CMSIS Definitions
+  Configuration of the Processor and Core Peripherals
+  @{
+*/
+/******************************************************************************
+* Interrupt Definitions                                                       *
+******************************************************************************/
+typedef enum IRQn
+{
+  NonMaskableInt_IRQn         = -14,    /* 2  Non Maskable Interrupt */
+  HardFault_IRQn              = -13,    /* 3  Hard Fault Interrupt */
+  SVCall_IRQn                 = -5,     /* 11 SV Call Interrupt */
+  PendSV_IRQn                 = -2,     /* 14 Pend SV Interrupt */
+  SysTick_IRQn                = -1,     /* 15 System Tick Interrupt */
+  DEBUGSS_INT_IRQn            = 0,      /* 16 DEBUGSS_INT Interrupt */
+  WWDT0_INT_IRQn              = 0,      /* 16 WWDT0_INT Interrupt */
+  FLASHCTL_INT_IRQn           = 0,      /* 16 FLASHCTL_INT Interrupt */
+  SYSCTL_INT_IRQn             = 0,      /* 16 SYSCTL_INT Interrupt */
+  COMP0_INT_IRQn              = 1,      /* 17 COMP0_INT Interrupt */
+  GPIOA_INT_IRQn              = 1,      /* 17 GPIOA_INT Interrupt */
+  TRNG_INT_IRQn               = 1,      /* 17 TRNG_INT Interrupt */
+  GPIOB_INT_IRQn              = 1,      /* 17 GPIOB_INT Interrupt */
+  GPIOC_INT_IRQn              = 1,      /* 17 GPIOC_INT Interrupt */
+  TIMG12_INT_IRQn             = 2,      /* 18 TIMG12_INT Interrupt */
+  UART4_INT_IRQn              = 3,      /* 19 UART4_INT Interrupt */
+  ADC0_INT_IRQn               = 4,      /* 20 ADC0_INT Interrupt */
+  SPI0_INT_IRQn               = 9,      /* 25 SPI0_INT Interrupt */
+  SPI1_INT_IRQn               = 10,     /* 26 SPI1_INT Interrupt */
+  UART2_INT_IRQn              = 13,     /* 29 UART2_INT Interrupt */
+  UART3_INT_IRQn              = 14,     /* 30 UART3_INT Interrupt */
+  UART0_INT_IRQn              = 15,     /* 31 UART0_INT Interrupt */
+  UART1_INT_IRQn              = 16,     /* 32 UART1_INT Interrupt */
+  TIMA0_INT_IRQn              = 18,     /* 34 TIMA0_INT Interrupt */
+  TIMG8_INT_IRQn              = 20,     /* 36 TIMG8_INT Interrupt */
+  TIMG0_INT_IRQn              = 21,     /* 37 TIMG0_INT Interrupt */
+  TIMG4_INT_IRQn              = 22,     /* 38 TIMG4_INT Interrupt */
+  TIMG5_INT_IRQn              = 23,     /* 39 TIMG5_INT Interrupt */
+  I2C0_INT_IRQn               = 24,     /* 40 I2C0_INT Interrupt */
+  I2C1_INT_IRQn               = 25,     /* 41 I2C1_INT Interrupt */
+  I2C2_INT_IRQn               = 26,     /* 42 I2C2_INT Interrupt */
+  AESADV_INT_IRQn             = 28,     /* 44 AESADV_INT Interrupt */
+  LFSS_INT_IRQn               = 30,     /* 46 LFSS_INT Interrupt */
+  RTC_A_INT_IRQn              = 30,     /* 46 RTC_A_INT Interrupt */
+  TAMPERIO_INT_IRQn           = 30,     /* 46 TAMPERIO_INT Interrupt */
+  DMA_INT_IRQn                = 31,     /* 47 DMA_INT Interrupt */
+} IRQn_Type;
+
+#define NonMaskableInt_VECn     2     /* Non Maskable Interrupt */
+#define HardFault_VECn          3     /* Hard Fault Interrupt */
+#define SVCall_VECn             11    /* SV Call Interrupt */
+#define PendSV_VECn             14    /* Pend SV Interrupt */
+#define SysTick_VECn            15    /* System Tick Interrupt */
+#define DEBUGSS_INT_VECn        16    /* DEBUGSS_INT Interrupt */
+#define WWDT0_INT_VECn          16    /* WWDT0_INT Interrupt */
+#define FLASHCTL_INT_VECn       16    /* FLASHCTL_INT Interrupt */
+#define SYSCTL_INT_VECn         16    /* SYSCTL_INT Interrupt */
+#define COMP0_INT_VECn          17    /* COMP0_INT Interrupt */
+#define GPIOA_INT_VECn          17    /* GPIOA_INT Interrupt */
+#define TRNG_INT_VECn           17    /* TRNG_INT Interrupt */
+#define GPIOB_INT_VECn          17    /* GPIOB_INT Interrupt */
+#define GPIOC_INT_VECn          17    /* GPIOC_INT Interrupt */
+#define TIMG12_INT_VECn         18    /* TIMG12_INT Interrupt */
+#define UART4_INT_VECn          19    /* UART4_INT Interrupt */
+#define ADC0_INT_VECn           20    /* ADC0_INT Interrupt */
+#define SPI0_INT_VECn           25    /* SPI0_INT Interrupt */
+#define SPI1_INT_VECn           26    /* SPI1_INT Interrupt */
+#define UART2_INT_VECn          29    /* UART2_INT Interrupt */
+#define UART3_INT_VECn          30    /* UART3_INT Interrupt */
+#define UART0_INT_VECn          31    /* UART0_INT Interrupt */
+#define UART1_INT_VECn          32    /* UART1_INT Interrupt */
+#define TIMA0_INT_VECn          34    /* TIMA0_INT Interrupt */
+#define TIMG8_INT_VECn          36    /* TIMG8_INT Interrupt */
+#define TIMG0_INT_VECn          37    /* TIMG0_INT Interrupt */
+#define TIMG4_INT_VECn          38    /* TIMG4_INT Interrupt */
+#define TIMG5_INT_VECn          39    /* TIMG5_INT Interrupt */
+#define I2C0_INT_VECn           40    /* I2C0_INT Interrupt */
+#define I2C1_INT_VECn           41    /* I2C1_INT Interrupt */
+#define I2C2_INT_VECn           42    /* I2C2_INT Interrupt */
+#define AESADV_INT_VECn         44    /* AESADV_INT Interrupt */
+#define LFSS_INT_VECn           46    /* LFSS_INT Interrupt */
+#define RTC_A_INT_VECn          46,   /* RTC_A_INT Interrupt */
+#define TAMPERIO_INT_VECn       46,   /* TAMPERIO_INT Interrupt */
+#define DMA_INT_VECn            47    /* DMA_INT Interrupt */
+
+
+/******************************************************************************
+* Ignore unused variables                                                     *
+******************************************************************************/
+
+#if   defined (__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined (__ICCARM__)
+  #pragma language=extended
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wc11-extensions"
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning 586
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+/******************************************************************************
+* Processor and Core Peripheral Section                                       *
+******************************************************************************/
+
+#define __CM0PLUS_REV           0x0001U    /* Core revision r0p1 */
+#define __MPU_PRESENT           0x0001U    /* MPU present */
+#define __VTOR_PRESENT          0x0001U    /* VTOR present */
+#define __NVIC_PRIO_BITS        0x0002U    /* Number of bits used for Priority Levels */
+#define __Vendor_SysTickConfig  0x0000U    /* Set to 1 if different SysTick Config is used */
+
+#include "core_cm0plus.h"                  /* Processor and core peripherals */
+
+/******************************************************************************
+* Peripheral headers                                                          *
+******************************************************************************/
+/** @addtogroup MSPM0L122X_Peripherals MSPM0L122X Peripherals
+  MSPM0L122X Peripheral registers structures
+  @{
+*/
+
+#include <ti/devices/msp/peripherals/hw_adc12.h>
+#include <ti/devices/msp/peripherals/hw_aesadv.h>
+#include <ti/devices/msp/peripherals/hw_comp.h>
+#include <ti/devices/msp/peripherals/hw_crcp.h>
+#include <ti/devices/msp/peripherals/hw_dma.h>
+#include <ti/devices/msp/peripherals/hw_flashctl.h>
+#include <ti/devices/msp/peripherals/hw_gpio.h>
+#include <ti/devices/msp/peripherals/hw_gptimer.h>
+#include <ti/devices/msp/peripherals/hw_i2c.h>
+#include <ti/devices/msp/peripherals/hw_lfss.h>
+#include <ti/devices/msp/peripherals/hw_iomux.h>
+#include <ti/devices/msp/peripherals/hw_keystorectl.h>
+#include <ti/devices/msp/peripherals/hw_lfss.h>
+#include <ti/devices/msp/peripherals/hw_rtc.h>
+#include <ti/devices/msp/peripherals/hw_spi.h>
+#include <ti/devices/msp/peripherals/hw_trng.h>
+#include <ti/devices/msp/peripherals/hw_uart.h>
+#include <ti/devices/msp/peripherals/hw_vref.h>
+#include <ti/devices/msp/peripherals/hw_wuc.h>
+#include <ti/devices/msp/peripherals/hw_wwdt.h>
+#include <ti/devices/msp/peripherals/m0p/hw_factoryregion.h>
+#include <ti/devices/msp/peripherals/m0p/hw_cpuss.h>
+#include <ti/devices/msp/peripherals/m0p/hw_debugss.h>
+#include <ti/devices/msp/peripherals/m0p/hw_sysctl.h>
+
+#define __MSPM0_HAS_ADC12__
+#define __MSPM0_HAS_COMP__
+#define __MSPM0_HAS_GPIO__
+#define __MSPM0_HAS_TIMER_A__
+#define __MSPM0_HAS_TIMER_G__
+#define __MSPM0_HAS_I2C__
+#define __MSPM0_HAS_SPI__
+#define __MSPM0_HAS_TRNG__
+#define __MSPM0_HAS_RTC_A__
+#define __MSPM0_HAS_UART_EXTD__
+#define __MSPM0_HAS_UART_MAIN__
+#define __MSPM0_HAS_VREF__
+#define __MSPM0_HAS_WWDT__
+#define __MSPM0_HAS_AESADV__
+#define __MSPM0_HAS_CRCP__
+#define __MSPM0_HAS_KEYSTORE_CTL__
+#define __MSPM0_HAS_LFSS__
+#define __MSPM0_HAS_SCRATCHPAD__
+#define __MSPM0_HAS_TIO__
+#define __MSPM0_HAS_WDT__
+#define __MSPM0_HAS_ECC__
+
+
+/*@}*/ /* end of group MSPM0L122X_Peripherals */
+
+/******************************************************************************
+* Device and peripheral memory map                                            *
+******************************************************************************/
+/** @addtogroup MSPM0L122X_MemoryMap MSPM0L122X Memory Mapping
+  @{
+*/
+
+#define DEBUGSS_BASE                   (0x400C7000U)     /*!< Base address of module DEBUGSS */
+#define COMP0_BASE                     (0x40008000U)     /*!< Base address of module COMP0 */
+#define WWDT0_BASE                     (0x40080000U)     /*!< Base address of module WWDT0 */
+#define I2C1_BASE                      (0x400F2000U)     /*!< Base address of module I2C1 */
+#define UART0_BASE                     (0x40108000U)     /*!< Base address of module UART0 */
+#define GPIOA_BASE                     (0x400A0000U)     /*!< Base address of module GPIOA */
+#define I2C0_BASE                      (0x400F0000U)     /*!< Base address of module I2C0 */
+#define UART2_BASE                     (0x40100000U)     /*!< Base address of module UART2 */
+#define ADC0_BASE                      (0x40004000U)     /*!< Base address of module ADC0 */
+#define ADC0_PERIPHERALREGIONSVT_BASE  (0x4055A000U)     /*!< Base address of module ADC0_PERIPHERALREGIONSVT */
+#define SPI0_BASE                      (0x40468000U)     /*!< Base address of module SPI0 */
+#define VREF_BASE                      (0x40030000U)     /*!< Base address of module VREF */
+#define SPI1_BASE                      (0x4046A000U)     /*!< Base address of module SPI1 */
+#define KEYSTORECTL_BASE               (0x400AC000U)     /*!< Base address of module KEYSTORECTL */
+#define TRNG_BASE                      (0x40444000U)     /*!< Base address of module TRNG */
+#define UART3_BASE                     (0x40102000U)     /*!< Base address of module UART3 */
+#define UART1_BASE                     (0x4010A000U)     /*!< Base address of module UART1 */
+#define UART4_BASE                     (0x40104000U)     /*!< Base address of module UART4 */
+#define I2C2_BASE                      (0x400F4000U)     /*!< Base address of module I2C2 */
+#define GPIOB_BASE                     (0x400A2000U)     /*!< Base address of module GPIOB */
+#define GPIOC_BASE                     (0x400A4000U)     /*!< Base address of module GPIOC */
+#define FLASHCTL_BASE                  (0x400CD000U)     /*!< Base address of module FLASHCTL */
+#define AESADV_BASE                    (0x40442000U)     /*!< Base address of module AESADV */
+#define CRCP0_BASE                     (0x40440000U)     /*!< Base address of module CRCP0 */
+#define TIMG0_BASE                     (0x40084000U)     /*!< Base address of module TIMG0 */
+#define TIMG4_BASE                     (0x4008C000U)     /*!< Base address of module TIMG4 */
+#define TIMG8_BASE                     (0x40090000U)     /*!< Base address of module TIMG8 */
+#define TIMG12_BASE                    (0x40870000U)     /*!< Base address of module TIMG12 */
+#define TIMA0_BASE                     (0x40860000U)     /*!< Base address of module TIMA0 */
+#define DMA_BASE                       (0x4042A000U)     /*!< Base address of module DMA */
+#define LFSS_BASE                      (0x40094000U)     /*!< Base address of module LFSS */
+#define RTC_A_BASE                     (0x40094000U)     /*!< Base address of module RTC_A */
+#define SYSCTL_BASE                    (0x400AF000U)     /*!< Base address of module SYSCTL */
+#define TIMG5_BASE                     (0x4008E000U)     /*!< Base address of module TIMG5 */
+#define IOMUX_BASE                     (0x40428000U)     /*!< Base address of module IOMUX */
+#define CPUSS_BASE                     (0x40400000U)     /*!< Base address of module CPUSS */
+#define WUC_BASE                       (0x40424000U)     /*!< Base address of module WUC */
+#define FACTORYREGION_BASE             (0x41C40000U)     /*!< Base address of module FACTORYREGION */
+
+
+/*@}*/ /* end of group MSPM0L122X_MemoryMap */
+
+/******************************************************************************
+* Peripheral declarations                                                     *
+******************************************************************************/
+/** @addtogroup MSPM0L122X_PeripheralDecl MSPM0L122X Peripheral Declaration
+  @{
+*/
+
+static DEBUGSS_Regs                             * const DEBUGSS                        = ((DEBUGSS_Regs *) DEBUGSS_BASE);
+static COMP_Regs                                * const COMP0                          = ((COMP_Regs *) COMP0_BASE);
+static WWDT_Regs                                * const WWDT0                          = ((WWDT_Regs *) WWDT0_BASE);
+static I2C_Regs                                 * const I2C1                           = ((I2C_Regs *) I2C1_BASE);
+static UART_Regs                                * const UART0                          = ((UART_Regs *) UART0_BASE);
+static GPIO_Regs                                * const GPIOA                          = ((GPIO_Regs *) GPIOA_BASE);
+static I2C_Regs                                 * const I2C0                           = ((I2C_Regs *) I2C0_BASE);
+static UART_Regs                                * const UART2                          = ((UART_Regs *) UART2_BASE);
+static ADC12_Regs                               * const ADC0                           = ((ADC12_Regs *) ADC0_BASE);
+static ADC12_PERIPHERALREGIONSVT_Regs           * const ADC0_PERIPHERALREGIONSVT       = ((ADC12_PERIPHERALREGIONSVT_Regs *) ADC0_PERIPHERALREGIONSVT_BASE);
+static SPI_Regs                                 * const SPI0                           = ((SPI_Regs *) SPI0_BASE);
+static VREF_Regs                                * const VREF                           = ((VREF_Regs *) VREF_BASE);
+static SPI_Regs                                 * const SPI1                           = ((SPI_Regs *) SPI1_BASE);
+static KEYSTORECTL_Regs                         * const KEYSTORECTL                    = ((KEYSTORECTL_Regs *) KEYSTORECTL_BASE);
+static TRNG_Regs                                * const TRNG                           = ((TRNG_Regs *) TRNG_BASE);
+static UART_Regs                                * const UART3                          = ((UART_Regs *) UART3_BASE);
+static UART_Regs                                * const UART1                          = ((UART_Regs *) UART1_BASE);
+static UART_Regs                                * const UART4                          = ((UART_Regs *) UART4_BASE);
+static I2C_Regs                                 * const I2C2                           = ((I2C_Regs *) I2C2_BASE);
+static GPIO_Regs                                * const GPIOB                          = ((GPIO_Regs *) GPIOB_BASE);
+static GPIO_Regs                                * const GPIOC                          = ((GPIO_Regs *) GPIOC_BASE);
+static FLASHCTL_Regs                            * const FLASHCTL                       = ((FLASHCTL_Regs *) FLASHCTL_BASE);
+static AESADV_Regs                              * const AESADV                         = ((AESADV_Regs *) AESADV_BASE);
+static CRCP_Regs                                * const CRCP0                          = ((CRCP_Regs *) CRCP0_BASE);
+static GPTIMER_Regs                             * const TIMG0                          = ((GPTIMER_Regs *) TIMG0_BASE);
+static GPTIMER_Regs                             * const TIMG4                          = ((GPTIMER_Regs *) TIMG4_BASE);
+static GPTIMER_Regs                             * const TIMG8                          = ((GPTIMER_Regs *) TIMG8_BASE);
+static GPTIMER_Regs                             * const TIMG12                         = ((GPTIMER_Regs *) TIMG12_BASE);
+static GPTIMER_Regs                             * const TIMA0                          = ((GPTIMER_Regs *) TIMA0_BASE);
+static DMA_Regs                                 * const DMA                            = ((DMA_Regs *) DMA_BASE);
+static LFSS_Regs                                * const LFSS                           = ((LFSS_Regs *) LFSS_BASE);
+static RTC_Regs                                 * const RTC_A                          = ((RTC_Regs *) RTC_A_BASE);
+static SYSCTL_Regs                              * const SYSCTL                         = ((SYSCTL_Regs *) SYSCTL_BASE);
+static GPTIMER_Regs                             * const TIMG5                          = ((GPTIMER_Regs *) TIMG5_BASE);
+static IOMUX_Regs                               * const IOMUX                          = ((IOMUX_Regs *) IOMUX_BASE);
+static CPUSS_Regs                               * const CPUSS                          = ((CPUSS_Regs *) CPUSS_BASE);
+static WUC_Regs                                 * const WUC                            = ((WUC_Regs *) WUC_BASE);
+static FACTORYREGION_OPEN_Regs                  * const FACTORYREGION                  = ((FACTORYREGION_OPEN_Regs *) FACTORYREGION_BASE);
+
+/******************************************************************************
+* SYS parameters                                                              *
+******************************************************************************/
+
+#define DMA_SYS_N_DMA_CHANNEL                         (7)       /* !< Number of DMA channels implemented in DMA. */
+#define DMA_SYS_N_DMA_FULL_CHANNEL                    (3)       /* !< Number of FULL-DMA channels implemented in DMA. */
+#define FLASHCTL_SYS_DATAWIDTH                        (64)      /* !< Data bit width of a single flash word. */
+#define ADC_SYS_NUM_ANALOG_CHAN                       (32)      /* !< Number of analog channels. */
+#define I2C_SYS_FENTRIES                              (8)       /* !< Number of FIFO entries */
+#define FLASHCTL_SYS_WEPROTAWIDTH                     (32)      /* !< Bit width of WEPROTA register */
+#define FLASHCTL_SYS_WEPROTBWIDTH                     (16)      /* !< Bit width of WEPROTB register */
+#define FLASHCTL_SYS_WEPROTCWIDTH                     (0)       /* !< Bit width of WEPROTC register */
+
+/******************************************************************************
+* DMA Triggers                                                                *
+******************************************************************************/
+
+/* External DMA Triggers */
+#define DMA_SOFTWARE_TRIG                             (0)
+#define DMA_GENERIC_SUB0_TRIG                         (1)
+#define DMA_GENERIC_SUB1_TRIG                         (2)
+#define DMA_AESADV_AES_0_TRIG                         (3)
+#define DMA_AESADV_AES_1_TRIG                         (4)
+#define DMA_I2C0_TX_TRIG                              (5)
+#define DMA_I2C0_RX_TRIG                              (6)
+#define DMA_I2C1_TX_TRIG                              (7)
+#define DMA_I2C1_RX_TRIG                              (8)
+#define DMA_I2C2_TX_TRIG                              (9)
+#define DMA_I2C2_RX_TRIG                              (10)
+#define DMA_SPI0_RX_TRIG                              (11)
+#define DMA_SPI0_TX_TRIG                              (12)
+#define DMA_SPI1_RX_TRIG                              (13)
+#define DMA_SPI1_TX_TRIG                              (14)
+#define DMA_UART0_RX_TRIG                             (15)
+#define DMA_UART0_TX_TRIG                             (16)
+#define DMA_UART1_RX_TRIG                             (17)
+#define DMA_UART1_TX_TRIG                             (18)
+#define DMA_UART2_RX_TRIG                             (19)
+#define DMA_UART2_TX_TRIG                             (20)
+#define DMA_UART3_RX_TRIG                             (21)
+#define DMA_UART3_TX_TRIG                             (22)
+#define DMA_UART4_RX_TRIG                             (23)
+#define DMA_UART4_TX_TRIG                             (24)
+#define DMA_ADC0_EVT_GEN_BD_TRIG                      (25)
+
+/* Internal DMA Triggers */
+#define DMA_CH_0_TRIG                                 (0)
+#define DMA_CH_1_TRIG                                 (1)
+#define DMA_CH_2_TRIG                                 (2)
+#define DMA_CH_3_TRIG                                 (3)
+#define DMA_CH_4_TRIG                                 (4)
+#define DMA_CH_5_TRIG                                 (5)
+#define DMA_CH_6_TRIG                                 (6)
+#define DMA_CH_7_TRIG                                 (7)
+#define DMA_CH_8_TRIG                                 (8)
+#define DMA_CH_9_TRIG                                 (9)
+#define DMA_CH_10_TRIG                                (10)
+#define DMA_CH_11_TRIG                                (11)
+#define DMA_CH_12_TRIG                                (12)
+#define DMA_CH_13_TRIG                                (13)
+#define DMA_CH_14_TRIG                                (14)
+#define DMA_CH_15_TRIG                                (15)
+
+
+/******************************************************************************
+* IOMUX Pin Definitions                                                       *
+******************************************************************************/
+
+typedef enum IOMUX_PINCM
+{
+  IOMUX_PINCM1         = (0),
+  IOMUX_PINCM2         = (1),
+  IOMUX_PINCM3         = (2),
+  IOMUX_PINCM4         = (3),
+  IOMUX_PINCM5         = (4),
+  IOMUX_PINCM6         = (5),
+  IOMUX_PINCM7         = (6),
+  IOMUX_PINCM8         = (7),
+  IOMUX_PINCM9         = (8),
+  IOMUX_PINCM10        = (9),
+  IOMUX_PINCM11        = (10),
+  IOMUX_PINCM12        = (11),
+  IOMUX_PINCM13        = (12),
+  IOMUX_PINCM14        = (13),
+  IOMUX_PINCM15        = (14),
+  IOMUX_PINCM16        = (15),
+  IOMUX_PINCM17        = (16),
+  IOMUX_PINCM18        = (17),
+  IOMUX_PINCM19        = (18),
+  IOMUX_PINCM20        = (19),
+  IOMUX_PINCM21        = (20),
+  IOMUX_PINCM22        = (21),
+  IOMUX_PINCM23        = (22),
+  IOMUX_PINCM24        = (23),
+  IOMUX_PINCM25        = (24),
+  IOMUX_PINCM26        = (25),
+  IOMUX_PINCM27        = (26),
+  IOMUX_PINCM28        = (27),
+  IOMUX_PINCM29        = (28),
+  IOMUX_PINCM30        = (29),
+  IOMUX_PINCM31        = (30),
+  IOMUX_PINCM32        = (31),
+  IOMUX_PINCM33        = (32),
+  IOMUX_PINCM34        = (33),
+  IOMUX_PINCM35        = (34),
+  IOMUX_PINCM36        = (35),
+  IOMUX_PINCM37        = (36),
+  IOMUX_PINCM38        = (37),
+  IOMUX_PINCM39        = (38),
+  IOMUX_PINCM40        = (39),
+  IOMUX_PINCM41        = (40),
+  IOMUX_PINCM42        = (41),
+  IOMUX_PINCM43        = (42),
+  IOMUX_PINCM44        = (43),
+  IOMUX_PINCM45        = (44),
+  IOMUX_PINCM46        = (45),
+  IOMUX_PINCM47        = (46),
+  IOMUX_PINCM48        = (47),
+  IOMUX_PINCM49        = (48),
+  IOMUX_PINCM50        = (49),
+  IOMUX_PINCM51        = (50),
+  IOMUX_PINCM52        = (51),
+  IOMUX_PINCM53        = (52),
+  IOMUX_PINCM54        = (53),
+  IOMUX_PINCM55        = (54),
+  IOMUX_PINCM56        = (55),
+  IOMUX_PINCM57        = (56),
+  IOMUX_PINCM58        = (57),
+  IOMUX_PINCM59        = (58),
+  IOMUX_PINCM60        = (59),
+  IOMUX_PINCM61        = (60),
+  IOMUX_PINCM62        = (61),
+  IOMUX_PINCM63        = (62),
+  IOMUX_PINCM64        = (63),
+  IOMUX_PINCM65        = (64),
+  IOMUX_PINCM66        = (65),
+  IOMUX_PINCM67        = (66),
+  IOMUX_PINCM68        = (67),
+  IOMUX_PINCM69        = (68),
+  IOMUX_PINCM70        = (69),
+  IOMUX_PINCM71        = (70),
+  IOMUX_PINCM72        = (71),
+  IOMUX_PINCM73        = (72),
+  IOMUX_PINCM74        = (73),
+} IOMUX_PINCM;
+
+
+/* IOMUX_PINCM1[PF] Bits */
+#define IOMUX_PINCM1_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM1_PF_GPIOA_DIO00                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM1_PF_UART0_TX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM1_PF_I2C0_SDA                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM1_PF_TIMA0_CCP0                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM1_PF_TIMA_FAULT1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM1_PF_SYSCTL_FCC_IN                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM1_PF_TIMG8_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM1_PF_TIMG12_CCP0                   ((uint32_t)0X00000008)
+#define IOMUX_PINCM1_PF_TIMG0_CCP0                    ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM2[PF] Bits */
+#define IOMUX_PINCM2_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM2_PF_GPIOA_DIO01                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM2_PF_UART0_RX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM2_PF_I2C0_SCL                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM2_PF_TIMA0_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM2_PF_TIMA_FAULT2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM2_PF_TIMG8_IDX                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM2_PF_TIMG8_CCP0                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM2_PF_TIMG12_CCP1                   ((uint32_t)0X00000008)
+#define IOMUX_PINCM2_PF_TIMG0_CCP1                    ((uint32_t)0X00000009)
+#define IOMUX_PINCM2_PF_SPI0_CS3_CD_POCI3             ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM3[PF] Bits */
+#define IOMUX_PINCM3_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM3_PF_GPIOA_DIO28                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM3_PF_UART0_TX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM3_PF_I2C0_SDA                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM3_PF_TIMA0_CCP3                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM3_PF_TIMA_FAULT0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM3_PF_TIMG5_CCP0                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM3_PF_TIMA0_CCP1                    ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM4[PF] Bits */
+#define IOMUX_PINCM4_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM4_PF_GPIOA_DIO29                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM4_PF_I2C1_SCL                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM4_PF_UART2_RTS                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM4_PF_TIMG8_CCP0                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM4_PF_TIMG4_CCP0                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM4_PF_I2C2_SCL                      ((uint32_t)0X00000006)
+#define IOMUX_PINCM4_PF_UART0_CTS                     ((uint32_t)0X00000007)
+#define IOMUX_PINCM4_PF_SPI0_CS3_CD_POCI3             ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM5[PF] Bits */
+#define IOMUX_PINCM5_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM5_PF_GPIOA_DIO30                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM5_PF_I2C1_SDA                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM5_PF_UART2_CTS                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM5_PF_TIMG8_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM5_PF_TIMG4_CCP1                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM5_PF_I2C2_SDA                      ((uint32_t)0X00000006)
+#define IOMUX_PINCM5_PF_UART0_RTS                     ((uint32_t)0X00000007)
+#define IOMUX_PINCM5_PF_SPI0_CS2_POCI2                ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM6[PF] Bits */
+#define IOMUX_PINCM6_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM6_PF_GPIOA_DIO31                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM6_PF_UART0_RX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM6_PF_I2C0_SCL                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM6_PF_TIMA0_CCP3_CMPL               ((uint32_t)0X00000004)
+#define IOMUX_PINCM6_PF_TIMG12_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM6_PF_SYSCTL_CLK_OUT                ((uint32_t)0X00000006)
+#define IOMUX_PINCM6_PF_TIMG5_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM6_PF_SPI0_CS3_CD_POCI3             ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM7[PF] Bits */
+#define IOMUX_PINCM7_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM7_PF_GPIOA_DIO02                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM7_PF_TIMG8_CCP1                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM7_PF_SPI0_CS0                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM7_PF_TIMG5_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM7_PF_SPI1_CS0                      ((uint32_t)0X00000005)
+#define IOMUX_PINCM7_PF_TIMA0_CCP3_CMPL               ((uint32_t)0X00000006)
+#define IOMUX_PINCM7_PF_TIMA0_CCP2_CMPL               ((uint32_t)0X00000007)
+#define IOMUX_PINCM7_PF_TIMA_FAULT0                   ((uint32_t)0X00000008)
+#define IOMUX_PINCM7_PF_TIMA_FAULT1                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM7_PF_UART4_CTS                     ((uint32_t)0X0000000A)
+#define IOMUX_PINCM7_PF_TIMA0_CCP0                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM8[PF] Bits */
+#define IOMUX_PINCM8_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM8_PF_GPIOA_DIO03                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM8_PF_TIMG8_CCP0                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM8_PF_SPI0_CS1_POCI1                ((uint32_t)0X00000003)
+#define IOMUX_PINCM8_PF_I2C1_SDA                      ((uint32_t)0X00000004)
+#define IOMUX_PINCM8_PF_TIMA0_CCP1                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM8_PF_COMP0_OUT                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM8_PF_TIMG5_CCP0                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM8_PF_TIMA0_CCP2                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM8_PF_UART2_CTS                     ((uint32_t)0X00000009)
+#define IOMUX_PINCM8_PF_UART1_TX                      ((uint32_t)0X0000000A)
+#define IOMUX_PINCM8_PF_SPI0_CS3_CD_POCI3             ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM9[PF] Bits */
+#define IOMUX_PINCM9_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM9_PF_GPIOA_DIO04                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM9_PF_TIMG8_CCP1                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM9_PF_SPI0_POCI                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM9_PF_I2C1_SCL                      ((uint32_t)0X00000004)
+#define IOMUX_PINCM9_PF_TIMA0_CCP1_CMPL               ((uint32_t)0X00000005)
+#define IOMUX_PINCM9_PF_SYSCTL_LFCLKIN                ((uint32_t)0X00000006)
+#define IOMUX_PINCM9_PF_TIMG5_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM9_PF_TIMA0_CCP3                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM9_PF_UART2_RTS                     ((uint32_t)0X00000009)
+#define IOMUX_PINCM9_PF_UART1_RX                      ((uint32_t)0X0000000A)
+#define IOMUX_PINCM9_PF_SPI0_CS0                      ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM10[PF] Bits */
+#define IOMUX_PINCM10_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM10_PF_GPIOA_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM10_PF_TIMG8_CCP0                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM10_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM10_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM10_PF_TIMG0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM10_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000006)
+#define IOMUX_PINCM10_PF_TIMG4_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM10_PF_TIMA_FAULT1                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM10_PF_UART0_CTS                    ((uint32_t)0X00000009)
+#define IOMUX_PINCM10_PF_UART4_RTS                    ((uint32_t)0X0000000A)
+#define IOMUX_PINCM10_PF_UART1_TX                     ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM11[PF] Bits */
+#define IOMUX_PINCM11_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM11_PF_GPIOA_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM11_PF_TIMG8_CCP1                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM11_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM11_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM11_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM11_PF_SYSCTL_HFCLKIN               ((uint32_t)0X00000006)
+#define IOMUX_PINCM11_PF_TIMG4_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM11_PF_TIMA_FAULT0                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM11_PF_UART0_RTS                    ((uint32_t)0X00000009)
+#define IOMUX_PINCM11_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X0000000A)
+#define IOMUX_PINCM11_PF_UART1_RX                     ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM12[PF] Bits */
+#define IOMUX_PINCM12_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM12_PF_GPIOB_DIO00                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM12_PF_UART0_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM12_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM12_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM12_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM12_PF_TIMG0_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM12_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM13[PF] Bits */
+#define IOMUX_PINCM13_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM13_PF_GPIOB_DIO01                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM13_PF_UART0_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM13_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM13_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM13_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM13_PF_TIMG0_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM13_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM14[PF] Bits */
+#define IOMUX_PINCM14_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM14_PF_GPIOA_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM14_PF_COMP0_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM14_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000003)
+#define IOMUX_PINCM14_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM14_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM14_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM14_PF_TIMG5_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM14_PF_TIMA0_CCP1                   ((uint32_t)0X00000008)
+#define IOMUX_PINCM14_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000009)
+#define IOMUX_PINCM14_PF_SYSCTL_FCC_IN                ((uint32_t)0X0000000A)
+#define IOMUX_PINCM14_PF_SPI0_POCI                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM15[PF] Bits */
+#define IOMUX_PINCM15_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM15_PF_GPIOB_DIO02                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM15_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM15_PF_UART2_CTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM15_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM15_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM15_PF_UART1_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM15_PF_TIMG4_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM15_PF_UART2_TX                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM15_PF_TIMG12_CCP0                  ((uint32_t)0X00000009)
+#define IOMUX_PINCM15_PF_SYSCTL_HFCLKIN               ((uint32_t)0X0000000A)
+#define IOMUX_PINCM15_PF_SPI0_PICO                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM16[PF] Bits */
+#define IOMUX_PINCM16_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM16_PF_GPIOB_DIO03                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM16_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM16_PF_UART2_RTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM16_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM16_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM16_PF_UART1_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM16_PF_TIMG4_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM16_PF_UART2_RX                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM16_PF_TIMG12_CCP1                  ((uint32_t)0X00000009)
+#define IOMUX_PINCM16_PF_TIMA0_CCP0                   ((uint32_t)0X0000000A)
+#define IOMUX_PINCM16_PF_SPI0_SCLK                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM17[PF] Bits */
+#define IOMUX_PINCM17_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM17_PF_GPIOB_DIO04                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM17_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM17_PF_UART3_CTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM17_PF_TIMA0_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM17_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM17_PF_TIMG0_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM17_PF_TIMG4_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM18[PF] Bits */
+#define IOMUX_PINCM18_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM18_PF_GPIOB_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM18_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM18_PF_UART3_RTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM18_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000004)
+#define IOMUX_PINCM18_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM18_PF_TIMG0_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM18_PF_TIMG4_CCP1                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM19[PF] Bits */
+#define IOMUX_PINCM19_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM19_PF_GPIOA_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM19_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM19_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM19_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM19_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM19_PF_TIMA_FAULT2                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM19_PF_TIMA_FAULT0                  ((uint32_t)0X00000007)
+#define IOMUX_PINCM19_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000008)
+#define IOMUX_PINCM19_PF_TIMG5_CCP1                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM19_PF_SYSCTL_HFCLKIN               ((uint32_t)0X0000000A)
+#define IOMUX_PINCM19_PF_UART0_RTS                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM20[PF] Bits */
+#define IOMUX_PINCM20_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM20_PF_GPIOA_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM20_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM20_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM20_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM20_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM20_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+#define IOMUX_PINCM20_PF_TIMA0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM20_PF_LFSS_RTC_OUT                 ((uint32_t)0X00000008)
+#define IOMUX_PINCM20_PF_TIMG5_CCP0                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM20_PF_UART4_RTS                    ((uint32_t)0X0000000A)
+#define IOMUX_PINCM20_PF_UART0_CTS                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM21[PF] Bits */
+#define IOMUX_PINCM21_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM21_PF_GPIOB_DIO28                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM21_PF_I2C2_SCL                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM21_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM21_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM21_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM21_PF_TIMG0_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM22[PF] Bits */
+#define IOMUX_PINCM22_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM22_PF_GPIOB_DIO29                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM22_PF_I2C2_SDA                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM22_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM22_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM22_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM22_PF_TIMG0_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM23[PF] Bits */
+#define IOMUX_PINCM23_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM23_PF_GPIOB_DIO30                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM23_PF_UART1_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM23_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM23_PF_TIMA_FAULT2                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM23_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM23_PF_TIMG4_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM24[PF] Bits */
+#define IOMUX_PINCM24_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM24_PF_GPIOB_DIO31                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM24_PF_UART1_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM24_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM24_PF_TIMG8_IDX                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM24_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM24_PF_TIMG4_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM25[PF] Bits */
+#define IOMUX_PINCM25_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM25_PF_GPIOA_DIO10                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM25_PF_UART0_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM25_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM25_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM25_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM25_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+#define IOMUX_PINCM25_PF_TIMG0_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM25_PF_I2C1_SDA                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM25_PF_TIMG12_CCP0                  ((uint32_t)0X00000009)
+#define IOMUX_PINCM25_PF_TIMA_FAULT1                  ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM26[PF] Bits */
+#define IOMUX_PINCM26_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM26_PF_GPIOA_DIO11                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM26_PF_UART0_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM26_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM26_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM26_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM26_PF_COMP0_OUT                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM26_PF_TIMG0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM26_PF_I2C1_SCL                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM26_PF_TIMG12_CCP1                  ((uint32_t)0X00000009)
+#define IOMUX_PINCM26_PF_TIMA_FAULT0                  ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM27[PF] Bits */
+#define IOMUX_PINCM27_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM27_PF_GPIOB_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM27_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM27_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM27_PF_I2C2_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM27_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM27_PF_UART2_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM27_PF_TIMG4_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM27_PF_TIMA_FAULT2                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM27_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000009)
+#define IOMUX_PINCM27_PF_TIMG12_CCP0                  ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM28[PF] Bits */
+#define IOMUX_PINCM28_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM28_PF_GPIOB_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM28_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM28_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM28_PF_I2C2_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM28_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM28_PF_UART2_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM28_PF_TIMG4_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM28_PF_LCD_LCDLFCLK                 ((uint32_t)0X00000008)
+#define IOMUX_PINCM28_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000009)
+#define IOMUX_PINCM28_PF_TIMG12_CCP1                  ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM29[PF] Bits */
+#define IOMUX_PINCM29_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM29_PF_GPIOB_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM29_PF_UART1_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM29_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM29_PF_I2C2_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM29_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM29_PF_COMP0_OUT                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM29_PF_TIMG4_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM29_PF_LCD_LCDSON                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM30[PF] Bits */
+#define IOMUX_PINCM30_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM30_PF_GPIOB_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM30_PF_UART1_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM30_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM30_PF_I2C2_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM30_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM30_PF_TIMA0_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM30_PF_TIMG4_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM30_PF_LCD_LCDEN                    ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM31[PF] Bits */
+#define IOMUX_PINCM31_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM31_PF_GPIOB_DIO10                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM31_PF_TIMG0_CCP0                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM31_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM31_PF_COMP0_OUT                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM31_PF_TIMG4_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM31_PF_UART4_TX                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM31_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM32[PF] Bits */
+#define IOMUX_PINCM32_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM32_PF_GPIOB_DIO11                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM32_PF_TIMG0_CCP1                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM32_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM32_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000004)
+#define IOMUX_PINCM32_PF_TIMG4_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM32_PF_UART4_RX                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM32_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM33[PF] Bits */
+#define IOMUX_PINCM33_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM33_PF_GPIOB_DIO12                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM33_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM33_PF_TIMA0_CCP2                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM33_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM33_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM33_PF_UART4_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM33_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM34[PF] Bits */
+#define IOMUX_PINCM34_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM34_PF_GPIOB_DIO13                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM34_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM34_PF_TIMA0_CCP3                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM34_PF_TIMG12_CCP0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM34_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM34_PF_UART4_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM34_PF_SPI1_CS0                     ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM35[PF] Bits */
+#define IOMUX_PINCM35_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM35_PF_GPIOB_DIO14                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM35_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000002)
+#define IOMUX_PINCM35_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM35_PF_TIMG12_CCP1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM35_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM35_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM35_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM36[PF] Bits */
+#define IOMUX_PINCM36_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM36_PF_GPIOB_DIO15                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM36_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM36_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM36_PF_UART3_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM36_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM36_PF_TIMG5_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM36_PF_I2C2_SCL                     ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM37[PF] Bits */
+#define IOMUX_PINCM37_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM37_PF_GPIOB_DIO16                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM37_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM37_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM37_PF_UART3_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM37_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM37_PF_TIMG5_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM37_PF_I2C2_SDA                     ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM38[PF] Bits */
+#define IOMUX_PINCM38_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM38_PF_GPIOA_DIO12                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM38_PF_UART3_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM38_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM38_PF_COMP0_OUT                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM38_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM38_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000006)
+#define IOMUX_PINCM38_PF_TIMG0_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM38_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000008)
+#define IOMUX_PINCM38_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000009)
+#define IOMUX_PINCM38_PF_UART2_CTS                    ((uint32_t)0X0000000A)
+#define IOMUX_PINCM38_PF_UART1_CTS                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM39[PF] Bits */
+#define IOMUX_PINCM39_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM39_PF_GPIOA_DIO13                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM39_PF_UART3_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM39_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM39_PF_UART3_RX                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM39_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM39_PF_LFSS_RTC_OUT                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM39_PF_TIMG0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM39_PF_SPI1_CS0                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM39_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000009)
+#define IOMUX_PINCM39_PF_UART2_TX                     ((uint32_t)0X0000000A)
+#define IOMUX_PINCM39_PF_UART1_RTS                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM40[PF] Bits */
+#define IOMUX_PINCM40_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM40_PF_GPIOA_DIO14                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM40_PF_UART0_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM40_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM40_PF_UART3_TX                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM40_PF_TIMG12_CCP0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM40_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+#define IOMUX_PINCM40_PF_TIMG12_CCP1                  ((uint32_t)0X00000007)
+#define IOMUX_PINCM40_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000008)
+#define IOMUX_PINCM40_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000009)
+#define IOMUX_PINCM40_PF_UART2_RX                     ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM41[PF] Bits */
+#define IOMUX_PINCM41_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM41_PF_GPIOA_DIO15                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM41_PF_UART0_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM41_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM41_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM41_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM41_PF_I2C2_SCL                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM41_PF_TIMG8_IDX                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM41_PF_TIMG12_CCP0                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM41_PF_LCD_LCDEN                    ((uint32_t)0X00000009)
+#define IOMUX_PINCM41_PF_UART2_RTS                    ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM42[PF] Bits */
+#define IOMUX_PINCM42_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM42_PF_GPIOA_DIO16                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM42_PF_COMP0_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM42_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM42_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM42_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM42_PF_I2C2_SDA                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM42_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000007)
+#define IOMUX_PINCM42_PF_TIMG12_CCP1                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM42_PF_LCD_LCDSON                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM42_PF_UART2_CTS                    ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM43[PF] Bits */
+#define IOMUX_PINCM43_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM43_PF_GPIOC_DIO00                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM43_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM43_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM43_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM43_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM44[PF] Bits */
+#define IOMUX_PINCM44_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM44_PF_GPIOC_DIO01                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM44_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM44_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM44_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM44_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM45[PF] Bits */
+#define IOMUX_PINCM45_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM45_PF_GPIOC_DIO02                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM45_PF_I2C2_SCL                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM45_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM45_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM45_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM45_PF_TIMG0_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM46[PF] Bits */
+#define IOMUX_PINCM46_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM46_PF_GPIOC_DIO03                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM46_PF_I2C2_SDA                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM46_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM46_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM46_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM46_PF_TIMG0_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM47[PF] Bits */
+#define IOMUX_PINCM47_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM47_PF_GPIOC_DIO04                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM47_PF_UART3_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM47_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM47_PF_TIMA_FAULT2                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM47_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM47_PF_TIMG4_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM48[PF] Bits */
+#define IOMUX_PINCM48_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM48_PF_GPIOC_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM48_PF_UART3_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM48_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM48_PF_TIMG8_IDX                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM48_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM48_PF_TIMG4_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM49[PF] Bits */
+#define IOMUX_PINCM49_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM49_PF_GPIOA_DIO17                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM49_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM49_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM49_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM49_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM49_PF_TIMG5_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM49_PF_TIMG8_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM49_PF_TIMG12_CCP0                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM49_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000009)
+#define IOMUX_PINCM49_PF_LCD_LCDLFCLK                 ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM50[PF] Bits */
+#define IOMUX_PINCM50_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM50_PF_GPIOA_DIO18                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM50_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM50_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM50_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM50_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM50_PF_TIMG5_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM50_PF_TIMG8_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM50_PF_TIMG12_CCP1                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM50_PF_SPI0_CS0                     ((uint32_t)0X00000009)
+#define IOMUX_PINCM50_PF_LCD_LCDEN                    ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM51[PF] Bits */
+#define IOMUX_PINCM51_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM51_PF_GPIOA_DIO19                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM51_PF_DEBUGSS_SWDIO                ((uint32_t)0X00000002)
+#define IOMUX_PINCM51_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM51_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM51_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM51_PF_TIMG0_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM52[PF] Bits */
+#define IOMUX_PINCM52_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM52_PF_GPIOA_DIO20                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM52_PF_DEBUGSS_SWCLK                ((uint32_t)0X00000002)
+#define IOMUX_PINCM52_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM52_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM52_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM52_PF_TIMG0_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM53[PF] Bits */
+#define IOMUX_PINCM53_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM53_PF_GPIOB_DIO17                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM53_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM53_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM53_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM53_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM53_PF_TIMG0_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM53_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000007)
+#define IOMUX_PINCM53_PF_UART4_TX                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM53_PF_TIMG4_CCP0                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM53_PF_LCD_LCDSON                   ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM54[PF] Bits */
+#define IOMUX_PINCM54_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM54_PF_GPIOB_DIO18                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM54_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM54_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM54_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM54_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM54_PF_TIMG0_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM54_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000007)
+#define IOMUX_PINCM54_PF_UART4_RX                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM54_PF_TIMG4_CCP1                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM54_PF_LCD_LCDLFCLK                 ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM55[PF] Bits */
+#define IOMUX_PINCM55_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM55_PF_GPIOB_DIO19                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM55_PF_COMP0_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM55_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM55_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM55_PF_UART0_CTS                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM55_PF_TIMG5_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM55_PF_TIMG8_IDX                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM55_PF_UART2_CTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM55_PF_UART4_CTS                    ((uint32_t)0X00000009)
+#define IOMUX_PINCM55_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM56[PF] Bits */
+#define IOMUX_PINCM56_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM56_PF_GPIOA_DIO21                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM56_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM56_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM56_PF_UART1_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM56_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM56_PF_TIMG4_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM56_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000007)
+#define IOMUX_PINCM56_PF_UART2_CTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM56_PF_UART4_RTS                    ((uint32_t)0X00000009)
+#define IOMUX_PINCM56_PF_TIMG8_CCP0                   ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM57[PF] Bits */
+#define IOMUX_PINCM57_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM57_PF_GPIOA_DIO22                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM57_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM57_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM57_PF_UART1_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM57_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM57_PF_TIMG4_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM57_PF_TIMA0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM57_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000008)
+#define IOMUX_PINCM57_PF_I2C0_SCL                     ((uint32_t)0X00000009)
+#define IOMUX_PINCM57_PF_TIMG8_CCP1                   ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM58[PF] Bits */
+#define IOMUX_PINCM58_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM58_PF_GPIOC_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM58_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM58_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM58_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM58_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM59[PF] Bits */
+#define IOMUX_PINCM59_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM59_PF_GPIOC_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM59_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM59_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM59_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM59_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM60[PF] Bits */
+#define IOMUX_PINCM60_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM60_PF_GPIOC_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM60_PF_UART3_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM60_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM60_PF_TIMG5_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM60_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM61[PF] Bits */
+#define IOMUX_PINCM61_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM61_PF_GPIOC_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM61_PF_UART3_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM61_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM61_PF_TIMG5_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM61_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM62[PF] Bits */
+#define IOMUX_PINCM62_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM62_PF_GPIOB_DIO20                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM62_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000002)
+#define IOMUX_PINCM62_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM62_PF_TIMG12_CCP0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM62_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM62_PF_TIMA_FAULT1                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM62_PF_TIMA0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM62_PF_UART2_RTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM62_PF_I2C0_SDA                     ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM63[PF] Bits */
+#define IOMUX_PINCM63_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM63_PF_GPIOB_DIO21                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM63_PF_UART4_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM63_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM63_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM63_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM63_PF_UART1_TX                     ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM64[PF] Bits */
+#define IOMUX_PINCM64_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM64_PF_GPIOB_DIO22                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM64_PF_UART4_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM64_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM64_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM64_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM64_PF_UART1_RX                     ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM65[PF] Bits */
+#define IOMUX_PINCM65_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM65_PF_GPIOB_DIO23                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM65_PF_UART1_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM65_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM65_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM65_PF_COMP0_OUT                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM66[PF] Bits */
+#define IOMUX_PINCM66_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM66_PF_GPIOB_DIO24                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM66_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000002)
+#define IOMUX_PINCM66_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM66_PF_TIMG12_CCP1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM66_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM66_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM66_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000007)
+#define IOMUX_PINCM66_PF_UART2_RTS                    ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM67[PF] Bits */
+#define IOMUX_PINCM67_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM67_PF_GPIOA_DIO23                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM67_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM67_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM67_PF_I2C2_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM67_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM67_PF_TIMG8_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM67_PF_TIMG5_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM67_PF_UART3_CTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM67_PF_TIMG0_CCP0                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM67_PF_SPI1_CS1_POCI1               ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM68[PF] Bits */
+#define IOMUX_PINCM68_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM68_PF_GPIOA_DIO24                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM68_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM68_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM68_PF_I2C2_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM68_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM68_PF_TIMG8_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM68_PF_TIMG5_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM68_PF_UART3_RTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM68_PF_TIMG0_CCP1                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM68_PF_SPI1_CS2_POCI2               ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM69[PF] Bits */
+#define IOMUX_PINCM69_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM69_PF_GPIOA_DIO25                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM69_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM69_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM69_PF_TIMG12_CCP1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM69_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM69_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM69_PF_COMP0_OUT                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM69_PF_UART2_CTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM69_PF_UART3_TX                     ((uint32_t)0X00000009)
+#define IOMUX_PINCM69_PF_TIMG4_CCP0                   ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM70[PF] Bits */
+#define IOMUX_PINCM70_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM70_PF_GPIOB_DIO25                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM70_PF_UART0_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM70_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM70_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM70_PF_TIMA_FAULT1                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM70_PF_TIMA_FAULT2                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM70_PF_COMP0_OUT                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM70_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM71[PF] Bits */
+#define IOMUX_PINCM71_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM71_PF_GPIOB_DIO26                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM71_PF_UART0_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM71_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM71_PF_TIMA0_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM71_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM71_PF_TIMG4_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM71_PF_COMP0_OUT                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM71_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM72[PF] Bits */
+#define IOMUX_PINCM72_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM72_PF_GPIOB_DIO27                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM72_PF_COMP0_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM72_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM72_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000004)
+#define IOMUX_PINCM72_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM72_PF_TIMG4_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM73[PF] Bits */
+#define IOMUX_PINCM73_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM73_PF_GPIOA_DIO26                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM73_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM73_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM73_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM73_PF_TIMA_FAULT0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM73_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM73_PF_TIMG5_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM73_PF_UART2_RTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM73_PF_UART3_RX                     ((uint32_t)0X00000009)
+#define IOMUX_PINCM73_PF_TIMG4_CCP1                   ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM74[PF] Bits */
+#define IOMUX_PINCM74_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM74_PF_GPIOA_DIO27                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM74_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM74_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM74_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM74_PF_TIMA_FAULT2                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM74_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+#define IOMUX_PINCM74_PF_TIMG5_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM74_PF_LFSS_RTC_OUT                 ((uint32_t)0X00000008)
+#define IOMUX_PINCM74_PF_COMP0_OUT                    ((uint32_t)0X00000009)
+
+
+#if   defined (__CC_ARM)
+  #pragma pop
+#elif defined (__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+  #pragma clang diagnostic pop
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning restore
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+/*@}*/ /* end of group MSPM0L122X_PeripheralDecl */
+
+/*@}*/ /* end of group MSPM0L122X_Definitions */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_m0p_mspm0l122x__include */

--- a/mspm0/source/ti/devices/msp/m0p/mspm0l222x.h
+++ b/mspm0/source/ti/devices/msp/m0p/mspm0l222x.h
@@ -1,0 +1,1342 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/ 
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+   Redistributions of source code must retain the above copyright 
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the   
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_m0p_mspm0l222x__include
+#define ti_devices_msp_m0p_mspm0l222x__include
+
+/* Filename: mspm0l222x.h */
+/* Revised: 2023-01-05 21:32:53 */
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** @addtogroup MSPM0L222X_Definitions MSPM0L222X Definitions
+  This file defines all structures and symbols for MSPM0L222X
+  @{
+*/
+
+/** @addtogroup MSPM0L222X_CMSIS Device CMSIS Definitions
+  Configuration of the Processor and Core Peripherals
+  @{
+*/
+/******************************************************************************
+* Interrupt Definitions                                                       *
+******************************************************************************/
+typedef enum IRQn
+{
+  NonMaskableInt_IRQn         = -14,    /* 2  Non Maskable Interrupt */
+  HardFault_IRQn              = -13,    /* 3  Hard Fault Interrupt */
+  SVCall_IRQn                 = -5,     /* 11 SV Call Interrupt */
+  PendSV_IRQn                 = -2,     /* 14 Pend SV Interrupt */
+  SysTick_IRQn                = -1,     /* 15 System Tick Interrupt */
+  DEBUGSS_INT_IRQn            = 0,      /* 16 DEBUGSS_INT Interrupt */
+  WWDT0_INT_IRQn              = 0,      /* 16 WWDT0_INT Interrupt */
+  FLASHCTL_INT_IRQn           = 0,      /* 16 FLASHCTL_INT Interrupt */
+  SYSCTL_INT_IRQn             = 0,      /* 16 SYSCTL_INT Interrupt */
+  COMP0_INT_IRQn              = 1,      /* 17 COMP0_INT Interrupt */
+  GPIOA_INT_IRQn              = 1,      /* 17 GPIOA_INT Interrupt */
+  TRNG_INT_IRQn               = 1,      /* 17 TRNG_INT Interrupt */
+  GPIOB_INT_IRQn              = 1,      /* 17 GPIOB_INT Interrupt */
+  GPIOC_INT_IRQn              = 1,      /* 17 GPIOC_INT Interrupt */
+  TIMG12_INT_IRQn             = 2,      /* 18 TIMG12_INT Interrupt */
+  UART4_INT_IRQn              = 3,      /* 19 UART4_INT Interrupt */
+  ADC0_INT_IRQn               = 4,      /* 20 ADC0_INT Interrupt */
+  SPI0_INT_IRQn               = 9,      /* 25 SPI0_INT Interrupt */
+  SPI1_INT_IRQn               = 10,     /* 26 SPI1_INT Interrupt */
+  UART2_INT_IRQn              = 13,     /* 29 UART2_INT Interrupt */
+  UART3_INT_IRQn              = 14,     /* 30 UART3_INT Interrupt */
+  UART0_INT_IRQn              = 15,     /* 31 UART0_INT Interrupt */
+  UART1_INT_IRQn              = 16,     /* 32 UART1_INT Interrupt */
+  TIMA0_INT_IRQn              = 18,     /* 34 TIMA0_INT Interrupt */
+  TIMG8_INT_IRQn              = 20,     /* 36 TIMG8_INT Interrupt */
+  TIMG0_INT_IRQn              = 21,     /* 37 TIMG0_INT Interrupt */
+  TIMG4_INT_IRQn              = 22,     /* 38 TIMG4_INT Interrupt */
+  TIMG5_INT_IRQn              = 23,     /* 39 TIMG5_INT Interrupt */
+  I2C0_INT_IRQn               = 24,     /* 40 I2C0_INT Interrupt */
+  I2C1_INT_IRQn               = 25,     /* 41 I2C1_INT Interrupt */
+  I2C2_INT_IRQn               = 26,     /* 42 I2C2_INT Interrupt */
+  AESADV_INT_IRQn             = 28,     /* 44 AESADV_INT Interrupt */
+  LCD_INT_IRQn                = 29,     /* 45 LCD_INT Interrupt */
+  LFSS_INT_IRQn               = 30,     /* 46 LFSS_INT Interrupt */
+  RTC_A_INT_IRQn              = 30,     /* 46 RTC_A_INT Interrupt */
+  TAMPERIO_INT_IRQn           = 30,     /* 46 TAMPERIO_INT Interrupt */
+  DMA_INT_IRQn                = 31,     /* 47 DMA_INT Interrupt */
+} IRQn_Type;
+
+#define NonMaskableInt_VECn     2     /* Non Maskable Interrupt */
+#define HardFault_VECn          3     /* Hard Fault Interrupt */
+#define SVCall_VECn             11    /* SV Call Interrupt */
+#define PendSV_VECn             14    /* Pend SV Interrupt */
+#define SysTick_VECn            15    /* System Tick Interrupt */
+#define DEBUGSS_INT_VECn        16    /* DEBUGSS_INT Interrupt */
+#define WWDT0_INT_VECn          16    /* WWDT0_INT Interrupt */
+#define FLASHCTL_INT_VECn       16    /* FLASHCTL_INT Interrupt */
+#define SYSCTL_INT_VECn         16    /* SYSCTL_INT Interrupt */
+#define COMP0_INT_VECn          17    /* COMP0_INT Interrupt */
+#define GPIOA_INT_VECn          17    /* GPIOA_INT Interrupt */
+#define TRNG_INT_VECn           17    /* TRNG_INT Interrupt */
+#define GPIOB_INT_VECn          17    /* GPIOB_INT Interrupt */
+#define GPIOC_INT_VECn          17    /* GPIOC_INT Interrupt */
+#define TIMG12_INT_VECn         18    /* TIMG12_INT Interrupt */
+#define UART4_INT_VECn          19    /* UART4_INT Interrupt */
+#define ADC0_INT_VECn           20    /* ADC0_INT Interrupt */
+#define SPI0_INT_VECn           25    /* SPI0_INT Interrupt */
+#define SPI1_INT_VECn           26    /* SPI1_INT Interrupt */
+#define UART2_INT_VECn          29    /* UART2_INT Interrupt */
+#define UART3_INT_VECn          30    /* UART3_INT Interrupt */
+#define UART0_INT_VECn          31    /* UART0_INT Interrupt */
+#define UART1_INT_VECn          32    /* UART1_INT Interrupt */
+#define TIMA0_INT_VECn          34    /* TIMA0_INT Interrupt */
+#define TIMG8_INT_VECn          36    /* TIMG8_INT Interrupt */
+#define TIMG0_INT_VECn          37    /* TIMG0_INT Interrupt */
+#define TIMG4_INT_VECn          38    /* TIMG4_INT Interrupt */
+#define TIMG5_INT_VECn          39    /* TIMG5_INT Interrupt */
+#define I2C0_INT_VECn           40    /* I2C0_INT Interrupt */
+#define I2C1_INT_VECn           41    /* I2C1_INT Interrupt */
+#define I2C2_INT_VECn           42    /* I2C2_INT Interrupt */
+#define AESADV_INT_VECn         44    /* AESADV_INT Interrupt */
+#define LCD_INT_VECn            45    /* LCD_INT Interrupt */
+#define LFSS_INT_VECn           46    /* LFSS_INT Interrupt */
+#define RTC_A_INT_VECn          46,   /* RTC_A_INT Interrupt */
+#define TAMPERIO_INT_VECn       46,   /* TAMPERIO_INT Interrupt */
+#define DMA_INT_VECn            47    /* DMA_INT Interrupt */
+
+
+/******************************************************************************
+* Ignore unused variables                                                     *
+******************************************************************************/
+
+#if   defined (__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined (__ICCARM__)
+  #pragma language=extended
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wc11-extensions"
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning 586
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+/******************************************************************************
+* Processor and Core Peripheral Section                                       *
+******************************************************************************/
+
+#define __CM0PLUS_REV           0x0001U    /* Core revision r0p1 */
+#define __MPU_PRESENT           0x0001U    /* MPU present */
+#define __VTOR_PRESENT          0x0001U    /* VTOR present */
+#define __NVIC_PRIO_BITS        0x0002U    /* Number of bits used for Priority Levels */
+#define __Vendor_SysTickConfig  0x0000U    /* Set to 1 if different SysTick Config is used */
+
+#include "core_cm0plus.h"                  /* Processor and core peripherals */
+
+/******************************************************************************
+* Peripheral headers                                                          *
+******************************************************************************/
+/** @addtogroup MSPM0L222X_Peripherals MSPM0L222X Peripherals
+  MSPM0L222X Peripheral registers structures
+  @{
+*/
+
+#include <ti/devices/msp/peripherals/hw_adc12.h>
+#include <ti/devices/msp/peripherals/hw_aesadv.h>
+#include <ti/devices/msp/peripherals/hw_comp.h>
+#include <ti/devices/msp/peripherals/hw_crcp.h>
+#include <ti/devices/msp/peripherals/hw_dma.h>
+#include <ti/devices/msp/peripherals/hw_flashctl.h>
+#include <ti/devices/msp/peripherals/hw_gpio.h>
+#include <ti/devices/msp/peripherals/hw_gptimer.h>
+#include <ti/devices/msp/peripherals/hw_i2c.h>
+#include <ti/devices/msp/peripherals/hw_lfss.h>
+#include <ti/devices/msp/peripherals/hw_iomux.h>
+#include <ti/devices/msp/peripherals/hw_keystorectl.h>
+#include <ti/devices/msp/peripherals/hw_lcd.h>
+#include <ti/devices/msp/peripherals/hw_lfss.h>
+#include <ti/devices/msp/peripherals/hw_rtc.h>
+#include <ti/devices/msp/peripherals/hw_spi.h>
+#include <ti/devices/msp/peripherals/hw_trng.h>
+#include <ti/devices/msp/peripherals/hw_uart.h>
+#include <ti/devices/msp/peripherals/hw_vref.h>
+#include <ti/devices/msp/peripherals/hw_wuc.h>
+#include <ti/devices/msp/peripherals/hw_wwdt.h>
+#include <ti/devices/msp/peripherals/m0p/hw_factoryregion.h>
+#include <ti/devices/msp/peripherals/m0p/hw_cpuss.h>
+#include <ti/devices/msp/peripherals/m0p/hw_debugss.h>
+#include <ti/devices/msp/peripherals/m0p/hw_sysctl.h>
+
+#define __MSPM0_HAS_ADC12__
+#define __MSPM0_HAS_COMP__
+#define __MSPM0_HAS_GPIO__
+#define __MSPM0_HAS_TIMER_A__
+#define __MSPM0_HAS_TIMER_G__
+#define __MSPM0_HAS_I2C__
+#define __MSPM0_HAS_SPI__
+#define __MSPM0_HAS_TRNG__
+#define __MSPM0_HAS_RTC_A__
+#define __MSPM0_HAS_UART_EXTD__
+#define __MSPM0_HAS_UART_MAIN__
+#define __MSPM0_HAS_VREF__
+#define __MSPM0_HAS_WWDT__
+#define __MSPM0_HAS_AESADV__
+#define __MSPM0_HAS_CRCP__
+#define __MSPM0_HAS_KEYSTORE_CTL__
+#define __MSPM0_HAS_IWDT__
+#define __MSPM0_HAS_LCD__
+#define __MSPM0_HAS_LFSS__
+#define __MSPM0_HAS_SCRATCHPAD__
+#define __MSPM0_HAS_TIO__
+#define __MSPM0_HAS_ECC__
+
+
+/*@}*/ /* end of group MSPM0L222X_Peripherals */
+
+/******************************************************************************
+* Device and peripheral memory map                                            *
+******************************************************************************/
+/** @addtogroup MSPM0L222X_MemoryMap MSPM0L222X Memory Mapping
+  @{
+*/
+
+#define DEBUGSS_BASE                   (0x400C7000U)     /*!< Base address of module DEBUGSS */
+#define COMP0_BASE                     (0x40008000U)     /*!< Base address of module COMP0 */
+#define WWDT0_BASE                     (0x40080000U)     /*!< Base address of module WWDT0 */
+#define I2C1_BASE                      (0x400F2000U)     /*!< Base address of module I2C1 */
+#define UART0_BASE                     (0x40108000U)     /*!< Base address of module UART0 */
+#define GPIOA_BASE                     (0x400A0000U)     /*!< Base address of module GPIOA */
+#define I2C0_BASE                      (0x400F0000U)     /*!< Base address of module I2C0 */
+#define UART2_BASE                     (0x40100000U)     /*!< Base address of module UART2 */
+#define ADC0_BASE                      (0x40004000U)     /*!< Base address of module ADC0 */
+#define ADC0_PERIPHERALREGIONSVT_BASE  (0x4055A000U)     /*!< Base address of module ADC0_PERIPHERALREGIONSVT */
+#define SPI0_BASE                      (0x40468000U)     /*!< Base address of module SPI0 */
+#define VREF_BASE                      (0x40030000U)     /*!< Base address of module VREF */
+#define SPI1_BASE                      (0x4046A000U)     /*!< Base address of module SPI1 */
+#define KEYSTORECTL_BASE               (0x400AC000U)     /*!< Base address of module KEYSTORECTL */
+#define TRNG_BASE                      (0x40444000U)     /*!< Base address of module TRNG */
+#define UART3_BASE                     (0x40102000U)     /*!< Base address of module UART3 */
+#define UART1_BASE                     (0x4010A000U)     /*!< Base address of module UART1 */
+#define UART4_BASE                     (0x40104000U)     /*!< Base address of module UART4 */
+#define I2C2_BASE                      (0x400F4000U)     /*!< Base address of module I2C2 */
+#define GPIOB_BASE                     (0x400A2000U)     /*!< Base address of module GPIOB */
+#define GPIOC_BASE                     (0x400A4000U)     /*!< Base address of module GPIOC */
+#define FLASHCTL_BASE                  (0x400CD000U)     /*!< Base address of module FLASHCTL */
+#define AESADV_BASE                    (0x40442000U)     /*!< Base address of module AESADV */
+#define CRCP0_BASE                     (0x40440000U)     /*!< Base address of module CRCP0 */
+#define TIMG0_BASE                     (0x40084000U)     /*!< Base address of module TIMG0 */
+#define TIMG4_BASE                     (0x4008C000U)     /*!< Base address of module TIMG4 */
+#define TIMG8_BASE                     (0x40090000U)     /*!< Base address of module TIMG8 */
+#define TIMG12_BASE                    (0x40870000U)     /*!< Base address of module TIMG12 */
+#define TIMA0_BASE                     (0x40860000U)     /*!< Base address of module TIMA0 */
+#define DMA_BASE                       (0x4042A000U)     /*!< Base address of module DMA */
+#define LFSS_BASE                      (0x40094000U)     /*!< Base address of module LFSS */
+#define RTC_A_BASE                     (0x40094000U)     /*!< Base address of module RTC_A */
+#define SYSCTL_BASE                    (0x400AF000U)     /*!< Base address of module SYSCTL */
+#define TIMG5_BASE                     (0x4008E000U)     /*!< Base address of module TIMG5 */
+#define IOMUX_BASE                     (0x40428000U)     /*!< Base address of module IOMUX */
+#define LCD_BASE                       (0x40070000U)     /*!< Base address of module LCD */
+#define CPUSS_BASE                     (0x40400000U)     /*!< Base address of module CPUSS */
+#define WUC_BASE                       (0x40424000U)     /*!< Base address of module WUC */
+#define FACTORYREGION_BASE             (0x41C40000U)     /*!< Base address of module FACTORYREGION */
+
+
+/*@}*/ /* end of group MSPM0L222X_MemoryMap */
+
+/******************************************************************************
+* Peripheral declarations                                                     *
+******************************************************************************/
+/** @addtogroup MSPM0L222X_PeripheralDecl MSPM0L222X Peripheral Declaration
+  @{
+*/
+
+static DEBUGSS_Regs                             * const DEBUGSS                        = ((DEBUGSS_Regs *) DEBUGSS_BASE);
+static COMP_Regs                                * const COMP0                          = ((COMP_Regs *) COMP0_BASE);
+static WWDT_Regs                                * const WWDT0                          = ((WWDT_Regs *) WWDT0_BASE);
+static I2C_Regs                                 * const I2C1                           = ((I2C_Regs *) I2C1_BASE);
+static UART_Regs                                * const UART0                          = ((UART_Regs *) UART0_BASE);
+static GPIO_Regs                                * const GPIOA                          = ((GPIO_Regs *) GPIOA_BASE);
+static I2C_Regs                                 * const I2C0                           = ((I2C_Regs *) I2C0_BASE);
+static UART_Regs                                * const UART2                          = ((UART_Regs *) UART2_BASE);
+static ADC12_Regs                               * const ADC0                           = ((ADC12_Regs *) ADC0_BASE);
+static ADC12_PERIPHERALREGIONSVT_Regs           * const ADC0_PERIPHERALREGIONSVT       = ((ADC12_PERIPHERALREGIONSVT_Regs *) ADC0_PERIPHERALREGIONSVT_BASE);
+static SPI_Regs                                 * const SPI0                           = ((SPI_Regs *) SPI0_BASE);
+static VREF_Regs                                * const VREF                           = ((VREF_Regs *) VREF_BASE);
+static SPI_Regs                                 * const SPI1                           = ((SPI_Regs *) SPI1_BASE);
+static KEYSTORECTL_Regs                         * const KEYSTORECTL                    = ((KEYSTORECTL_Regs *) KEYSTORECTL_BASE);
+static TRNG_Regs                                * const TRNG                           = ((TRNG_Regs *) TRNG_BASE);
+static UART_Regs                                * const UART3                          = ((UART_Regs *) UART3_BASE);
+static UART_Regs                                * const UART1                          = ((UART_Regs *) UART1_BASE);
+static UART_Regs                                * const UART4                          = ((UART_Regs *) UART4_BASE);
+static I2C_Regs                                 * const I2C2                           = ((I2C_Regs *) I2C2_BASE);
+static GPIO_Regs                                * const GPIOB                          = ((GPIO_Regs *) GPIOB_BASE);
+static GPIO_Regs                                * const GPIOC                          = ((GPIO_Regs *) GPIOC_BASE);
+static FLASHCTL_Regs                            * const FLASHCTL                       = ((FLASHCTL_Regs *) FLASHCTL_BASE);
+static AESADV_Regs                              * const AESADV                         = ((AESADV_Regs *) AESADV_BASE);
+static CRCP_Regs                                * const CRCP0                          = ((CRCP_Regs *) CRCP0_BASE);
+static GPTIMER_Regs                             * const TIMG0                          = ((GPTIMER_Regs *) TIMG0_BASE);
+static GPTIMER_Regs                             * const TIMG4                          = ((GPTIMER_Regs *) TIMG4_BASE);
+static GPTIMER_Regs                             * const TIMG8                          = ((GPTIMER_Regs *) TIMG8_BASE);
+static GPTIMER_Regs                             * const TIMG12                         = ((GPTIMER_Regs *) TIMG12_BASE);
+static GPTIMER_Regs                             * const TIMA0                          = ((GPTIMER_Regs *) TIMA0_BASE);
+static DMA_Regs                                 * const DMA                            = ((DMA_Regs *) DMA_BASE);
+static LFSS_Regs                                * const LFSS                           = ((LFSS_Regs *) LFSS_BASE);
+static RTC_Regs                                 * const RTC_A                          = ((RTC_Regs *) RTC_A_BASE);
+static SYSCTL_Regs                              * const SYSCTL                         = ((SYSCTL_Regs *) SYSCTL_BASE);
+static GPTIMER_Regs                             * const TIMG5                          = ((GPTIMER_Regs *) TIMG5_BASE);
+static IOMUX_Regs                               * const IOMUX                          = ((IOMUX_Regs *) IOMUX_BASE);
+static LCD_Regs                                 * const LCD                            = ((LCD_Regs *) LCD_BASE);
+static CPUSS_Regs                               * const CPUSS                          = ((CPUSS_Regs *) CPUSS_BASE);
+static WUC_Regs                                 * const WUC                            = ((WUC_Regs *) WUC_BASE);
+static FACTORYREGION_OPEN_Regs                  * const FACTORYREGION                  = ((FACTORYREGION_OPEN_Regs *) FACTORYREGION_BASE);
+
+/******************************************************************************
+* SYS parameters                                                              *
+******************************************************************************/
+
+#define DMA_SYS_N_DMA_CHANNEL                         (7)       /* !< Number of DMA channels implemented in DMA. */
+#define DMA_SYS_N_DMA_FULL_CHANNEL                    (3)       /* !< Number of FULL-DMA channels implemented in DMA. */
+#define FLASHCTL_SYS_DATAWIDTH                        (64)      /* !< Data bit width of a single flash word. */
+#define ADC_SYS_NUM_ANALOG_CHAN                       (32)      /* !< Number of analog channels. */
+#define I2C_SYS_FENTRIES                              (8)       /* !< Number of FIFO entries */
+#define FLASHCTL_SYS_WEPROTAWIDTH                     (32)      /* !< Bit width of WEPROTA register */
+#define FLASHCTL_SYS_WEPROTBWIDTH                     (16)      /* !< Bit width of WEPROTB register */
+#define FLASHCTL_SYS_WEPROTCWIDTH                     (0)       /* !< Bit width of WEPROTC register */
+
+/******************************************************************************
+* DMA Triggers                                                                *
+******************************************************************************/
+
+/* External DMA Triggers */
+#define DMA_SOFTWARE_TRIG                             (0)
+#define DMA_GENERIC_SUB0_TRIG                         (1)
+#define DMA_GENERIC_SUB1_TRIG                         (2)
+#define DMA_AESADV_AES_0_TRIG                         (3)
+#define DMA_AESADV_AES_1_TRIG                         (4)
+#define DMA_I2C0_TX_TRIG                              (5)
+#define DMA_I2C0_RX_TRIG                              (6)
+#define DMA_I2C1_TX_TRIG                              (7)
+#define DMA_I2C1_RX_TRIG                              (8)
+#define DMA_I2C2_TX_TRIG                              (9)
+#define DMA_I2C2_RX_TRIG                              (10)
+#define DMA_SPI0_RX_TRIG                              (11)
+#define DMA_SPI0_TX_TRIG                              (12)
+#define DMA_SPI1_RX_TRIG                              (13)
+#define DMA_SPI1_TX_TRIG                              (14)
+#define DMA_UART0_RX_TRIG                             (15)
+#define DMA_UART0_TX_TRIG                             (16)
+#define DMA_UART1_RX_TRIG                             (17)
+#define DMA_UART1_TX_TRIG                             (18)
+#define DMA_UART2_RX_TRIG                             (19)
+#define DMA_UART2_TX_TRIG                             (20)
+#define DMA_UART3_RX_TRIG                             (21)
+#define DMA_UART3_TX_TRIG                             (22)
+#define DMA_UART4_RX_TRIG                             (23)
+#define DMA_UART4_TX_TRIG                             (24)
+#define DMA_ADC0_EVT_GEN_BD_TRIG                      (25)
+
+/* Internal DMA Triggers */
+#define DMA_CH_0_TRIG                                 (0)
+#define DMA_CH_1_TRIG                                 (1)
+#define DMA_CH_2_TRIG                                 (2)
+#define DMA_CH_3_TRIG                                 (3)
+#define DMA_CH_4_TRIG                                 (4)
+#define DMA_CH_5_TRIG                                 (5)
+#define DMA_CH_6_TRIG                                 (6)
+#define DMA_CH_7_TRIG                                 (7)
+#define DMA_CH_8_TRIG                                 (8)
+#define DMA_CH_9_TRIG                                 (9)
+#define DMA_CH_10_TRIG                                (10)
+#define DMA_CH_11_TRIG                                (11)
+#define DMA_CH_12_TRIG                                (12)
+#define DMA_CH_13_TRIG                                (13)
+#define DMA_CH_14_TRIG                                (14)
+#define DMA_CH_15_TRIG                                (15)
+
+
+/******************************************************************************
+* IOMUX Pin Definitions                                                       *
+******************************************************************************/
+
+typedef enum IOMUX_PINCM
+{
+  IOMUX_PINCM1         = (0),
+  IOMUX_PINCM2         = (1),
+  IOMUX_PINCM3         = (2),
+  IOMUX_PINCM4         = (3),
+  IOMUX_PINCM5         = (4),
+  IOMUX_PINCM6         = (5),
+  IOMUX_PINCM7         = (6),
+  IOMUX_PINCM8         = (7),
+  IOMUX_PINCM9         = (8),
+  IOMUX_PINCM10        = (9),
+  IOMUX_PINCM11        = (10),
+  IOMUX_PINCM12        = (11),
+  IOMUX_PINCM13        = (12),
+  IOMUX_PINCM14        = (13),
+  IOMUX_PINCM15        = (14),
+  IOMUX_PINCM16        = (15),
+  IOMUX_PINCM17        = (16),
+  IOMUX_PINCM18        = (17),
+  IOMUX_PINCM19        = (18),
+  IOMUX_PINCM20        = (19),
+  IOMUX_PINCM21        = (20),
+  IOMUX_PINCM22        = (21),
+  IOMUX_PINCM23        = (22),
+  IOMUX_PINCM24        = (23),
+  IOMUX_PINCM25        = (24),
+  IOMUX_PINCM26        = (25),
+  IOMUX_PINCM27        = (26),
+  IOMUX_PINCM28        = (27),
+  IOMUX_PINCM29        = (28),
+  IOMUX_PINCM30        = (29),
+  IOMUX_PINCM31        = (30),
+  IOMUX_PINCM32        = (31),
+  IOMUX_PINCM33        = (32),
+  IOMUX_PINCM34        = (33),
+  IOMUX_PINCM35        = (34),
+  IOMUX_PINCM36        = (35),
+  IOMUX_PINCM37        = (36),
+  IOMUX_PINCM38        = (37),
+  IOMUX_PINCM39        = (38),
+  IOMUX_PINCM40        = (39),
+  IOMUX_PINCM41        = (40),
+  IOMUX_PINCM42        = (41),
+  IOMUX_PINCM43        = (42),
+  IOMUX_PINCM44        = (43),
+  IOMUX_PINCM45        = (44),
+  IOMUX_PINCM46        = (45),
+  IOMUX_PINCM47        = (46),
+  IOMUX_PINCM48        = (47),
+  IOMUX_PINCM49        = (48),
+  IOMUX_PINCM50        = (49),
+  IOMUX_PINCM51        = (50),
+  IOMUX_PINCM52        = (51),
+  IOMUX_PINCM53        = (52),
+  IOMUX_PINCM54        = (53),
+  IOMUX_PINCM55        = (54),
+  IOMUX_PINCM56        = (55),
+  IOMUX_PINCM57        = (56),
+  IOMUX_PINCM58        = (57),
+  IOMUX_PINCM59        = (58),
+  IOMUX_PINCM60        = (59),
+  IOMUX_PINCM61        = (60),
+  IOMUX_PINCM62        = (61),
+  IOMUX_PINCM63        = (62),
+  IOMUX_PINCM64        = (63),
+  IOMUX_PINCM65        = (64),
+  IOMUX_PINCM66        = (65),
+  IOMUX_PINCM67        = (66),
+  IOMUX_PINCM68        = (67),
+  IOMUX_PINCM69        = (68),
+  IOMUX_PINCM70        = (69),
+  IOMUX_PINCM71        = (70),
+  IOMUX_PINCM72        = (71),
+  IOMUX_PINCM73        = (72),
+  IOMUX_PINCM74        = (73),
+} IOMUX_PINCM;
+
+
+/* IOMUX_PINCM1[PF] Bits */
+#define IOMUX_PINCM1_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM1_PF_GPIOA_DIO00                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM1_PF_UART0_TX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM1_PF_I2C0_SDA                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM1_PF_TIMA0_CCP0                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM1_PF_TIMA_FAULT1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM1_PF_SYSCTL_FCC_IN                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM1_PF_TIMG8_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM1_PF_TIMG12_CCP0                   ((uint32_t)0X00000008)
+#define IOMUX_PINCM1_PF_TIMG0_CCP0                    ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM2[PF] Bits */
+#define IOMUX_PINCM2_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM2_PF_GPIOA_DIO01                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM2_PF_UART0_RX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM2_PF_I2C0_SCL                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM2_PF_TIMA0_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM2_PF_TIMA_FAULT2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM2_PF_TIMG8_IDX                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM2_PF_TIMG8_CCP0                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM2_PF_TIMG12_CCP1                   ((uint32_t)0X00000008)
+#define IOMUX_PINCM2_PF_TIMG0_CCP1                    ((uint32_t)0X00000009)
+#define IOMUX_PINCM2_PF_SPI0_CS3_CD_POCI3             ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM3[PF] Bits */
+#define IOMUX_PINCM3_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM3_PF_GPIOA_DIO28                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM3_PF_UART0_TX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM3_PF_I2C0_SDA                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM3_PF_TIMA0_CCP3                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM3_PF_TIMA_FAULT0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM3_PF_TIMG5_CCP0                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM3_PF_TIMA0_CCP1                    ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM4[PF] Bits */
+#define IOMUX_PINCM4_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM4_PF_GPIOA_DIO29                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM4_PF_I2C1_SCL                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM4_PF_UART2_RTS                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM4_PF_TIMG8_CCP0                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM4_PF_TIMG4_CCP0                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM4_PF_I2C2_SCL                      ((uint32_t)0X00000006)
+#define IOMUX_PINCM4_PF_UART0_CTS                     ((uint32_t)0X00000007)
+#define IOMUX_PINCM4_PF_SPI0_CS3_CD_POCI3             ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM5[PF] Bits */
+#define IOMUX_PINCM5_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM5_PF_GPIOA_DIO30                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM5_PF_I2C1_SDA                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM5_PF_UART2_CTS                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM5_PF_TIMG8_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM5_PF_TIMG4_CCP1                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM5_PF_I2C2_SDA                      ((uint32_t)0X00000006)
+#define IOMUX_PINCM5_PF_UART0_RTS                     ((uint32_t)0X00000007)
+#define IOMUX_PINCM5_PF_SPI0_CS2_POCI2                ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM6[PF] Bits */
+#define IOMUX_PINCM6_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM6_PF_GPIOA_DIO31                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM6_PF_UART0_RX                      ((uint32_t)0X00000002)
+#define IOMUX_PINCM6_PF_I2C0_SCL                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM6_PF_TIMA0_CCP3_CMPL               ((uint32_t)0X00000004)
+#define IOMUX_PINCM6_PF_TIMG12_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM6_PF_SYSCTL_CLK_OUT                ((uint32_t)0X00000006)
+#define IOMUX_PINCM6_PF_TIMG5_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM6_PF_SPI0_CS3_CD_POCI3             ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM7[PF] Bits */
+#define IOMUX_PINCM7_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM7_PF_GPIOA_DIO02                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM7_PF_TIMG8_CCP1                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM7_PF_SPI0_CS0                      ((uint32_t)0X00000003)
+#define IOMUX_PINCM7_PF_TIMG5_CCP1                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM7_PF_SPI1_CS0                      ((uint32_t)0X00000005)
+#define IOMUX_PINCM7_PF_TIMA0_CCP3_CMPL               ((uint32_t)0X00000006)
+#define IOMUX_PINCM7_PF_TIMA0_CCP2_CMPL               ((uint32_t)0X00000007)
+#define IOMUX_PINCM7_PF_TIMA_FAULT0                   ((uint32_t)0X00000008)
+#define IOMUX_PINCM7_PF_TIMA_FAULT1                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM7_PF_UART4_CTS                     ((uint32_t)0X0000000A)
+#define IOMUX_PINCM7_PF_TIMA0_CCP0                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM8[PF] Bits */
+#define IOMUX_PINCM8_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM8_PF_GPIOA_DIO03                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM8_PF_TIMG8_CCP0                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM8_PF_SPI0_CS1_POCI1                ((uint32_t)0X00000003)
+#define IOMUX_PINCM8_PF_I2C1_SDA                      ((uint32_t)0X00000004)
+#define IOMUX_PINCM8_PF_TIMA0_CCP1                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM8_PF_COMP0_OUT                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM8_PF_TIMG5_CCP0                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM8_PF_TIMA0_CCP2                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM8_PF_UART2_CTS                     ((uint32_t)0X00000009)
+#define IOMUX_PINCM8_PF_UART1_TX                      ((uint32_t)0X0000000A)
+#define IOMUX_PINCM8_PF_SPI0_CS3_CD_POCI3             ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM9[PF] Bits */
+#define IOMUX_PINCM9_PF_UNCONNECTED                   ((uint32_t)0X00000000)
+#define IOMUX_PINCM9_PF_GPIOA_DIO04                   ((uint32_t)0X00000001)
+#define IOMUX_PINCM9_PF_TIMG8_CCP1                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM9_PF_SPI0_POCI                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM9_PF_I2C1_SCL                      ((uint32_t)0X00000004)
+#define IOMUX_PINCM9_PF_TIMA0_CCP1_CMPL               ((uint32_t)0X00000005)
+#define IOMUX_PINCM9_PF_SYSCTL_LFCLKIN                ((uint32_t)0X00000006)
+#define IOMUX_PINCM9_PF_TIMG5_CCP1                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM9_PF_TIMA0_CCP3                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM9_PF_UART2_RTS                     ((uint32_t)0X00000009)
+#define IOMUX_PINCM9_PF_UART1_RX                      ((uint32_t)0X0000000A)
+#define IOMUX_PINCM9_PF_SPI0_CS0                      ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM10[PF] Bits */
+#define IOMUX_PINCM10_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM10_PF_GPIOA_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM10_PF_TIMG8_CCP0                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM10_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM10_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM10_PF_TIMG0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM10_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000006)
+#define IOMUX_PINCM10_PF_TIMG4_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM10_PF_TIMA_FAULT1                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM10_PF_UART0_CTS                    ((uint32_t)0X00000009)
+#define IOMUX_PINCM10_PF_UART4_RTS                    ((uint32_t)0X0000000A)
+#define IOMUX_PINCM10_PF_UART1_TX                     ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM11[PF] Bits */
+#define IOMUX_PINCM11_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM11_PF_GPIOA_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM11_PF_TIMG8_CCP1                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM11_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM11_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM11_PF_TIMG0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM11_PF_SYSCTL_HFCLKIN               ((uint32_t)0X00000006)
+#define IOMUX_PINCM11_PF_TIMG4_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM11_PF_TIMA_FAULT0                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM11_PF_UART0_RTS                    ((uint32_t)0X00000009)
+#define IOMUX_PINCM11_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X0000000A)
+#define IOMUX_PINCM11_PF_UART1_RX                     ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM12[PF] Bits */
+#define IOMUX_PINCM12_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM12_PF_GPIOB_DIO00                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM12_PF_UART0_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM12_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM12_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM12_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM12_PF_TIMG0_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM12_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM13[PF] Bits */
+#define IOMUX_PINCM13_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM13_PF_GPIOB_DIO01                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM13_PF_UART0_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM13_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM13_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM13_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM13_PF_TIMG0_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM13_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM14[PF] Bits */
+#define IOMUX_PINCM14_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM14_PF_GPIOA_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM14_PF_COMP0_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM14_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000003)
+#define IOMUX_PINCM14_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM14_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM14_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM14_PF_TIMG5_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM14_PF_TIMA0_CCP1                   ((uint32_t)0X00000008)
+#define IOMUX_PINCM14_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000009)
+#define IOMUX_PINCM14_PF_SYSCTL_FCC_IN                ((uint32_t)0X0000000A)
+#define IOMUX_PINCM14_PF_SPI0_POCI                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM15[PF] Bits */
+#define IOMUX_PINCM15_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM15_PF_GPIOB_DIO02                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM15_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM15_PF_UART2_CTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM15_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM15_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM15_PF_UART1_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM15_PF_TIMG4_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM15_PF_UART2_TX                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM15_PF_TIMG12_CCP0                  ((uint32_t)0X00000009)
+#define IOMUX_PINCM15_PF_SYSCTL_HFCLKIN               ((uint32_t)0X0000000A)
+#define IOMUX_PINCM15_PF_SPI0_PICO                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM16[PF] Bits */
+#define IOMUX_PINCM16_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM16_PF_GPIOB_DIO03                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM16_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM16_PF_UART2_RTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM16_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM16_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM16_PF_UART1_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM16_PF_TIMG4_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM16_PF_UART2_RX                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM16_PF_TIMG12_CCP1                  ((uint32_t)0X00000009)
+#define IOMUX_PINCM16_PF_TIMA0_CCP0                   ((uint32_t)0X0000000A)
+#define IOMUX_PINCM16_PF_SPI0_SCLK                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM17[PF] Bits */
+#define IOMUX_PINCM17_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM17_PF_GPIOB_DIO04                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM17_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM17_PF_UART3_CTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM17_PF_TIMA0_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM17_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM17_PF_TIMG0_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM17_PF_TIMG4_CCP0                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM18[PF] Bits */
+#define IOMUX_PINCM18_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM18_PF_GPIOB_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM18_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM18_PF_UART3_RTS                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM18_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000004)
+#define IOMUX_PINCM18_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM18_PF_TIMG0_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM18_PF_TIMG4_CCP1                   ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM19[PF] Bits */
+#define IOMUX_PINCM19_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM19_PF_GPIOA_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM19_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM19_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM19_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM19_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM19_PF_TIMA_FAULT2                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM19_PF_TIMA_FAULT0                  ((uint32_t)0X00000007)
+#define IOMUX_PINCM19_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000008)
+#define IOMUX_PINCM19_PF_TIMG5_CCP1                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM19_PF_SYSCTL_HFCLKIN               ((uint32_t)0X0000000A)
+#define IOMUX_PINCM19_PF_UART0_RTS                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM20[PF] Bits */
+#define IOMUX_PINCM20_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM20_PF_GPIOA_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM20_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM20_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM20_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM20_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM20_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+#define IOMUX_PINCM20_PF_TIMA0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM20_PF_LFSS_RTC_OUT                 ((uint32_t)0X00000008)
+#define IOMUX_PINCM20_PF_TIMG5_CCP0                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM20_PF_UART4_RTS                    ((uint32_t)0X0000000A)
+#define IOMUX_PINCM20_PF_UART0_CTS                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM21[PF] Bits */
+#define IOMUX_PINCM21_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM21_PF_GPIOB_DIO28                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM21_PF_I2C2_SCL                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM21_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM21_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM21_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM21_PF_TIMG0_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM22[PF] Bits */
+#define IOMUX_PINCM22_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM22_PF_GPIOB_DIO29                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM22_PF_I2C2_SDA                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM22_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM22_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM22_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM22_PF_TIMG0_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM23[PF] Bits */
+#define IOMUX_PINCM23_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM23_PF_GPIOB_DIO30                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM23_PF_UART1_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM23_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM23_PF_TIMA_FAULT2                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM23_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM23_PF_TIMG4_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM24[PF] Bits */
+#define IOMUX_PINCM24_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM24_PF_GPIOB_DIO31                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM24_PF_UART1_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM24_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM24_PF_TIMG8_IDX                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM24_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM24_PF_TIMG4_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM25[PF] Bits */
+#define IOMUX_PINCM25_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM25_PF_GPIOA_DIO10                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM25_PF_UART0_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM25_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM25_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM25_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM25_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+#define IOMUX_PINCM25_PF_TIMG0_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM25_PF_I2C1_SDA                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM25_PF_TIMG12_CCP0                  ((uint32_t)0X00000009)
+#define IOMUX_PINCM25_PF_TIMA_FAULT1                  ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM26[PF] Bits */
+#define IOMUX_PINCM26_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM26_PF_GPIOA_DIO11                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM26_PF_UART0_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM26_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM26_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM26_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM26_PF_COMP0_OUT                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM26_PF_TIMG0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM26_PF_I2C1_SCL                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM26_PF_TIMG12_CCP1                  ((uint32_t)0X00000009)
+#define IOMUX_PINCM26_PF_TIMA_FAULT0                  ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM27[PF] Bits */
+#define IOMUX_PINCM27_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM27_PF_GPIOB_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM27_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM27_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM27_PF_I2C2_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM27_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM27_PF_UART2_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM27_PF_TIMG4_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM27_PF_TIMA_FAULT2                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM27_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000009)
+#define IOMUX_PINCM27_PF_TIMG12_CCP0                  ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM28[PF] Bits */
+#define IOMUX_PINCM28_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM28_PF_GPIOB_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM28_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM28_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM28_PF_I2C2_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM28_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM28_PF_UART2_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM28_PF_TIMG4_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM28_PF_LCD_LCDLFCLK                 ((uint32_t)0X00000008)
+#define IOMUX_PINCM28_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000009)
+#define IOMUX_PINCM28_PF_TIMG12_CCP1                  ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM29[PF] Bits */
+#define IOMUX_PINCM29_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM29_PF_GPIOB_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM29_PF_UART1_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM29_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM29_PF_I2C2_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM29_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM29_PF_COMP0_OUT                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM29_PF_TIMG4_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM29_PF_LCD_LCDSON                   ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM30[PF] Bits */
+#define IOMUX_PINCM30_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM30_PF_GPIOB_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM30_PF_UART1_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM30_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM30_PF_I2C2_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM30_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM30_PF_TIMA0_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM30_PF_TIMG4_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM30_PF_LCD_LCDEN                    ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM31[PF] Bits */
+#define IOMUX_PINCM31_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM31_PF_GPIOB_DIO10                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM31_PF_TIMG0_CCP0                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM31_PF_TIMG8_CCP0                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM31_PF_COMP0_OUT                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM31_PF_TIMG4_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM31_PF_UART4_TX                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM31_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM32[PF] Bits */
+#define IOMUX_PINCM32_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM32_PF_GPIOB_DIO11                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM32_PF_TIMG0_CCP1                   ((uint32_t)0X00000002)
+#define IOMUX_PINCM32_PF_TIMG8_CCP1                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM32_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000004)
+#define IOMUX_PINCM32_PF_TIMG4_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM32_PF_UART4_RX                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM32_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM33[PF] Bits */
+#define IOMUX_PINCM33_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM33_PF_GPIOB_DIO12                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM33_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM33_PF_TIMA0_CCP2                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM33_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM33_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM33_PF_UART4_CTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM33_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM34[PF] Bits */
+#define IOMUX_PINCM34_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM34_PF_GPIOB_DIO13                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM34_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM34_PF_TIMA0_CCP3                   ((uint32_t)0X00000003)
+#define IOMUX_PINCM34_PF_TIMG12_CCP0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM34_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM34_PF_UART4_RTS                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM34_PF_SPI1_CS0                     ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM35[PF] Bits */
+#define IOMUX_PINCM35_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM35_PF_GPIOB_DIO14                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM35_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000002)
+#define IOMUX_PINCM35_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM35_PF_TIMG12_CCP1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM35_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM35_PF_TIMG8_IDX                    ((uint32_t)0X00000006)
+#define IOMUX_PINCM35_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM36[PF] Bits */
+#define IOMUX_PINCM36_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM36_PF_GPIOB_DIO15                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM36_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM36_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM36_PF_UART3_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM36_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM36_PF_TIMG5_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM36_PF_I2C2_SCL                     ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM37[PF] Bits */
+#define IOMUX_PINCM37_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM37_PF_GPIOB_DIO16                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM37_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM37_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM37_PF_UART3_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM37_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM37_PF_TIMG5_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM37_PF_I2C2_SDA                     ((uint32_t)0X00000007)
+
+/* IOMUX_PINCM38[PF] Bits */
+#define IOMUX_PINCM38_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM38_PF_GPIOA_DIO12                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM38_PF_UART3_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM38_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM38_PF_COMP0_OUT                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM38_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM38_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000006)
+#define IOMUX_PINCM38_PF_TIMG0_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM38_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000008)
+#define IOMUX_PINCM38_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000009)
+#define IOMUX_PINCM38_PF_UART2_CTS                    ((uint32_t)0X0000000A)
+#define IOMUX_PINCM38_PF_UART1_CTS                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM39[PF] Bits */
+#define IOMUX_PINCM39_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM39_PF_GPIOA_DIO13                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM39_PF_UART3_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM39_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM39_PF_UART3_RX                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM39_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM39_PF_LFSS_RTC_OUT                 ((uint32_t)0X00000006)
+#define IOMUX_PINCM39_PF_TIMG0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM39_PF_SPI1_CS0                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM39_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000009)
+#define IOMUX_PINCM39_PF_UART2_TX                     ((uint32_t)0X0000000A)
+#define IOMUX_PINCM39_PF_UART1_RTS                    ((uint32_t)0X0000000B)
+
+/* IOMUX_PINCM40[PF] Bits */
+#define IOMUX_PINCM40_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM40_PF_GPIOA_DIO14                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM40_PF_UART0_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM40_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM40_PF_UART3_TX                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM40_PF_TIMG12_CCP0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM40_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+#define IOMUX_PINCM40_PF_TIMG12_CCP1                  ((uint32_t)0X00000007)
+#define IOMUX_PINCM40_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000008)
+#define IOMUX_PINCM40_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000009)
+#define IOMUX_PINCM40_PF_UART2_RX                     ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM41[PF] Bits */
+#define IOMUX_PINCM41_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM41_PF_GPIOA_DIO15                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM41_PF_UART0_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM41_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM41_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM41_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM41_PF_I2C2_SCL                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM41_PF_TIMG8_IDX                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM41_PF_TIMG12_CCP0                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM41_PF_LCD_LCDEN                    ((uint32_t)0X00000009)
+#define IOMUX_PINCM41_PF_UART2_RTS                    ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM42[PF] Bits */
+#define IOMUX_PINCM42_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM42_PF_GPIOA_DIO16                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM42_PF_COMP0_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM42_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM42_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM42_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM42_PF_I2C2_SDA                     ((uint32_t)0X00000006)
+#define IOMUX_PINCM42_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000007)
+#define IOMUX_PINCM42_PF_TIMG12_CCP1                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM42_PF_LCD_LCDSON                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM42_PF_UART2_CTS                    ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM43[PF] Bits */
+#define IOMUX_PINCM43_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM43_PF_GPIOC_DIO00                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM43_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM43_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM43_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM43_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM44[PF] Bits */
+#define IOMUX_PINCM44_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM44_PF_GPIOC_DIO01                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM44_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM44_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM44_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM44_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM45[PF] Bits */
+#define IOMUX_PINCM45_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM45_PF_GPIOC_DIO02                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM45_PF_I2C2_SCL                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM45_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM45_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM45_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM45_PF_TIMG0_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM46[PF] Bits */
+#define IOMUX_PINCM46_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM46_PF_GPIOC_DIO03                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM46_PF_I2C2_SDA                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM46_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM46_PF_TIMA_FAULT1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM46_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM46_PF_TIMG0_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM47[PF] Bits */
+#define IOMUX_PINCM47_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM47_PF_GPIOC_DIO04                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM47_PF_UART3_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM47_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM47_PF_TIMA_FAULT2                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM47_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM47_PF_TIMG4_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM48[PF] Bits */
+#define IOMUX_PINCM48_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM48_PF_GPIOC_DIO05                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM48_PF_UART3_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM48_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM48_PF_TIMG8_IDX                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM48_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM48_PF_TIMG4_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM49[PF] Bits */
+#define IOMUX_PINCM49_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM49_PF_GPIOA_DIO17                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM49_PF_UART1_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM49_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM49_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM49_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM49_PF_TIMG5_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM49_PF_TIMG8_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM49_PF_TIMG12_CCP0                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM49_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000009)
+#define IOMUX_PINCM49_PF_LCD_LCDLFCLK                 ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM50[PF] Bits */
+#define IOMUX_PINCM50_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM50_PF_GPIOA_DIO18                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM50_PF_UART1_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM50_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM50_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM50_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM50_PF_TIMG5_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM50_PF_TIMG8_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM50_PF_TIMG12_CCP1                  ((uint32_t)0X00000008)
+#define IOMUX_PINCM50_PF_SPI0_CS0                     ((uint32_t)0X00000009)
+#define IOMUX_PINCM50_PF_LCD_LCDEN                    ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM51[PF] Bits */
+#define IOMUX_PINCM51_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM51_PF_GPIOA_DIO19                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM51_PF_DEBUGSS_SWDIO                ((uint32_t)0X00000002)
+#define IOMUX_PINCM51_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM51_PF_I2C1_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM51_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM51_PF_TIMG0_CCP0                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM52[PF] Bits */
+#define IOMUX_PINCM52_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM52_PF_GPIOA_DIO20                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM52_PF_DEBUGSS_SWCLK                ((uint32_t)0X00000002)
+#define IOMUX_PINCM52_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM52_PF_I2C1_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM52_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM52_PF_TIMG0_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM53[PF] Bits */
+#define IOMUX_PINCM53_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM53_PF_GPIOB_DIO17                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM53_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM53_PF_SPI0_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM53_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM53_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM53_PF_TIMG0_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM53_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000007)
+#define IOMUX_PINCM53_PF_UART4_TX                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM53_PF_TIMG4_CCP0                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM53_PF_LCD_LCDSON                   ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM54[PF] Bits */
+#define IOMUX_PINCM54_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM54_PF_GPIOB_DIO18                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM54_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM54_PF_SPI0_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM54_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM54_PF_TIMA0_CCP2_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM54_PF_TIMG0_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM54_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000007)
+#define IOMUX_PINCM54_PF_UART4_RX                     ((uint32_t)0X00000008)
+#define IOMUX_PINCM54_PF_TIMG4_CCP1                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM54_PF_LCD_LCDLFCLK                 ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM55[PF] Bits */
+#define IOMUX_PINCM55_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM55_PF_GPIOB_DIO19                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM55_PF_COMP0_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM55_PF_SPI0_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM55_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM55_PF_UART0_CTS                    ((uint32_t)0X00000005)
+#define IOMUX_PINCM55_PF_TIMG5_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM55_PF_TIMG8_IDX                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM55_PF_UART2_CTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM55_PF_UART4_CTS                    ((uint32_t)0X00000009)
+#define IOMUX_PINCM55_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM56[PF] Bits */
+#define IOMUX_PINCM56_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM56_PF_GPIOA_DIO21                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM56_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM56_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM56_PF_UART1_CTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM56_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM56_PF_TIMG4_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM56_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000007)
+#define IOMUX_PINCM56_PF_UART2_CTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM56_PF_UART4_RTS                    ((uint32_t)0X00000009)
+#define IOMUX_PINCM56_PF_TIMG8_CCP0                   ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM57[PF] Bits */
+#define IOMUX_PINCM57_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM57_PF_GPIOA_DIO22                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM57_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM57_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM57_PF_UART1_RTS                    ((uint32_t)0X00000004)
+#define IOMUX_PINCM57_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM57_PF_TIMG4_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM57_PF_TIMA0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM57_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000008)
+#define IOMUX_PINCM57_PF_I2C0_SCL                     ((uint32_t)0X00000009)
+#define IOMUX_PINCM57_PF_TIMG8_CCP1                   ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM58[PF] Bits */
+#define IOMUX_PINCM58_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM58_PF_GPIOC_DIO06                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM58_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM58_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM58_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM58_PF_TIMA0_CCP0                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM59[PF] Bits */
+#define IOMUX_PINCM59_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM59_PF_GPIOC_DIO07                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM59_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM59_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM59_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM59_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM60[PF] Bits */
+#define IOMUX_PINCM60_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM60_PF_GPIOC_DIO08                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM60_PF_UART3_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM60_PF_SPI1_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM60_PF_TIMG5_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM60_PF_TIMA0_CCP1                   ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM61[PF] Bits */
+#define IOMUX_PINCM61_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM61_PF_GPIOC_DIO09                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM61_PF_UART3_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM61_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM61_PF_TIMG5_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM61_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM62[PF] Bits */
+#define IOMUX_PINCM62_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM62_PF_GPIOB_DIO20                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM62_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000002)
+#define IOMUX_PINCM62_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM62_PF_TIMG12_CCP0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM62_PF_TIMA0_CCP2                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM62_PF_TIMA_FAULT1                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM62_PF_TIMA0_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM62_PF_UART2_RTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM62_PF_I2C0_SDA                     ((uint32_t)0X00000009)
+
+/* IOMUX_PINCM63[PF] Bits */
+#define IOMUX_PINCM63_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM63_PF_GPIOB_DIO21                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM63_PF_UART4_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM63_PF_SPI1_POCI                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM63_PF_I2C0_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM63_PF_TIMG8_CCP0                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM63_PF_UART1_TX                     ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM64[PF] Bits */
+#define IOMUX_PINCM64_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM64_PF_GPIOB_DIO22                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM64_PF_UART4_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM64_PF_SPI1_PICO                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM64_PF_I2C0_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM64_PF_TIMG8_CCP1                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM64_PF_UART1_RX                     ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM65[PF] Bits */
+#define IOMUX_PINCM65_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM65_PF_GPIOB_DIO23                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM65_PF_UART1_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM65_PF_SPI1_SCLK                    ((uint32_t)0X00000003)
+#define IOMUX_PINCM65_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM65_PF_COMP0_OUT                    ((uint32_t)0X00000005)
+
+/* IOMUX_PINCM66[PF] Bits */
+#define IOMUX_PINCM66_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM66_PF_GPIOB_DIO24                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM66_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000002)
+#define IOMUX_PINCM66_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM66_PF_TIMG12_CCP1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM66_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM66_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM66_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000007)
+#define IOMUX_PINCM66_PF_UART2_RTS                    ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM67[PF] Bits */
+#define IOMUX_PINCM67_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM67_PF_GPIOA_DIO23                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM67_PF_UART2_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM67_PF_SPI0_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM67_PF_I2C2_SCL                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM67_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM67_PF_TIMG8_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM67_PF_TIMG5_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM67_PF_UART3_CTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM67_PF_TIMG0_CCP0                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM67_PF_SPI1_CS1_POCI1               ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM68[PF] Bits */
+#define IOMUX_PINCM68_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM68_PF_GPIOA_DIO24                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM68_PF_UART2_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM68_PF_SPI0_CS2_POCI2               ((uint32_t)0X00000003)
+#define IOMUX_PINCM68_PF_I2C2_SDA                     ((uint32_t)0X00000004)
+#define IOMUX_PINCM68_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM68_PF_TIMG8_CCP1                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM68_PF_TIMG5_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM68_PF_UART3_RTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM68_PF_TIMG0_CCP1                   ((uint32_t)0X00000009)
+#define IOMUX_PINCM68_PF_SPI1_CS2_POCI2               ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM69[PF] Bits */
+#define IOMUX_PINCM69_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM69_PF_GPIOA_DIO25                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM69_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM69_PF_SPI1_CS3_CD_POCI3            ((uint32_t)0X00000003)
+#define IOMUX_PINCM69_PF_TIMG12_CCP1                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM69_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM69_PF_TIMA0_CCP1_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM69_PF_COMP0_OUT                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM69_PF_UART2_CTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM69_PF_UART3_TX                     ((uint32_t)0X00000009)
+#define IOMUX_PINCM69_PF_TIMG4_CCP0                   ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM70[PF] Bits */
+#define IOMUX_PINCM70_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM70_PF_GPIOB_DIO25                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM70_PF_UART0_CTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM70_PF_SPI0_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM70_PF_TIMA_FAULT0                  ((uint32_t)0X00000004)
+#define IOMUX_PINCM70_PF_TIMA_FAULT1                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM70_PF_TIMA_FAULT2                  ((uint32_t)0X00000006)
+#define IOMUX_PINCM70_PF_COMP0_OUT                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM70_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM71[PF] Bits */
+#define IOMUX_PINCM71_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM71_PF_GPIOB_DIO26                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM71_PF_UART0_RTS                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM71_PF_SPI0_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM71_PF_TIMA0_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM71_PF_TIMA0_CCP3                   ((uint32_t)0X00000005)
+#define IOMUX_PINCM71_PF_TIMG4_CCP0                   ((uint32_t)0X00000006)
+#define IOMUX_PINCM71_PF_COMP0_OUT                    ((uint32_t)0X00000007)
+#define IOMUX_PINCM71_PF_SYSCTL_FCC_IN                ((uint32_t)0X00000008)
+
+/* IOMUX_PINCM72[PF] Bits */
+#define IOMUX_PINCM72_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM72_PF_GPIOB_DIO27                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM72_PF_COMP0_OUT                    ((uint32_t)0X00000002)
+#define IOMUX_PINCM72_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM72_PF_TIMA0_CCP0_CMPL              ((uint32_t)0X00000004)
+#define IOMUX_PINCM72_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000005)
+#define IOMUX_PINCM72_PF_TIMG4_CCP1                   ((uint32_t)0X00000006)
+
+/* IOMUX_PINCM73[PF] Bits */
+#define IOMUX_PINCM73_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM73_PF_GPIOA_DIO26                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM73_PF_UART3_TX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM73_PF_SPI1_CS0                     ((uint32_t)0X00000003)
+#define IOMUX_PINCM73_PF_TIMG8_CCP0                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM73_PF_TIMA_FAULT0                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM73_PF_TIMA0_CCP3_CMPL              ((uint32_t)0X00000006)
+#define IOMUX_PINCM73_PF_TIMG5_CCP0                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM73_PF_UART2_RTS                    ((uint32_t)0X00000008)
+#define IOMUX_PINCM73_PF_UART3_RX                     ((uint32_t)0X00000009)
+#define IOMUX_PINCM73_PF_TIMG4_CCP1                   ((uint32_t)0X0000000A)
+
+/* IOMUX_PINCM74[PF] Bits */
+#define IOMUX_PINCM74_PF_UNCONNECTED                  ((uint32_t)0X00000000)
+#define IOMUX_PINCM74_PF_GPIOA_DIO27                  ((uint32_t)0X00000001)
+#define IOMUX_PINCM74_PF_UART3_RX                     ((uint32_t)0X00000002)
+#define IOMUX_PINCM74_PF_SPI1_CS1_POCI1               ((uint32_t)0X00000003)
+#define IOMUX_PINCM74_PF_TIMG8_CCP1                   ((uint32_t)0X00000004)
+#define IOMUX_PINCM74_PF_TIMA_FAULT2                  ((uint32_t)0X00000005)
+#define IOMUX_PINCM74_PF_SYSCTL_CLK_OUT               ((uint32_t)0X00000006)
+#define IOMUX_PINCM74_PF_TIMG5_CCP1                   ((uint32_t)0X00000007)
+#define IOMUX_PINCM74_PF_LFSS_RTC_OUT                 ((uint32_t)0X00000008)
+#define IOMUX_PINCM74_PF_COMP0_OUT                    ((uint32_t)0X00000009)
+
+
+#if   defined (__CC_ARM)
+  #pragma pop
+#elif defined (__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+  #pragma clang diagnostic pop
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning restore
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+/*@}*/ /* end of group MSPM0L222X_PeripheralDecl */
+
+/*@}*/ /* end of group MSPM0L222X_Definitions */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_m0p_mspm0l222x__include */

--- a/mspm0/source/ti/devices/msp/msp.h
+++ b/mspm0/source/ti/devices/msp/msp.h
@@ -1,0 +1,79 @@
+/*****************************************************************************
+
+  Copyright (C) 2020 Texas Instruments Incorporated - http://www.ti.com/ 
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+   Redistributions of source code must retain the above copyright 
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the   
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+/* This file automatically includes the specific device header file
+   without the need to include a specific device header.
+   The device #define is set automatically through the toolchain on basis
+   of the device chosen in the device selection menu (.e.g -D__MICRO1__).      */
+
+#ifndef ti_devices_msp_msp__include
+#define ti_devices_msp_msp__include
+
+/* This preliminary header file does not have a version number -  build date: 2020-08-28 14:25:07 */
+
+/******************************************************************************
+* MSP devices
+******************************************************************************/
+
+#include <ti/devices/DeviceFamily.h>
+
+#if (DeviceFamily_ID == DeviceFamily_ID_MSPM0G110X)
+#include <ti/devices/msp/m0p/mspm0g110x.h>
+#elif (DeviceFamily_ID == DeviceFamily_ID_MSPM0G150X)
+#include <ti/devices/msp/m0p/mspm0g150x.h>
+#elif (DeviceFamily_ID == DeviceFamily_ID_MSPM0G310X)
+#include <ti/devices/msp/m0p/mspm0g310x.h>
+#elif (DeviceFamily_ID == DeviceFamily_ID_MSPM0G350X)
+#include <ti/devices/msp/m0p/mspm0g350x.h>
+#elif (DeviceFamily_ID == DeviceFamily_ID_MSPM0L110X)
+#include <ti/devices/msp/m0p/mspm0l110x.h>
+#elif (DeviceFamily_ID == DeviceFamily_ID_MSPM0L130X)
+#include <ti/devices/msp/m0p/mspm0l130x.h>
+#elif (DeviceFamily_ID == DeviceFamily_ID_MSPM0L134X)
+#include <ti/devices/msp/m0p/mspm0l134x.h>
+#elif (DeviceFamily_ID == DeviceFamily_ID_MSPM0C110X) || (DeviceFamily_ID == DeviceFamily_ID_MSPS003FX)
+#include <ti/devices/msp/m0p/mspm0c110x.h>
+#elif (DeviceFamily_ID == DeviceFamily_ID_MSPM0L222X)
+#include <ti/devices/msp/m0p/mspm0l222x.h>
+#elif (DeviceFamily_ID == DeviceFamily_ID_MSPM0L122X)
+#include <ti/devices/msp/m0p/mspm0l122x.h>
+
+/********************************************************************
+ *
+ ********************************************************************/
+#else
+#error "Failed to match a default include file"
+#endif
+
+#endif /* ti_devices_msp_msp__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_adc12.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_adc12.h
@@ -1,0 +1,4030 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_adc12__include
+#define ti_devices_msp_peripherals_hw_adc12__include
+
+/* Filename: hw_adc12.h */
+/* Revised: 2023-05-10 21:21:24 */
+/* Revision: ea14887e6b01ba9500da04a57268943a18f1cefd */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* ADC12 Registers
+******************************************************************************/
+#define ADC12_SVTMEM_OFS                         ((uint32_t)0x00000000U)
+#define ADC12_DMA_TRIG_OFS                       ((uint32_t)0x00001080U)
+#define ADC12_GEN_EVENT_OFS                      ((uint32_t)0x00001050U)
+#define ADC12_CPU_INT_OFS                        ((uint32_t)0x00001020U)
+#define ADC12_GPRCM_OFS                          ((uint32_t)0x00000800U)
+#define ADC12_ULLMEM_OFS                         ((uint32_t)0x00000000U)
+
+
+/** @addtogroup ADC12_SVTMEM
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[88];
+  __I  uint32_t FIFODATA;                          /* !< (@ 0x00000160) FIFO Data Register */
+       uint32_t RESERVED1[71];
+  __I  uint32_t MEMRES[24];                        /* !< (@ 0x00000280) Memory Result Register */
+} ADC12_SVTMEM_Regs;
+
+/*@}*/ /* end of group ADC12_SVTMEM */
+
+/** @addtogroup ADC12_PERIPHERALREGIONSVT
+  @{
+*/
+
+typedef struct {
+  ADC12_SVTMEM_Regs  SVTMEM;                            /* !< (@ 0x00000000) */
+} ADC12_PERIPHERALREGIONSVT_Regs;
+
+/*@}*/ /* end of group ADC12_PERIPHERALREGIONSVT */
+
+/** @addtogroup ADC12_DMA_TRIG
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001080) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001088) Interrupt mask extension */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001090) Raw interrupt status extension */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001098) Masked interrupt status extension */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x000010A0) Interrupt set extension */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x000010A8) Interrupt clear extension */
+} ADC12_DMA_TRIG_Regs;
+
+/*@}*/ /* end of group ADC12_DMA_TRIG */
+
+/** @addtogroup ADC12_GEN_EVENT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001050) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001058) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001060) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001068) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001070) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001078) Interrupt clear */
+} ADC12_GEN_EVENT_Regs;
+
+/*@}*/ /* end of group ADC12_GEN_EVENT */
+
+/** @addtogroup ADC12_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} ADC12_CPU_INT_Regs;
+
+/*@}*/ /* end of group ADC12_CPU_INT */
+
+/** @addtogroup ADC12_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00000808) ADC clock configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} ADC12_GPRCM_Regs;
+
+/*@}*/ /* end of group ADC12_GPRCM */
+
+/** @addtogroup ADC12_ULLMEM
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[256];
+  __IO uint32_t FSUB_0;                            /* !< (@ 0x00000400) Subscriber Configuration Register. */
+       uint32_t RESERVED1[16];
+  __IO uint32_t FPUB_1;                            /* !< (@ 0x00000444) Publisher Configuration Register. */
+       uint32_t RESERVED2[238];
+  ADC12_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED3[514];
+  ADC12_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED4;
+  ADC12_GEN_EVENT_Regs  GEN_EVENT;                         /* !< (@ 0x00001050) */
+       uint32_t RESERVED5;
+  ADC12_DMA_TRIG_Regs  DMA_TRIG;                          /* !< (@ 0x00001080) */
+       uint32_t RESERVED6[13];
+  __I  uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED7[6];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Module Description */
+  __IO uint32_t CTL0;                              /* !< (@ 0x00001100) Control Register 0 */
+  __IO uint32_t CTL1;                              /* !< (@ 0x00001104) Control Register 1 */
+  __IO uint32_t CTL2;                              /* !< (@ 0x00001108) Control Register 2 */
+  __IO uint32_t CTL3;                              /* !< (@ 0x0000110C) Control Register 3 */
+  __IO uint32_t CLKFREQ;                           /* !< (@ 0x00001110) Sample Clock Frequency Range Register */
+  __IO uint32_t SCOMP0;                            /* !< (@ 0x00001114) Sample Time Compare 0 Register */
+  __IO uint32_t SCOMP1;                            /* !< (@ 0x00001118) Sample Time Compare 1 Register */
+  __IO uint32_t REFCFG;                            /* !< (@ 0x0000111C) Reference Buffer Configuration Register */
+       uint32_t RESERVED8[10];
+  __IO uint32_t WCLOW;                             /* !< (@ 0x00001148) Window Comparator Low Threshold Register */
+       uint32_t RESERVED9;
+  __IO uint32_t WCHIGH;                            /* !< (@ 0x00001150) Window Comparator High Threshold Register */
+       uint32_t RESERVED10[3];
+  __I  uint32_t FIFODATA;                          /* !< (@ 0x00001160) FIFO Data Register */
+       uint32_t RESERVED11[3];
+  __I  uint32_t ASCRES;                            /* !< (@ 0x00001170) ASC Result Register */
+       uint32_t RESERVED12[3];
+  __IO uint32_t MEMCTL[24];                        /* !< (@ 0x00001180) Conversion Memory Control Register */
+       uint32_t RESERVED13[40];
+  __I  uint32_t MEMRES[24];                        /* !< (@ 0x00001280) Memory Result Register */
+       uint32_t RESERVED14[24];
+  __I  uint32_t STATUS;                            /* !< (@ 0x00001340) Status Register */
+} ADC12_ULLMEM_Regs;
+
+/*@}*/ /* end of group ADC12_ULLMEM */
+
+/** @addtogroup ADC12
+  @{
+*/
+
+typedef struct {
+  ADC12_ULLMEM_Regs  ULLMEM;                            /* !< (@ 0x00000000) */
+} ADC12_Regs;
+
+/*@}*/ /* end of group ADC12 */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* ADC12 Register Control Bits
+******************************************************************************/
+
+/* ADC12_PERIPHERALREGIONSVT_SVTMEM_FIFODATA Bits */
+/* ADC12_PERIPHERALREGIONSVT_SVTMEM_FIFODATA[DATA] Bits */
+#define ADC12_PERIPHERALREGIONSVT_SVTMEM_FIFODATA_DATA_OFS (0)                             /* !< DATA Offset */
+#define ADC12_PERIPHERALREGIONSVT_SVTMEM_FIFODATA_DATA_MASK ((uint32_t)0xFFFFFFFFU)         /* !< Read from this data field returns
+                                                                                    the ADC sample from FIFO. */
+
+/* ADC12_PERIPHERALREGIONSVT_SVTMEM_MEMRES Bits */
+/* ADC12_PERIPHERALREGIONSVT_SVTMEM_MEMRES[DATA] Bits */
+#define ADC12_PERIPHERALREGIONSVT_SVTMEM_MEMRES_DATA_OFS (0)                             /* !< DATA Offset */
+#define ADC12_PERIPHERALREGIONSVT_SVTMEM_MEMRES_DATA_MASK ((uint32_t)0x0000FFFFU)         /* !< MEMRES result register. If DF = 0,
+                                                                                    unsigned binary: The conversion
+                                                                                    results are right aligned. In 10 and
+                                                                                    8 bit modes, the unused MSB bits are
+                                                                                    forced to 0.  If DF = 1,
+                                                                                    2s-complement format: The conversion
+                                                                                    results are left aligned. In 10 and 8
+                                                                                    bit modes, the unused LSB bits are
+                                                                                    forced to 0. The data is stored in
+                                                                                    the right-justified format and is
+                                                                                    converted to the left-justified
+                                                                                    2s-complement format during read
+                                                                                    back. */
+
+/* ADC12_DMA_TRIG_IIDX Bits */
+/* ADC12_DMA_TRIG_IIDX[STAT] Bits */
+#define ADC12_DMA_TRIG_IIDX_STAT_OFS             (0)                             /* !< STAT Offset */
+#define ADC12_DMA_TRIG_IIDX_STAT_MASK            ((uint32_t)0x000003FFU)         /* !< Interrupt index status */
+#define ADC12_DMA_TRIG_IIDX_STAT_NO_INTR         ((uint32_t)0x00000000U)         /* !< No bit is set means there is no
+                                                                                    pending interrupt request */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG0      ((uint32_t)0x00000009U)         /* !< MEMRES0 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG1      ((uint32_t)0x0000000AU)         /* !< MEMRES1 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG2      ((uint32_t)0x0000000BU)         /* !< MEMRES2 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG3      ((uint32_t)0x0000000CU)         /* !< MEMRES3 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG4      ((uint32_t)0x0000000DU)         /* !< MEMRES4 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG5      ((uint32_t)0x0000000EU)         /* !< MEMRES5 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG6      ((uint32_t)0x0000000FU)         /* !< MEMRES6 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG7      ((uint32_t)0x00000010U)         /* !< MEMRES7 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG8      ((uint32_t)0x00000011U)         /* !< MEMRES8 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG9      ((uint32_t)0x00000012U)         /* !< MEMRES9 data  loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG10     ((uint32_t)0x00000013U)         /* !< MEMRES10 data  loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG11     ((uint32_t)0x00000014U)         /* !< MEMRES11 data  loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG12     ((uint32_t)0x00000015U)         /* !< MEMRES12 data  loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG13     ((uint32_t)0x00000016U)         /* !< MEMRES13 data  loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG14     ((uint32_t)0x00000017U)         /* !< MEMRES14 data  loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG15     ((uint32_t)0x00000018U)         /* !< MEMRES15 data  loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG16     ((uint32_t)0x00000019U)         /* !< MEMRES16 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG17     ((uint32_t)0x0000001AU)         /* !< MEMRES17 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG18     ((uint32_t)0x0000001BU)         /* !< MEMRES18 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG19     ((uint32_t)0x0000001CU)         /* !< MEMRES19 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG20     ((uint32_t)0x0000001DU)         /* !< MEMRES20 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG21     ((uint32_t)0x0000001EU)         /* !< MEMRES21 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG22     ((uint32_t)0x0000001FU)         /* !< MEMRES22 data loaded interrupt */
+#define ADC12_DMA_TRIG_IIDX_STAT_MEMRESIFG23     ((uint32_t)0x00000020U)         /* !< MEMRES23 data loaded interrupt */
+
+/* ADC12_DMA_TRIG_IMASK Bits */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG0] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG0_OFS      (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG0_MASK     ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG0_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG0_SET      ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG1] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG1_OFS      (9)                             /* !< MEMRESIFG1 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG1_MASK     ((uint32_t)0x00000200U)         /* !< Raw interrupt status for MEMRES1.
+                                                                                    This bit is set to 1 when MEMRES1 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES1 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG1_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG1_SET      ((uint32_t)0x00000200U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG2] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG2_OFS      (10)                            /* !< MEMRESIFG2 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG2_MASK     ((uint32_t)0x00000400U)         /* !< Raw interrupt status for MEMRES2.
+                                                                                    This bit is set to 1 when MEMRES2 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES2 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG2_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG2_SET      ((uint32_t)0x00000400U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG3] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG3_OFS      (11)                            /* !< MEMRESIFG3 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG3_MASK     ((uint32_t)0x00000800U)         /* !< Raw interrupt status for MEMRES3.
+                                                                                    This bit is set to 1 when MEMRES3 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES3 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG3_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG3_SET      ((uint32_t)0x00000800U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG4] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG4_OFS      (12)                            /* !< MEMRESIFG4 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG4_MASK     ((uint32_t)0x00001000U)         /* !< Raw interrupt status for MEMRES4.
+                                                                                    This bit is set to 1 when MEMRES4 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES4 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG4_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG4_SET      ((uint32_t)0x00001000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG5] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG5_OFS      (13)                            /* !< MEMRESIFG5 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG5_MASK     ((uint32_t)0x00002000U)         /* !< Raw interrupt status for MEMRES5.
+                                                                                    This bit is set to 1 when MEMRES5 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES5 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG5_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG5_SET      ((uint32_t)0x00002000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG6] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG6_OFS      (14)                            /* !< MEMRESIFG6 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG6_MASK     ((uint32_t)0x00004000U)         /* !< Raw interrupt status for MEMRES6.
+                                                                                    This bit is set to 1 when MEMRES6 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES6 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG6_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG6_SET      ((uint32_t)0x00004000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG7] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG7_OFS      (15)                            /* !< MEMRESIFG7 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG7_MASK     ((uint32_t)0x00008000U)         /* !< Raw interrupt status for MEMRES7.
+                                                                                    This bit is set to 1 when MEMRES7 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES7 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG7_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG7_SET      ((uint32_t)0x00008000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG9] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG9_OFS      (17)                            /* !< MEMRESIFG9 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG9_MASK     ((uint32_t)0x00020000U)         /* !< Raw interrupt status for MEMRES9.
+                                                                                    This bit is set to 1 when MEMRES9 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES9 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG9_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG9_SET      ((uint32_t)0x00020000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG10] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG10_OFS     (18)                            /* !< MEMRESIFG10 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG10_MASK    ((uint32_t)0x00040000U)         /* !< Raw interrupt status for MEMRES10.
+                                                                                    This bit is set to 1 when MEMRES10 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES10 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG10_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG10_SET     ((uint32_t)0x00040000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG11] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG11_OFS     (19)                            /* !< MEMRESIFG11 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG11_MASK    ((uint32_t)0x00080000U)         /* !< Raw interrupt status for MEMRES11.
+                                                                                    This bit is set to 1 when MEMRES11 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES11 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG11_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG11_SET     ((uint32_t)0x00080000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG12] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG12_OFS     (20)                            /* !< MEMRESIFG12 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG12_MASK    ((uint32_t)0x00100000U)         /* !< Raw interrupt status for MEMRES12.
+                                                                                    This bit is set to 1 when MEMRES12 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES12 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG12_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG12_SET     ((uint32_t)0x00100000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG13] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG13_OFS     (21)                            /* !< MEMRESIFG13 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG13_MASK    ((uint32_t)0x00200000U)         /* !< Raw interrupt status for MEMRES13.
+                                                                                    This bit is set to 1 when MEMRES13 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES13 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG13_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG13_SET     ((uint32_t)0x00200000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG14] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG14_OFS     (22)                            /* !< MEMRESIFG14 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG14_MASK    ((uint32_t)0x00400000U)         /* !< Raw interrupt status for MEMRES14.
+                                                                                    This bit is set to 1 when MEMRES14 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES14 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG14_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG14_SET     ((uint32_t)0x00400000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG15] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG15_OFS     (23)                            /* !< MEMRESIFG15 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG15_MASK    ((uint32_t)0x00800000U)         /* !< Raw interrupt status for MEMRES15.
+                                                                                    This bit is set to 1 when MEMRES15 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES15 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG15_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG15_SET     ((uint32_t)0x00800000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG16] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG16_OFS     (24)                            /* !< MEMRESIFG16 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG16_MASK    ((uint32_t)0x01000000U)         /* !< Raw interrupt status for MEMRES16.
+                                                                                    This bit is set to 1 when MEMRES16 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES16 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG16_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG16_SET     ((uint32_t)0x01000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG17] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG17_OFS     (25)                            /* !< MEMRESIFG17 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG17_MASK    ((uint32_t)0x02000000U)         /* !< Raw interrupt status for MEMRES17.
+                                                                                    This bit is set to 1 when MEMRES17 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES17 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG17_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG17_SET     ((uint32_t)0x02000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG18] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG18_OFS     (26)                            /* !< MEMRESIFG18 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG18_MASK    ((uint32_t)0x04000000U)         /* !< Raw interrupt status for MEMRES18.
+                                                                                    This bit is set to 1 when MEMRES18 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES18 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG18_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG18_SET     ((uint32_t)0x04000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG19] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG19_OFS     (27)                            /* !< MEMRESIFG19 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG19_MASK    ((uint32_t)0x08000000U)         /* !< Raw interrupt status for MEMRES19.
+                                                                                    This bit is set to 1 when MEMRES19 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES19 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG19_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG19_SET     ((uint32_t)0x08000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG20] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG20_OFS     (28)                            /* !< MEMRESIFG20 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG20_MASK    ((uint32_t)0x10000000U)         /* !< Raw interrupt status for MEMRES20.
+                                                                                    This bit is set to 1 when MEMRES20 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES20 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG20_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG20_SET     ((uint32_t)0x10000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG22] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG22_OFS     (30)                            /* !< MEMRESIFG22 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG22_MASK    ((uint32_t)0x40000000U)         /* !< Raw interrupt status for MEMRES22.
+                                                                                    This bit is set to 1 when MEMRES22 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES22 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG22_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG22_SET     ((uint32_t)0x40000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG23] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG23_OFS     (31)                            /* !< MEMRESIFG23 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG23_MASK    ((uint32_t)0x80000000U)         /* !< Raw interrupt status for MEMRES23.
+                                                                                    This bit is set to 1 when MEMRES23 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES23 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG23_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG23_SET     ((uint32_t)0x80000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG8] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG8_OFS      (16)                            /* !< MEMRESIFG8 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG8_MASK     ((uint32_t)0x00010000U)         /* !< Raw interrupt status for MEMRES8.
+                                                                                    This bit is set to 1 when MEMRES8 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES8 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG8_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG8_SET      ((uint32_t)0x00010000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_IMASK[MEMRESIFG21] Bits */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG21_OFS     (29)                            /* !< MEMRESIFG21 Offset */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG21_MASK    ((uint32_t)0x20000000U)         /* !< Raw interrupt status for MEMRES21.
+                                                                                    This bit is set to 1 when MEMRES21 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES21 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG21_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_IMASK_MEMRESIFG21_SET     ((uint32_t)0x20000000U)         /* !< A new data is ready to be read. */
+
+/* ADC12_DMA_TRIG_RIS Bits */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG0] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG0_OFS        (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG0_MASK       ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG0_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG0_SET        ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG1] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG1_OFS        (9)                             /* !< MEMRESIFG1 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG1_MASK       ((uint32_t)0x00000200U)         /* !< Raw interrupt status for MEMRES1.
+                                                                                    This bit is set to 1 when MEMRES1 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES1 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG1_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG1_SET        ((uint32_t)0x00000200U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG2] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG2_OFS        (10)                            /* !< MEMRESIFG2 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG2_MASK       ((uint32_t)0x00000400U)         /* !< Raw interrupt status for MEMRES2.
+                                                                                    This bit is set to 1 when MEMRES2 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES2 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG2_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG2_SET        ((uint32_t)0x00000400U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG3] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG3_OFS        (11)                            /* !< MEMRESIFG3 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG3_MASK       ((uint32_t)0x00000800U)         /* !< Raw interrupt status for MEMRES3.
+                                                                                    This bit is set to 1 when MEMRES3 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES3 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG3_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG3_SET        ((uint32_t)0x00000800U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG4] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG4_OFS        (12)                            /* !< MEMRESIFG4 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG4_MASK       ((uint32_t)0x00001000U)         /* !< Raw interrupt status for MEMRES4.
+                                                                                    This bit is set to 1 when MEMRES4 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES4 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG4_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG4_SET        ((uint32_t)0x00001000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG5] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG5_OFS        (13)                            /* !< MEMRESIFG5 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG5_MASK       ((uint32_t)0x00002000U)         /* !< Raw interrupt status for MEMRES5.
+                                                                                    This bit is set to 1 when MEMRES5 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES5 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG5_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG5_SET        ((uint32_t)0x00002000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG6] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG6_OFS        (14)                            /* !< MEMRESIFG6 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG6_MASK       ((uint32_t)0x00004000U)         /* !< Raw interrupt status for MEMRES6.
+                                                                                    This bit is set to 1 when MEMRES6 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES6 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG6_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG6_SET        ((uint32_t)0x00004000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG7] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG7_OFS        (15)                            /* !< MEMRESIFG7 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG7_MASK       ((uint32_t)0x00008000U)         /* !< Raw interrupt status for MEMRES7.
+                                                                                    This bit is set to 1 when MEMRES7 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES7 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG7_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG7_SET        ((uint32_t)0x00008000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG9] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG9_OFS        (17)                            /* !< MEMRESIFG9 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG9_MASK       ((uint32_t)0x00020000U)         /* !< Raw interrupt status for MEMRES9.
+                                                                                    This bit is set to 1 when MEMRES9 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES9 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG9_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG9_SET        ((uint32_t)0x00020000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG10] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG10_OFS       (18)                            /* !< MEMRESIFG10 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG10_MASK      ((uint32_t)0x00040000U)         /* !< Raw interrupt status for MEMRES10.
+                                                                                    This bit is set to 1 when MEMRES10 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES10 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG10_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG10_SET       ((uint32_t)0x00040000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG11] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG11_OFS       (19)                            /* !< MEMRESIFG11 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG11_MASK      ((uint32_t)0x00080000U)         /* !< Raw interrupt status for MEMRES11.
+                                                                                    This bit is set to 1 when MEMRES11 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES11 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG11_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG11_SET       ((uint32_t)0x00080000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG12] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG12_OFS       (20)                            /* !< MEMRESIFG12 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG12_MASK      ((uint32_t)0x00100000U)         /* !< Raw interrupt status for MEMRES12.
+                                                                                    This bit is set to 1 when MEMRES12 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES12 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG12_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG12_SET       ((uint32_t)0x00100000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG13] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG13_OFS       (21)                            /* !< MEMRESIFG13 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG13_MASK      ((uint32_t)0x00200000U)         /* !< Raw interrupt status for MEMRES13.
+                                                                                    This bit is set to 1 when MEMRES13 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES13 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG13_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG13_SET       ((uint32_t)0x00200000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG14] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG14_OFS       (22)                            /* !< MEMRESIFG14 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG14_MASK      ((uint32_t)0x00400000U)         /* !< Raw interrupt status for MEMRES14.
+                                                                                    This bit is set to 1 when MEMRES14 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES14 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG14_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG14_SET       ((uint32_t)0x00400000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG15] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG15_OFS       (23)                            /* !< MEMRESIFG15 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG15_MASK      ((uint32_t)0x00800000U)         /* !< Raw interrupt status for MEMRES15.
+                                                                                    This bit is set to 1 when MEMRES15 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES15 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG15_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG15_SET       ((uint32_t)0x00800000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG16] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG16_OFS       (24)                            /* !< MEMRESIFG16 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG16_MASK      ((uint32_t)0x01000000U)         /* !< Raw interrupt status for MEMRES16.
+                                                                                    This bit is set to 1 when MEMRES16 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES16 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG16_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG16_SET       ((uint32_t)0x01000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG17] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG17_OFS       (25)                            /* !< MEMRESIFG17 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG17_MASK      ((uint32_t)0x02000000U)         /* !< Raw interrupt status for MEMRES17.
+                                                                                    This bit is set to 1 when MEMRES17 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES17 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG17_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG17_SET       ((uint32_t)0x02000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG18] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG18_OFS       (26)                            /* !< MEMRESIFG18 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG18_MASK      ((uint32_t)0x04000000U)         /* !< Raw interrupt status for MEMRES18.
+                                                                                    This bit is set to 1 when MEMRES18 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES18 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG18_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG18_SET       ((uint32_t)0x04000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG19] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG19_OFS       (27)                            /* !< MEMRESIFG19 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG19_MASK      ((uint32_t)0x08000000U)         /* !< Raw interrupt status for MEMRES19.
+                                                                                    This bit is set to 1 when MEMRES19 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES19 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG19_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG19_SET       ((uint32_t)0x08000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG20] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG20_OFS       (28)                            /* !< MEMRESIFG20 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG20_MASK      ((uint32_t)0x10000000U)         /* !< Raw interrupt status for MEMRES20.
+                                                                                    This bit is set to 1 when MEMRES20 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES20 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG20_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG20_SET       ((uint32_t)0x10000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG22] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG22_OFS       (30)                            /* !< MEMRESIFG22 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG22_MASK      ((uint32_t)0x40000000U)         /* !< Raw interrupt status for MEMRES22.
+                                                                                    This bit is set to 1 when MEMRES22 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES22 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG22_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG22_SET       ((uint32_t)0x40000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG23] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG23_OFS       (31)                            /* !< MEMRESIFG23 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG23_MASK      ((uint32_t)0x80000000U)         /* !< Raw interrupt status for MEMRES23.
+                                                                                    This bit is set to 1 when MEMRES23 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES23 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG23_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG23_SET       ((uint32_t)0x80000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG8] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG8_OFS        (16)                            /* !< MEMRESIFG8 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG8_MASK       ((uint32_t)0x00010000U)         /* !< Raw interrupt status for MEMRES8.
+                                                                                    This bit is set to 1 when MEMRES8 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES8 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG8_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG8_SET        ((uint32_t)0x00010000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_RIS[MEMRESIFG21] Bits */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG21_OFS       (29)                            /* !< MEMRESIFG21 Offset */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG21_MASK      ((uint32_t)0x20000000U)         /* !< Raw interrupt status for MEMRES21.
+                                                                                    This bit is set to 1 when MEMRES21 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES21 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG21_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_RIS_MEMRESIFG21_SET       ((uint32_t)0x20000000U)         /* !< A new data is ready to be read. */
+
+/* ADC12_DMA_TRIG_MIS Bits */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG0] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG0_OFS        (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG0_MASK       ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG0_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG0_SET        ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG1] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG1_OFS        (9)                             /* !< MEMRESIFG1 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG1_MASK       ((uint32_t)0x00000200U)         /* !< Raw interrupt status for MEMRES1.
+                                                                                    This bit is set to 1 when MEMRES1 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES1 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG1_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG1_SET        ((uint32_t)0x00000200U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG2] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG2_OFS        (10)                            /* !< MEMRESIFG2 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG2_MASK       ((uint32_t)0x00000400U)         /* !< Raw interrupt status for MEMRES2.
+                                                                                    This bit is set to 1 when MEMRES2 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES2 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG2_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG2_SET        ((uint32_t)0x00000400U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG3] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG3_OFS        (11)                            /* !< MEMRESIFG3 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG3_MASK       ((uint32_t)0x00000800U)         /* !< Raw interrupt status for MEMRES3.
+                                                                                    This bit is set to 1 when MEMRES3 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES3 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG3_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG3_SET        ((uint32_t)0x00000800U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG4] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG4_OFS        (12)                            /* !< MEMRESIFG4 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG4_MASK       ((uint32_t)0x00001000U)         /* !< Raw interrupt status for MEMRES4.
+                                                                                    This bit is set to 1 when MEMRES4 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES4 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG4_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG4_SET        ((uint32_t)0x00001000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG5] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG5_OFS        (13)                            /* !< MEMRESIFG5 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG5_MASK       ((uint32_t)0x00002000U)         /* !< Raw interrupt status for MEMRES5.
+                                                                                    This bit is set to 1 when MEMRES5 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES5 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG5_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG5_SET        ((uint32_t)0x00002000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG6] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG6_OFS        (14)                            /* !< MEMRESIFG6 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG6_MASK       ((uint32_t)0x00004000U)         /* !< Raw interrupt status for MEMRES6.
+                                                                                    This bit is set to 1 when MEMRES6 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES6 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG6_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG6_SET        ((uint32_t)0x00004000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG7] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG7_OFS        (15)                            /* !< MEMRESIFG7 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG7_MASK       ((uint32_t)0x00008000U)         /* !< Raw interrupt status for MEMRES7.
+                                                                                    This bit is set to 1 when MEMRES7 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES7 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG7_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG7_SET        ((uint32_t)0x00008000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG9] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG9_OFS        (17)                            /* !< MEMRESIFG9 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG9_MASK       ((uint32_t)0x00020000U)         /* !< Raw interrupt status for MEMRES9.
+                                                                                    This bit is set to 1 when MEMRES9 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES9 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG9_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG9_SET        ((uint32_t)0x00020000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG10] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG10_OFS       (18)                            /* !< MEMRESIFG10 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG10_MASK      ((uint32_t)0x00040000U)         /* !< Raw interrupt status for MEMRES10.
+                                                                                    This bit is set to 1 when MEMRES10 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES10 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG10_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG10_SET       ((uint32_t)0x00040000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG11] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG11_OFS       (19)                            /* !< MEMRESIFG11 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG11_MASK      ((uint32_t)0x00080000U)         /* !< Raw interrupt status for MEMRES11.
+                                                                                    This bit is set to 1 when MEMRES11 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES11 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG11_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG11_SET       ((uint32_t)0x00080000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG12] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG12_OFS       (20)                            /* !< MEMRESIFG12 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG12_MASK      ((uint32_t)0x00100000U)         /* !< Raw interrupt status for MEMRES12.
+                                                                                    This bit is set to 1 when MEMRES12 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES12 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG12_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG12_SET       ((uint32_t)0x00100000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG13] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG13_OFS       (21)                            /* !< MEMRESIFG13 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG13_MASK      ((uint32_t)0x00200000U)         /* !< Raw interrupt status for MEMRES13.
+                                                                                    This bit is set to 1 when MEMRES13 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES13 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG13_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG13_SET       ((uint32_t)0x00200000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG14] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG14_OFS       (22)                            /* !< MEMRESIFG14 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG14_MASK      ((uint32_t)0x00400000U)         /* !< Raw interrupt status for MEMRES14.
+                                                                                    This bit is set to 1 when MEMRES14 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES14 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG14_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG14_SET       ((uint32_t)0x00400000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG15] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG15_OFS       (23)                            /* !< MEMRESIFG15 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG15_MASK      ((uint32_t)0x00800000U)         /* !< Raw interrupt status for MEMRES15.
+                                                                                    This bit is set to 1 when MEMRES15 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES15 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG15_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG15_SET       ((uint32_t)0x00800000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG16] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG16_OFS       (24)                            /* !< MEMRESIFG16 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG16_MASK      ((uint32_t)0x01000000U)         /* !< Raw interrupt status for MEMRES16.
+                                                                                    This bit is set to 1 when MEMRES16 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES16 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG16_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG16_SET       ((uint32_t)0x01000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG17] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG17_OFS       (25)                            /* !< MEMRESIFG17 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG17_MASK      ((uint32_t)0x02000000U)         /* !< Raw interrupt status for MEMRES17.
+                                                                                    This bit is set to 1 when MEMRES17 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES17 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG17_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG17_SET       ((uint32_t)0x02000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG18] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG18_OFS       (26)                            /* !< MEMRESIFG18 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG18_MASK      ((uint32_t)0x04000000U)         /* !< Raw interrupt status for MEMRES18.
+                                                                                    This bit is set to 1 when MEMRES18 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES18 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG18_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG18_SET       ((uint32_t)0x04000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG19] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG19_OFS       (27)                            /* !< MEMRESIFG19 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG19_MASK      ((uint32_t)0x08000000U)         /* !< Raw interrupt status for MEMRES19.
+                                                                                    This bit is set to 1 when MEMRES19 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES19 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG19_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG19_SET       ((uint32_t)0x08000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG20] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG20_OFS       (28)                            /* !< MEMRESIFG20 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG20_MASK      ((uint32_t)0x10000000U)         /* !< Raw interrupt status for MEMRES20.
+                                                                                    This bit is set to 1 when MEMRES20 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES20 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG20_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG20_SET       ((uint32_t)0x10000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG22] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG22_OFS       (30)                            /* !< MEMRESIFG22 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG22_MASK      ((uint32_t)0x40000000U)         /* !< Raw interrupt status for MEMRES22.
+                                                                                    This bit is set to 1 when MEMRES22 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES22 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG22_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG22_SET       ((uint32_t)0x40000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG23] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG23_OFS       (31)                            /* !< MEMRESIFG23 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG23_MASK      ((uint32_t)0x80000000U)         /* !< Raw interrupt status for MEMRES23.
+                                                                                    This bit is set to 1 when MEMRES23 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES23 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG23_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG23_SET       ((uint32_t)0x80000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG8] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG8_OFS        (16)                            /* !< MEMRESIFG8 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG8_MASK       ((uint32_t)0x00010000U)         /* !< Raw interrupt status for MEMRES8.
+                                                                                    This bit is set to 1 when MEMRES8 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES8 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG8_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG8_SET        ((uint32_t)0x00010000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_MIS[MEMRESIFG21] Bits */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG21_OFS       (29)                            /* !< MEMRESIFG21 Offset */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG21_MASK      ((uint32_t)0x20000000U)         /* !< Raw interrupt status for MEMRES21.
+                                                                                    This bit is set to 1 when MEMRES21 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES21 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG21_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_MIS_MEMRESIFG21_SET       ((uint32_t)0x20000000U)         /* !< A new data is ready to be read. */
+
+/* ADC12_DMA_TRIG_ISET Bits */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG0] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG0_OFS       (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG0_MASK      ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG0_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG0_SET       ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG1] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG1_OFS       (9)                             /* !< MEMRESIFG1 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG1_MASK      ((uint32_t)0x00000200U)         /* !< Raw interrupt status for MEMRES1.
+                                                                                    This bit is set to 1 when MEMRES1 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES1 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG1_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG1_SET       ((uint32_t)0x00000200U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG2] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG2_OFS       (10)                            /* !< MEMRESIFG2 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG2_MASK      ((uint32_t)0x00000400U)         /* !< Raw interrupt status for MEMRES2.
+                                                                                    This bit is set to 1 when MEMRES2 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES2 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG2_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG2_SET       ((uint32_t)0x00000400U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG3] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG3_OFS       (11)                            /* !< MEMRESIFG3 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG3_MASK      ((uint32_t)0x00000800U)         /* !< Raw interrupt status for MEMRES3.
+                                                                                    This bit is set to 1 when MEMRES3 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES3 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG3_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG3_SET       ((uint32_t)0x00000800U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG4] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG4_OFS       (12)                            /* !< MEMRESIFG4 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG4_MASK      ((uint32_t)0x00001000U)         /* !< Raw interrupt status for MEMRES4.
+                                                                                    This bit is set to 1 when MEMRES4 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES4 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG4_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG4_SET       ((uint32_t)0x00001000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG5] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG5_OFS       (13)                            /* !< MEMRESIFG5 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG5_MASK      ((uint32_t)0x00002000U)         /* !< Raw interrupt status for MEMRES5.
+                                                                                    This bit is set to 1 when MEMRES5 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES5 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG5_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG5_SET       ((uint32_t)0x00002000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG6] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG6_OFS       (14)                            /* !< MEMRESIFG6 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG6_MASK      ((uint32_t)0x00004000U)         /* !< Raw interrupt status for MEMRES6.
+                                                                                    This bit is set to 1 when MEMRES6 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES6 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG6_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG6_SET       ((uint32_t)0x00004000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG7] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG7_OFS       (15)                            /* !< MEMRESIFG7 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG7_MASK      ((uint32_t)0x00008000U)         /* !< Raw interrupt status for MEMRES7.
+                                                                                    This bit is set to 1 when MEMRES7 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES7 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG7_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG7_SET       ((uint32_t)0x00008000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG9] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG9_OFS       (17)                            /* !< MEMRESIFG9 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG9_MASK      ((uint32_t)0x00020000U)         /* !< Raw interrupt status for MEMRES9.
+                                                                                    This bit is set to 1 when MEMRES9 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES9 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG9_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG9_SET       ((uint32_t)0x00020000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG10] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG10_OFS      (18)                            /* !< MEMRESIFG10 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG10_MASK     ((uint32_t)0x00040000U)         /* !< Raw interrupt status for MEMRES10.
+                                                                                    This bit is set to 1 when MEMRES10 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES10 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG10_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG10_SET      ((uint32_t)0x00040000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG11] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG11_OFS      (19)                            /* !< MEMRESIFG11 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG11_MASK     ((uint32_t)0x00080000U)         /* !< Raw interrupt status for MEMRES11.
+                                                                                    This bit is set to 1 when MEMRES11 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES11 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG11_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG11_SET      ((uint32_t)0x00080000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG12] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG12_OFS      (20)                            /* !< MEMRESIFG12 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG12_MASK     ((uint32_t)0x00100000U)         /* !< Raw interrupt status for MEMRES12.
+                                                                                    This bit is set to 1 when MEMRES12 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES12 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG12_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG12_SET      ((uint32_t)0x00100000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG13] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG13_OFS      (21)                            /* !< MEMRESIFG13 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG13_MASK     ((uint32_t)0x00200000U)         /* !< Raw interrupt status for MEMRES13.
+                                                                                    This bit is set to 1 when MEMRES13 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES13 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG13_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG13_SET      ((uint32_t)0x00200000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG14] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG14_OFS      (22)                            /* !< MEMRESIFG14 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG14_MASK     ((uint32_t)0x00400000U)         /* !< Raw interrupt status for MEMRES14.
+                                                                                    This bit is set to 1 when MEMRES14 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES14 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG14_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG14_SET      ((uint32_t)0x00400000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG15] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG15_OFS      (23)                            /* !< MEMRESIFG15 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG15_MASK     ((uint32_t)0x00800000U)         /* !< Raw interrupt status for MEMRES15.
+                                                                                    This bit is set to 1 when MEMRES15 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES15 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG15_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG15_SET      ((uint32_t)0x00800000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG16] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG16_OFS      (24)                            /* !< MEMRESIFG16 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG16_MASK     ((uint32_t)0x01000000U)         /* !< Raw interrupt status for MEMRES16.
+                                                                                    This bit is set to 1 when MEMRES16 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES16 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG16_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG16_SET      ((uint32_t)0x01000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG17] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG17_OFS      (25)                            /* !< MEMRESIFG17 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG17_MASK     ((uint32_t)0x02000000U)         /* !< Raw interrupt status for MEMRES17.
+                                                                                    This bit is set to 1 when MEMRES17 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES17 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG17_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG17_SET      ((uint32_t)0x02000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG18] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG18_OFS      (26)                            /* !< MEMRESIFG18 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG18_MASK     ((uint32_t)0x04000000U)         /* !< Raw interrupt status for MEMRES18.
+                                                                                    This bit is set to 1 when MEMRES18 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES18 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG18_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG18_SET      ((uint32_t)0x04000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG19] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG19_OFS      (27)                            /* !< MEMRESIFG19 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG19_MASK     ((uint32_t)0x08000000U)         /* !< Raw interrupt status for MEMRES19.
+                                                                                    This bit is set to 1 when MEMRES19 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES19 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG19_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG19_SET      ((uint32_t)0x08000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG20] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG20_OFS      (28)                            /* !< MEMRESIFG20 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG20_MASK     ((uint32_t)0x10000000U)         /* !< Raw interrupt status for MEMRES20.
+                                                                                    This bit is set to 1 when MEMRES20 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES20 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG20_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG20_SET      ((uint32_t)0x10000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG22] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG22_OFS      (30)                            /* !< MEMRESIFG22 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG22_MASK     ((uint32_t)0x40000000U)         /* !< Raw interrupt status for MEMRES22.
+                                                                                    This bit is set to 1 when MEMRES22 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES22 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG22_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG22_SET      ((uint32_t)0x40000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG23] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG23_OFS      (31)                            /* !< MEMRESIFG23 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG23_MASK     ((uint32_t)0x80000000U)         /* !< Raw interrupt status for MEMRES23.
+                                                                                    This bit is set to 1 when MEMRES23 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES23 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG23_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG23_SET      ((uint32_t)0x80000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG8] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG8_OFS       (16)                            /* !< MEMRESIFG8 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG8_MASK      ((uint32_t)0x00010000U)         /* !< Raw interrupt status for MEMRES8.
+                                                                                    This bit is set to 1 when MEMRES8 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES8 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG8_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG8_SET       ((uint32_t)0x00010000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ISET[MEMRESIFG21] Bits */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG21_OFS      (29)                            /* !< MEMRESIFG21 Offset */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG21_MASK     ((uint32_t)0x20000000U)         /* !< Raw interrupt status for MEMRES21.
+                                                                                    This bit is set to 1 when MEMRES21 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES21 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG21_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ISET_MEMRESIFG21_SET      ((uint32_t)0x20000000U)         /* !< A new data is ready to be read. */
+
+/* ADC12_DMA_TRIG_ICLR Bits */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG0] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG0_OFS       (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG0_MASK      ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG0_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG0_CLR       ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG1] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG1_OFS       (9)                             /* !< MEMRESIFG1 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG1_MASK      ((uint32_t)0x00000200U)         /* !< Raw interrupt status for MEMRES1.
+                                                                                    This bit is set to 1 when MEMRES1 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES1 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG1_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG1_CLR       ((uint32_t)0x00000200U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG2] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG2_OFS       (10)                            /* !< MEMRESIFG2 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG2_MASK      ((uint32_t)0x00000400U)         /* !< Raw interrupt status for MEMRES2.
+                                                                                    This bit is set to 1 when MEMRES2 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES2 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG2_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG2_CLR       ((uint32_t)0x00000400U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG3] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG3_OFS       (11)                            /* !< MEMRESIFG3 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG3_MASK      ((uint32_t)0x00000800U)         /* !< Raw interrupt status for MEMRES3.
+                                                                                    This bit is set to 1 when MEMRES3 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES3 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG3_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG3_CLR       ((uint32_t)0x00000800U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG4] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG4_OFS       (12)                            /* !< MEMRESIFG4 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG4_MASK      ((uint32_t)0x00001000U)         /* !< Raw interrupt status for MEMRES4.
+                                                                                    This bit is set to 1 when MEMRES4 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES4 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG4_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG4_CLR       ((uint32_t)0x00001000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG5] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG5_OFS       (13)                            /* !< MEMRESIFG5 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG5_MASK      ((uint32_t)0x00002000U)         /* !< Raw interrupt status for MEMRES5.
+                                                                                    This bit is set to 1 when MEMRES5 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES5 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG5_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG5_CLR       ((uint32_t)0x00002000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG6] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG6_OFS       (14)                            /* !< MEMRESIFG6 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG6_MASK      ((uint32_t)0x00004000U)         /* !< Raw interrupt status for MEMRES6.
+                                                                                    This bit is set to 1 when MEMRES6 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES6 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG6_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG6_CLR       ((uint32_t)0x00004000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG7] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG7_OFS       (15)                            /* !< MEMRESIFG7 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG7_MASK      ((uint32_t)0x00008000U)         /* !< Raw interrupt status for MEMRES7.
+                                                                                    This bit is set to 1 when MEMRES7 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES7 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG7_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG7_CLR       ((uint32_t)0x00008000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG9] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG9_OFS       (17)                            /* !< MEMRESIFG9 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG9_MASK      ((uint32_t)0x00020000U)         /* !< Raw interrupt status for MEMRES9.
+                                                                                    This bit is set to 1 when MEMRES9 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES9 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG9_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG9_CLR       ((uint32_t)0x00020000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG10] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG10_OFS      (18)                            /* !< MEMRESIFG10 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG10_MASK     ((uint32_t)0x00040000U)         /* !< Raw interrupt status for MEMRES10.
+                                                                                    This bit is set to 1 when MEMRES10 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES10 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG10_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG10_CLR      ((uint32_t)0x00040000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG11] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG11_OFS      (19)                            /* !< MEMRESIFG11 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG11_MASK     ((uint32_t)0x00080000U)         /* !< Raw interrupt status for MEMRES11.
+                                                                                    This bit is set to 1 when MEMRES11 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES11 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG11_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG11_CLR      ((uint32_t)0x00080000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG12] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG12_OFS      (20)                            /* !< MEMRESIFG12 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG12_MASK     ((uint32_t)0x00100000U)         /* !< Raw interrupt status for MEMRES12.
+                                                                                    This bit is set to 1 when MEMRES12 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES12 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG12_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG12_CLR      ((uint32_t)0x00100000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG13] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG13_OFS      (21)                            /* !< MEMRESIFG13 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG13_MASK     ((uint32_t)0x00200000U)         /* !< Raw interrupt status for MEMRES13.
+                                                                                    This bit is set to 1 when MEMRES13 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES13 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG13_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG13_CLR      ((uint32_t)0x00200000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG14] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG14_OFS      (22)                            /* !< MEMRESIFG14 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG14_MASK     ((uint32_t)0x00400000U)         /* !< Raw interrupt status for MEMRES14.
+                                                                                    This bit is set to 1 when MEMRES14 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES14 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG14_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG14_CLR      ((uint32_t)0x00400000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG15] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG15_OFS      (23)                            /* !< MEMRESIFG15 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG15_MASK     ((uint32_t)0x00800000U)         /* !< Raw interrupt status for MEMRES15.
+                                                                                    This bit is set to 1 when MEMRES15 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES15 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG15_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG15_CLR      ((uint32_t)0x00800000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG16] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG16_OFS      (24)                            /* !< MEMRESIFG16 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG16_MASK     ((uint32_t)0x01000000U)         /* !< Raw interrupt status for MEMRES16.
+                                                                                    This bit is set to 1 when MEMRES16 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES16 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG16_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG16_CLR      ((uint32_t)0x01000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG17] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG17_OFS      (25)                            /* !< MEMRESIFG17 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG17_MASK     ((uint32_t)0x02000000U)         /* !< Raw interrupt status for MEMRES17.
+                                                                                    This bit is set to 1 when MEMRES17 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES17 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG17_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG17_CLR      ((uint32_t)0x02000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG18] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG18_OFS      (26)                            /* !< MEMRESIFG18 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG18_MASK     ((uint32_t)0x04000000U)         /* !< Raw interrupt status for MEMRES18.
+                                                                                    This bit is set to 1 when MEMRES18 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES18 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG18_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG18_CLR      ((uint32_t)0x04000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG19] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG19_OFS      (27)                            /* !< MEMRESIFG19 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG19_MASK     ((uint32_t)0x08000000U)         /* !< Raw interrupt status for MEMRES19.
+                                                                                    This bit is set to 1 when MEMRES19 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES19 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG19_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG19_CLR      ((uint32_t)0x08000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG20] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG20_OFS      (28)                            /* !< MEMRESIFG20 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG20_MASK     ((uint32_t)0x10000000U)         /* !< Raw interrupt status for MEMRES20.
+                                                                                    This bit is set to 1 when MEMRES20 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES20 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG20_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG20_CLR      ((uint32_t)0x10000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG22] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG22_OFS      (30)                            /* !< MEMRESIFG22 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG22_MASK     ((uint32_t)0x40000000U)         /* !< Raw interrupt status for MEMRES22.
+                                                                                    This bit is set to 1 when MEMRES22 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES22 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG22_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG22_CLR      ((uint32_t)0x40000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG23] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG23_OFS      (31)                            /* !< MEMRESIFG23 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG23_MASK     ((uint32_t)0x80000000U)         /* !< Raw interrupt status for MEMRES23.
+                                                                                    This bit is set to 1 when MEMRES23 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES23 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG23_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG23_CLR      ((uint32_t)0x80000000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG8] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG8_OFS       (16)                            /* !< MEMRESIFG8 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG8_MASK      ((uint32_t)0x00010000U)         /* !< Raw interrupt status for MEMRES8.
+                                                                                    This bit is set to 1 when MEMRES8 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES8 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG8_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG8_CLR       ((uint32_t)0x00010000U)         /* !< A new data is ready to be read. */
+/* ADC12_DMA_TRIG_ICLR[MEMRESIFG21] Bits */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG21_OFS      (29)                            /* !< MEMRESIFG21 Offset */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG21_MASK     ((uint32_t)0x20000000U)         /* !< Raw interrupt status for MEMRES21.
+                                                                                    This bit is set to 1 when MEMRES21 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES21 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG21_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_DMA_TRIG_ICLR_MEMRESIFG21_CLR      ((uint32_t)0x20000000U)         /* !< A new data is ready to be read. */
+
+/* ADC12_GEN_EVENT_IIDX Bits */
+/* ADC12_GEN_EVENT_IIDX[STAT] Bits */
+#define ADC12_GEN_EVENT_IIDX_STAT_OFS            (0)                             /* !< STAT Offset */
+#define ADC12_GEN_EVENT_IIDX_STAT_MASK           ((uint32_t)0x000003FFU)         /* !< Interrupt index status */
+#define ADC12_GEN_EVENT_IIDX_STAT_NO_INTR        ((uint32_t)0x00000000U)         /* !< No bit is set means there is no
+                                                                                    pending interrupt request */
+#define ADC12_GEN_EVENT_IIDX_STAT_HIGHIFG        ((uint32_t)0x00000003U)         /* !< High threshold compare interrupt */
+#define ADC12_GEN_EVENT_IIDX_STAT_LOWIFG         ((uint32_t)0x00000004U)         /* !< Low threshold compare interrupt */
+#define ADC12_GEN_EVENT_IIDX_STAT_INIFG          ((uint32_t)0x00000005U)         /* !< Primary Sequence In range
+                                                                                    comparator interrupt */
+#define ADC12_GEN_EVENT_IIDX_STAT_MEMRESIFG0     ((uint32_t)0x00000009U)         /* !< MEMRES0 data loaded interrupt */
+
+/* ADC12_GEN_EVENT_IMASK Bits */
+/* ADC12_GEN_EVENT_IMASK[INIFG] Bits */
+#define ADC12_GEN_EVENT_IMASK_INIFG_OFS          (4)                             /* !< INIFG Offset */
+#define ADC12_GEN_EVENT_IMASK_INIFG_MASK         ((uint32_t)0x00000010U)         /* !< Mask INIFG in MIS_EX register. */
+#define ADC12_GEN_EVENT_IMASK_INIFG_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_IMASK_INIFG_SET          ((uint32_t)0x00000010U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_IMASK[LOWIFG] Bits */
+#define ADC12_GEN_EVENT_IMASK_LOWIFG_OFS         (3)                             /* !< LOWIFG Offset */
+#define ADC12_GEN_EVENT_IMASK_LOWIFG_MASK        ((uint32_t)0x00000008U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being below than the
+                                                                                    WCLOWx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_GEN_EVENT_IMASK_LOWIFG_CLR         ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_IMASK_LOWIFG_SET         ((uint32_t)0x00000008U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_IMASK[HIGHIFG] Bits */
+#define ADC12_GEN_EVENT_IMASK_HIGHIFG_OFS        (2)                             /* !< HIGHIFG Offset */
+#define ADC12_GEN_EVENT_IMASK_HIGHIFG_MASK       ((uint32_t)0x00000004U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being higher than the
+                                                                                    WCHIGHx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_GEN_EVENT_IMASK_HIGHIFG_CLR        ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_IMASK_HIGHIFG_SET        ((uint32_t)0x00000004U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_IMASK[MEMRESIFG0] Bits */
+#define ADC12_GEN_EVENT_IMASK_MEMRESIFG0_OFS     (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_GEN_EVENT_IMASK_MEMRESIFG0_MASK    ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_GEN_EVENT_IMASK_MEMRESIFG0_CLR     ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_GEN_EVENT_IMASK_MEMRESIFG0_SET     ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+
+/* ADC12_GEN_EVENT_RIS Bits */
+/* ADC12_GEN_EVENT_RIS[INIFG] Bits */
+#define ADC12_GEN_EVENT_RIS_INIFG_OFS            (4)                             /* !< INIFG Offset */
+#define ADC12_GEN_EVENT_RIS_INIFG_MASK           ((uint32_t)0x00000010U)         /* !< Mask INIFG in MIS_EX register. */
+#define ADC12_GEN_EVENT_RIS_INIFG_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_RIS_INIFG_SET            ((uint32_t)0x00000010U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_RIS[LOWIFG] Bits */
+#define ADC12_GEN_EVENT_RIS_LOWIFG_OFS           (3)                             /* !< LOWIFG Offset */
+#define ADC12_GEN_EVENT_RIS_LOWIFG_MASK          ((uint32_t)0x00000008U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being below than the
+                                                                                    WCLOWx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_GEN_EVENT_RIS_LOWIFG_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_RIS_LOWIFG_SET           ((uint32_t)0x00000008U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_RIS[HIGHIFG] Bits */
+#define ADC12_GEN_EVENT_RIS_HIGHIFG_OFS          (2)                             /* !< HIGHIFG Offset */
+#define ADC12_GEN_EVENT_RIS_HIGHIFG_MASK         ((uint32_t)0x00000004U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being higher than the
+                                                                                    WCHIGHx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_GEN_EVENT_RIS_HIGHIFG_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_RIS_HIGHIFG_SET          ((uint32_t)0x00000004U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_RIS[MEMRESIFG0] Bits */
+#define ADC12_GEN_EVENT_RIS_MEMRESIFG0_OFS       (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_GEN_EVENT_RIS_MEMRESIFG0_MASK      ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_GEN_EVENT_RIS_MEMRESIFG0_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_GEN_EVENT_RIS_MEMRESIFG0_SET       ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+
+/* ADC12_GEN_EVENT_MIS Bits */
+/* ADC12_GEN_EVENT_MIS[INIFG] Bits */
+#define ADC12_GEN_EVENT_MIS_INIFG_OFS            (4)                             /* !< INIFG Offset */
+#define ADC12_GEN_EVENT_MIS_INIFG_MASK           ((uint32_t)0x00000010U)         /* !< Mask INIFG in MIS_EX register. */
+#define ADC12_GEN_EVENT_MIS_INIFG_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_MIS_INIFG_SET            ((uint32_t)0x00000010U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_MIS[LOWIFG] Bits */
+#define ADC12_GEN_EVENT_MIS_LOWIFG_OFS           (3)                             /* !< LOWIFG Offset */
+#define ADC12_GEN_EVENT_MIS_LOWIFG_MASK          ((uint32_t)0x00000008U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being below than the
+                                                                                    WCLOWx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_GEN_EVENT_MIS_LOWIFG_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_MIS_LOWIFG_SET           ((uint32_t)0x00000008U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_MIS[HIGHIFG] Bits */
+#define ADC12_GEN_EVENT_MIS_HIGHIFG_OFS          (2)                             /* !< HIGHIFG Offset */
+#define ADC12_GEN_EVENT_MIS_HIGHIFG_MASK         ((uint32_t)0x00000004U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being higher than the
+                                                                                    WCHIGHx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_GEN_EVENT_MIS_HIGHIFG_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_MIS_HIGHIFG_SET          ((uint32_t)0x00000004U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_MIS[MEMRESIFG0] Bits */
+#define ADC12_GEN_EVENT_MIS_MEMRESIFG0_OFS       (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_GEN_EVENT_MIS_MEMRESIFG0_MASK      ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_GEN_EVENT_MIS_MEMRESIFG0_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_GEN_EVENT_MIS_MEMRESIFG0_SET       ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+
+/* ADC12_GEN_EVENT_ISET Bits */
+/* ADC12_GEN_EVENT_ISET[INIFG] Bits */
+#define ADC12_GEN_EVENT_ISET_INIFG_OFS           (4)                             /* !< INIFG Offset */
+#define ADC12_GEN_EVENT_ISET_INIFG_MASK          ((uint32_t)0x00000010U)         /* !< Mask INIFG in MIS_EX register. */
+#define ADC12_GEN_EVENT_ISET_INIFG_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_ISET_INIFG_SET           ((uint32_t)0x00000010U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_ISET[LOWIFG] Bits */
+#define ADC12_GEN_EVENT_ISET_LOWIFG_OFS          (3)                             /* !< LOWIFG Offset */
+#define ADC12_GEN_EVENT_ISET_LOWIFG_MASK         ((uint32_t)0x00000008U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being below than the
+                                                                                    WCLOWx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_GEN_EVENT_ISET_LOWIFG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_ISET_LOWIFG_SET          ((uint32_t)0x00000008U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_ISET[HIGHIFG] Bits */
+#define ADC12_GEN_EVENT_ISET_HIGHIFG_OFS         (2)                             /* !< HIGHIFG Offset */
+#define ADC12_GEN_EVENT_ISET_HIGHIFG_MASK        ((uint32_t)0x00000004U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being higher than the
+                                                                                    WCHIGHx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_GEN_EVENT_ISET_HIGHIFG_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_ISET_HIGHIFG_SET         ((uint32_t)0x00000004U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_ISET[MEMRESIFG0] Bits */
+#define ADC12_GEN_EVENT_ISET_MEMRESIFG0_OFS      (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_GEN_EVENT_ISET_MEMRESIFG0_MASK     ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_GEN_EVENT_ISET_MEMRESIFG0_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_GEN_EVENT_ISET_MEMRESIFG0_SET      ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+
+/* ADC12_GEN_EVENT_ICLR Bits */
+/* ADC12_GEN_EVENT_ICLR[INIFG] Bits */
+#define ADC12_GEN_EVENT_ICLR_INIFG_OFS           (4)                             /* !< INIFG Offset */
+#define ADC12_GEN_EVENT_ICLR_INIFG_MASK          ((uint32_t)0x00000010U)         /* !< Mask INIFG in MIS_EX register. */
+#define ADC12_GEN_EVENT_ICLR_INIFG_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_ICLR_INIFG_CLR           ((uint32_t)0x00000010U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_ICLR[LOWIFG] Bits */
+#define ADC12_GEN_EVENT_ICLR_LOWIFG_OFS          (3)                             /* !< LOWIFG Offset */
+#define ADC12_GEN_EVENT_ICLR_LOWIFG_MASK         ((uint32_t)0x00000008U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being below than the
+                                                                                    WCLOWx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_GEN_EVENT_ICLR_LOWIFG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_ICLR_LOWIFG_CLR          ((uint32_t)0x00000008U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_ICLR[HIGHIFG] Bits */
+#define ADC12_GEN_EVENT_ICLR_HIGHIFG_OFS         (2)                             /* !< HIGHIFG Offset */
+#define ADC12_GEN_EVENT_ICLR_HIGHIFG_MASK        ((uint32_t)0x00000004U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being higher than the
+                                                                                    WCHIGHx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_GEN_EVENT_ICLR_HIGHIFG_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_GEN_EVENT_ICLR_HIGHIFG_CLR         ((uint32_t)0x00000004U)         /* !< Interrupt is pending. */
+/* ADC12_GEN_EVENT_ICLR[MEMRESIFG0] Bits */
+#define ADC12_GEN_EVENT_ICLR_MEMRESIFG0_OFS      (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_GEN_EVENT_ICLR_MEMRESIFG0_MASK     ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_GEN_EVENT_ICLR_MEMRESIFG0_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_GEN_EVENT_ICLR_MEMRESIFG0_CLR      ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+
+/* ADC12_CPU_INT_IIDX Bits */
+/* ADC12_CPU_INT_IIDX[STAT] Bits */
+#define ADC12_CPU_INT_IIDX_STAT_OFS              (0)                             /* !< STAT Offset */
+#define ADC12_CPU_INT_IIDX_STAT_MASK             ((uint32_t)0x000003FFU)         /* !< Interrupt index status */
+#define ADC12_CPU_INT_IIDX_STAT_NO_INTR          ((uint32_t)0x00000000U)         /* !< No bit is set means there is no
+                                                                                    pending interrupt request */
+#define ADC12_CPU_INT_IIDX_STAT_OVIFG            ((uint32_t)0x00000001U)         /* !< MEMRESx overflow interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_TOVIFG           ((uint32_t)0x00000002U)         /* !< Sequence Conversion time overflow
+                                                                                    interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_HIGHIFG          ((uint32_t)0x00000003U)         /* !< High threshold compare interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_LOWIFG           ((uint32_t)0x00000004U)         /* !< Low threshold compare interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_INIFG            ((uint32_t)0x00000005U)         /* !< Primary Sequence In range
+                                                                                    comparator interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_DMADONE          ((uint32_t)0x00000006U)         /* !< DMA done interrupt, generated on
+                                                                                    DMA transfer completion, */
+#define ADC12_CPU_INT_IIDX_STAT_UVIFG            ((uint32_t)0x00000007U)         /* !< MEMRESx underflow interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG0       ((uint32_t)0x00000009U)         /* !< MEMRES0 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG1       ((uint32_t)0x0000000AU)         /* !< MEMRES1 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG2       ((uint32_t)0x0000000BU)         /* !< MEMRES2 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG3       ((uint32_t)0x0000000CU)         /* !< MEMRES3 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG4       ((uint32_t)0x0000000DU)         /* !< MEMRES4 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG5       ((uint32_t)0x0000000EU)         /* !< MEMRES5 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG6       ((uint32_t)0x0000000FU)         /* !< MEMRES6 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG7       ((uint32_t)0x00000010U)         /* !< MEMRES7 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG8       ((uint32_t)0x00000011U)         /* !< MEMRES8 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG9       ((uint32_t)0x00000012U)         /* !< MEMRES9 data  loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG10      ((uint32_t)0x00000013U)         /* !< MEMRES10 data  loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG11      ((uint32_t)0x00000014U)         /* !< MEMRES11 data  loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG12      ((uint32_t)0x00000015U)         /* !< MEMRES12 data  loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG13      ((uint32_t)0x00000016U)         /* !< MEMRES13 data  loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG14      ((uint32_t)0x00000017U)         /* !< MEMRES14 data  loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG15      ((uint32_t)0x00000018U)         /* !< MEMRES15 data  loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG16      ((uint32_t)0x00000019U)         /* !< MEMRES16 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG17      ((uint32_t)0x0000001AU)         /* !< MEMRES17 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG18      ((uint32_t)0x0000001BU)         /* !< MEMRES18 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG19      ((uint32_t)0x0000001CU)         /* !< MEMRES19 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG20      ((uint32_t)0x0000001DU)         /* !< MEMRES20 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG21      ((uint32_t)0x0000001EU)         /* !< MEMRES21 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG22      ((uint32_t)0x0000001FU)         /* !< MEMRES22 data loaded interrupt */
+#define ADC12_CPU_INT_IIDX_STAT_MEMRESIFG23      ((uint32_t)0x00000020U)         /* !< MEMRES23 data loaded interrupt */
+
+/* ADC12_CPU_INT_IMASK Bits */
+/* ADC12_CPU_INT_IMASK[INIFG] Bits */
+#define ADC12_CPU_INT_IMASK_INIFG_OFS            (4)                             /* !< INIFG Offset */
+#define ADC12_CPU_INT_IMASK_INIFG_MASK           ((uint32_t)0x00000010U)         /* !< Mask INIFG in MIS_EX register. */
+#define ADC12_CPU_INT_IMASK_INIFG_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_IMASK_INIFG_SET            ((uint32_t)0x00000010U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_IMASK[LOWIFG] Bits */
+#define ADC12_CPU_INT_IMASK_LOWIFG_OFS           (3)                             /* !< LOWIFG Offset */
+#define ADC12_CPU_INT_IMASK_LOWIFG_MASK          ((uint32_t)0x00000008U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being below than the
+                                                                                    WCLOWx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_IMASK_LOWIFG_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_IMASK_LOWIFG_SET           ((uint32_t)0x00000008U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_IMASK[HIGHIFG] Bits */
+#define ADC12_CPU_INT_IMASK_HIGHIFG_OFS          (2)                             /* !< HIGHIFG Offset */
+#define ADC12_CPU_INT_IMASK_HIGHIFG_MASK         ((uint32_t)0x00000004U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being higher than the
+                                                                                    WCHIGHx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_IMASK_HIGHIFG_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_IMASK_HIGHIFG_SET          ((uint32_t)0x00000004U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_IMASK[OVIFG] Bits */
+#define ADC12_CPU_INT_IMASK_OVIFG_OFS            (0)                             /* !< OVIFG Offset */
+#define ADC12_CPU_INT_IMASK_OVIFG_MASK           ((uint32_t)0x00000001U)         /* !< Raw interrupt flag for MEMRESx
+                                                                                    overflow. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_IMASK_OVIFG_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_IMASK_OVIFG_SET            ((uint32_t)0x00000001U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_IMASK[UVIFG] Bits */
+#define ADC12_CPU_INT_IMASK_UVIFG_OFS            (6)                             /* !< UVIFG Offset */
+#define ADC12_CPU_INT_IMASK_UVIFG_MASK           ((uint32_t)0x00000040U)         /* !< Raw interrupt flag for MEMRESx
+                                                                                    underflow. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR is set to 1. */
+#define ADC12_CPU_INT_IMASK_UVIFG_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_IMASK_UVIFG_SET            ((uint32_t)0x00000040U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_IMASK[TOVIFG] Bits */
+#define ADC12_CPU_INT_IMASK_TOVIFG_OFS           (1)                             /* !< TOVIFG Offset */
+#define ADC12_CPU_INT_IMASK_TOVIFG_MASK          ((uint32_t)0x00000002U)         /* !< Raw interrupt flag for sequence
+                                                                                    conversion timeout overflow. This bit
+                                                                                    is reset to 0 by IIDX read or when
+                                                                                    corresponding bit in ICLR_EX is set
+                                                                                    to 1. */
+#define ADC12_CPU_INT_IMASK_TOVIFG_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_IMASK_TOVIFG_SET           ((uint32_t)0x00000002U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_IMASK[DMADONE] Bits */
+#define ADC12_CPU_INT_IMASK_DMADONE_OFS          (5)                             /* !< DMADONE Offset */
+#define ADC12_CPU_INT_IMASK_DMADONE_MASK         ((uint32_t)0x00000020U)         /* !< Raw interrupt flag for DMADONE.
+                                                                                    This bit is reset to 0 by IIDX read
+                                                                                    or when corresponding bit in ICLR_EX
+                                                                                    is set to 1. */
+#define ADC12_CPU_INT_IMASK_DMADONE_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_IMASK_DMADONE_SET          ((uint32_t)0x00000020U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG0] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG0_OFS       (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG0_MASK      ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG0_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG0_SET       ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG1] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG1_OFS       (9)                             /* !< MEMRESIFG1 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG1_MASK      ((uint32_t)0x00000200U)         /* !< Raw interrupt status for MEMRES1.
+                                                                                    This bit is set to 1 when MEMRES1 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES1 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG1_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG1_SET       ((uint32_t)0x00000200U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG2] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG2_OFS       (10)                            /* !< MEMRESIFG2 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG2_MASK      ((uint32_t)0x00000400U)         /* !< Raw interrupt status for MEMRES2.
+                                                                                    This bit is set to 1 when MEMRES2 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES2 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG2_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG2_SET       ((uint32_t)0x00000400U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG3] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG3_OFS       (11)                            /* !< MEMRESIFG3 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG3_MASK      ((uint32_t)0x00000800U)         /* !< Raw interrupt status for MEMRES3.
+                                                                                    This bit is set to 1 when MEMRES3 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES3 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG3_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG3_SET       ((uint32_t)0x00000800U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG4] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG4_OFS       (12)                            /* !< MEMRESIFG4 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG4_MASK      ((uint32_t)0x00001000U)         /* !< Raw interrupt status for MEMRES4.
+                                                                                    This bit is set to 1 when MEMRES4 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES4 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG4_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG4_SET       ((uint32_t)0x00001000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG5] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG5_OFS       (13)                            /* !< MEMRESIFG5 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG5_MASK      ((uint32_t)0x00002000U)         /* !< Raw interrupt status for MEMRES5.
+                                                                                    This bit is set to 1 when MEMRES5 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES5 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG5_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG5_SET       ((uint32_t)0x00002000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG6] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG6_OFS       (14)                            /* !< MEMRESIFG6 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG6_MASK      ((uint32_t)0x00004000U)         /* !< Raw interrupt status for MEMRES6.
+                                                                                    This bit is set to 1 when MEMRES6 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES6 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG6_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG6_SET       ((uint32_t)0x00004000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG7] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG7_OFS       (15)                            /* !< MEMRESIFG7 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG7_MASK      ((uint32_t)0x00008000U)         /* !< Raw interrupt status for MEMRES7.
+                                                                                    This bit is set to 1 when MEMRES7 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES7 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG7_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG7_SET       ((uint32_t)0x00008000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG9] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG9_OFS       (17)                            /* !< MEMRESIFG9 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG9_MASK      ((uint32_t)0x00020000U)         /* !< Raw interrupt status for MEMRES9.
+                                                                                    This bit is set to 1 when MEMRES9 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES9 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG9_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG9_SET       ((uint32_t)0x00020000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG10] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG10_OFS      (18)                            /* !< MEMRESIFG10 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG10_MASK     ((uint32_t)0x00040000U)         /* !< Raw interrupt status for MEMRES10.
+                                                                                    This bit is set to 1 when MEMRES10 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES10 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG10_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG10_SET      ((uint32_t)0x00040000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG11] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG11_OFS      (19)                            /* !< MEMRESIFG11 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG11_MASK     ((uint32_t)0x00080000U)         /* !< Raw interrupt status for MEMRES11.
+                                                                                    This bit is set to 1 when MEMRES11 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES11 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG11_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG11_SET      ((uint32_t)0x00080000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG12] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG12_OFS      (20)                            /* !< MEMRESIFG12 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG12_MASK     ((uint32_t)0x00100000U)         /* !< Raw interrupt status for MEMRES12.
+                                                                                    This bit is set to 1 when MEMRES12 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES12 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG12_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG12_SET      ((uint32_t)0x00100000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG13] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG13_OFS      (21)                            /* !< MEMRESIFG13 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG13_MASK     ((uint32_t)0x00200000U)         /* !< Raw interrupt status for MEMRES13.
+                                                                                    This bit is set to 1 when MEMRES13 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES13 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG13_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG13_SET      ((uint32_t)0x00200000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG14] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG14_OFS      (22)                            /* !< MEMRESIFG14 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG14_MASK     ((uint32_t)0x00400000U)         /* !< Raw interrupt status for MEMRES14.
+                                                                                    This bit is set to 1 when MEMRES14 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES14 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG14_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG14_SET      ((uint32_t)0x00400000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG15] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG15_OFS      (23)                            /* !< MEMRESIFG15 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG15_MASK     ((uint32_t)0x00800000U)         /* !< Raw interrupt status for MEMRES15.
+                                                                                    This bit is set to 1 when MEMRES15 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES15 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG15_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG15_SET      ((uint32_t)0x00800000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG16] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG16_OFS      (24)                            /* !< MEMRESIFG16 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG16_MASK     ((uint32_t)0x01000000U)         /* !< Raw interrupt status for MEMRES16.
+                                                                                    This bit is set to 1 when MEMRES16 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES16 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG16_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG16_SET      ((uint32_t)0x01000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG17] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG17_OFS      (25)                            /* !< MEMRESIFG17 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG17_MASK     ((uint32_t)0x02000000U)         /* !< Raw interrupt status for MEMRES17.
+                                                                                    This bit is set to 1 when MEMRES17 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES17 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG17_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG17_SET      ((uint32_t)0x02000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG18] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG18_OFS      (26)                            /* !< MEMRESIFG18 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG18_MASK     ((uint32_t)0x04000000U)         /* !< Raw interrupt status for MEMRES18.
+                                                                                    This bit is set to 1 when MEMRES18 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES18 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG18_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG18_SET      ((uint32_t)0x04000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG19] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG19_OFS      (27)                            /* !< MEMRESIFG19 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG19_MASK     ((uint32_t)0x08000000U)         /* !< Raw interrupt status for MEMRES19.
+                                                                                    This bit is set to 1 when MEMRES19 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES19 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG19_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG19_SET      ((uint32_t)0x08000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG20] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG20_OFS      (28)                            /* !< MEMRESIFG20 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG20_MASK     ((uint32_t)0x10000000U)         /* !< Raw interrupt status for MEMRES20.
+                                                                                    This bit is set to 1 when MEMRES20 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES20 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG20_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG20_SET      ((uint32_t)0x10000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG22] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG22_OFS      (30)                            /* !< MEMRESIFG22 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG22_MASK     ((uint32_t)0x40000000U)         /* !< Raw interrupt status for MEMRES22.
+                                                                                    This bit is set to 1 when MEMRES22 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES22 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG22_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG22_SET      ((uint32_t)0x40000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG23] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG23_OFS      (31)                            /* !< MEMRESIFG23 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG23_MASK     ((uint32_t)0x80000000U)         /* !< Raw interrupt status for MEMRES23.
+                                                                                    This bit is set to 1 when MEMRES23 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES23 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG23_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG23_SET      ((uint32_t)0x80000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG8] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG8_OFS       (16)                            /* !< MEMRESIFG8 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG8_MASK      ((uint32_t)0x00010000U)         /* !< Raw interrupt status for MEMRES8.
+                                                                                    This bit is set to 1 when MEMRES8 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES8 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG8_CLR       ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG8_SET       ((uint32_t)0x00010000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[MEMRESIFG21] Bits */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG21_OFS      (29)                            /* !< MEMRESIFG21 Offset */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG21_MASK     ((uint32_t)0x20000000U)         /* !< Raw interrupt status for MEMRES21.
+                                                                                    This bit is set to 1 when MEMRES21 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES21 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG21_CLR      ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_IMASK_MEMRESIFG21_SET      ((uint32_t)0x20000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_IMASK[ASCDONE] Bits */
+#define ADC12_CPU_INT_IMASK_ASCDONE_OFS          (7)                             /* !< ASCDONE Offset */
+#define ADC12_CPU_INT_IMASK_ASCDONE_MASK         ((uint32_t)0x00000080U)         /* !< Mask for ASC done raw interrupt
+                                                                                    flag */
+#define ADC12_CPU_INT_IMASK_ASCDONE_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_IMASK_ASCDONE_SET          ((uint32_t)0x00000080U)         /* !< Interrupt is pending. */
+
+/* ADC12_CPU_INT_RIS Bits */
+/* ADC12_CPU_INT_RIS[INIFG] Bits */
+#define ADC12_CPU_INT_RIS_INIFG_OFS              (4)                             /* !< INIFG Offset */
+#define ADC12_CPU_INT_RIS_INIFG_MASK             ((uint32_t)0x00000010U)         /* !< Mask INIFG in MIS_EX register. */
+#define ADC12_CPU_INT_RIS_INIFG_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_RIS_INIFG_SET              ((uint32_t)0x00000010U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_RIS[LOWIFG] Bits */
+#define ADC12_CPU_INT_RIS_LOWIFG_OFS             (3)                             /* !< LOWIFG Offset */
+#define ADC12_CPU_INT_RIS_LOWIFG_MASK            ((uint32_t)0x00000008U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being below than the
+                                                                                    WCLOWx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_RIS_LOWIFG_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_RIS_LOWIFG_SET             ((uint32_t)0x00000008U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_RIS[HIGHIFG] Bits */
+#define ADC12_CPU_INT_RIS_HIGHIFG_OFS            (2)                             /* !< HIGHIFG Offset */
+#define ADC12_CPU_INT_RIS_HIGHIFG_MASK           ((uint32_t)0x00000004U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being higher than the
+                                                                                    WCHIGHx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_RIS_HIGHIFG_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_RIS_HIGHIFG_SET            ((uint32_t)0x00000004U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_RIS[OVIFG] Bits */
+#define ADC12_CPU_INT_RIS_OVIFG_OFS              (0)                             /* !< OVIFG Offset */
+#define ADC12_CPU_INT_RIS_OVIFG_MASK             ((uint32_t)0x00000001U)         /* !< Raw interrupt flag for MEMRESx
+                                                                                    overflow. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_RIS_OVIFG_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_RIS_OVIFG_SET              ((uint32_t)0x00000001U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_RIS[UVIFG] Bits */
+#define ADC12_CPU_INT_RIS_UVIFG_OFS              (6)                             /* !< UVIFG Offset */
+#define ADC12_CPU_INT_RIS_UVIFG_MASK             ((uint32_t)0x00000040U)         /* !< Raw interrupt flag for MEMRESx
+                                                                                    underflow. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR is set to 1. */
+#define ADC12_CPU_INT_RIS_UVIFG_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_RIS_UVIFG_SET              ((uint32_t)0x00000040U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_RIS[TOVIFG] Bits */
+#define ADC12_CPU_INT_RIS_TOVIFG_OFS             (1)                             /* !< TOVIFG Offset */
+#define ADC12_CPU_INT_RIS_TOVIFG_MASK            ((uint32_t)0x00000002U)         /* !< Raw interrupt flag for sequence
+                                                                                    conversion trigger overflow. This bit
+                                                                                    is reset to 0 by IIDX read or when
+                                                                                    corresponding bit in ICLR_EX is set
+                                                                                    to 1. */
+#define ADC12_CPU_INT_RIS_TOVIFG_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_RIS_TOVIFG_SET             ((uint32_t)0x00000002U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_RIS[DMADONE] Bits */
+#define ADC12_CPU_INT_RIS_DMADONE_OFS            (5)                             /* !< DMADONE Offset */
+#define ADC12_CPU_INT_RIS_DMADONE_MASK           ((uint32_t)0x00000020U)         /* !< Raw interrupt flag for DMADONE.
+                                                                                    This bit is reset to 0 by IIDX read
+                                                                                    or when corresponding bit in ICLR_EX
+                                                                                    is set to 1. */
+#define ADC12_CPU_INT_RIS_DMADONE_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_RIS_DMADONE_SET            ((uint32_t)0x00000020U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG0] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG0_OFS         (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG0_MASK        ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG0_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG0_SET         ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG1] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG1_OFS         (9)                             /* !< MEMRESIFG1 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG1_MASK        ((uint32_t)0x00000200U)         /* !< Raw interrupt status for MEMRES1.
+                                                                                    This bit is set to 1 when MEMRES1 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES1 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG1_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG1_SET         ((uint32_t)0x00000200U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG2] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG2_OFS         (10)                            /* !< MEMRESIFG2 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG2_MASK        ((uint32_t)0x00000400U)         /* !< Raw interrupt status for MEMRES2.
+                                                                                    This bit is set to 1 when MEMRES2 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES2 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG2_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG2_SET         ((uint32_t)0x00000400U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG3] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG3_OFS         (11)                            /* !< MEMRESIFG3 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG3_MASK        ((uint32_t)0x00000800U)         /* !< Raw interrupt status for MEMRES3.
+                                                                                    This bit is set to 1 when MEMRES3 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES3 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG3_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG3_SET         ((uint32_t)0x00000800U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG4] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG4_OFS         (12)                            /* !< MEMRESIFG4 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG4_MASK        ((uint32_t)0x00001000U)         /* !< Raw interrupt status for MEMRES4.
+                                                                                    This bit is set to 1 when MEMRES4 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES4 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG4_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG4_SET         ((uint32_t)0x00001000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG5] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG5_OFS         (13)                            /* !< MEMRESIFG5 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG5_MASK        ((uint32_t)0x00002000U)         /* !< Raw interrupt status for MEMRES5.
+                                                                                    This bit is set to 1 when MEMRES5 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES5 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG5_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG5_SET         ((uint32_t)0x00002000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG6] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG6_OFS         (14)                            /* !< MEMRESIFG6 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG6_MASK        ((uint32_t)0x00004000U)         /* !< Raw interrupt status for MEMRES6.
+                                                                                    This bit is set to 1 when MEMRES6 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES6 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG6_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG6_SET         ((uint32_t)0x00004000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG7] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG7_OFS         (15)                            /* !< MEMRESIFG7 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG7_MASK        ((uint32_t)0x00008000U)         /* !< Raw interrupt status for MEMRES7.
+                                                                                    This bit is set to 1 when MEMRES7 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES7 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG7_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG7_SET         ((uint32_t)0x00008000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG9] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG9_OFS         (17)                            /* !< MEMRESIFG9 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG9_MASK        ((uint32_t)0x00020000U)         /* !< Raw interrupt status for MEMRES9.
+                                                                                    This bit is set to 1 when MEMRES9 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES9 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG9_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG9_SET         ((uint32_t)0x00020000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG10] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG10_OFS        (18)                            /* !< MEMRESIFG10 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG10_MASK       ((uint32_t)0x00040000U)         /* !< Raw interrupt status for MEMRES10.
+                                                                                    This bit is set to 1 when MEMRES10 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES10 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG10_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG10_SET        ((uint32_t)0x00040000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG11] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG11_OFS        (19)                            /* !< MEMRESIFG11 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG11_MASK       ((uint32_t)0x00080000U)         /* !< Raw interrupt status for MEMRES11.
+                                                                                    This bit is set to 1 when MEMRES11 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES11 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG11_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG11_SET        ((uint32_t)0x00080000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG12] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG12_OFS        (20)                            /* !< MEMRESIFG12 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG12_MASK       ((uint32_t)0x00100000U)         /* !< Raw interrupt status for MEMRES12.
+                                                                                    This bit is set to 1 when MEMRES12 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES12 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG12_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG12_SET        ((uint32_t)0x00100000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG13] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG13_OFS        (21)                            /* !< MEMRESIFG13 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG13_MASK       ((uint32_t)0x00200000U)         /* !< Raw interrupt status for MEMRES13.
+                                                                                    This bit is set to 1 when MEMRES13 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES13 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG13_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG13_SET        ((uint32_t)0x00200000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG14] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG14_OFS        (22)                            /* !< MEMRESIFG14 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG14_MASK       ((uint32_t)0x00400000U)         /* !< Raw interrupt status for MEMRES14.
+                                                                                    This bit is set to 1 when MEMRES14 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES14 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG14_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG14_SET        ((uint32_t)0x00400000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG15] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG15_OFS        (23)                            /* !< MEMRESIFG15 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG15_MASK       ((uint32_t)0x00800000U)         /* !< Raw interrupt status for MEMRES15.
+                                                                                    This bit is set to 1 when MEMRES15 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES15 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG15_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG15_SET        ((uint32_t)0x00800000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG16] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG16_OFS        (24)                            /* !< MEMRESIFG16 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG16_MASK       ((uint32_t)0x01000000U)         /* !< Raw interrupt status for MEMRES16.
+                                                                                    This bit is set to 1 when MEMRES16 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES16 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG16_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG16_SET        ((uint32_t)0x01000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG17] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG17_OFS        (25)                            /* !< MEMRESIFG17 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG17_MASK       ((uint32_t)0x02000000U)         /* !< Raw interrupt status for MEMRES17.
+                                                                                    This bit is set to 1 when MEMRES17 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES17 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG17_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG17_SET        ((uint32_t)0x02000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG18] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG18_OFS        (26)                            /* !< MEMRESIFG18 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG18_MASK       ((uint32_t)0x04000000U)         /* !< Raw interrupt status for MEMRES18.
+                                                                                    This bit is set to 1 when MEMRES18 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES18 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG18_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG18_SET        ((uint32_t)0x04000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG19] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG19_OFS        (27)                            /* !< MEMRESIFG19 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG19_MASK       ((uint32_t)0x08000000U)         /* !< Raw interrupt status for MEMRES19.
+                                                                                    This bit is set to 1 when MEMRES19 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES19 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG19_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG19_SET        ((uint32_t)0x08000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG20] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG20_OFS        (28)                            /* !< MEMRESIFG20 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG20_MASK       ((uint32_t)0x10000000U)         /* !< Raw interrupt status for MEMRES20.
+                                                                                    This bit is set to 1 when MEMRES20 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES20 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG20_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG20_SET        ((uint32_t)0x10000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG22] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG22_OFS        (30)                            /* !< MEMRESIFG22 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG22_MASK       ((uint32_t)0x40000000U)         /* !< Raw interrupt status for MEMRES22.
+                                                                                    This bit is set to 1 when MEMRES22 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES22 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG22_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG22_SET        ((uint32_t)0x40000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG23] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG23_OFS        (31)                            /* !< MEMRESIFG23 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG23_MASK       ((uint32_t)0x80000000U)         /* !< Raw interrupt status for MEMRES23.
+                                                                                    This bit is set to 1 when MEMRES23 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES23 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG23_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG23_SET        ((uint32_t)0x80000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG8] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG8_OFS         (16)                            /* !< MEMRESIFG8 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG8_MASK        ((uint32_t)0x00010000U)         /* !< Raw interrupt status for MEMRES8.
+                                                                                    This bit is set to 1 when MEMRES8 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES8 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG8_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG8_SET         ((uint32_t)0x00010000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[MEMRESIFG21] Bits */
+#define ADC12_CPU_INT_RIS_MEMRESIFG21_OFS        (29)                            /* !< MEMRESIFG21 Offset */
+#define ADC12_CPU_INT_RIS_MEMRESIFG21_MASK       ((uint32_t)0x20000000U)         /* !< Raw interrupt status for MEMRES21.
+                                                                                    This bit is set to 1 when MEMRES21 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES21 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_RIS_MEMRESIFG21_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_RIS_MEMRESIFG21_SET        ((uint32_t)0x20000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_RIS[ASCDONE] Bits */
+#define ADC12_CPU_INT_RIS_ASCDONE_OFS            (7)                             /* !< ASCDONE Offset */
+#define ADC12_CPU_INT_RIS_ASCDONE_MASK           ((uint32_t)0x00000080U)         /* !< Raw interrupt flag for ASC done */
+#define ADC12_CPU_INT_RIS_ASCDONE_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_RIS_ASCDONE_SET            ((uint32_t)0x00000080U)         /* !< Interrupt is pending. */
+
+/* ADC12_CPU_INT_MIS Bits */
+/* ADC12_CPU_INT_MIS[INIFG] Bits */
+#define ADC12_CPU_INT_MIS_INIFG_OFS              (4)                             /* !< INIFG Offset */
+#define ADC12_CPU_INT_MIS_INIFG_MASK             ((uint32_t)0x00000010U)         /* !< Mask INIFG in MIS_EX register. */
+#define ADC12_CPU_INT_MIS_INIFG_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_MIS_INIFG_SET              ((uint32_t)0x00000010U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_MIS[LOWIFG] Bits */
+#define ADC12_CPU_INT_MIS_LOWIFG_OFS             (3)                             /* !< LOWIFG Offset */
+#define ADC12_CPU_INT_MIS_LOWIFG_MASK            ((uint32_t)0x00000008U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being below than the
+                                                                                    WCLOWx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_MIS_LOWIFG_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_MIS_LOWIFG_SET             ((uint32_t)0x00000008U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_MIS[HIGHIFG] Bits */
+#define ADC12_CPU_INT_MIS_HIGHIFG_OFS            (2)                             /* !< HIGHIFG Offset */
+#define ADC12_CPU_INT_MIS_HIGHIFG_MASK           ((uint32_t)0x00000004U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being higher than the
+                                                                                    WCHIGHx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_MIS_HIGHIFG_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_MIS_HIGHIFG_SET            ((uint32_t)0x00000004U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_MIS[OVIFG] Bits */
+#define ADC12_CPU_INT_MIS_OVIFG_OFS              (0)                             /* !< OVIFG Offset */
+#define ADC12_CPU_INT_MIS_OVIFG_MASK             ((uint32_t)0x00000001U)         /* !< Raw interrupt flag for MEMRESx
+                                                                                    overflow. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_MIS_OVIFG_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_MIS_OVIFG_SET              ((uint32_t)0x00000001U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_MIS[UVIFG] Bits */
+#define ADC12_CPU_INT_MIS_UVIFG_OFS              (6)                             /* !< UVIFG Offset */
+#define ADC12_CPU_INT_MIS_UVIFG_MASK             ((uint32_t)0x00000040U)         /* !< Raw interrupt flag for MEMRESx
+                                                                                    underflow. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR is set to 1. */
+#define ADC12_CPU_INT_MIS_UVIFG_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_MIS_UVIFG_SET              ((uint32_t)0x00000040U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_MIS[TOVIFG] Bits */
+#define ADC12_CPU_INT_MIS_TOVIFG_OFS             (1)                             /* !< TOVIFG Offset */
+#define ADC12_CPU_INT_MIS_TOVIFG_MASK            ((uint32_t)0x00000002U)         /* !< Raw interrupt flag for sequence
+                                                                                    conversion timeout overflow. This bit
+                                                                                    is reset to 0 by IIDX read or when
+                                                                                    corresponding bit in ICLR_EX is set
+                                                                                    to 1. */
+#define ADC12_CPU_INT_MIS_TOVIFG_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_MIS_TOVIFG_SET             ((uint32_t)0x00000002U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_MIS[DMADONE] Bits */
+#define ADC12_CPU_INT_MIS_DMADONE_OFS            (5)                             /* !< DMADONE Offset */
+#define ADC12_CPU_INT_MIS_DMADONE_MASK           ((uint32_t)0x00000020U)         /* !< Raw interrupt flag for DMADONE.
+                                                                                    This bit is reset to 0 by IIDX read
+                                                                                    or when corresponding bit in ICLR_EX
+                                                                                    is set to 1. */
+#define ADC12_CPU_INT_MIS_DMADONE_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_MIS_DMADONE_SET            ((uint32_t)0x00000020U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG0] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG0_OFS         (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG0_MASK        ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG0_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG0_SET         ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG1] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG1_OFS         (9)                             /* !< MEMRESIFG1 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG1_MASK        ((uint32_t)0x00000200U)         /* !< Raw interrupt status for MEMRES1.
+                                                                                    This bit is set to 1 when MEMRES1 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES1 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG1_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG1_SET         ((uint32_t)0x00000200U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG2] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG2_OFS         (10)                            /* !< MEMRESIFG2 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG2_MASK        ((uint32_t)0x00000400U)         /* !< Raw interrupt status for MEMRES2.
+                                                                                    This bit is set to 1 when MEMRES2 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES2 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG2_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG2_SET         ((uint32_t)0x00000400U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG3] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG3_OFS         (11)                            /* !< MEMRESIFG3 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG3_MASK        ((uint32_t)0x00000800U)         /* !< Raw interrupt status for MEMRES3.
+                                                                                    This bit is set to 1 when MEMRES3 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES3 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG3_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG3_SET         ((uint32_t)0x00000800U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG4] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG4_OFS         (12)                            /* !< MEMRESIFG4 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG4_MASK        ((uint32_t)0x00001000U)         /* !< Raw interrupt status for MEMRES4.
+                                                                                    This bit is set to 1 when MEMRES4 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES4 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG4_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG4_SET         ((uint32_t)0x00001000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG5] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG5_OFS         (13)                            /* !< MEMRESIFG5 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG5_MASK        ((uint32_t)0x00002000U)         /* !< Raw interrupt status for MEMRES5.
+                                                                                    This bit is set to 1 when MEMRES5 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES5 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG5_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG5_SET         ((uint32_t)0x00002000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG6] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG6_OFS         (14)                            /* !< MEMRESIFG6 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG6_MASK        ((uint32_t)0x00004000U)         /* !< Raw interrupt status for MEMRES6.
+                                                                                    This bit is set to 1 when MEMRES6 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES6 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG6_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG6_SET         ((uint32_t)0x00004000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG7] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG7_OFS         (15)                            /* !< MEMRESIFG7 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG7_MASK        ((uint32_t)0x00008000U)         /* !< Raw interrupt status for MEMRES7.
+                                                                                    This bit is set to 1 when MEMRES7 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES7 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG7_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG7_SET         ((uint32_t)0x00008000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG9] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG9_OFS         (17)                            /* !< MEMRESIFG9 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG9_MASK        ((uint32_t)0x00020000U)         /* !< Raw interrupt status for MEMRES9.
+                                                                                    This bit is set to 1 when MEMRES9 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES9 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG9_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG9_SET         ((uint32_t)0x00020000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG10] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG10_OFS        (18)                            /* !< MEMRESIFG10 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG10_MASK       ((uint32_t)0x00040000U)         /* !< Raw interrupt status for MEMRES10.
+                                                                                    This bit is set to 1 when MEMRES10 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES10 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG10_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG10_SET        ((uint32_t)0x00040000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG11] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG11_OFS        (19)                            /* !< MEMRESIFG11 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG11_MASK       ((uint32_t)0x00080000U)         /* !< Raw interrupt status for MEMRES11.
+                                                                                    This bit is set to 1 when MEMRES11 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES11 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG11_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG11_SET        ((uint32_t)0x00080000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG12] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG12_OFS        (20)                            /* !< MEMRESIFG12 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG12_MASK       ((uint32_t)0x00100000U)         /* !< Raw interrupt status for MEMRES12.
+                                                                                    This bit is set to 1 when MEMRES12 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES12 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG12_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG12_SET        ((uint32_t)0x00100000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG13] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG13_OFS        (21)                            /* !< MEMRESIFG13 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG13_MASK       ((uint32_t)0x00200000U)         /* !< Raw interrupt status for MEMRES13.
+                                                                                    This bit is set to 1 when MEMRES13 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES13 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG13_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG13_SET        ((uint32_t)0x00200000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG14] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG14_OFS        (22)                            /* !< MEMRESIFG14 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG14_MASK       ((uint32_t)0x00400000U)         /* !< Raw interrupt status for MEMRES14.
+                                                                                    This bit is set to 1 when MEMRES14 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES14 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG14_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG14_SET        ((uint32_t)0x00400000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG15] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG15_OFS        (23)                            /* !< MEMRESIFG15 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG15_MASK       ((uint32_t)0x00800000U)         /* !< Raw interrupt status for MEMRES15.
+                                                                                    This bit is set to 1 when MEMRES15 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES15 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG15_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG15_SET        ((uint32_t)0x00800000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG16] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG16_OFS        (24)                            /* !< MEMRESIFG16 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG16_MASK       ((uint32_t)0x01000000U)         /* !< Raw interrupt status for MEMRES16.
+                                                                                    This bit is set to 1 when MEMRES16 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES16 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG16_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG16_SET        ((uint32_t)0x01000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG17] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG17_OFS        (25)                            /* !< MEMRESIFG17 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG17_MASK       ((uint32_t)0x02000000U)         /* !< Raw interrupt status for MEMRES17.
+                                                                                    This bit is set to 1 when MEMRES17 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES17 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG17_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG17_SET        ((uint32_t)0x02000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG18] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG18_OFS        (26)                            /* !< MEMRESIFG18 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG18_MASK       ((uint32_t)0x04000000U)         /* !< Raw interrupt status for MEMRES18.
+                                                                                    This bit is set to 1 when MEMRES18 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES18 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG18_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG18_SET        ((uint32_t)0x04000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG19] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG19_OFS        (27)                            /* !< MEMRESIFG19 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG19_MASK       ((uint32_t)0x08000000U)         /* !< Raw interrupt status for MEMRES19.
+                                                                                    This bit is set to 1 when MEMRES19 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES19 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG19_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG19_SET        ((uint32_t)0x08000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG20] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG20_OFS        (28)                            /* !< MEMRESIFG20 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG20_MASK       ((uint32_t)0x10000000U)         /* !< Raw interrupt status for MEMRES20.
+                                                                                    This bit is set to 1 when MEMRES20 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES20 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG20_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG20_SET        ((uint32_t)0x10000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG22] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG22_OFS        (30)                            /* !< MEMRESIFG22 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG22_MASK       ((uint32_t)0x40000000U)         /* !< Raw interrupt status for MEMRES22.
+                                                                                    This bit is set to 1 when MEMRES22 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES22 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG22_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG22_SET        ((uint32_t)0x40000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG23] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG23_OFS        (31)                            /* !< MEMRESIFG23 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG23_MASK       ((uint32_t)0x80000000U)         /* !< Raw interrupt status for MEMRES23.
+                                                                                    This bit is set to 1 when MEMRES23 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES23 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG23_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG23_SET        ((uint32_t)0x80000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG8] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG8_OFS         (16)                            /* !< MEMRESIFG8 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG8_MASK        ((uint32_t)0x00010000U)         /* !< Raw interrupt status for MEMRES8.
+                                                                                    This bit is set to 1 when MEMRES8 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES8 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG8_CLR         ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG8_SET         ((uint32_t)0x00010000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[MEMRESIFG21] Bits */
+#define ADC12_CPU_INT_MIS_MEMRESIFG21_OFS        (29)                            /* !< MEMRESIFG21 Offset */
+#define ADC12_CPU_INT_MIS_MEMRESIFG21_MASK       ((uint32_t)0x20000000U)         /* !< Raw interrupt status for MEMRES21.
+                                                                                    This bit is set to 1 when MEMRES21 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES21 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_MIS_MEMRESIFG21_CLR        ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_MIS_MEMRESIFG21_SET        ((uint32_t)0x20000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_MIS[ASCDONE] Bits */
+#define ADC12_CPU_INT_MIS_ASCDONE_OFS            (7)                             /* !< ASCDONE Offset */
+#define ADC12_CPU_INT_MIS_ASCDONE_MASK           ((uint32_t)0x00000080U)         /* !< Masked interrupt status for ASC
+                                                                                    done */
+#define ADC12_CPU_INT_MIS_ASCDONE_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_MIS_ASCDONE_SET            ((uint32_t)0x00000080U)         /* !< Interrupt is pending. */
+
+/* ADC12_CPU_INT_ISET Bits */
+/* ADC12_CPU_INT_ISET[INIFG] Bits */
+#define ADC12_CPU_INT_ISET_INIFG_OFS             (4)                             /* !< INIFG Offset */
+#define ADC12_CPU_INT_ISET_INIFG_MASK            ((uint32_t)0x00000010U)         /* !< Mask INIFG in MIS_EX register. */
+#define ADC12_CPU_INT_ISET_INIFG_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ISET_INIFG_SET             ((uint32_t)0x00000010U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ISET[LOWIFG] Bits */
+#define ADC12_CPU_INT_ISET_LOWIFG_OFS            (3)                             /* !< LOWIFG Offset */
+#define ADC12_CPU_INT_ISET_LOWIFG_MASK           ((uint32_t)0x00000008U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being below than the
+                                                                                    WCLOWx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_ISET_LOWIFG_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ISET_LOWIFG_SET            ((uint32_t)0x00000008U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ISET[HIGHIFG] Bits */
+#define ADC12_CPU_INT_ISET_HIGHIFG_OFS           (2)                             /* !< HIGHIFG Offset */
+#define ADC12_CPU_INT_ISET_HIGHIFG_MASK          ((uint32_t)0x00000004U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being higher than the
+                                                                                    WCHIGHx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_ISET_HIGHIFG_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ISET_HIGHIFG_SET           ((uint32_t)0x00000004U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ISET[OVIFG] Bits */
+#define ADC12_CPU_INT_ISET_OVIFG_OFS             (0)                             /* !< OVIFG Offset */
+#define ADC12_CPU_INT_ISET_OVIFG_MASK            ((uint32_t)0x00000001U)         /* !< Raw interrupt flag for MEMRESx
+                                                                                    overflow. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_ISET_OVIFG_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ISET_OVIFG_SET             ((uint32_t)0x00000001U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ISET[UVIFG] Bits */
+#define ADC12_CPU_INT_ISET_UVIFG_OFS             (6)                             /* !< UVIFG Offset */
+#define ADC12_CPU_INT_ISET_UVIFG_MASK            ((uint32_t)0x00000040U)         /* !< Raw interrupt flag for MEMRESx
+                                                                                    underflow. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_ISET_UVIFG_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ISET_UVIFG_SET             ((uint32_t)0x00000040U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ISET[TOVIFG] Bits */
+#define ADC12_CPU_INT_ISET_TOVIFG_OFS            (1)                             /* !< TOVIFG Offset */
+#define ADC12_CPU_INT_ISET_TOVIFG_MASK           ((uint32_t)0x00000002U)         /* !< Raw interrupt flag for sequence
+                                                                                    conversion timeout overflow. This bit
+                                                                                    is reset to 0 by IIDX read or when
+                                                                                    corresponding bit in ICLR_EX is set
+                                                                                    to 1. */
+#define ADC12_CPU_INT_ISET_TOVIFG_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ISET_TOVIFG_SET            ((uint32_t)0x00000002U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ISET[DMADONE] Bits */
+#define ADC12_CPU_INT_ISET_DMADONE_OFS           (5)                             /* !< DMADONE Offset */
+#define ADC12_CPU_INT_ISET_DMADONE_MASK          ((uint32_t)0x00000020U)         /* !< Raw interrupt flag for DMADONE.
+                                                                                    This bit is reset to 0 by IIDX read
+                                                                                    or when corresponding bit in ICLR_EX
+                                                                                    is set to 1. */
+#define ADC12_CPU_INT_ISET_DMADONE_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ISET_DMADONE_SET           ((uint32_t)0x00000020U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG0] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG0_OFS        (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG0_MASK       ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG0_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG0_SET        ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG1] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG1_OFS        (9)                             /* !< MEMRESIFG1 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG1_MASK       ((uint32_t)0x00000200U)         /* !< Raw interrupt status for MEMRES1.
+                                                                                    This bit is set to 1 when MEMRES1 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES1 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG1_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG1_SET        ((uint32_t)0x00000200U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG2] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG2_OFS        (10)                            /* !< MEMRESIFG2 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG2_MASK       ((uint32_t)0x00000400U)         /* !< Raw interrupt status for MEMRES2.
+                                                                                    This bit is set to 1 when MEMRES2 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES2 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG2_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG2_SET        ((uint32_t)0x00000400U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG3] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG3_OFS        (11)                            /* !< MEMRESIFG3 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG3_MASK       ((uint32_t)0x00000800U)         /* !< Raw interrupt status for MEMRES3.
+                                                                                    This bit is set to 1 when MEMRES3 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES3 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG3_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG3_SET        ((uint32_t)0x00000800U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG4] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG4_OFS        (12)                            /* !< MEMRESIFG4 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG4_MASK       ((uint32_t)0x00001000U)         /* !< Raw interrupt status for MEMRES4.
+                                                                                    This bit is set to 1 when MEMRES4 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES4 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG4_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG4_SET        ((uint32_t)0x00001000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG5] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG5_OFS        (13)                            /* !< MEMRESIFG5 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG5_MASK       ((uint32_t)0x00002000U)         /* !< Raw interrupt status for MEMRES5.
+                                                                                    This bit is set to 1 when MEMRES5 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES5 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG5_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG5_SET        ((uint32_t)0x00002000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG6] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG6_OFS        (14)                            /* !< MEMRESIFG6 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG6_MASK       ((uint32_t)0x00004000U)         /* !< Raw interrupt status for MEMRES6.
+                                                                                    This bit is set to 1 when MEMRES6 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES6 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG6_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG6_SET        ((uint32_t)0x00004000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG7] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG7_OFS        (15)                            /* !< MEMRESIFG7 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG7_MASK       ((uint32_t)0x00008000U)         /* !< Raw interrupt status for MEMRES7.
+                                                                                    This bit is set to 1 when MEMRES7 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES7 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG7_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG7_SET        ((uint32_t)0x00008000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG9] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG9_OFS        (17)                            /* !< MEMRESIFG9 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG9_MASK       ((uint32_t)0x00020000U)         /* !< Raw interrupt status for MEMRES9.
+                                                                                    This bit is set to 1 when MEMRES9 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES9 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG9_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG9_SET        ((uint32_t)0x00020000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG10] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG10_OFS       (18)                            /* !< MEMRESIFG10 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG10_MASK      ((uint32_t)0x00040000U)         /* !< Raw interrupt status for MEMRES10.
+                                                                                    This bit is set to 1 when MEMRES10 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES10 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG10_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG10_SET       ((uint32_t)0x00040000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG11] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG11_OFS       (19)                            /* !< MEMRESIFG11 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG11_MASK      ((uint32_t)0x00080000U)         /* !< Raw interrupt status for MEMRES11.
+                                                                                    This bit is set to 1 when MEMRES11 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES11 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG11_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG11_SET       ((uint32_t)0x00080000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG12] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG12_OFS       (20)                            /* !< MEMRESIFG12 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG12_MASK      ((uint32_t)0x00100000U)         /* !< Raw interrupt status for MEMRES12.
+                                                                                    This bit is set to 1 when MEMRES12 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES12 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG12_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG12_SET       ((uint32_t)0x00100000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG13] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG13_OFS       (21)                            /* !< MEMRESIFG13 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG13_MASK      ((uint32_t)0x00200000U)         /* !< Raw interrupt status for MEMRES13.
+                                                                                    This bit is set to 1 when MEMRES13 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES13 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG13_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG13_SET       ((uint32_t)0x00200000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG14] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG14_OFS       (22)                            /* !< MEMRESIFG14 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG14_MASK      ((uint32_t)0x00400000U)         /* !< Raw interrupt status for MEMRES14.
+                                                                                    This bit is set to 1 when MEMRES14 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES14 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG14_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG14_SET       ((uint32_t)0x00400000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG15] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG15_OFS       (23)                            /* !< MEMRESIFG15 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG15_MASK      ((uint32_t)0x00800000U)         /* !< Raw interrupt status for MEMRES15.
+                                                                                    This bit is set to 1 when MEMRES15 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES15 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG15_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG15_SET       ((uint32_t)0x00800000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG16] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG16_OFS       (24)                            /* !< MEMRESIFG16 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG16_MASK      ((uint32_t)0x01000000U)         /* !< Raw interrupt status for MEMRES16.
+                                                                                    This bit is set to 1 when MEMRES16 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES16 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG16_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG16_SET       ((uint32_t)0x01000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG17] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG17_OFS       (25)                            /* !< MEMRESIFG17 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG17_MASK      ((uint32_t)0x02000000U)         /* !< Raw interrupt status for MEMRES17.
+                                                                                    This bit is set to 1 when MEMRES17 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES17 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG17_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG17_SET       ((uint32_t)0x02000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG18] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG18_OFS       (26)                            /* !< MEMRESIFG18 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG18_MASK      ((uint32_t)0x04000000U)         /* !< Raw interrupt status for MEMRES18.
+                                                                                    This bit is set to 1 when MEMRES18 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES18 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG18_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG18_SET       ((uint32_t)0x04000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG19] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG19_OFS       (27)                            /* !< MEMRESIFG19 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG19_MASK      ((uint32_t)0x08000000U)         /* !< Raw interrupt status for MEMRES19.
+                                                                                    This bit is set to 1 when MEMRES19 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES19 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG19_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG19_SET       ((uint32_t)0x08000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG20] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG20_OFS       (28)                            /* !< MEMRESIFG20 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG20_MASK      ((uint32_t)0x10000000U)         /* !< Raw interrupt status for MEMRES20.
+                                                                                    This bit is set to 1 when MEMRES20 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES20 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG20_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG20_SET       ((uint32_t)0x10000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG22] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG22_OFS       (30)                            /* !< MEMRESIFG22 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG22_MASK      ((uint32_t)0x40000000U)         /* !< Raw interrupt status for MEMRES22.
+                                                                                    This bit is set to 1 when MEMRES22 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES22 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG22_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG22_SET       ((uint32_t)0x40000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG23] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG23_OFS       (31)                            /* !< MEMRESIFG23 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG23_MASK      ((uint32_t)0x80000000U)         /* !< Raw interrupt status for MEMRES23.
+                                                                                    This bit is set to 1 when MEMRES23 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES23 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG23_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG23_SET       ((uint32_t)0x80000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG8] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG8_OFS        (16)                            /* !< MEMRESIFG8 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG8_MASK       ((uint32_t)0x00010000U)         /* !< Raw interrupt status for MEMRES8.
+                                                                                    This bit is set to 1 when MEMRES8 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES8 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG8_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG8_SET        ((uint32_t)0x00010000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[MEMRESIFG21] Bits */
+#define ADC12_CPU_INT_ISET_MEMRESIFG21_OFS       (29)                            /* !< MEMRESIFG21 Offset */
+#define ADC12_CPU_INT_ISET_MEMRESIFG21_MASK      ((uint32_t)0x20000000U)         /* !< Raw interrupt status for MEMRES21.
+                                                                                    This bit is set to 1 when MEMRES21 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES21 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ISET_MEMRESIFG21_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ISET_MEMRESIFG21_SET       ((uint32_t)0x20000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ISET[ASCDONE] Bits */
+#define ADC12_CPU_INT_ISET_ASCDONE_OFS           (7)                             /* !< ASCDONE Offset */
+#define ADC12_CPU_INT_ISET_ASCDONE_MASK          ((uint32_t)0x00000080U)         /* !< Set ASC done flag in RIS */
+#define ADC12_CPU_INT_ISET_ASCDONE_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ISET_ASCDONE_SET           ((uint32_t)0x00000080U)         /* !< Interrupt is pending. */
+
+/* ADC12_CPU_INT_ICLR Bits */
+/* ADC12_CPU_INT_ICLR[INIFG] Bits */
+#define ADC12_CPU_INT_ICLR_INIFG_OFS             (4)                             /* !< INIFG Offset */
+#define ADC12_CPU_INT_ICLR_INIFG_MASK            ((uint32_t)0x00000010U)         /* !< Mask INIFG in MIS_EX register. */
+#define ADC12_CPU_INT_ICLR_INIFG_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ICLR_INIFG_CLR             ((uint32_t)0x00000010U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ICLR[LOWIFG] Bits */
+#define ADC12_CPU_INT_ICLR_LOWIFG_OFS            (3)                             /* !< LOWIFG Offset */
+#define ADC12_CPU_INT_ICLR_LOWIFG_MASK           ((uint32_t)0x00000008U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being below than the
+                                                                                    WCLOWx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_ICLR_LOWIFG_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ICLR_LOWIFG_CLR            ((uint32_t)0x00000008U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ICLR[HIGHIFG] Bits */
+#define ADC12_CPU_INT_ICLR_HIGHIFG_OFS           (2)                             /* !< HIGHIFG Offset */
+#define ADC12_CPU_INT_ICLR_HIGHIFG_MASK          ((uint32_t)0x00000004U)         /* !< Raw interrupt flag for the MEMRESx
+                                                                                    result register being higher than the
+                                                                                    WCHIGHx threshold of the window
+                                                                                    comparator. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_ICLR_HIGHIFG_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ICLR_HIGHIFG_CLR           ((uint32_t)0x00000004U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ICLR[OVIFG] Bits */
+#define ADC12_CPU_INT_ICLR_OVIFG_OFS             (0)                             /* !< OVIFG Offset */
+#define ADC12_CPU_INT_ICLR_OVIFG_MASK            ((uint32_t)0x00000001U)         /* !< Raw interrupt flag for MEMRESx
+                                                                                    overflow. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_ICLR_OVIFG_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ICLR_OVIFG_CLR             ((uint32_t)0x00000001U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ICLR[UVIFG] Bits */
+#define ADC12_CPU_INT_ICLR_UVIFG_OFS             (6)                             /* !< UVIFG Offset */
+#define ADC12_CPU_INT_ICLR_UVIFG_MASK            ((uint32_t)0x00000040U)         /* !< Raw interrupt flag for MEMRESx
+                                                                                    underflow. This bit is reset to 0 by
+                                                                                    IIDX read or when corresponding bit
+                                                                                    in ICLR_EX is set to 1. */
+#define ADC12_CPU_INT_ICLR_UVIFG_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ICLR_UVIFG_CLR             ((uint32_t)0x00000040U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ICLR[TOVIFG] Bits */
+#define ADC12_CPU_INT_ICLR_TOVIFG_OFS            (1)                             /* !< TOVIFG Offset */
+#define ADC12_CPU_INT_ICLR_TOVIFG_MASK           ((uint32_t)0x00000002U)         /* !< Raw interrupt flag for sequence
+                                                                                    conversion timeout overflow. This bit
+                                                                                    is reset to 0 by IIDX read or when
+                                                                                    corresponding bit in ICLR_EX is set
+                                                                                    to 1. */
+#define ADC12_CPU_INT_ICLR_TOVIFG_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ICLR_TOVIFG_CLR            ((uint32_t)0x00000002U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ICLR[DMADONE] Bits */
+#define ADC12_CPU_INT_ICLR_DMADONE_OFS           (5)                             /* !< DMADONE Offset */
+#define ADC12_CPU_INT_ICLR_DMADONE_MASK          ((uint32_t)0x00000020U)         /* !< Raw interrupt flag for DMADONE.
+                                                                                    This bit is reset to 0 by IIDX read
+                                                                                    or when corresponding bit in ICLR_EX
+                                                                                    is set to 1. */
+#define ADC12_CPU_INT_ICLR_DMADONE_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ICLR_DMADONE_CLR           ((uint32_t)0x00000020U)         /* !< Interrupt is pending. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG0] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG0_OFS        (8)                             /* !< MEMRESIFG0 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG0_MASK       ((uint32_t)0x00000100U)         /* !< Raw interrupt status for MEMRES0.
+                                                                                    This bit is set to 1 when MEMRES0 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES0 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG0_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG0_CLR        ((uint32_t)0x00000100U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG1] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG1_OFS        (9)                             /* !< MEMRESIFG1 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG1_MASK       ((uint32_t)0x00000200U)         /* !< Raw interrupt status for MEMRES1.
+                                                                                    This bit is set to 1 when MEMRES1 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES1 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG1_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG1_CLR        ((uint32_t)0x00000200U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG2] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG2_OFS        (10)                            /* !< MEMRESIFG2 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG2_MASK       ((uint32_t)0x00000400U)         /* !< Raw interrupt status for MEMRES2.
+                                                                                    This bit is set to 1 when MEMRES2 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES2 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG2_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG2_CLR        ((uint32_t)0x00000400U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG3] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG3_OFS        (11)                            /* !< MEMRESIFG3 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG3_MASK       ((uint32_t)0x00000800U)         /* !< Raw interrupt status for MEMRES3.
+                                                                                    This bit is set to 1 when MEMRES3 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES3 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG3_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG3_CLR        ((uint32_t)0x00000800U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG4] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG4_OFS        (12)                            /* !< MEMRESIFG4 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG4_MASK       ((uint32_t)0x00001000U)         /* !< Raw interrupt status for MEMRES4.
+                                                                                    This bit is set to 1 when MEMRES4 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES4 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG4_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG4_CLR        ((uint32_t)0x00001000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG5] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG5_OFS        (13)                            /* !< MEMRESIFG5 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG5_MASK       ((uint32_t)0x00002000U)         /* !< Raw interrupt status for MEMRES5.
+                                                                                    This bit is set to 1 when MEMRES5 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES5 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG5_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG5_CLR        ((uint32_t)0x00002000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG6] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG6_OFS        (14)                            /* !< MEMRESIFG6 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG6_MASK       ((uint32_t)0x00004000U)         /* !< Raw interrupt status for MEMRES6.
+                                                                                    This bit is set to 1 when MEMRES6 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES6 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG6_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG6_CLR        ((uint32_t)0x00004000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG7] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG7_OFS        (15)                            /* !< MEMRESIFG7 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG7_MASK       ((uint32_t)0x00008000U)         /* !< Raw interrupt status for MEMRES7.
+                                                                                    This bit is set to 1 when MEMRES7 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES7 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG7_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG7_CLR        ((uint32_t)0x00008000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG9] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG9_OFS        (17)                            /* !< MEMRESIFG9 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG9_MASK       ((uint32_t)0x00020000U)         /* !< Raw interrupt status for MEMRES9.
+                                                                                    This bit is set to 1 when MEMRES9 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES9 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG9_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG9_CLR        ((uint32_t)0x00020000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG10] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG10_OFS       (18)                            /* !< MEMRESIFG10 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG10_MASK      ((uint32_t)0x00040000U)         /* !< Raw interrupt status for MEMRES10.
+                                                                                    This bit is set to 1 when MEMRES10 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES10 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG10_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG10_CLR       ((uint32_t)0x00040000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG11] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG11_OFS       (19)                            /* !< MEMRESIFG11 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG11_MASK      ((uint32_t)0x00080000U)         /* !< Raw interrupt status for MEMRES11.
+                                                                                    This bit is set to 1 when MEMRES11 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES11 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG11_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG11_CLR       ((uint32_t)0x00080000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG12] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG12_OFS       (20)                            /* !< MEMRESIFG12 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG12_MASK      ((uint32_t)0x00100000U)         /* !< Raw interrupt status for MEMRES12.
+                                                                                    This bit is set to 1 when MEMRES12 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES12 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG12_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG12_CLR       ((uint32_t)0x00100000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG13] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG13_OFS       (21)                            /* !< MEMRESIFG13 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG13_MASK      ((uint32_t)0x00200000U)         /* !< Raw interrupt status for MEMRES13.
+                                                                                    This bit is set to 1 when MEMRES13 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES13 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG13_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG13_CLR       ((uint32_t)0x00200000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG14] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG14_OFS       (22)                            /* !< MEMRESIFG14 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG14_MASK      ((uint32_t)0x00400000U)         /* !< Raw interrupt status for MEMRES14.
+                                                                                    This bit is set to 1 when MEMRES14 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES14 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG14_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG14_CLR       ((uint32_t)0x00400000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG15] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG15_OFS       (23)                            /* !< MEMRESIFG15 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG15_MASK      ((uint32_t)0x00800000U)         /* !< Raw interrupt status for MEMRES15.
+                                                                                    This bit is set to 1 when MEMRES15 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES15 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG15_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG15_CLR       ((uint32_t)0x00800000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG16] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG16_OFS       (24)                            /* !< MEMRESIFG16 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG16_MASK      ((uint32_t)0x01000000U)         /* !< Raw interrupt status for MEMRES16.
+                                                                                    This bit is set to 1 when MEMRES16 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES16 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG16_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG16_CLR       ((uint32_t)0x01000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG17] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG17_OFS       (25)                            /* !< MEMRESIFG17 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG17_MASK      ((uint32_t)0x02000000U)         /* !< Raw interrupt status for MEMRES17.
+                                                                                    This bit is set to 1 when MEMRES17 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES17 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG17_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG17_CLR       ((uint32_t)0x02000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG18] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG18_OFS       (26)                            /* !< MEMRESIFG18 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG18_MASK      ((uint32_t)0x04000000U)         /* !< Raw interrupt status for MEMRES18.
+                                                                                    This bit is set to 1 when MEMRES18 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES18 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG18_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG18_CLR       ((uint32_t)0x04000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG19] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG19_OFS       (27)                            /* !< MEMRESIFG19 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG19_MASK      ((uint32_t)0x08000000U)         /* !< Raw interrupt status for MEMRES19.
+                                                                                    This bit is set to 1 when MEMRES19 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES19 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG19_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG19_CLR       ((uint32_t)0x08000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG20] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG20_OFS       (28)                            /* !< MEMRESIFG20 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG20_MASK      ((uint32_t)0x10000000U)         /* !< Raw interrupt status for MEMRES20.
+                                                                                    This bit is set to 1 when MEMRES20 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES20 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG20_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG20_CLR       ((uint32_t)0x10000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG22] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG22_OFS       (30)                            /* !< MEMRESIFG22 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG22_MASK      ((uint32_t)0x40000000U)         /* !< Raw interrupt status for MEMRES22.
+                                                                                    This bit is set to 1 when MEMRES22 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES22 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG22_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG22_CLR       ((uint32_t)0x40000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG23] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG23_OFS       (31)                            /* !< MEMRESIFG23 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG23_MASK      ((uint32_t)0x80000000U)         /* !< Raw interrupt status for MEMRES23.
+                                                                                    This bit is set to 1 when MEMRES23 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES23 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG23_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG23_CLR       ((uint32_t)0x80000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG8] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG8_OFS        (16)                            /* !< MEMRESIFG8 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG8_MASK       ((uint32_t)0x00010000U)         /* !< Raw interrupt status for MEMRES8.
+                                                                                    This bit is set to 1 when MEMRES8 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES8 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG8_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG8_CLR        ((uint32_t)0x00010000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[MEMRESIFG21] Bits */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG21_OFS       (29)                            /* !< MEMRESIFG21 Offset */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG21_MASK      ((uint32_t)0x20000000U)         /* !< Raw interrupt status for MEMRES21.
+                                                                                    This bit is set to 1 when MEMRES21 is
+                                                                                    loaded with a new conversion result.
+                                                                                    Reading MEMRES21 register will clear
+                                                                                    this bit, or when the corresponding
+                                                                                    bit in ICLR is set to 1 */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG21_NO_EFFECT ((uint32_t)0x00000000U)         /* !< No new data ready. */
+#define ADC12_CPU_INT_ICLR_MEMRESIFG21_CLR       ((uint32_t)0x20000000U)         /* !< A new data is ready to be read. */
+/* ADC12_CPU_INT_ICLR[ASCDONE] Bits */
+#define ADC12_CPU_INT_ICLR_ASCDONE_OFS           (7)                             /* !< ASCDONE Offset */
+#define ADC12_CPU_INT_ICLR_ASCDONE_MASK          ((uint32_t)0x00000080U)         /* !< Clear ASC done flag in RIS */
+#define ADC12_CPU_INT_ICLR_ASCDONE_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Interrupt is not pending. */
+#define ADC12_CPU_INT_ICLR_ASCDONE_CLR           ((uint32_t)0x00000080U)         /* !< Interrupt is pending. */
+
+/* ADC12_PWREN Bits */
+/* ADC12_PWREN[ENABLE] Bits */
+#define ADC12_PWREN_ENABLE_OFS                   (0)                             /* !< ENABLE Offset */
+#define ADC12_PWREN_ENABLE_MASK                  ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define ADC12_PWREN_ENABLE_DISABLE               ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define ADC12_PWREN_ENABLE_ENABLE                ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* ADC12_PWREN[KEY] Bits */
+#define ADC12_PWREN_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define ADC12_PWREN_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define ADC12_PWREN_KEY_UNLOCK_W                 ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* ADC12_RSTCTL Bits */
+/* ADC12_RSTCTL[RESETSTKYCLR] Bits */
+#define ADC12_RSTCTL_RESETSTKYCLR_OFS            (1)                             /* !< RESETSTKYCLR Offset */
+#define ADC12_RSTCTL_RESETSTKYCLR_MASK           ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define ADC12_RSTCTL_RESETSTKYCLR_NOP            ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define ADC12_RSTCTL_RESETSTKYCLR_CLR            ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* ADC12_RSTCTL[RESETASSERT] Bits */
+#define ADC12_RSTCTL_RESETASSERT_OFS             (0)                             /* !< RESETASSERT Offset */
+#define ADC12_RSTCTL_RESETASSERT_MASK            ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define ADC12_RSTCTL_RESETASSERT_NOP             ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define ADC12_RSTCTL_RESETASSERT_ASSERT          ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* ADC12_RSTCTL[KEY] Bits */
+#define ADC12_RSTCTL_KEY_OFS                     (24)                            /* !< KEY Offset */
+#define ADC12_RSTCTL_KEY_MASK                    ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define ADC12_RSTCTL_KEY_UNLOCK_W                ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* ADC12_CLKCFG Bits */
+/* ADC12_CLKCFG[SAMPCLK] Bits */
+#define ADC12_CLKCFG_SAMPCLK_OFS                 (0)                             /* !< SAMPCLK Offset */
+#define ADC12_CLKCFG_SAMPCLK_MASK                ((uint32_t)0x00000003U)         /* !< ADC sample clock source selection. */
+#define ADC12_CLKCFG_SAMPCLK_ULPCLK              ((uint32_t)0x00000000U)         /* !< ULPCLK is the source of ADC sample
+                                                                                    clock. */
+#define ADC12_CLKCFG_SAMPCLK_SYSOSC              ((uint32_t)0x00000001U)         /* !< SYSOSC is the source of ADC sample
+                                                                                    clock. */
+#define ADC12_CLKCFG_SAMPCLK_HFCLK               ((uint32_t)0x00000002U)         /* !< HFCLK clock is the source of ADC
+                                                                                    sample clock. Note : HFCLK may not be
+                                                                                    available on all the devices. */
+/* ADC12_CLKCFG[CCONRUN] Bits */
+#define ADC12_CLKCFG_CCONRUN_OFS                 (4)                             /* !< CCONRUN Offset */
+#define ADC12_CLKCFG_CCONRUN_MASK                ((uint32_t)0x00000010U)         /* !< CCONRUN: Forces SYSOSC to run at
+                                                                                    base frequency when device is in RUN
+                                                                                    mode which can be used as ADC sample
+                                                                                    or conversion clock source. */
+#define ADC12_CLKCFG_CCONRUN_DISABLE             ((uint32_t)0x00000000U)         /* !< ADC conversion clock source is not
+                                                                                    kept continuously on during RUN mode. */
+#define ADC12_CLKCFG_CCONRUN_ENABLE              ((uint32_t)0x00000010U)         /* !< ADC conversion clock source kept
+                                                                                    continuously on during RUN mode. */
+/* ADC12_CLKCFG[CCONSTOP] Bits */
+#define ADC12_CLKCFG_CCONSTOP_OFS                (5)                             /* !< CCONSTOP Offset */
+#define ADC12_CLKCFG_CCONSTOP_MASK               ((uint32_t)0x00000020U)         /* !< CCONSTOP: Forces SYSOSC to run at
+                                                                                    base frequency when device is in STOP
+                                                                                    mode which can be used as ADC sample
+                                                                                    or conversion clock source. */
+#define ADC12_CLKCFG_CCONSTOP_DISABLE            ((uint32_t)0x00000000U)         /* !< ADC conversion clock source is not
+                                                                                    kept continuously on during STOP
+                                                                                    mode. */
+#define ADC12_CLKCFG_CCONSTOP_ENABLE             ((uint32_t)0x00000020U)         /* !< ADC conversion clock source kept
+                                                                                    continuously on during STOP mode. */
+/* ADC12_CLKCFG[KEY] Bits */
+#define ADC12_CLKCFG_KEY_OFS                     (24)                            /* !< KEY Offset */
+#define ADC12_CLKCFG_KEY_MASK                    ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define ADC12_CLKCFG_KEY_UNLOCK_W                ((uint32_t)0xA9000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* ADC12_STAT Bits */
+/* ADC12_STAT[RESETSTKY] Bits */
+#define ADC12_STAT_RESETSTKY_OFS                 (16)                            /* !< RESETSTKY Offset */
+#define ADC12_STAT_RESETSTKY_MASK                ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define ADC12_STAT_RESETSTKY_NORES               ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define ADC12_STAT_RESETSTKY_RESET               ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* ADC12_FSUB_0 Bits */
+/* ADC12_FSUB_0[CHANID] Bits */
+#define ADC12_FSUB_0_CHANID_OFS                  (0)                             /* !< CHANID Offset */
+#define ADC12_FSUB_0_CHANID_MASK                 ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define ADC12_FSUB_0_CHANID_MNIMUM               ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define ADC12_FSUB_0_CHANID_UNCONNECTED          ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define ADC12_FSUB_0_CHANID_MAXIMUM              ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 255. */
+
+/* ADC12_FPUB_1 Bits */
+/* ADC12_FPUB_1[CHANID] Bits */
+#define ADC12_FPUB_1_CHANID_OFS                  (0)                             /* !< CHANID Offset */
+#define ADC12_FPUB_1_CHANID_MASK                 ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define ADC12_FPUB_1_CHANID_MNIMUM               ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define ADC12_FPUB_1_CHANID_UNCONNECTED          ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define ADC12_FPUB_1_CHANID_MAXIMUM              ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 255. */
+
+/* ADC12_EVT_MODE Bits */
+/* ADC12_EVT_MODE[INT0_CFG] Bits */
+#define ADC12_EVT_MODE_INT0_CFG_OFS              (0)                             /* !< INT0_CFG Offset */
+#define ADC12_EVT_MODE_INT0_CFG_MASK             ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to CPU_INT */
+#define ADC12_EVT_MODE_INT0_CFG_DISABLE          ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define ADC12_EVT_MODE_INT0_CFG_SOFTWARE         ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define ADC12_EVT_MODE_INT0_CFG_HARDWARE         ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* ADC12_EVT_MODE[EVT1_CFG] Bits */
+#define ADC12_EVT_MODE_EVT1_CFG_OFS              (2)                             /* !< EVT1_CFG Offset */
+#define ADC12_EVT_MODE_EVT1_CFG_MASK             ((uint32_t)0x0000000CU)         /* !< Event line mode select for event
+                                                                                    corresponding to GEN_EVENT */
+#define ADC12_EVT_MODE_EVT1_CFG_DISABLE          ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define ADC12_EVT_MODE_EVT1_CFG_SOFTWARE         ((uint32_t)0x00000004U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define ADC12_EVT_MODE_EVT1_CFG_HARDWARE         ((uint32_t)0x00000008U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* ADC12_DESC Bits */
+/* ADC12_DESC[MINREV] Bits */
+#define ADC12_DESC_MINREV_OFS                    (0)                             /* !< MINREV Offset */
+#define ADC12_DESC_MINREV_MASK                   ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+#define ADC12_DESC_MINREV_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define ADC12_DESC_MINREV_MAXIMUM                ((uint32_t)0x0000000FU)         /* !< Highest possible value */
+/* ADC12_DESC[MAJREV] Bits */
+#define ADC12_DESC_MAJREV_OFS                    (4)                             /* !< MAJREV Offset */
+#define ADC12_DESC_MAJREV_MASK                   ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+#define ADC12_DESC_MAJREV_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define ADC12_DESC_MAJREV_MAXIMUM                ((uint32_t)0x000000F0U)         /* !< Highest possible value */
+/* ADC12_DESC[INSTNUM] Bits */
+#define ADC12_DESC_INSTNUM_OFS                   (8)                             /* !< INSTNUM Offset */
+#define ADC12_DESC_INSTNUM_MASK                  ((uint32_t)0x00000F00U)         /* !< Instance Number within the device.
+                                                                                    This will be a parameter to the RTL
+                                                                                    for modules that can have multiple
+                                                                                    instances */
+/* ADC12_DESC[FEATUREVER] Bits */
+#define ADC12_DESC_FEATUREVER_OFS                (12)                            /* !< FEATUREVER Offset */
+#define ADC12_DESC_FEATUREVER_MASK               ((uint32_t)0x0000F000U)         /* !< Feature Set for the module
+                                                                                    *instance* */
+#define ADC12_DESC_FEATUREVER_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define ADC12_DESC_FEATUREVER_MAXIMUM            ((uint32_t)0x0000F000U)         /* !< Highest possible value */
+/* ADC12_DESC[MODULEID] Bits */
+#define ADC12_DESC_MODULEID_OFS                  (16)                            /* !< MODULEID Offset */
+#define ADC12_DESC_MODULEID_MASK                 ((uint32_t)0xFFFF0000U)         /* !< Module identification contains a
+                                                                                    unique peripheral identification
+                                                                                    number. The assignments are
+                                                                                    maintained in a central database for
+                                                                                    all of the platform modules to ensure
+                                                                                    uniqueness. */
+#define ADC12_DESC_MODULEID_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define ADC12_DESC_MODULEID_MAXIMUM              ((uint32_t)0xFFFF0000U)         /* !< Highest possible value */
+
+/* ADC12_CTL0 Bits */
+/* ADC12_CTL0[ENC] Bits */
+#define ADC12_CTL0_ENC_OFS                       (0)                             /* !< ENC Offset */
+#define ADC12_CTL0_ENC_MASK                      ((uint32_t)0x00000001U)         /* !< Enable conversion */
+#define ADC12_CTL0_ENC_OFF                       ((uint32_t)0x00000000U)         /* !< Conversion disabled. ENC change
+                                                                                    from ON to OFF will abort single or
+                                                                                    repeat sequence on a MEMCTLx
+                                                                                    boundary. The current conversion will
+                                                                                    finish and result stored in
+                                                                                    corresponding MEMRESx. */
+#define ADC12_CTL0_ENC_ON                        ((uint32_t)0x00000001U)         /* !< Conversion enabled. ADC sequencer
+                                                                                    waits for valid trigger (software or
+                                                                                    hardware). */
+/* ADC12_CTL0[PWRDN] Bits */
+#define ADC12_CTL0_PWRDN_OFS                     (16)                            /* !< PWRDN Offset */
+#define ADC12_CTL0_PWRDN_MASK                    ((uint32_t)0x00010000U)         /* !< Power down policy */
+#define ADC12_CTL0_PWRDN_AUTO                    ((uint32_t)0x00000000U)         /* !< ADC is powered down on completion
+                                                                                    of a conversion if there is no
+                                                                                    pending trigger */
+#define ADC12_CTL0_PWRDN_MANUAL                  ((uint32_t)0x00010000U)         /* !< ADC remains powered on as long as
+                                                                                    it is enabled through software. */
+/* ADC12_CTL0[SCLKDIV] Bits */
+#define ADC12_CTL0_SCLKDIV_OFS                   (24)                            /* !< SCLKDIV Offset */
+#define ADC12_CTL0_SCLKDIV_MASK                  ((uint32_t)0x07000000U)         /* !< Sample clock divider */
+#define ADC12_CTL0_SCLKDIV_DIV_BY_1              ((uint32_t)0x00000000U)         /* !< Do not divide clock source */
+#define ADC12_CTL0_SCLKDIV_DIV_BY_2              ((uint32_t)0x01000000U)         /* !< Divide clock source by 2 */
+#define ADC12_CTL0_SCLKDIV_DIV_BY_4              ((uint32_t)0x02000000U)         /* !< Divide clock source by 4 */
+#define ADC12_CTL0_SCLKDIV_DIV_BY_8              ((uint32_t)0x03000000U)         /* !< Divide clock source by 8 */
+#define ADC12_CTL0_SCLKDIV_DIV_BY_16             ((uint32_t)0x04000000U)         /* !< Divide clock source by 16 */
+#define ADC12_CTL0_SCLKDIV_DIV_BY_24             ((uint32_t)0x05000000U)         /* !< Divide clock source by 24 */
+#define ADC12_CTL0_SCLKDIV_DIV_BY_32             ((uint32_t)0x06000000U)         /* !< Divide clock source by 32 */
+#define ADC12_CTL0_SCLKDIV_DIV_BY_48             ((uint32_t)0x07000000U)         /* !< Divide clock source by 48 */
+
+/* ADC12_CTL1 Bits */
+/* ADC12_CTL1[TRIGSRC] Bits */
+#define ADC12_CTL1_TRIGSRC_OFS                   (0)                             /* !< TRIGSRC Offset */
+#define ADC12_CTL1_TRIGSRC_MASK                  ((uint32_t)0x00000001U)         /* !< Sample trigger source */
+#define ADC12_CTL1_TRIGSRC_SOFTWARE              ((uint32_t)0x00000000U)         /* !< Software trigger */
+#define ADC12_CTL1_TRIGSRC_EVENT                 ((uint32_t)0x00000001U)         /* !< Hardware event trigger */
+/* ADC12_CTL1[SC] Bits */
+#define ADC12_CTL1_SC_OFS                        (8)                             /* !< SC Offset */
+#define ADC12_CTL1_SC_MASK                       ((uint32_t)0x00000100U)         /* !< Start of conversion */
+#define ADC12_CTL1_SC_STOP                       ((uint32_t)0x00000000U)         /* !< When SAMPMODE is set to MANUAL,
+                                                                                    clearing this bit will end the sample
+                                                                                    phase and the conversion phase will
+                                                                                    start. When SAMPMODE is set to AUTO,
+                                                                                    writing 0 has no effect. */
+#define ADC12_CTL1_SC_START                      ((uint32_t)0x00000100U)         /* !< When SAMPMODE is set to MANUAL,
+                                                                                    setting this bit will start the
+                                                                                    sample phase. Sample phase will last
+                                                                                    as long as this bit is set.  When
+                                                                                    SAMPMODE is set to AUTO, setting this
+                                                                                    bit will trigger the timer based
+                                                                                    sample time. */
+/* ADC12_CTL1[CONSEQ] Bits */
+#define ADC12_CTL1_CONSEQ_OFS                    (16)                            /* !< CONSEQ Offset */
+#define ADC12_CTL1_CONSEQ_MASK                   ((uint32_t)0x00030000U)         /* !< Conversion sequence mode */
+#define ADC12_CTL1_CONSEQ_SINGLE                 ((uint32_t)0x00000000U)         /* !< ADC channel in MEMCTLx pointed by
+                                                                                    STARTADD will be converted once */
+#define ADC12_CTL1_CONSEQ_SEQUENCE               ((uint32_t)0x00010000U)         /* !< ADC channel sequence pointed by
+                                                                                    STARTADD and ENDADD will be converted
+                                                                                    once */
+#define ADC12_CTL1_CONSEQ_REPEATSINGLE           ((uint32_t)0x00020000U)         /* !< ADC channel in MEMCTLx pointed by
+                                                                                    STARTADD will be converted repeatedly */
+#define ADC12_CTL1_CONSEQ_REPEATSEQUENCE         ((uint32_t)0x00030000U)         /* !< ADC channel sequence pointed by
+                                                                                    STARTADD and ENDADD will be converted
+                                                                                    repeatedly */
+/* ADC12_CTL1[SAMPMODE] Bits */
+#define ADC12_CTL1_SAMPMODE_OFS                  (20)                            /* !< SAMPMODE Offset */
+#define ADC12_CTL1_SAMPMODE_MASK                 ((uint32_t)0x00100000U)         /* !< Sample mode. This bit selects the
+                                                                                    source of the sampling signal.
+                                                                                    MANUAL option is not valid when
+                                                                                    TRIGSRC is selected as hardware event
+                                                                                    trigger. */
+#define ADC12_CTL1_SAMPMODE_AUTO                 ((uint32_t)0x00000000U)         /* !< Sample timer high phase is used as
+                                                                                    sample signal */
+#define ADC12_CTL1_SAMPMODE_MANUAL               ((uint32_t)0x00100000U)         /* !< Software trigger is used as sample
+                                                                                    signal */
+/* ADC12_CTL1[AVGN] Bits */
+#define ADC12_CTL1_AVGN_OFS                      (24)                            /* !< AVGN Offset */
+#define ADC12_CTL1_AVGN_MASK                     ((uint32_t)0x07000000U)         /* !< Hardware averager numerator.
+                                                                                    Selects number of conversions to
+                                                                                    accumulate for current MEMCTLx and
+                                                                                    then it is divided by AVGD. Result
+                                                                                    will be stored in MEMRESx. */
+#define ADC12_CTL1_AVGN_DISABLE                  ((uint32_t)0x00000000U)         /* !< Disables averager */
+#define ADC12_CTL1_AVGN_AVG_2                    ((uint32_t)0x01000000U)         /* !< Averages 2 conversions before
+                                                                                    storing in MEMRESx register */
+#define ADC12_CTL1_AVGN_AVG_4                    ((uint32_t)0x02000000U)         /* !< Averages 4 conversions before
+                                                                                    storing in MEMRESx register */
+#define ADC12_CTL1_AVGN_AVG_8                    ((uint32_t)0x03000000U)         /* !< Averages 8 conversions before
+                                                                                    storing in MEMRESx register */
+#define ADC12_CTL1_AVGN_AVG_16                   ((uint32_t)0x04000000U)         /* !< Averages 16 conversions before
+                                                                                    storing in MEMRESx register */
+#define ADC12_CTL1_AVGN_AVG_32                   ((uint32_t)0x05000000U)         /* !< Averages 32 conversions before
+                                                                                    storing in MEMRESx register */
+#define ADC12_CTL1_AVGN_AVG_64                   ((uint32_t)0x06000000U)         /* !< Averages 64 conversions before
+                                                                                    storing in MEMRESx register */
+#define ADC12_CTL1_AVGN_AVG_128                  ((uint32_t)0x07000000U)         /* !< Averages 128 conversions before
+                                                                                    storing in MEMRESx register */
+/* ADC12_CTL1[AVGD] Bits */
+#define ADC12_CTL1_AVGD_OFS                      (28)                            /* !< AVGD Offset */
+#define ADC12_CTL1_AVGD_MASK                     ((uint32_t)0x70000000U)         /* !< Hardware averager denominator. The
+                                                                                    number to divide the accumulated
+                                                                                    value by (this is a shift). Note
+                                                                                    result register is maximum of 16-bits
+                                                                                    long so if not shifted appropriately
+                                                                                    result will be truncated. */
+#define ADC12_CTL1_AVGD_SHIFT0                   ((uint32_t)0x00000000U)         /* !< No shift */
+#define ADC12_CTL1_AVGD_SHIFT1                   ((uint32_t)0x10000000U)         /* !< 1 bit shift */
+#define ADC12_CTL1_AVGD_SHIFT2                   ((uint32_t)0x20000000U)         /* !< 2 bit shift */
+#define ADC12_CTL1_AVGD_SHIFT3                   ((uint32_t)0x30000000U)         /* !< 3 bit shift */
+#define ADC12_CTL1_AVGD_SHIFT4                   ((uint32_t)0x40000000U)         /* !< 4 bit shift */
+#define ADC12_CTL1_AVGD_SHIFT5                   ((uint32_t)0x50000000U)         /* !< 5 bit shift */
+#define ADC12_CTL1_AVGD_SHIFT6                   ((uint32_t)0x60000000U)         /* !< 6 bit shift */
+#define ADC12_CTL1_AVGD_SHIFT7                   ((uint32_t)0x70000000U)         /* !< 7 bit shift */
+
+/* ADC12_CTL2 Bits */
+/* ADC12_CTL2[DF] Bits */
+#define ADC12_CTL2_DF_OFS                        (0)                             /* !< DF Offset */
+#define ADC12_CTL2_DF_MASK                       ((uint32_t)0x00000001U)         /* !< Data read-back format. Data is
+                                                                                    always stored in binary unsigned
+                                                                                    format. */
+#define ADC12_CTL2_DF_UNSIGNED                   ((uint32_t)0x00000000U)         /* !< Digital result reads as Binary
+                                                                                    Unsigned. */
+#define ADC12_CTL2_DF_SIGNED                     ((uint32_t)0x00000001U)         /* !< Digital result reads Signed Binary.
+                                                                                    (2s complement), left aligned. */
+/* ADC12_CTL2[RES] Bits */
+#define ADC12_CTL2_RES_OFS                       (1)                             /* !< RES Offset */
+#define ADC12_CTL2_RES_MASK                      ((uint32_t)0x00000006U)         /* !< Resolution. These bits define the
+                                                                                    resolution of ADC conversion result.
+                                                                                    Note : A value of 3 defaults to
+                                                                                    12-bits resolution. */
+#define ADC12_CTL2_RES_BIT_12                    ((uint32_t)0x00000000U)         /* !< 12-bits resolution */
+#define ADC12_CTL2_RES_BIT_10                    ((uint32_t)0x00000002U)         /* !< 10-bits resolution */
+#define ADC12_CTL2_RES_BIT_8                     ((uint32_t)0x00000004U)         /* !< 8-bits resolution */
+/* ADC12_CTL2[STARTADD] Bits */
+#define ADC12_CTL2_STARTADD_OFS                  (16)                            /* !< STARTADD Offset */
+#define ADC12_CTL2_STARTADD_MASK                 ((uint32_t)0x001F0000U)         /* !< Sequencer start address. These bits
+                                                                                    select which MEMCTLx is used for
+                                                                                    single conversion or as first MEMCTL
+                                                                                    for sequence mode.  The value of
+                                                                                    STARTADD is 0x00 to 0x17,
+                                                                                    corresponding to MEMRES0 to MEMRES23. */
+#define ADC12_CTL2_STARTADD_ADDR_00              ((uint32_t)0x00000000U)         /* !< MEMCTL0 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_01              ((uint32_t)0x00010000U)         /* !< MEMCTL1 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_02              ((uint32_t)0x00020000U)         /* !< MEMCTL2 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_03              ((uint32_t)0x00030000U)         /* !< MEMCTL3 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_04              ((uint32_t)0x00040000U)         /* !< MEMCTL4 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_05              ((uint32_t)0x00050000U)         /* !< MEMCTL5 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_06              ((uint32_t)0x00060000U)         /* !< MEMCTL6 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_07              ((uint32_t)0x00070000U)         /* !< MEMCTL7 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_08              ((uint32_t)0x00080000U)         /* !< MEMCTL8 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_09              ((uint32_t)0x00090000U)         /* !< MEMCTL9 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_10              ((uint32_t)0x000A0000U)         /* !< MEMCTL10 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_11              ((uint32_t)0x000B0000U)         /* !< MEMCTL11 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_12              ((uint32_t)0x000C0000U)         /* !< MEMCTL12 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_13              ((uint32_t)0x000D0000U)         /* !< MEMCTL13 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_14              ((uint32_t)0x000E0000U)         /* !< MEMCTL14 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_15              ((uint32_t)0x000F0000U)         /* !< MEMCTL15 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_16              ((uint32_t)0x00100000U)         /* !< MEMCTL16 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_17              ((uint32_t)0x00110000U)         /* !< MEMCTL17 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_18              ((uint32_t)0x00120000U)         /* !< MEMCTL18 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_19              ((uint32_t)0x00130000U)         /* !< MEMCTL19 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_20              ((uint32_t)0x00140000U)         /* !< MEMCTL20 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_21              ((uint32_t)0x00150000U)         /* !< MEMCTL21 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_22              ((uint32_t)0x00160000U)         /* !< MEMCTL22 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+#define ADC12_CTL2_STARTADD_ADDR_23              ((uint32_t)0x00170000U)         /* !< MEMCTL23 is selected as start
+                                                                                    address of a sequence or for a single
+                                                                                    conversion. */
+/* ADC12_CTL2[ENDADD] Bits */
+#define ADC12_CTL2_ENDADD_OFS                    (24)                            /* !< ENDADD Offset */
+#define ADC12_CTL2_ENDADD_MASK                   ((uint32_t)0x1F000000U)         /* !< Sequence end address. These bits
+                                                                                    select which MEMCTLx is the last one
+                                                                                    for the sequence mode. The value of
+                                                                                    ENDADD is 0x00 to 0x17, corresponding
+                                                                                    to MEMRES0 to MEMRES23. */
+#define ADC12_CTL2_ENDADD_ADDR_00                ((uint32_t)0x00000000U)         /* !< MEMCTL0 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_01                ((uint32_t)0x01000000U)         /* !< MEMCTL1 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_02                ((uint32_t)0x02000000U)         /* !< MEMCTL2 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_03                ((uint32_t)0x03000000U)         /* !< MEMCTL3 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_04                ((uint32_t)0x04000000U)         /* !< MEMCTL4 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_05                ((uint32_t)0x05000000U)         /* !< MEMCTL5 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_06                ((uint32_t)0x06000000U)         /* !< MEMCTL6 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_07                ((uint32_t)0x07000000U)         /* !< MEMCTL7 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_08                ((uint32_t)0x08000000U)         /* !< MEMCTL8 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_09                ((uint32_t)0x09000000U)         /* !< MEMCTL9 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_10                ((uint32_t)0x0A000000U)         /* !< MEMCTL10 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_11                ((uint32_t)0x0B000000U)         /* !< MEMCTL11 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_12                ((uint32_t)0x0C000000U)         /* !< MEMCTL12 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_13                ((uint32_t)0x0D000000U)         /* !< MEMCTL13 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_14                ((uint32_t)0x0E000000U)         /* !< MEMCTL14 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_15                ((uint32_t)0x0F000000U)         /* !< MEMCTL15 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_16                ((uint32_t)0x10000000U)         /* !< MEMCTL16 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_17                ((uint32_t)0x11000000U)         /* !< MEMCTL17 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_18                ((uint32_t)0x12000000U)         /* !< MEMCTL18 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_19                ((uint32_t)0x13000000U)         /* !< MEMCTL19 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_20                ((uint32_t)0x14000000U)         /* !< MEMCTL20 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_21                ((uint32_t)0x15000000U)         /* !< MEMCTL21 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_22                ((uint32_t)0x16000000U)         /* !< MEMCTL22 is selected as end address
+                                                                                    of sequence. */
+#define ADC12_CTL2_ENDADD_ADDR_23                ((uint32_t)0x17000000U)         /* !< MEMCTL23 is selected as end address
+                                                                                    of sequence. */
+/* ADC12_CTL2[DMAEN] Bits */
+#define ADC12_CTL2_DMAEN_OFS                     (8)                             /* !< DMAEN Offset */
+#define ADC12_CTL2_DMAEN_MASK                    ((uint32_t)0x00000100U)         /* !< Enable DMA trigger for data
+                                                                                    transfer.  Note: DMAEN bit is cleared
+                                                                                    by hardware based on DMA done signal
+                                                                                    at the end of data transfer. Software
+                                                                                    has to re-enable DMAEN bit for ADC to
+                                                                                    generate DMA triggers. */
+#define ADC12_CTL2_DMAEN_DISABLE                 ((uint32_t)0x00000000U)         /* !< DMA trigger not enabled */
+#define ADC12_CTL2_DMAEN_ENABLE                  ((uint32_t)0x00000100U)         /* !< DMA trigger enabled */
+/* ADC12_CTL2[SAMPCNT] Bits */
+#define ADC12_CTL2_SAMPCNT_OFS                   (11)                            /* !< SAMPCNT Offset */
+#define ADC12_CTL2_SAMPCNT_MASK                  ((uint32_t)0x0000F800U)         /* !< Number of ADC converted samples to
+                                                                                    be transferred on a DMA trigger */
+#define ADC12_CTL2_SAMPCNT_MIN                   ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define ADC12_CTL2_SAMPCNT_MAX                   ((uint32_t)0x0000C000U)         /* !< Maximum value */
+/* ADC12_CTL2[FIFOEN] Bits */
+#define ADC12_CTL2_FIFOEN_OFS                    (10)                            /* !< FIFOEN Offset */
+#define ADC12_CTL2_FIFOEN_MASK                   ((uint32_t)0x00000400U)         /* !< Enable FIFO based operation */
+#define ADC12_CTL2_FIFOEN_DISABLE                ((uint32_t)0x00000000U)         /* !< Disable */
+#define ADC12_CTL2_FIFOEN_ENABLE                 ((uint32_t)0x00000400U)         /* !< Enable */
+
+/* ADC12_CTL3 Bits */
+/* ADC12_CTL3[ASCCHSEL] Bits */
+#define ADC12_CTL3_ASCCHSEL_OFS                  (0)                             /* !< ASCCHSEL Offset */
+#define ADC12_CTL3_ASCCHSEL_MASK                 ((uint32_t)0x0000001FU)         /* !< ASC channel select */
+#define ADC12_CTL3_ASCCHSEL_CHAN_0               ((uint32_t)0x00000000U)         /* !< Selects channel 0 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_1               ((uint32_t)0x00000001U)         /* !< Selects channel 1 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_2               ((uint32_t)0x00000002U)         /* !< Selects channel 2 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_3               ((uint32_t)0x00000003U)         /* !< Selects channel 3 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_4               ((uint32_t)0x00000004U)         /* !< Selects channel 4 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_5               ((uint32_t)0x00000005U)         /* !< Selects channel 5 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_6               ((uint32_t)0x00000006U)         /* !< Selects channel 6 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_7               ((uint32_t)0x00000007U)         /* !< Selects channel 7 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_8               ((uint32_t)0x00000008U)         /* !< Selects channel 8 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_9               ((uint32_t)0x00000009U)         /* !< Selects channel 9 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_10              ((uint32_t)0x0000000AU)         /* !< Selects channel 10 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_11              ((uint32_t)0x0000000BU)         /* !< Selects channel 11 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_12              ((uint32_t)0x0000000CU)         /* !< Selects channel 12 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_13              ((uint32_t)0x0000000DU)         /* !< Selects channel 13 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_14              ((uint32_t)0x0000000EU)         /* !< Selects channel 14 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_15              ((uint32_t)0x0000000FU)         /* !< Selects channel 15 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_16              ((uint32_t)0x00000010U)         /* !< Selects channel 16 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_17              ((uint32_t)0x00000011U)         /* !< Selects channel 17 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_18              ((uint32_t)0x00000012U)         /* !< Selects channel 18 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_19              ((uint32_t)0x00000013U)         /* !< Selects channel 19 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_20              ((uint32_t)0x00000014U)         /* !< Selects channel 20 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_21              ((uint32_t)0x00000015U)         /* !< Selects channel 21 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_22              ((uint32_t)0x00000016U)         /* !< Selects channel 22 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_23              ((uint32_t)0x00000017U)         /* !< Selects channel 23 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_24              ((uint32_t)0x00000018U)         /* !< Selects channel 24 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_25              ((uint32_t)0x00000019U)         /* !< Selects channel 25 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_26              ((uint32_t)0x0000001AU)         /* !< Selects channel 26 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_27              ((uint32_t)0x0000001BU)         /* !< Selects channel 27 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_28              ((uint32_t)0x0000001CU)         /* !< Selects channel 28 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_29              ((uint32_t)0x0000001DU)         /* !< Selects channel 29 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_30              ((uint32_t)0x0000001EU)         /* !< Selects channel 30 */
+#define ADC12_CTL3_ASCCHSEL_CHAN_31              ((uint32_t)0x0000001FU)         /* !< Selects channel 31 */
+/* ADC12_CTL3[ASCSTIME] Bits */
+#define ADC12_CTL3_ASCSTIME_OFS                  (8)                             /* !< ASCSTIME Offset */
+#define ADC12_CTL3_ASCSTIME_MASK                 ((uint32_t)0x00000100U)         /* !< ASC sample time compare value
+                                                                                    select. This is used to select
+                                                                                    between SCOMP0 and SCOMP1 registers
+                                                                                    for ASC operation. */
+#define ADC12_CTL3_ASCSTIME_SEL_SCOMP0           ((uint32_t)0x00000000U)         /* !< Select SCOMP0 */
+#define ADC12_CTL3_ASCSTIME_SEL_SCOMP1           ((uint32_t)0x00000100U)         /* !< Select SCOMP1 */
+/* ADC12_CTL3[ASCVRSEL] Bits */
+#define ADC12_CTL3_ASCVRSEL_OFS                  (12)                            /* !< ASCVRSEL Offset */
+#define ADC12_CTL3_ASCVRSEL_MASK                 ((uint32_t)0x00003000U)         /* !< Selects voltage reference for ASC
+                                                                                    operation. VEREFM must be connected
+                                                                                    to on-board ground when external
+                                                                                    reference option is selected. Note:
+                                                                                    Writing value 0x3 defaults to INTREF. */
+#define ADC12_CTL3_ASCVRSEL_VDDA                 ((uint32_t)0x00000000U)         /* !< VDDA reference. */
+#define ADC12_CTL3_ASCVRSEL_EXTREF               ((uint32_t)0x00001000U)         /* !< EXTREF pin reference. */
+#define ADC12_CTL3_ASCVRSEL_INTREF               ((uint32_t)0x00002000U)         /* !< Internal reference. */
+
+/* ADC12_CLKFREQ Bits */
+/* ADC12_CLKFREQ[FRANGE] Bits */
+#define ADC12_CLKFREQ_FRANGE_OFS                 (0)                             /* !< FRANGE Offset */
+#define ADC12_CLKFREQ_FRANGE_MASK                ((uint32_t)0x00000007U)         /* !< Frequency Range. */
+#define ADC12_CLKFREQ_FRANGE_RANGE1TO4           ((uint32_t)0x00000000U)         /* !< 1 to 4 MHz */
+#define ADC12_CLKFREQ_FRANGE_RANGE4TO8           ((uint32_t)0x00000001U)         /* !< >4 to 8 MHz */
+#define ADC12_CLKFREQ_FRANGE_RANGE8TO16          ((uint32_t)0x00000002U)         /* !< >8 to 16 MHz */
+#define ADC12_CLKFREQ_FRANGE_RANGE16TO20         ((uint32_t)0x00000003U)         /* !< >16 to 20 MHz */
+#define ADC12_CLKFREQ_FRANGE_RANGE20TO24         ((uint32_t)0x00000004U)         /* !< >20 to 24 MHz */
+#define ADC12_CLKFREQ_FRANGE_RANGE24TO32         ((uint32_t)0x00000005U)         /* !< >24 to 32 MHz */
+#define ADC12_CLKFREQ_FRANGE_RANGE32TO40         ((uint32_t)0x00000006U)         /* !< >32 to 40 MHz */
+#define ADC12_CLKFREQ_FRANGE_RANGE40TO48         ((uint32_t)0x00000007U)         /* !< >40 to 48 MHz */
+
+/* ADC12_SCOMP0 Bits */
+/* ADC12_SCOMP0[VAL] Bits */
+#define ADC12_SCOMP0_VAL_OFS                     (0)                             /* !< VAL Offset */
+#define ADC12_SCOMP0_VAL_MASK                    ((uint32_t)0x000003FFU)         /* !< Specifies the number of sample
+                                                                                    clocks. When VAL = 0 or 1, number of
+                                                                                    sample clocks = Sample clock divide
+                                                                                    value. When VAL > 1, number of sample
+                                                                                    clocks = VAL x Sample clock divide
+                                                                                    value. Note: Sample clock divide
+                                                                                    value is not the value written to
+                                                                                    SCLKDIV but the actual divide value
+                                                                                    (SCLKDIV = 2 implies divide value is
+                                                                                    4). Example: VAL = 4, SCLKDIV = 3
+                                                                                    implies 32 sample clock cycles. */
+
+/* ADC12_SCOMP1 Bits */
+/* ADC12_SCOMP1[VAL] Bits */
+#define ADC12_SCOMP1_VAL_OFS                     (0)                             /* !< VAL Offset */
+#define ADC12_SCOMP1_VAL_MASK                    ((uint32_t)0x000003FFU)         /* !< Specifies the number of sample
+                                                                                    clocks. When VAL = 0 or 1, number of
+                                                                                    sample clocks = Sample clock divide
+                                                                                    value. When VAL > 1, number of sample
+                                                                                    clocks = VAL x Sample clock divide
+                                                                                    value. Note: Sample clock divide
+                                                                                    value is not the value written to
+                                                                                    SCLKDIV but the actual divide value
+                                                                                    (SCLKDIV = 2 implies divide value is
+                                                                                    4). Example: VAL = 4, SCLKDIV = 3
+                                                                                    implies 32 sample clock cycles. */
+
+/* ADC12_REFCFG Bits */
+/* ADC12_REFCFG[REFEN] Bits */
+#define ADC12_REFCFG_REFEN_OFS                   (0)                             /* !< REFEN Offset */
+#define ADC12_REFCFG_REFEN_MASK                  ((uint32_t)0x00000001U)         /* !< Reference buffer enable */
+#define ADC12_REFCFG_REFEN_DISABLE               ((uint32_t)0x00000000U)         /* !< Disable */
+#define ADC12_REFCFG_REFEN_ENABLE                ((uint32_t)0x00000001U)         /* !< Enable */
+/* ADC12_REFCFG[REFVSEL] Bits */
+#define ADC12_REFCFG_REFVSEL_OFS                 (1)                             /* !< REFVSEL Offset */
+#define ADC12_REFCFG_REFVSEL_MASK                ((uint32_t)0x00000002U)         /* !< Configures reference buffer output
+                                                                                    voltage */
+#define ADC12_REFCFG_REFVSEL_V2P5                ((uint32_t)0x00000000U)         /* !< Reference buffer generates 2.5 V
+                                                                                    output */
+#define ADC12_REFCFG_REFVSEL_V1P4                ((uint32_t)0x00000002U)         /* !< Reference buffer generates 1.4 V
+                                                                                    output */
+/* ADC12_REFCFG[IBPROG] Bits */
+#define ADC12_REFCFG_IBPROG_OFS                  (3)                             /* !< IBPROG Offset */
+#define ADC12_REFCFG_IBPROG_MASK                 ((uint32_t)0x00000018U)         /* !< Configures reference buffer bias
+                                                                                    current output value */
+#define ADC12_REFCFG_IBPROG_VAL0                 ((uint32_t)0x00000000U)         /* !< 1uA */
+#define ADC12_REFCFG_IBPROG_VAL1                 ((uint32_t)0x00000008U)         /* !< 0.5uA */
+#define ADC12_REFCFG_IBPROG_VAL2                 ((uint32_t)0x00000010U)         /* !< 2uA */
+#define ADC12_REFCFG_IBPROG_VAL3                 ((uint32_t)0x00000018U)         /* !< 0.67uA */
+
+/* ADC12_WCLOW Bits */
+/* ADC12_WCLOW[DATA] Bits */
+#define ADC12_WCLOW_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define ADC12_WCLOW_DATA_MASK                    ((uint32_t)0x0000FFFFU)         /* !< If DF = 0, unsigned binary format
+                                                                                    has to be used.  The value based on
+                                                                                    the resolution has to be right
+                                                                                    aligned with the MSB on the left. For
+                                                                                    10-bits and 8-bits resolution, unused
+                                                                                    bits have to be 0s.  If DF = 1,
+                                                                                    2s-complement format has to be used.
+                                                                                    The value based on the resolution has
+                                                                                    to be left aligned with the LSB on
+                                                                                    the right.  For 10-bits and 8-bits
+                                                                                    resolution, unused bits have to be
+                                                                                    0s. */
+
+/* ADC12_WCHIGH Bits */
+/* ADC12_WCHIGH[DATA] Bits */
+#define ADC12_WCHIGH_DATA_OFS                    (0)                             /* !< DATA Offset */
+#define ADC12_WCHIGH_DATA_MASK                   ((uint32_t)0x0000FFFFU)         /* !< If DF = 0, unsigned binary format
+                                                                                    has to be used. The threshold value
+                                                                                    has to be right aligned, with the MSB
+                                                                                    on the left. For 10-bits and 8-bits
+                                                                                    resolution, unused bit have to be 0s.
+                                                                                    If DF = 1, 2s-complement format has
+                                                                                    to be used. The value based on the
+                                                                                    resolution has to be left aligned
+                                                                                    with the LSB on the right.  For
+                                                                                    10-bits and 8-bits resolution, unused
+                                                                                    bit have to be 0s. */
+
+/* ADC12_ULLMEM_FIFODATA Bits */
+/* ADC12_ULLMEM_FIFODATA[DATA] Bits */
+#define ADC12_ULLMEM_FIFODATA_DATA_OFS           (0)                             /* !< DATA Offset */
+#define ADC12_ULLMEM_FIFODATA_DATA_MASK          ((uint32_t)0xFFFFFFFFU)         /* !< Read from this data field returns
+                                                                                    the ADC sample from FIFO. */
+
+/* ADC12_ASCRES Bits */
+/* ADC12_ASCRES[DATA] Bits */
+#define ADC12_ASCRES_DATA_OFS                    (0)                             /* !< DATA Offset */
+#define ADC12_ASCRES_DATA_MASK                   ((uint32_t)0x0000FFFFU)         /* !< Result of ADC ad-hoc single
+                                                                                    conversion. If DF = 0, unsigned
+                                                                                    binary: The conversion result is
+                                                                                    right aligned. In 10 and 8 bit modes,
+                                                                                    the unused MSB bits are forced to 0.
+                                                                                    If DF = 1, 2s-complement format: The
+                                                                                    conversion result is left aligned. In
+                                                                                    10 and 8 bit modes, the unused LSB
+                                                                                    bits are forced to 0. The data is
+                                                                                    stored in the right-justified format
+                                                                                    and is converted to the
+                                                                                    left-justified 2s-complement format
+                                                                                    during read back. */
+
+/* ADC12_MEMCTL Bits */
+/* ADC12_MEMCTL[CHANSEL] Bits */
+#define ADC12_MEMCTL_CHANSEL_OFS                 (0)                             /* !< CHANSEL Offset */
+#define ADC12_MEMCTL_CHANSEL_MASK                ((uint32_t)0x0000001FU)         /* !< Input channel select. */
+#define ADC12_MEMCTL_CHANSEL_CHAN_0              ((uint32_t)0x00000000U)         /* !< Selects channel 0 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_1              ((uint32_t)0x00000001U)         /* !< Selects channel 1 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_2              ((uint32_t)0x00000002U)         /* !< Selects channel 2 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_3              ((uint32_t)0x00000003U)         /* !< Selects channel 3 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_4              ((uint32_t)0x00000004U)         /* !< Selects channel 4 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_5              ((uint32_t)0x00000005U)         /* !< Selects channel 5 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_6              ((uint32_t)0x00000006U)         /* !< Selects channel 6 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_7              ((uint32_t)0x00000007U)         /* !< Selects channel 7 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_8              ((uint32_t)0x00000008U)         /* !< Selects channel 8 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_9              ((uint32_t)0x00000009U)         /* !< Selects channel 9 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_10             ((uint32_t)0x0000000AU)         /* !< Selects channel 10 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_11             ((uint32_t)0x0000000BU)         /* !< Selects channel 11 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_12             ((uint32_t)0x0000000CU)         /* !< Selects channel 12 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_13             ((uint32_t)0x0000000DU)         /* !< Selects channel 13 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_14             ((uint32_t)0x0000000EU)         /* !< Selects channel 14 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_15             ((uint32_t)0x0000000FU)         /* !< Selects channel 15 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_16             ((uint32_t)0x00000010U)         /* !< Selects channel 16 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_17             ((uint32_t)0x00000011U)         /* !< Selects channel 17 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_18             ((uint32_t)0x00000012U)         /* !< Selects channel 18 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_19             ((uint32_t)0x00000013U)         /* !< Selects channel 19 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_20             ((uint32_t)0x00000014U)         /* !< Selects channel 20 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_21             ((uint32_t)0x00000015U)         /* !< Selects channel 21 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_22             ((uint32_t)0x00000016U)         /* !< Selects channel 22 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_23             ((uint32_t)0x00000017U)         /* !< Selects channel 23 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_24             ((uint32_t)0x00000018U)         /* !< Selects channel 24 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_25             ((uint32_t)0x00000019U)         /* !< Selects channel 25 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_26             ((uint32_t)0x0000001AU)         /* !< Selects channel 26 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_27             ((uint32_t)0x0000001BU)         /* !< Selects channel 27 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_28             ((uint32_t)0x0000001CU)         /* !< Selects channel 28 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_29             ((uint32_t)0x0000001DU)         /* !< Selects channel 29 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_30             ((uint32_t)0x0000001EU)         /* !< Selects channel 30 */
+#define ADC12_MEMCTL_CHANSEL_CHAN_31             ((uint32_t)0x0000001FU)         /* !< Selects channel 31 */
+/* ADC12_MEMCTL[TRIG] Bits */
+#define ADC12_MEMCTL_TRIG_OFS                    (24)                            /* !< TRIG Offset */
+#define ADC12_MEMCTL_TRIG_MASK                   ((uint32_t)0x01000000U)         /* !< Trigger policy. Indicates if a
+                                                                                    trigger will be needed to step to the
+                                                                                    next MEMCTL in the sequence or to
+                                                                                    perform next conversion in the case
+                                                                                    of repeat single channel conversions. */
+#define ADC12_MEMCTL_TRIG_AUTO_NEXT              ((uint32_t)0x00000000U)         /* !< Next conversion is automatic */
+#define ADC12_MEMCTL_TRIG_TRIGGER_NEXT           ((uint32_t)0x01000000U)         /* !< Next conversion requires a trigger */
+/* ADC12_MEMCTL[VRSEL] Bits */
+#define ADC12_MEMCTL_VRSEL_OFS                   (8)                             /* !< VRSEL Offset */
+#define ADC12_MEMCTL_VRSEL_MASK                  ((uint32_t)0x00000300U)         /* !< Voltage reference selection. VEREFM
+                                                                                    must be connected to on-board ground
+                                                                                    when external reference option is
+                                                                                    selected. Note: Writing value 0x3
+                                                                                    defaults to INTREF. */
+#define ADC12_MEMCTL_VRSEL_VDDA                  ((uint32_t)0x00000000U)         /* !< VDDA reference */
+#define ADC12_MEMCTL_VRSEL_EXTREF                ((uint32_t)0x00000100U)         /* !< External reference from pin */
+#define ADC12_MEMCTL_VRSEL_INTREF                ((uint32_t)0x00000200U)         /* !< Internal reference */
+/* ADC12_MEMCTL[WINCOMP] Bits */
+#define ADC12_MEMCTL_WINCOMP_OFS                 (28)                            /* !< WINCOMP Offset */
+#define ADC12_MEMCTL_WINCOMP_MASK                ((uint32_t)0x10000000U)         /* !< Enable window comparator. */
+#define ADC12_MEMCTL_WINCOMP_DISABLE             ((uint32_t)0x00000000U)         /* !< Disable */
+#define ADC12_MEMCTL_WINCOMP_ENABLE              ((uint32_t)0x10000000U)         /* !< Enable */
+/* ADC12_MEMCTL[BCSEN] Bits */
+#define ADC12_MEMCTL_BCSEN_OFS                   (20)                            /* !< BCSEN Offset */
+#define ADC12_MEMCTL_BCSEN_MASK                  ((uint32_t)0x00100000U)         /* !< Enable burn out current source. */
+#define ADC12_MEMCTL_BCSEN_DISABLE               ((uint32_t)0x00000000U)         /* !< Disable */
+#define ADC12_MEMCTL_BCSEN_ENABLE                ((uint32_t)0x00100000U)         /* !< Enable */
+/* ADC12_MEMCTL[AVGEN] Bits */
+#define ADC12_MEMCTL_AVGEN_OFS                   (16)                            /* !< AVGEN Offset */
+#define ADC12_MEMCTL_AVGEN_MASK                  ((uint32_t)0x00010000U)         /* !< Enable hardware averaging. */
+#define ADC12_MEMCTL_AVGEN_DISABLE               ((uint32_t)0x00000000U)         /* !< Averaging disabled. */
+#define ADC12_MEMCTL_AVGEN_ENABLE                ((uint32_t)0x00010000U)         /* !< Averaging enabled. */
+/* ADC12_MEMCTL[STIME] Bits */
+#define ADC12_MEMCTL_STIME_OFS                   (12)                            /* !< STIME Offset */
+#define ADC12_MEMCTL_STIME_MASK                  ((uint32_t)0x00001000U)         /* !< Selects the source of sample timer
+                                                                                    period between SCOMP0 and SCOMP1. */
+#define ADC12_MEMCTL_STIME_SEL_SCOMP0            ((uint32_t)0x00000000U)         /* !< Select SCOMP0 */
+#define ADC12_MEMCTL_STIME_SEL_SCOMP1            ((uint32_t)0x00001000U)         /* !< Select SCOMP1 */
+
+/* ADC12_ULLMEM_MEMRES Bits */
+/* ADC12_ULLMEM_MEMRES[DATA] Bits */
+#define ADC12_ULLMEM_MEMRES_DATA_OFS             (0)                             /* !< DATA Offset */
+#define ADC12_ULLMEM_MEMRES_DATA_MASK            ((uint32_t)0x0000FFFFU)         /* !< MEMRES result register. If DF = 0,
+                                                                                    unsigned binary: The conversion
+                                                                                    results are right aligned. In 10 and
+                                                                                    8 bit modes, the unused MSB bits are
+                                                                                    forced to 0.  If DF = 1,
+                                                                                    2s-complement format: The conversion
+                                                                                    results are left aligned. In 10 and 8
+                                                                                    bit modes, the unused LSB bits are
+                                                                                    forced to 0. The data is stored in
+                                                                                    the right-justified format and is
+                                                                                    converted to the left-justified
+                                                                                    2s-complement format during read
+                                                                                    back. */
+
+/* ADC12_STATUS Bits */
+/* ADC12_STATUS[BUSY] Bits */
+#define ADC12_STATUS_BUSY_OFS                    (0)                             /* !< BUSY Offset */
+#define ADC12_STATUS_BUSY_MASK                   ((uint32_t)0x00000001U)         /* !< Busy. This bit indicates that an
+                                                                                    active ADC sample or conversion
+                                                                                    operation is in progress. */
+#define ADC12_STATUS_BUSY_IDLE                   ((uint32_t)0x00000000U)         /* !< No ADC sampling or conversion in
+                                                                                    progress. */
+#define ADC12_STATUS_BUSY_ACTIVE                 ((uint32_t)0x00000001U)         /* !< ADC sampling or conversion is in
+                                                                                    progress. */
+/* ADC12_STATUS[REFBUFRDY] Bits */
+#define ADC12_STATUS_REFBUFRDY_OFS               (1)                             /* !< REFBUFRDY Offset */
+#define ADC12_STATUS_REFBUFRDY_MASK              ((uint32_t)0x00000002U)         /* !< Indicates reference buffer is
+                                                                                    powered up and ready. */
+#define ADC12_STATUS_REFBUFRDY_NOTREADY          ((uint32_t)0x00000000U)         /* !< Not ready */
+#define ADC12_STATUS_REFBUFRDY_READY             ((uint32_t)0x00000002U)         /* !< Ready */
+/* ADC12_STATUS[ASCACT] Bits */
+#define ADC12_STATUS_ASCACT_OFS                  (2)                             /* !< ASCACT Offset */
+#define ADC12_STATUS_ASCACT_MASK                 ((uint32_t)0x00000004U)         /* !< ASC active */
+#define ADC12_STATUS_ASCACT_IDLE                 ((uint32_t)0x00000000U)         /* !< Idle or done */
+#define ADC12_STATUS_ASCACT_ACTIVE               ((uint32_t)0x00000004U)         /* !< ASC active */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_adc12__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_aes.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_aes.h
@@ -1,0 +1,901 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_aes__include
+#define ti_devices_msp_peripherals_hw_aes__include
+
+/* Filename: hw_aes.h */
+/* Revised: 2023-06-13 16:16:59 */
+/* Revision: af41564566f5317723aed3e5efba7edbc3faf9e6 */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* AES Registers
+******************************************************************************/
+#define AES_DMA_TRIG2_OFS                        ((uint32_t)0x000010B0U)
+#define AES_DMA_TRIG1_OFS                        ((uint32_t)0x00001080U)
+#define AES_DMA_TRIG0_OFS                        ((uint32_t)0x00001050U)
+#define AES_CPU_INT_OFS                          ((uint32_t)0x00001020U)
+#define AES_GPRCM_OFS                            ((uint32_t)0x00000800U)
+
+
+/** @addtogroup AES_DMA_TRIG2
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x000010B0) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x000010B8) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x000010C0) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x000010C8) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x000010D0) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x000010D8) Interrupt clear */
+} AES_DMA_TRIG2_Regs;
+
+/*@}*/ /* end of group AES_DMA_TRIG2 */
+
+/** @addtogroup AES_DMA_TRIG1
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001080) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001088) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001090) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001098) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x000010A0) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x000010A8) Interrupt clear */
+} AES_DMA_TRIG1_Regs;
+
+/*@}*/ /* end of group AES_DMA_TRIG1 */
+
+/** @addtogroup AES_DMA_TRIG0
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001050) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001058) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001060) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001068) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001070) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001078) Interrupt clear */
+} AES_DMA_TRIG0_Regs;
+
+/*@}*/ /* end of group AES_DMA_TRIG0 */
+
+/** @addtogroup AES_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} AES_CPU_INT_Regs;
+
+/*@}*/ /* end of group AES_CPU_INT */
+
+/** @addtogroup AES_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} AES_GPRCM_Regs;
+
+/*@}*/ /* end of group AES_GPRCM */
+
+/** @addtogroup AES
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  AES_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED1[512];
+  __IO uint32_t PDBGCTL;                           /* !< (@ 0x00001018) Peripheral Debug Control */
+       uint32_t RESERVED2;
+  AES_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED3;
+  AES_DMA_TRIG0_Regs  DMA_TRIG0;                         /* !< (@ 0x00001050) */
+       uint32_t RESERVED4;
+  AES_DMA_TRIG1_Regs  DMA_TRIG1;                         /* !< (@ 0x00001080) */
+       uint32_t RESERVED5;
+  AES_DMA_TRIG2_Regs  DMA_TRIG2;                         /* !< (@ 0x000010B0) */
+       uint32_t RESERVED6;
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED7[7];
+  __IO uint32_t AESACTL0;                          /* !< (@ 0x00001100) AES accelerator control register 0 */
+  __IO uint32_t AESACTL1;                          /* !< (@ 0x00001104) AES accelerator control register 1 */
+  __IO uint32_t AESASTAT;                          /* !< (@ 0x00001108) aes accelerator status register */
+  __O  uint32_t AESAKEY;                           /* !< (@ 0x0000110C) aes accelerator key register */
+  __O  uint32_t AESADIN;                           /* !< (@ 0x00001110) aes accelerator data in register */
+  __I  uint32_t AESADOUT;                          /* !< (@ 0x00001114) aes accelerator data out register */
+  __O  uint32_t AESAXDIN;                          /* !< (@ 0x00001118) aes accelerator xored data in register */
+  __O  uint32_t AESAXIN;                           /* !< (@ 0x0000111C) aes accelerator xored data in register (no
+                                                      trigger) */
+} AES_Regs;
+
+/*@}*/ /* end of group AES */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* AES Register Control Bits
+******************************************************************************/
+
+/* AES_DMA_TRIG2_IIDX Bits */
+/* AES_DMA_TRIG2_IIDX[STAT] Bits */
+#define AES_DMA_TRIG2_IIDX_STAT_OFS              (0)                             /* !< STAT Offset */
+#define AES_DMA_TRIG2_IIDX_STAT_MASK             ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define AES_DMA_TRIG2_IIDX_STAT_NO_INTR          ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define AES_DMA_TRIG2_IIDX_STAT_DMA2             ((uint32_t)0x00000004U)         /* !< AES trigger 2 DMA */
+
+/* AES_DMA_TRIG2_IMASK Bits */
+/* AES_DMA_TRIG2_IMASK[DMA2] Bits */
+#define AES_DMA_TRIG2_IMASK_DMA2_OFS             (3)                             /* !< DMA2 Offset */
+#define AES_DMA_TRIG2_IMASK_DMA2_MASK            ((uint32_t)0x00000008U)         /* !< DMA2 event mask. */
+#define AES_DMA_TRIG2_IMASK_DMA2_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AES_DMA_TRIG2_IMASK_DMA2_SET             ((uint32_t)0x00000008U)         /* !< Set Interrrupt Mask */
+
+/* AES_DMA_TRIG2_RIS Bits */
+/* AES_DMA_TRIG2_RIS[DMA2] Bits */
+#define AES_DMA_TRIG2_RIS_DMA2_OFS               (3)                             /* !< DMA2 Offset */
+#define AES_DMA_TRIG2_RIS_DMA2_MASK              ((uint32_t)0x00000008U)         /* !< DMA2 event */
+#define AES_DMA_TRIG2_RIS_DMA2_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AES_DMA_TRIG2_RIS_DMA2_SET               ((uint32_t)0x00000008U)         /* !< Interrupt occured */
+
+/* AES_DMA_TRIG2_MIS Bits */
+/* AES_DMA_TRIG2_MIS[DMA2] Bits */
+#define AES_DMA_TRIG2_MIS_DMA2_OFS               (3)                             /* !< DMA2 Offset */
+#define AES_DMA_TRIG2_MIS_DMA2_MASK              ((uint32_t)0x00000008U)         /* !< DMA2 event */
+#define AES_DMA_TRIG2_MIS_DMA2_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AES_DMA_TRIG2_MIS_DMA2_SET               ((uint32_t)0x00000008U)         /* !< Interrupt occured */
+
+/* AES_DMA_TRIG2_ISET Bits */
+/* AES_DMA_TRIG2_ISET[DMA2] Bits */
+#define AES_DMA_TRIG2_ISET_DMA2_OFS              (3)                             /* !< DMA2 Offset */
+#define AES_DMA_TRIG2_ISET_DMA2_MASK             ((uint32_t)0x00000008U)         /* !< DMA2 event */
+#define AES_DMA_TRIG2_ISET_DMA2_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AES_DMA_TRIG2_ISET_DMA2_SET              ((uint32_t)0x00000008U)         /* !< Set Interrupt */
+
+/* AES_DMA_TRIG2_ICLR Bits */
+/* AES_DMA_TRIG2_ICLR[DMA2] Bits */
+#define AES_DMA_TRIG2_ICLR_DMA2_OFS              (3)                             /* !< DMA2 Offset */
+#define AES_DMA_TRIG2_ICLR_DMA2_MASK             ((uint32_t)0x00000008U)         /* !< DMA2 event */
+#define AES_DMA_TRIG2_ICLR_DMA2_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AES_DMA_TRIG2_ICLR_DMA2_CLR              ((uint32_t)0x00000008U)         /* !< Clear Interrupt */
+
+/* AES_DMA_TRIG1_IIDX Bits */
+/* AES_DMA_TRIG1_IIDX[STAT] Bits */
+#define AES_DMA_TRIG1_IIDX_STAT_OFS              (0)                             /* !< STAT Offset */
+#define AES_DMA_TRIG1_IIDX_STAT_MASK             ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define AES_DMA_TRIG1_IIDX_STAT_NO_INTR          ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define AES_DMA_TRIG1_IIDX_STAT_DMA1             ((uint32_t)0x00000003U)         /* !< AES trigger 1 DMA */
+
+/* AES_DMA_TRIG1_IMASK Bits */
+/* AES_DMA_TRIG1_IMASK[DMA1] Bits */
+#define AES_DMA_TRIG1_IMASK_DMA1_OFS             (2)                             /* !< DMA1 Offset */
+#define AES_DMA_TRIG1_IMASK_DMA1_MASK            ((uint32_t)0x00000004U)         /* !< DMA1 event mask. */
+#define AES_DMA_TRIG1_IMASK_DMA1_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AES_DMA_TRIG1_IMASK_DMA1_SET             ((uint32_t)0x00000004U)         /* !< Set Interrrupt Mask */
+
+/* AES_DMA_TRIG1_RIS Bits */
+/* AES_DMA_TRIG1_RIS[DMA1] Bits */
+#define AES_DMA_TRIG1_RIS_DMA1_OFS               (2)                             /* !< DMA1 Offset */
+#define AES_DMA_TRIG1_RIS_DMA1_MASK              ((uint32_t)0x00000004U)         /* !< DMA1 event */
+#define AES_DMA_TRIG1_RIS_DMA1_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AES_DMA_TRIG1_RIS_DMA1_SET               ((uint32_t)0x00000004U)         /* !< Interrupt occured */
+
+/* AES_DMA_TRIG1_MIS Bits */
+/* AES_DMA_TRIG1_MIS[DMA1] Bits */
+#define AES_DMA_TRIG1_MIS_DMA1_OFS               (2)                             /* !< DMA1 Offset */
+#define AES_DMA_TRIG1_MIS_DMA1_MASK              ((uint32_t)0x00000004U)         /* !< DMA1 event */
+#define AES_DMA_TRIG1_MIS_DMA1_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AES_DMA_TRIG1_MIS_DMA1_SET               ((uint32_t)0x00000004U)         /* !< Interrupt occured */
+
+/* AES_DMA_TRIG1_ISET Bits */
+/* AES_DMA_TRIG1_ISET[DMA1] Bits */
+#define AES_DMA_TRIG1_ISET_DMA1_OFS              (2)                             /* !< DMA1 Offset */
+#define AES_DMA_TRIG1_ISET_DMA1_MASK             ((uint32_t)0x00000004U)         /* !< DMA1 event */
+#define AES_DMA_TRIG1_ISET_DMA1_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AES_DMA_TRIG1_ISET_DMA1_SET              ((uint32_t)0x00000004U)         /* !< Set Interrupt */
+
+/* AES_DMA_TRIG1_ICLR Bits */
+/* AES_DMA_TRIG1_ICLR[DMA1] Bits */
+#define AES_DMA_TRIG1_ICLR_DMA1_OFS              (2)                             /* !< DMA1 Offset */
+#define AES_DMA_TRIG1_ICLR_DMA1_MASK             ((uint32_t)0x00000004U)         /* !< DMA1 event */
+#define AES_DMA_TRIG1_ICLR_DMA1_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AES_DMA_TRIG1_ICLR_DMA1_CLR              ((uint32_t)0x00000004U)         /* !< Clear Interrupt */
+
+/* AES_DMA_TRIG0_IIDX Bits */
+/* AES_DMA_TRIG0_IIDX[STAT] Bits */
+#define AES_DMA_TRIG0_IIDX_STAT_OFS              (0)                             /* !< STAT Offset */
+#define AES_DMA_TRIG0_IIDX_STAT_MASK             ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define AES_DMA_TRIG0_IIDX_STAT_NO_INTR          ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define AES_DMA_TRIG0_IIDX_STAT_DMA0             ((uint32_t)0x00000002U)         /* !< AES trigger 0 DMA */
+
+/* AES_DMA_TRIG0_IMASK Bits */
+/* AES_DMA_TRIG0_IMASK[DMA0] Bits */
+#define AES_DMA_TRIG0_IMASK_DMA0_OFS             (1)                             /* !< DMA0 Offset */
+#define AES_DMA_TRIG0_IMASK_DMA0_MASK            ((uint32_t)0x00000002U)         /* !< DMA0 event mask. */
+#define AES_DMA_TRIG0_IMASK_DMA0_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AES_DMA_TRIG0_IMASK_DMA0_SET             ((uint32_t)0x00000002U)         /* !< Set Interrrupt Mask */
+
+/* AES_DMA_TRIG0_RIS Bits */
+/* AES_DMA_TRIG0_RIS[DMA0] Bits */
+#define AES_DMA_TRIG0_RIS_DMA0_OFS               (1)                             /* !< DMA0 Offset */
+#define AES_DMA_TRIG0_RIS_DMA0_MASK              ((uint32_t)0x00000002U)         /* !< DMA0 event */
+#define AES_DMA_TRIG0_RIS_DMA0_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AES_DMA_TRIG0_RIS_DMA0_SET               ((uint32_t)0x00000002U)         /* !< Interrupt occured */
+
+/* AES_DMA_TRIG0_MIS Bits */
+/* AES_DMA_TRIG0_MIS[DMA0] Bits */
+#define AES_DMA_TRIG0_MIS_DMA0_OFS               (1)                             /* !< DMA0 Offset */
+#define AES_DMA_TRIG0_MIS_DMA0_MASK              ((uint32_t)0x00000002U)         /* !< DMA0 event */
+#define AES_DMA_TRIG0_MIS_DMA0_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AES_DMA_TRIG0_MIS_DMA0_SET               ((uint32_t)0x00000002U)         /* !< Interrupt occured */
+
+/* AES_DMA_TRIG0_ISET Bits */
+/* AES_DMA_TRIG0_ISET[DMA0] Bits */
+#define AES_DMA_TRIG0_ISET_DMA0_OFS              (1)                             /* !< DMA0 Offset */
+#define AES_DMA_TRIG0_ISET_DMA0_MASK             ((uint32_t)0x00000002U)         /* !< DMA0 */
+#define AES_DMA_TRIG0_ISET_DMA0_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AES_DMA_TRIG0_ISET_DMA0_SET              ((uint32_t)0x00000002U)         /* !< Set Interrupt */
+
+/* AES_DMA_TRIG0_ICLR Bits */
+/* AES_DMA_TRIG0_ICLR[DMA0] Bits */
+#define AES_DMA_TRIG0_ICLR_DMA0_OFS              (1)                             /* !< DMA0 Offset */
+#define AES_DMA_TRIG0_ICLR_DMA0_MASK             ((uint32_t)0x00000002U)         /* !< DMA0 event */
+#define AES_DMA_TRIG0_ICLR_DMA0_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AES_DMA_TRIG0_ICLR_DMA0_CLR              ((uint32_t)0x00000002U)         /* !< Clear Interrupt */
+
+/* AES_CPU_INT_IIDX Bits */
+/* AES_CPU_INT_IIDX[STAT] Bits */
+#define AES_CPU_INT_IIDX_STAT_OFS                (0)                             /* !< STAT Offset */
+#define AES_CPU_INT_IIDX_STAT_MASK               ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define AES_CPU_INT_IIDX_STAT_NO_INTR            ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define AES_CPU_INT_IIDX_STAT_AESRDY             ((uint32_t)0x00000001U)         /* !< AES ready interrupt, set when the
+                                                                                    selected AES operation was completed
+                                                                                    and the result can be read from
+                                                                                    AESADOUT */
+
+/* AES_CPU_INT_IMASK Bits */
+/* AES_CPU_INT_IMASK[AESRDY] Bits */
+#define AES_CPU_INT_IMASK_AESRDY_OFS             (0)                             /* !< AESRDY Offset */
+#define AES_CPU_INT_IMASK_AESRDY_MASK            ((uint32_t)0x00000001U)         /* !< AES ready interrupt, set when the
+                                                                                    selected AES operation was completed
+                                                                                    and the result can be read from
+                                                                                    AESADOUT. */
+#define AES_CPU_INT_IMASK_AESRDY_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AES_CPU_INT_IMASK_AESRDY_SET             ((uint32_t)0x00000001U)         /* !< Set Interrrupt Mask */
+
+/* AES_CPU_INT_RIS Bits */
+/* AES_CPU_INT_RIS[AESRDY] Bits */
+#define AES_CPU_INT_RIS_AESRDY_OFS               (0)                             /* !< AESRDY Offset */
+#define AES_CPU_INT_RIS_AESRDY_MASK              ((uint32_t)0x00000001U)         /* !< AES ready interrupt, set when the
+                                                                                    selected AES operation was completed
+                                                                                    and the result can be read from
+                                                                                    AESADOUT. */
+#define AES_CPU_INT_RIS_AESRDY_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AES_CPU_INT_RIS_AESRDY_SET               ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+
+/* AES_CPU_INT_MIS Bits */
+/* AES_CPU_INT_MIS[AESRDY] Bits */
+#define AES_CPU_INT_MIS_AESRDY_OFS               (0)                             /* !< AESRDY Offset */
+#define AES_CPU_INT_MIS_AESRDY_MASK              ((uint32_t)0x00000001U)         /* !< AES ready interrupt, set when the
+                                                                                    selected AES operation was completed
+                                                                                    and the result can be read from
+                                                                                    AESADOUT. */
+#define AES_CPU_INT_MIS_AESRDY_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AES_CPU_INT_MIS_AESRDY_SET               ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+
+/* AES_CPU_INT_ISET Bits */
+/* AES_CPU_INT_ISET[AESRDY] Bits */
+#define AES_CPU_INT_ISET_AESRDY_OFS              (0)                             /* !< AESRDY Offset */
+#define AES_CPU_INT_ISET_AESRDY_MASK             ((uint32_t)0x00000001U)         /* !< AES ready interrupt, set when the
+                                                                                    selected AES operation was completed
+                                                                                    and the result can be read from
+                                                                                    AESADOUT. */
+#define AES_CPU_INT_ISET_AESRDY_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AES_CPU_INT_ISET_AESRDY_SET              ((uint32_t)0x00000001U)         /* !< Set Interrupt */
+
+/* AES_CPU_INT_ICLR Bits */
+/* AES_CPU_INT_ICLR[AESRDY] Bits */
+#define AES_CPU_INT_ICLR_AESRDY_OFS              (0)                             /* !< AESRDY Offset */
+#define AES_CPU_INT_ICLR_AESRDY_MASK             ((uint32_t)0x00000001U)         /* !< AES ready interrupt, set when the
+                                                                                    selected AES operation was completed
+                                                                                    and the result can be read from
+                                                                                    AESADOUT. */
+#define AES_CPU_INT_ICLR_AESRDY_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AES_CPU_INT_ICLR_AESRDY_CLR              ((uint32_t)0x00000001U)         /* !< Clear Interrupt */
+
+/* AES_PWREN Bits */
+/* AES_PWREN[ENABLE] Bits */
+#define AES_PWREN_ENABLE_OFS                     (0)                             /* !< ENABLE Offset */
+#define AES_PWREN_ENABLE_MASK                    ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define AES_PWREN_ENABLE_DISABLE                 ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define AES_PWREN_ENABLE_ENABLE                  ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* AES_PWREN[KEY] Bits */
+#define AES_PWREN_KEY_OFS                        (24)                            /* !< KEY Offset */
+#define AES_PWREN_KEY_MASK                       ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define AES_PWREN_KEY_UNLOCK_W                   ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* AES_RSTCTL Bits */
+/* AES_RSTCTL[RESETSTKYCLR] Bits */
+#define AES_RSTCTL_RESETSTKYCLR_OFS              (1)                             /* !< RESETSTKYCLR Offset */
+#define AES_RSTCTL_RESETSTKYCLR_MASK             ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define AES_RSTCTL_RESETSTKYCLR_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AES_RSTCTL_RESETSTKYCLR_CLR              ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* AES_RSTCTL[RESETASSERT] Bits */
+#define AES_RSTCTL_RESETASSERT_OFS               (0)                             /* !< RESETASSERT Offset */
+#define AES_RSTCTL_RESETASSERT_MASK              ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define AES_RSTCTL_RESETASSERT_NOP               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AES_RSTCTL_RESETASSERT_ASSERT            ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* AES_RSTCTL[KEY] Bits */
+#define AES_RSTCTL_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define AES_RSTCTL_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define AES_RSTCTL_KEY_UNLOCK_W                  ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* AES_STAT Bits */
+/* AES_STAT[RESETSTKY] Bits */
+#define AES_STAT_RESETSTKY_OFS                   (16)                            /* !< RESETSTKY Offset */
+#define AES_STAT_RESETSTKY_MASK                  ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define AES_STAT_RESETSTKY_NORES                 ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define AES_STAT_RESETSTKY_RESET                 ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* AES_PDBGCTL Bits */
+/* AES_PDBGCTL[FREE] Bits */
+#define AES_PDBGCTL_FREE_OFS                     (0)                             /* !< FREE Offset */
+#define AES_PDBGCTL_FREE_MASK                    ((uint32_t)0x00000001U)         /* !< Free run control */
+#define AES_PDBGCTL_FREE_STOP                    ((uint32_t)0x00000000U)         /* !< The peripheral freezes
+                                                                                    functionality while the Core Halted
+                                                                                    input is asserted and resumes when it
+                                                                                    is deasserted. */
+#define AES_PDBGCTL_FREE_RUN                     ((uint32_t)0x00000001U)         /* !< The peripheral ignores the state of
+                                                                                    the Core Halted input */
+/* AES_PDBGCTL[SOFT] Bits */
+#define AES_PDBGCTL_SOFT_OFS                     (1)                             /* !< SOFT Offset */
+#define AES_PDBGCTL_SOFT_MASK                    ((uint32_t)0x00000002U)         /* !< Soft halt boundary control. This
+                                                                                    function is only available, if [FREE]
+                                                                                    is set to 'STOP' */
+#define AES_PDBGCTL_SOFT_IMMEDIATE               ((uint32_t)0x00000000U)         /* !< The peripheral will halt
+                                                                                    immediately, even if the resultant
+                                                                                    state will result in corruption if
+                                                                                    the system is restarted */
+#define AES_PDBGCTL_SOFT_DELAYED                 ((uint32_t)0x00000002U)         /* !< The peripheral blocks the debug
+                                                                                    freeze until it has reached a
+                                                                                    boundary where it can resume without
+                                                                                    corruption */
+
+/* AES_EVT_MODE Bits */
+/* AES_EVT_MODE[INT0_CFG] Bits */
+#define AES_EVT_MODE_INT0_CFG_OFS                (0)                             /* !< INT0_CFG Offset */
+#define AES_EVT_MODE_INT0_CFG_MASK               ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT0] */
+#define AES_EVT_MODE_INT0_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define AES_EVT_MODE_INT0_CFG_SOFTWARE           ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define AES_EVT_MODE_INT0_CFG_HARDWARE           ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* AES_EVT_MODE[EVT1_CFG] Bits */
+#define AES_EVT_MODE_EVT1_CFG_OFS                (2)                             /* !< EVT1_CFG Offset */
+#define AES_EVT_MODE_EVT1_CFG_MASK               ((uint32_t)0x0000000CU)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT1] */
+#define AES_EVT_MODE_EVT1_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define AES_EVT_MODE_EVT1_CFG_SOFTWARE           ((uint32_t)0x00000004U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define AES_EVT_MODE_EVT1_CFG_HARDWARE           ((uint32_t)0x00000008U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* AES_EVT_MODE[EVT2_CFG] Bits */
+#define AES_EVT_MODE_EVT2_CFG_OFS                (4)                             /* !< EVT2_CFG Offset */
+#define AES_EVT_MODE_EVT2_CFG_MASK               ((uint32_t)0x00000030U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT2] */
+#define AES_EVT_MODE_EVT2_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define AES_EVT_MODE_EVT2_CFG_SOFTWARE           ((uint32_t)0x00000010U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define AES_EVT_MODE_EVT2_CFG_HARDWARE           ((uint32_t)0x00000020U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* AES_EVT_MODE[EVT3_CFG] Bits */
+#define AES_EVT_MODE_EVT3_CFG_OFS                (6)                             /* !< EVT3_CFG Offset */
+#define AES_EVT_MODE_EVT3_CFG_MASK               ((uint32_t)0x000000C0U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT2] */
+#define AES_EVT_MODE_EVT3_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define AES_EVT_MODE_EVT3_CFG_SOFTWARE           ((uint32_t)0x00000040U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define AES_EVT_MODE_EVT3_CFG_HARDWARE           ((uint32_t)0x00000080U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* AES_AESACTL0 Bits */
+/* AES_AESACTL0[OPX] Bits */
+#define AES_AESACTL0_OPX_OFS                     (0)                             /* !< OPX Offset */
+#define AES_AESACTL0_OPX_MASK                    ((uint32_t)0x00000003U)         /* !< AES operation. The AESOPx bits are
+                                                                                    not reset by AESSWRST = 1. Writes are
+                                                                                    ignored when AESCMEN = 1 and
+                                                                                    AESBLKCNTx > 0. 00b = Encryption. 01b
+                                                                                    = Decryption. The provided key is the
+                                                                                    same key used for encryption. 10b =
+                                                                                    Generate first round key required for
+                                                                                    decryption. 11b = Decryption. The
+                                                                                    provided key is the first round key
+                                                                                    required for decryption. */
+#define AES_AESACTL0_OPX_OP0                     ((uint32_t)0x00000000U)         /* !< Encryption */
+#define AES_AESACTL0_OPX_OP1                     ((uint32_t)0x00000001U)         /* !< Decryption. The provided key is the
+                                                                                    same key used for encryption. */
+#define AES_AESACTL0_OPX_OP2                     ((uint32_t)0x00000002U)         /* !< Generate first round key required
+                                                                                    for decryption. */
+#define AES_AESACTL0_OPX_OP3                     ((uint32_t)0x00000003U)         /* !< Decryption. The provided key is the
+                                                                                    first round key required for
+                                                                                    decryption. */
+/* AES_AESACTL0[KLX] Bits */
+#define AES_AESACTL0_KLX_OFS                     (2)                             /* !< KLX Offset */
+#define AES_AESACTL0_KLX_MASK                    ((uint32_t)0x0000000CU)         /* !< AES key length.  These bits define
+                                                                                    which of the 1 AES standards is
+                                                                                    performed. The AESKLx bits are not
+                                                                                    reset by AESSWRST = 1. Writes are
+                                                                                    ignored when AESCMEN = 1 and
+                                                                                    AESBLKCNTx > 0. */
+#define AES_AESACTL0_KLX_AES128                  ((uint32_t)0x00000000U)         /* !< The key size is 128 bit. */
+#define AES_AESACTL0_KLX_AES256                  ((uint32_t)0x00000008U)         /* !< The key size is 256 bit. */
+/* AES_AESACTL0[CMX] Bits */
+#define AES_AESACTL0_CMX_OFS                     (5)                             /* !< CMX Offset */
+#define AES_AESACTL0_CMX_MASK                    ((uint32_t)0x00000060U)         /* !< AES cipher mode select. These bits
+                                                                                    are ignored for AESCMEN = 0. Writes
+                                                                                    are ignored when AESCMEN = 1 and
+                                                                                    AESBLKCNTx > 0. 00b = ECB 01b = CBC
+                                                                                    10b = OFB 11b = CFB */
+#define AES_AESACTL0_CMX_ECB                     ((uint32_t)0x00000000U)         /* !< ECB */
+#define AES_AESACTL0_CMX_CBC                     ((uint32_t)0x00000020U)         /* !< CBC */
+#define AES_AESACTL0_CMX_OFB                     ((uint32_t)0x00000040U)         /* !< OFB */
+#define AES_AESACTL0_CMX_CFB                     ((uint32_t)0x00000060U)         /* !< CFB */
+/* AES_AESACTL0[SWRST] Bits */
+#define AES_AESACTL0_SWRST_OFS                   (7)                             /* !< SWRST Offset */
+#define AES_AESACTL0_SWRST_MASK                  ((uint32_t)0x00000080U)         /* !< AES software reset.  Immediately
+                                                                                    resets the complete AES accelerator
+                                                                                    module even when busy except for the
+                                                                                    AESRDYIE, the AESKLx and the AESOPx
+                                                                                    bits. It also clears the (internal)
+                                                                                    state memory. The AESSWRST bit is
+                                                                                    automatically reset and is always
+                                                                                    read as zero. 0b = No reset 1b =
+                                                                                    Reset AES accelerator module */
+#define AES_AESACTL0_SWRST_NORST                 ((uint32_t)0x00000000U)         /* !< No reset. */
+#define AES_AESACTL0_SWRST_RST                   ((uint32_t)0x00000080U)         /* !< Reset AES accelerator module. */
+/* AES_AESACTL0[ERRFG] Bits */
+#define AES_AESACTL0_ERRFG_OFS                   (11)                            /* !< ERRFG Offset */
+#define AES_AESACTL0_ERRFG_MASK                  ((uint32_t)0x00000800U)         /* !< AES error flag.  AESAKEY or AESADIN
+                                                                                    were written while an AES operation
+                                                                                    was in progress. The bit must be
+                                                                                    cleared by software. 0b = No error 1b
+                                                                                    = Error occurred */
+#define AES_AESACTL0_ERRFG_NOERR                 ((uint32_t)0x00000000U)         /* !< No error */
+#define AES_AESACTL0_ERRFG_ERR                   ((uint32_t)0x00000800U)         /* !< Error occurred */
+/* AES_AESACTL0[CMEN] Bits */
+#define AES_AESACTL0_CMEN_OFS                    (15)                            /* !< CMEN Offset */
+#define AES_AESACTL0_CMEN_MASK                   ((uint32_t)0x00008000U)         /* !< AESCMEN enables the support of the
+                                                                                    cipher modes ECB, CBC, OFB and CFB
+                                                                                    together with the DMA. Writes are
+                                                                                    ignored when AESCMEN = 1 and
+                                                                                    AESBLKCNTx > 0. 0 = No DMA triggers
+                                                                                    are generated. 1 = DMA cipher mode
+                                                                                    support operation is enabled and the
+                                                                                    corresponding DMA triggers are
+                                                                                    generated. */
+#define AES_AESACTL0_CMEN_DISABLE                ((uint32_t)0x00000000U)         /* !< No DMA triggers are generated. */
+#define AES_AESACTL0_CMEN_ENABLE                 ((uint32_t)0x00008000U)         /* !< DMA cipher mode support operation
+                                                                                    is enabled and the corresponding DMA
+                                                                                    triggers are generated. */
+
+/* AES_AESACTL1 Bits */
+/* AES_AESACTL1[BLKCNTX] Bits */
+#define AES_AESACTL1_BLKCNTX_OFS                 (0)                             /* !< BLKCNTX Offset */
+#define AES_AESACTL1_BLKCNTX_MASK                ((uint32_t)0x000000FFU)         /* !< Cipher Block Counter. Number of
+                                                                                    blocks to be encrypted or decrypted
+                                                                                    with block cipher modes enabled
+                                                                                    (AESCMEN = 1). Ignored if AESCMEN =
+                                                                                    0. The block counter decrements with
+                                                                                    each performed encryption or
+                                                                                    decryption. Writes are ignored when
+                                                                                    AESCMEN = 1 and AESBLKCNTx > 0. */
+#define AES_AESACTL1_BLKCNTX_MINNUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define AES_AESACTL1_BLKCNTX_ENABLE              ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+
+/* AES_AESASTAT Bits */
+/* AES_AESASTAT[BUSY] Bits */
+#define AES_AESASTAT_BUSY_OFS                    (0)                             /* !< BUSY Offset */
+#define AES_AESASTAT_BUSY_MASK                   ((uint32_t)0x00000001U)         /* !< AES accelerator module busy;
+                                                                                    encryption, decryption, or key
+                                                                                    generation in progress.  0 = Not busy
+                                                                                    1 = Busy */
+#define AES_AESASTAT_BUSY_IDLE                   ((uint32_t)0x00000000U)         /* !< Not busy */
+#define AES_AESASTAT_BUSY_BUSY                   ((uint32_t)0x00000001U)         /* !< Busy */
+/* AES_AESASTAT[KEYWR] Bits */
+#define AES_AESASTAT_KEYWR_OFS                   (1)                             /* !< KEYWR Offset */
+#define AES_AESASTAT_KEYWR_MASK                  ((uint32_t)0x00000002U)         /* !< All bytes written to AESAKEY. This
+                                                                                    bit can be modified by software but
+                                                                                    it must not be reset by software (10)
+                                                                                    if AESCMEN=1. Changing its state by
+                                                                                    software also resets the AESKEYCNTx
+                                                                                    bits. AESKEYWR is reset by PUC,
+                                                                                    AESSWRST, an error condition,
+                                                                                    changing AESOPx, changing AESKLx, and
+                                                                                    the start to (over)write a new key.
+                                                                                    Because it is reset when AESOPx is
+                                                                                    changed it can be set by software
+                                                                                    again to indicate that the loaded key
+                                                                                    is still valid. */
+#define AES_AESASTAT_KEYWR_NALL                  ((uint32_t)0x00000000U)         /* !< Not all bytes written */
+#define AES_AESASTAT_KEYWR_ALL                   ((uint32_t)0x00000002U)         /* !< All bytes written */
+/* AES_AESASTAT[DINWR] Bits */
+#define AES_AESASTAT_DINWR_OFS                   (2)                             /* !< DINWR Offset */
+#define AES_AESASTAT_DINWR_MASK                  ((uint32_t)0x00000004U)         /* !< All 16 bytes written to AESADIN,
+                                                                                    AESAXDIN or AESAXIN. Changing its
+                                                                                    state by software also resets the
+                                                                                    AESDINCNTx bits. AESDINWR is reset by
+                                                                                    PUC, AESSWRST, an error condition,
+                                                                                    changing AESOPx, changing AESKLx, the
+                                                                                    start to (over)write the data, and
+                                                                                    when the AES accelerator is busy.
+                                                                                    Because it is reset when AESOPx or
+                                                                                    AESKLx is changed it can be set by
+                                                                                    software again to indicate that the
+                                                                                    current data is still valid.  0 = Not
+                                                                                    all bytes written  1 = All bytes
+                                                                                    written */
+#define AES_AESASTAT_DINWR_NALL                  ((uint32_t)0x00000000U)         /* !< Not all bytes written */
+#define AES_AESASTAT_DINWR_ALL                   ((uint32_t)0x00000004U)         /* !< All bytes written */
+/* AES_AESASTAT[DOUTRD] Bits */
+#define AES_AESASTAT_DOUTRD_OFS                  (3)                             /* !< DOUTRD Offset */
+#define AES_AESASTAT_DOUTRD_MASK                 ((uint32_t)0x00000008U)         /* !< All 16 bytes read from AESADOUT.
+                                                                                    AESDOUTRD is reset by PUC, AESSWRST,
+                                                                                    an error condition, changing AESOPx,
+                                                                                    changing AESKLx, when the AES
+                                                                                    accelerator is busy, and when the
+                                                                                    output data is read again.  0 = Not
+                                                                                    all bytes read 1 = All bytes read */
+#define AES_AESASTAT_DOUTRD_NALL                 ((uint32_t)0x00000000U)         /* !< Not all bytes read */
+#define AES_AESASTAT_DOUTRD_ALL                  ((uint32_t)0x00000008U)         /* !< All bytes read */
+/* AES_AESASTAT[KEYCNTX] Bits */
+#define AES_AESASTAT_KEYCNTX_OFS                 (4)                             /* !< KEYCNTX Offset */
+#define AES_AESASTAT_KEYCNTX_MASK                ((uint32_t)0x000000F0U)         /* !< Bytes written to AESAKEY when
+                                                                                    AESKLx = 00, half-words written to
+                                                                                    AESAKEY if AESKLx = b10. Reset when
+                                                                                    AESKEYWR is reset. If AESKEYCNTx = 0
+                                                                                    and AESKEYWR = 0, no bytes were
+                                                                                    written. If AESKEYCNTx = 0 and
+                                                                                    AESKEYWR = 1, all bytes were written. */
+#define AES_AESASTAT_KEYCNTX_MINNUM              ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESASTAT_KEYCNTX_MAXNUM              ((uint32_t)0x000000F0U)         /* !< Highest possible value */
+/* AES_AESASTAT[DINCNTX] Bits */
+#define AES_AESASTAT_DINCNTX_OFS                 (8)                             /* !< DINCNTX Offset */
+#define AES_AESASTAT_DINCNTX_MASK                ((uint32_t)0x00000F00U)         /* !< Bytes written to AESADIN, AESAXDIN
+                                                                                    or AESAXIN. Reset when AESDINWR is
+                                                                                    reset. If AESDINCNTx = 0 and AESDINWR
+                                                                                    = 0, no bytes were written. If
+                                                                                    AESDINCNTx = 0 and AESDINWR = 1, all
+                                                                                    bytes were written. */
+#define AES_AESASTAT_DINCNTX_MINNUM              ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESASTAT_DINCNTX_MAXNUM              ((uint32_t)0x00000F00U)         /* !< Highest possible value */
+/* AES_AESASTAT[DOUTCNTX] Bits */
+#define AES_AESASTAT_DOUTCNTX_OFS                (12)                            /* !< DOUTCNTX Offset */
+#define AES_AESASTAT_DOUTCNTX_MASK               ((uint32_t)0x0000F000U)         /* !< Bytes read from AESADOUT. Reset
+                                                                                    when AESDOUTRD is reset. If
+                                                                                    AESDOUTCNTx = 0 and AESDOUTRD = 0, no
+                                                                                    bytes were read. If AESDOUTCNTx = 0
+                                                                                    and AESDOUTRD = 1, all bytes were
+                                                                                    read. */
+#define AES_AESASTAT_DOUTCNTX_MINNUM             ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESASTAT_DOUTCNTX_MAXNUM             ((uint32_t)0x0000F000U)         /* !< Highest possible value */
+
+/* AES_AESAKEY Bits */
+/* AES_AESAKEY[KEY0X] Bits */
+#define AES_AESAKEY_KEY0X_OFS                    (0)                             /* !< KEY0X Offset */
+#define AES_AESAKEY_KEY0X_MASK                   ((uint32_t)0x000000FFU)         /* !< AES key byte n when AESAKEY is
+                                                                                    written as word. AES next key byte
+                                                                                    when AESAKEY is written as byte. Do
+                                                                                    not mix word and byte access. Always
+                                                                                    reads as zero. The key is reset by
+                                                                                    PUC or by AESSWRST = 1. */
+#define AES_AESAKEY_KEY0X_MINNUM                 ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESAKEY_KEY0X_MAXNUM                 ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+/* AES_AESAKEY[KEY1X] Bits */
+#define AES_AESAKEY_KEY1X_OFS                    (8)                             /* !< KEY1X Offset */
+#define AES_AESAKEY_KEY1X_MASK                   ((uint32_t)0x0000FF00U)         /* !< AES key byte n+1 when AESAKEY is
+                                                                                    written as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. Always reads as
+                                                                                    zero. The key is reset by PUC or by
+                                                                                    AESSWRST = 1. */
+#define AES_AESAKEY_KEY1X_MINNUM                 ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESAKEY_KEY1X_MAXNUM                 ((uint32_t)0x0000FF00U)         /* !< Highest possible value */
+/* AES_AESAKEY[KEY2X] Bits */
+#define AES_AESAKEY_KEY2X_OFS                    (16)                            /* !< KEY2X Offset */
+#define AES_AESAKEY_KEY2X_MASK                   ((uint32_t)0x00FF0000U)         /* !< AES key byte n+2 when AESAKEY is
+                                                                                    written as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. Always reads as
+                                                                                    zero. The key is reset by PUC or by
+                                                                                    AESSWRST = 1. */
+#define AES_AESAKEY_KEY2X_MINNUM                 ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESAKEY_KEY2X_MAXNUM                 ((uint32_t)0x00FF0000U)         /* !< Highest possible value */
+/* AES_AESAKEY[KEY3X] Bits */
+#define AES_AESAKEY_KEY3X_OFS                    (24)                            /* !< KEY3X Offset */
+#define AES_AESAKEY_KEY3X_MASK                   ((uint32_t)0xFF000000U)         /* !< AES key byte n+3 when AESAKEY is
+                                                                                    written as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. Always reads as
+                                                                                    zero. The key is reset by PUC or by
+                                                                                    AESSWRST = 1. */
+#define AES_AESAKEY_KEY3X_MINNUM                 ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESAKEY_KEY3X_MAXNUM                 ((uint32_t)0xFF000000U)         /* !< Highest possible value */
+
+/* AES_AESADIN Bits */
+/* AES_AESADIN[DIN0X] Bits */
+#define AES_AESADIN_DIN0X_OFS                    (0)                             /* !< DIN0X Offset */
+#define AES_AESADIN_DIN0X_MASK                   ((uint32_t)0x000000FFU)         /* !< AES data in byte n when AESADIN is
+                                                                                    written as word. AES next data in
+                                                                                    byte when AESADIN is written as byte.
+                                                                                    Do not mix word and byte access.
+                                                                                    Always reads as zero. */
+#define AES_AESADIN_DIN0X_MINNUM                 ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESADIN_DIN0X_MAXNUM                 ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+/* AES_AESADIN[DIN1X] Bits */
+#define AES_AESADIN_DIN1X_OFS                    (8)                             /* !< DIN1X Offset */
+#define AES_AESADIN_DIN1X_MASK                   ((uint32_t)0x0000FF00U)         /* !< AES data in byte n+1 when AESADIN
+                                                                                    is written as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. Always reads as
+                                                                                    zero. */
+#define AES_AESADIN_DIN1X_MINNUM                 ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESADIN_DIN1X_MAXNUM                 ((uint32_t)0x0000FF00U)         /* !< Highest possible value */
+/* AES_AESADIN[DIN2X] Bits */
+#define AES_AESADIN_DIN2X_OFS                    (16)                            /* !< DIN2X Offset */
+#define AES_AESADIN_DIN2X_MASK                   ((uint32_t)0x00FF0000U)         /* !< AES data in byte n+2 when AESADIN
+                                                                                    is written as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. Always reads as
+                                                                                    zero. */
+#define AES_AESADIN_DIN2X_MINNUM                 ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESADIN_DIN2X_MAXNUM                 ((uint32_t)0x00FF0000U)         /* !< Highest possible value */
+/* AES_AESADIN[DIN3X] Bits */
+#define AES_AESADIN_DIN3X_OFS                    (24)                            /* !< DIN3X Offset */
+#define AES_AESADIN_DIN3X_MASK                   ((uint32_t)0xFF000000U)         /* !< AES data in byte n+3 when AESADIN
+                                                                                    is written as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. Always reads as
+                                                                                    zero. */
+#define AES_AESADIN_DIN3X_MINNUM                 ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESADIN_DIN3X_MAXNUM                 ((uint32_t)0xFF000000U)         /* !< Highest possible value */
+
+/* AES_AESADOUT Bits */
+/* AES_AESADOUT[DOUT0X] Bits */
+#define AES_AESADOUT_DOUT0X_OFS                  (0)                             /* !< DOUT0X Offset */
+#define AES_AESADOUT_DOUT0X_MASK                 ((uint32_t)0x000000FFU)         /* !< AES data out byte n when AESADOUT
+                                                                                    is read as word. AES next data out
+                                                                                    byte when AESADOUT is read as byte.
+                                                                                    Do not mix word and byte access. */
+#define AES_AESADOUT_DOUT0X_MINNUM               ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESADOUT_DOUT0X_MAXNUM               ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+/* AES_AESADOUT[DOUT1X] Bits */
+#define AES_AESADOUT_DOUT1X_OFS                  (8)                             /* !< DOUT1X Offset */
+#define AES_AESADOUT_DOUT1X_MASK                 ((uint32_t)0x0000FF00U)         /* !< AES data out byte n+1 when AESADOUT
+                                                                                    is read as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. */
+#define AES_AESADOUT_DOUT1X_MINNUM               ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESADOUT_DOUT1X_MAXNUM               ((uint32_t)0x0000FF00U)         /* !< Highest possible value */
+/* AES_AESADOUT[DOUT2X] Bits */
+#define AES_AESADOUT_DOUT2X_OFS                  (16)                            /* !< DOUT2X Offset */
+#define AES_AESADOUT_DOUT2X_MASK                 ((uint32_t)0x00FF0000U)         /* !< AES data out byte n+2 when AESADOUT
+                                                                                    is read as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. */
+#define AES_AESADOUT_DOUT2X_MINNUM               ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESADOUT_DOUT2X_MAXNUM               ((uint32_t)0x00FF0000U)         /* !< Highest possible value */
+/* AES_AESADOUT[DOUT3X] Bits */
+#define AES_AESADOUT_DOUT3X_OFS                  (24)                            /* !< DOUT3X Offset */
+#define AES_AESADOUT_DOUT3X_MASK                 ((uint32_t)0xFF000000U)         /* !< AES data out byte n+3 when AESADOUT
+                                                                                    is read as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. */
+#define AES_AESADOUT_DOUT3X_MINNUM               ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESADOUT_DOUT3X_MAXNUM               ((uint32_t)0xFF000000U)         /* !< Highest possible value */
+
+/* AES_AESAXDIN Bits */
+/* AES_AESAXDIN[XDIN0X] Bits */
+#define AES_AESAXDIN_XDIN0X_OFS                  (0)                             /* !< XDIN0X Offset */
+#define AES_AESAXDIN_XDIN0X_MASK                 ((uint32_t)0x000000FFU)         /* !< AES data in byte n when AESAXDIN is
+                                                                                    written as word. AES next data in
+                                                                                    byte when AESAXDIN is written as
+                                                                                    byte. Do not mix word and byte
+                                                                                    access. Always reads as zero. */
+#define AES_AESAXDIN_XDIN0X_MINNUM               ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESAXDIN_XDIN0X_MAXNUM               ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+/* AES_AESAXDIN[XDIN1X] Bits */
+#define AES_AESAXDIN_XDIN1X_OFS                  (8)                             /* !< XDIN1X Offset */
+#define AES_AESAXDIN_XDIN1X_MASK                 ((uint32_t)0x0000FF00U)         /* !< AES data in byte n+1 when AESAXDIN
+                                                                                    is written as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. Always reads as
+                                                                                    zero. */
+#define AES_AESAXDIN_XDIN1X_MINNUM               ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESAXDIN_XDIN1X_MAXNUM               ((uint32_t)0x0000FF00U)         /* !< Highest possible value */
+/* AES_AESAXDIN[XDIN2X] Bits */
+#define AES_AESAXDIN_XDIN2X_OFS                  (16)                            /* !< XDIN2X Offset */
+#define AES_AESAXDIN_XDIN2X_MASK                 ((uint32_t)0x00FF0000U)         /* !< AES data in byte n+2 when AESAXDIN
+                                                                                    is written as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. Always reads as
+                                                                                    zero. */
+#define AES_AESAXDIN_XDIN2X_MINNUM               ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESAXDIN_XDIN2X_MAXNUM               ((uint32_t)0x00FF0000U)         /* !< Highest possible value */
+/* AES_AESAXDIN[XDIN3X] Bits */
+#define AES_AESAXDIN_XDIN3X_OFS                  (24)                            /* !< XDIN3X Offset */
+#define AES_AESAXDIN_XDIN3X_MASK                 ((uint32_t)0xFF000000U)         /* !< AES data in byte n+3 when AESAXDIN
+                                                                                    is written as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. Always reads as
+                                                                                    zero. */
+#define AES_AESAXDIN_XDIN3X_MINNUM               ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESAXDIN_XDIN3X_MAXNUM               ((uint32_t)0xFF000000U)         /* !< Highest possible value */
+
+/* AES_AESAXIN Bits */
+/* AES_AESAXIN[XIN0X] Bits */
+#define AES_AESAXIN_XIN0X_OFS                    (0)                             /* !< XIN0X Offset */
+#define AES_AESAXIN_XIN0X_MASK                   ((uint32_t)0x000000FFU)         /* !< AES data in byte n when AESAXIN is
+                                                                                    written as word. AES next data in
+                                                                                    byte when AESAXIN is written as byte.
+                                                                                    Do not mix word and byte access.
+                                                                                    Always reads as zero. */
+#define AES_AESAXIN_XIN0X_MINNUM                 ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESAXIN_XIN0X_MAXNUM                 ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+/* AES_AESAXIN[XIN1X] Bits */
+#define AES_AESAXIN_XIN1X_OFS                    (8)                             /* !< XIN1X Offset */
+#define AES_AESAXIN_XIN1X_MASK                   ((uint32_t)0x0000FF00U)         /* !< AES data in byte n+1 when AESAXIN
+                                                                                    is written as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. Always reads as
+                                                                                    zero. */
+#define AES_AESAXIN_XIN1X_MINNUM                 ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESAXIN_XIN1X_MAXNUM                 ((uint32_t)0x0000FF00U)         /* !< Highest possible value */
+/* AES_AESAXIN[XIN2X] Bits */
+#define AES_AESAXIN_XIN2X_OFS                    (16)                            /* !< XIN2X Offset */
+#define AES_AESAXIN_XIN2X_MASK                   ((uint32_t)0x00FF0000U)         /* !< AES data in byte n+2 when AESAXIN
+                                                                                    is written as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. Always reads as
+                                                                                    zero. */
+#define AES_AESAXIN_XIN2X_MINNUM                 ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESAXIN_XIN2X_MAXNUM                 ((uint32_t)0x00FF0000U)         /* !< Highest possible value */
+/* AES_AESAXIN[XIN3X] Bits */
+#define AES_AESAXIN_XIN3X_OFS                    (24)                            /* !< XIN3X Offset */
+#define AES_AESAXIN_XIN3X_MASK                   ((uint32_t)0xFF000000U)         /* !< AES data in byte n+3 when AESAXIN
+                                                                                    is written as word. Do not use these
+                                                                                    bits for byte access. Do not mix word
+                                                                                    and byte access. Always reads as
+                                                                                    zero. */
+#define AES_AESAXIN_XIN3X_MINNUM                 ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define AES_AESAXIN_XIN3X_MAXNUM                 ((uint32_t)0xFF000000U)         /* !< Highest possible value */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_aes__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_aesadv.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_aesadv.h
@@ -1,0 +1,1303 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/ 
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+   Redistributions of source code must retain the above copyright 
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the   
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_aesadv__include
+#define ti_devices_msp_peripherals_hw_aesadv__include
+
+/* Filename: hw_aesadv.h */
+/* Revised: 2023-12-19 15:17:12 */
+/* Revision: 66de12cdc985948e62986db704f24a4ffca2a1c5 */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* AESADV Registers
+******************************************************************************/
+#define AESADV_DMA_TRIG_DATAOUT_OFS              ((uint32_t)0x00001080U)
+#define AESADV_DMA_TRIG_DATAIN_OFS               ((uint32_t)0x00001050U)
+#define AESADV_CPU_INT_OFS                       ((uint32_t)0x00001020U)
+#define AESADV_GPRCM_OFS                         ((uint32_t)0x00000800U)
+
+
+/** @addtogroup AESADV_DMA_TRIG_DATAOUT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001080) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001088) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001090) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001098) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x000010A0) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x000010A8) Interrupt clear */
+} AESADV_DMA_TRIG_DATAOUT_Regs;
+
+/*@}*/ /* end of group AESADV_DMA_TRIG_DATAOUT */
+
+/** @addtogroup AESADV_DMA_TRIG_DATAIN
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001050) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001058) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001060) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001068) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001070) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001078) Interrupt clear */
+} AESADV_DMA_TRIG_DATAIN_Regs;
+
+/*@}*/ /* end of group AESADV_DMA_TRIG_DATAIN */
+
+/** @addtogroup AESADV_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} AESADV_CPU_INT_Regs;
+
+/*@}*/ /* end of group AESADV_CPU_INT */
+
+/** @addtogroup AESADV_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} AESADV_GPRCM_Regs;
+
+/*@}*/ /* end of group AESADV_GPRCM */
+
+/** @addtogroup AESADV
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  AESADV_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED1[512];
+  __I  uint32_t PDBGCTL;                           /* !< (@ 0x00001018) Peripheral Debug Control */
+       uint32_t RESERVED2;
+  AESADV_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED3;
+  AESADV_DMA_TRIG_DATAIN_Regs  DMA_TRIG_DATAIN;                   /* !< (@ 0x00001050) */
+       uint32_t RESERVED4;
+  AESADV_DMA_TRIG_DATAOUT_Regs  DMA_TRIG_DATAOUT;                  /* !< (@ 0x00001080) */
+       uint32_t RESERVED5[13];
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED6[7];
+  __O  uint32_t GCMCCM_TAG0;                       /* !< (@ 0x00001100) CBC-MAC third key (LSW) / GCM & CCM Intermediate
+                                                      TAG (LSW) */
+  __O  uint32_t GCMCCM_TAG1;                       /* !< (@ 0x00001104) CBC-MAC third key / GCM & CCM Intermediate TAG */
+  __O  uint32_t GCMCCM_TAG2;                       /* !< (@ 0x00001108) CBC-MAC third key / GCM & CCM Intermediate TAG */
+  __O  uint32_t GCMCCM_TAG3;                       /* !< (@ 0x0000110C) CBC-MAC third key (MSW) / GCM & CCM Intermediate
+                                                      TAG (MSW) */
+  __O  uint32_t GHASH_H0;                          /* !< (@ 0x00001110) CCM & CBC-MAC second key (LSW) / GCM Hash Key
+                                                      input (LSW) */
+  __O  uint32_t GHASH_H1;                          /* !< (@ 0x00001114) CCM & CBC-MAC second key  / GCM Hash Key input */
+  __O  uint32_t GHASH_H2;                          /* !< (@ 0x00001118) CCM & CBC-MAC second key  / GCM Hash Key input */
+  __O  uint32_t GHASH_H3;                          /* !< (@ 0x0000111C) CCM & CBC-MAC second key (MSW) / GCM Hash Key
+                                                      input (MSW) */
+  __O  uint32_t KEY0;                              /* !< (@ 0x00001120) KEY (LSW) */
+  __O  uint32_t KEY1;                              /* !< (@ 0x00001124) KEY */
+  __O  uint32_t KEY2;                              /* !< (@ 0x00001128) KEY */
+  __O  uint32_t KEY3;                              /* !< (@ 0x0000112C) KEY */
+  __O  uint32_t KEY4;                              /* !< (@ 0x00001130) KEY */
+  __O  uint32_t KEY5;                              /* !< (@ 0x00001134) KEY */
+  __O  uint32_t KEY6;                              /* !< (@ 0x00001138) KEY */
+  __O  uint32_t KEY7;                              /* !< (@ 0x0000113C) KEY (MSW) */
+  __IO uint32_t IV0;                               /* !< (@ 0x00001140) IV (LSW) */
+  __IO uint32_t IV1;                               /* !< (@ 0x00001144) IV */
+  __IO uint32_t IV2;                               /* !< (@ 0x00001148) IV */
+  __IO uint32_t IV3;                               /* !< (@ 0x0000114C) IV */
+  __IO uint32_t CTRL;                              /* !< (@ 0x00001150) Input/Output Buffer Control and Mode selection */
+  __O  uint32_t C_LENGTH_0;                        /* !< (@ 0x00001154) Crypto data length (LSW) */
+  __O  uint32_t C_LENGTH_1;                        /* !< (@ 0x00001158) Crypto data length (MSW) */
+  __O  uint32_t AAD_LENGTH;                        /* !< (@ 0x0000115C) AAD Data Length */
+  __IO uint32_t DATA0;                             /* !< (@ 0x00001160) Data input (LSW) / Data output (LSW) */
+  __IO uint32_t DATA1;                             /* !< (@ 0x00001164) Data input / Data output */
+  __IO uint32_t DATA2;                             /* !< (@ 0x00001168) Data input / Data output */
+  __IO uint32_t DATA3;                             /* !< (@ 0x0000116C) Data input (LSW) / Data output (MSW) */
+  __I  uint32_t TAG0;                              /* !< (@ 0x00001170) Hash result (LSW) */
+  __I  uint32_t TAG1;                              /* !< (@ 0x00001174) Hash result */
+  __I  uint32_t TAG2;                              /* !< (@ 0x00001178) Hash result */
+  __I  uint32_t TAG3;                              /* !< (@ 0x0000117C) Hash result (MSW) */
+  __I  uint32_t STATUS;                            /* !< (@ 0x00001180) Status */
+  __O  uint32_t DATA_IN;                           /* !< (@ 0x00001184) Data in alias register */
+  __I  uint32_t DATA_OUT;                          /* !< (@ 0x00001188) Data out alias register */
+       uint32_t RESERVED7[17];
+  __O  uint32_t FORCE_IN_AV;                       /* !< (@ 0x000011D0) Data control register for input data */
+  __IO uint32_t CCM_ALN_WRD;                       /* !< (@ 0x000011D4) AES-CCM AAD alignment data word */
+  __IO uint32_t BLK_CNT0;                          /* !< (@ 0x000011D8) Internal block counter (LSW) */
+  __IO uint32_t BLK_CNT1;                          /* !< (@ 0x000011DC) Internal block counter (MSW) */
+       uint32_t RESERVED8[5];
+  __IO uint32_t DMA_HS;                            /* !< (@ 0x000011F4) Control register for DMA handshaking */
+} AESADV_Regs;
+
+/*@}*/ /* end of group AESADV */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* AESADV Register Control Bits
+******************************************************************************/
+
+/* AESADV_DMA_TRIG_DATAOUT_IIDX Bits */
+/* AESADV_DMA_TRIG_DATAOUT_IIDX[STAT] Bits */
+#define AESADV_DMA_TRIG_DATAOUT_IIDX_STAT_OFS    (0)                             /* !< STAT Offset */
+#define AESADV_DMA_TRIG_DATAOUT_IIDX_STAT_MASK   ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define AESADV_DMA_TRIG_DATAOUT_IIDX_STAT_NO_INTR ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define AESADV_DMA_TRIG_DATAOUT_IIDX_STAT_TRIG1  ((uint32_t)0x00000001U)         /* !< AES DMA Trigger 1 (Data Output
+                                                                                    trigger) */
+
+/* AESADV_DMA_TRIG_DATAOUT_IMASK Bits */
+/* AESADV_DMA_TRIG_DATAOUT_IMASK[TRIG1] Bits */
+#define AESADV_DMA_TRIG_DATAOUT_IMASK_TRIG1_OFS  (0)                             /* !< TRIG1 Offset */
+#define AESADV_DMA_TRIG_DATAOUT_IMASK_TRIG1_MASK ((uint32_t)0x00000001U)         /* !< TRIG1 event mask. */
+#define AESADV_DMA_TRIG_DATAOUT_IMASK_TRIG1_CLR  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_DMA_TRIG_DATAOUT_IMASK_TRIG1_SET  ((uint32_t)0x00000001U)         /* !< Set Interrrupt Mask */
+
+/* AESADV_DMA_TRIG_DATAOUT_RIS Bits */
+/* AESADV_DMA_TRIG_DATAOUT_RIS[TRIG1] Bits */
+#define AESADV_DMA_TRIG_DATAOUT_RIS_TRIG1_OFS    (0)                             /* !< TRIG1 Offset */
+#define AESADV_DMA_TRIG_DATAOUT_RIS_TRIG1_MASK   ((uint32_t)0x00000001U)         /* !< TRIG1 event */
+#define AESADV_DMA_TRIG_DATAOUT_RIS_TRIG1_CLR    ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AESADV_DMA_TRIG_DATAOUT_RIS_TRIG1_SET    ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+
+/* AESADV_DMA_TRIG_DATAOUT_MIS Bits */
+/* AESADV_DMA_TRIG_DATAOUT_MIS[TRIG1] Bits */
+#define AESADV_DMA_TRIG_DATAOUT_MIS_TRIG1_OFS    (0)                             /* !< TRIG1 Offset */
+#define AESADV_DMA_TRIG_DATAOUT_MIS_TRIG1_MASK   ((uint32_t)0x00000001U)         /* !< TRIG1 event */
+#define AESADV_DMA_TRIG_DATAOUT_MIS_TRIG1_CLR    ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AESADV_DMA_TRIG_DATAOUT_MIS_TRIG1_SET    ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+
+/* AESADV_DMA_TRIG_DATAOUT_ISET Bits */
+/* AESADV_DMA_TRIG_DATAOUT_ISET[TRIG1] Bits */
+#define AESADV_DMA_TRIG_DATAOUT_ISET_TRIG1_OFS   (0)                             /* !< TRIG1 Offset */
+#define AESADV_DMA_TRIG_DATAOUT_ISET_TRIG1_MASK  ((uint32_t)0x00000001U)         /* !< TRIG1 event */
+#define AESADV_DMA_TRIG_DATAOUT_ISET_TRIG1_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AESADV_DMA_TRIG_DATAOUT_ISET_TRIG1_SET   ((uint32_t)0x00000001U)         /* !< Set Interrupt */
+
+/* AESADV_DMA_TRIG_DATAOUT_ICLR Bits */
+/* AESADV_DMA_TRIG_DATAOUT_ICLR[TRIG1] Bits */
+#define AESADV_DMA_TRIG_DATAOUT_ICLR_TRIG1_OFS   (0)                             /* !< TRIG1 Offset */
+#define AESADV_DMA_TRIG_DATAOUT_ICLR_TRIG1_MASK  ((uint32_t)0x00000001U)         /* !< TRIG1 event */
+#define AESADV_DMA_TRIG_DATAOUT_ICLR_TRIG1_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AESADV_DMA_TRIG_DATAOUT_ICLR_TRIG1_CLR   ((uint32_t)0x00000001U)         /* !< Clear Interrupt */
+
+/* AESADV_DMA_TRIG_DATAIN_IIDX Bits */
+/* AESADV_DMA_TRIG_DATAIN_IIDX[STAT] Bits */
+#define AESADV_DMA_TRIG_DATAIN_IIDX_STAT_OFS     (0)                             /* !< STAT Offset */
+#define AESADV_DMA_TRIG_DATAIN_IIDX_STAT_MASK    ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define AESADV_DMA_TRIG_DATAIN_IIDX_STAT_NO_INTR ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define AESADV_DMA_TRIG_DATAIN_IIDX_STAT_TRIG0   ((uint32_t)0x00000001U)         /* !< AES trigger 0 DMA (Data Input
+                                                                                    trigger) */
+
+/* AESADV_DMA_TRIG_DATAIN_IMASK Bits */
+/* AESADV_DMA_TRIG_DATAIN_IMASK[TRIG0] Bits */
+#define AESADV_DMA_TRIG_DATAIN_IMASK_TRIG0_OFS   (0)                             /* !< TRIG0 Offset */
+#define AESADV_DMA_TRIG_DATAIN_IMASK_TRIG0_MASK  ((uint32_t)0x00000001U)         /* !< TRIG0 event mask. */
+#define AESADV_DMA_TRIG_DATAIN_IMASK_TRIG0_CLR   ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_DMA_TRIG_DATAIN_IMASK_TRIG0_SET   ((uint32_t)0x00000001U)         /* !< Set Interrrupt Mask */
+
+/* AESADV_DMA_TRIG_DATAIN_RIS Bits */
+/* AESADV_DMA_TRIG_DATAIN_RIS[TRIG0] Bits */
+#define AESADV_DMA_TRIG_DATAIN_RIS_TRIG0_OFS     (0)                             /* !< TRIG0 Offset */
+#define AESADV_DMA_TRIG_DATAIN_RIS_TRIG0_MASK    ((uint32_t)0x00000001U)         /* !< TRIG0 event */
+#define AESADV_DMA_TRIG_DATAIN_RIS_TRIG0_CLR     ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AESADV_DMA_TRIG_DATAIN_RIS_TRIG0_SET     ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+
+/* AESADV_DMA_TRIG_DATAIN_MIS Bits */
+/* AESADV_DMA_TRIG_DATAIN_MIS[TRIG0] Bits */
+#define AESADV_DMA_TRIG_DATAIN_MIS_TRIG0_OFS     (0)                             /* !< TRIG0 Offset */
+#define AESADV_DMA_TRIG_DATAIN_MIS_TRIG0_MASK    ((uint32_t)0x00000001U)         /* !< TRIG0 event */
+#define AESADV_DMA_TRIG_DATAIN_MIS_TRIG0_CLR     ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AESADV_DMA_TRIG_DATAIN_MIS_TRIG0_SET     ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+
+/* AESADV_DMA_TRIG_DATAIN_ISET Bits */
+/* AESADV_DMA_TRIG_DATAIN_ISET[TRIG0] Bits */
+#define AESADV_DMA_TRIG_DATAIN_ISET_TRIG0_OFS    (0)                             /* !< TRIG0 Offset */
+#define AESADV_DMA_TRIG_DATAIN_ISET_TRIG0_MASK   ((uint32_t)0x00000001U)         /* !< TRIG0 */
+#define AESADV_DMA_TRIG_DATAIN_ISET_TRIG0_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AESADV_DMA_TRIG_DATAIN_ISET_TRIG0_SET    ((uint32_t)0x00000001U)         /* !< Set Interrupt */
+
+/* AESADV_DMA_TRIG_DATAIN_ICLR Bits */
+/* AESADV_DMA_TRIG_DATAIN_ICLR[TRIG0] Bits */
+#define AESADV_DMA_TRIG_DATAIN_ICLR_TRIG0_OFS    (0)                             /* !< TRIG0 Offset */
+#define AESADV_DMA_TRIG_DATAIN_ICLR_TRIG0_MASK   ((uint32_t)0x00000001U)         /* !< TRIG0 event */
+#define AESADV_DMA_TRIG_DATAIN_ICLR_TRIG0_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AESADV_DMA_TRIG_DATAIN_ICLR_TRIG0_CLR    ((uint32_t)0x00000001U)         /* !< Clear Interrupt */
+
+/* AESADV_CPU_INT_IIDX Bits */
+/* AESADV_CPU_INT_IIDX[STAT] Bits */
+#define AESADV_CPU_INT_IIDX_STAT_OFS             (0)                             /* !< STAT Offset */
+#define AESADV_CPU_INT_IIDX_STAT_MASK            ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define AESADV_CPU_INT_IIDX_STAT_NO_INTR         ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define AESADV_CPU_INT_IIDX_STAT_OUTPUTRDY       ((uint32_t)0x00000001U)         /* !< This indicates that the core has an
+                                                                                    output available to be read out. This
+                                                                                    should not be used if DMA handshake
+                                                                                    is used (AES_DMA_HS.DMA_DATA_ACK set
+                                                                                    to 1) */
+#define AESADV_CPU_INT_IIDX_STAT_INPUTRDY        ((uint32_t)0x00000002U)         /* !< This indicates that the engine can
+                                                                                    take new input. This should not be
+                                                                                    used if DMA handshake is used
+                                                                                    (AES_DMA_HS.DMA_DATA_ACK set to 1) */
+#define AESADV_CPU_INT_IIDX_STAT_SAVEDCNTXTRDY   ((uint32_t)0x00000003U)         /* !< This bit indicates that an AES
+                                                                                    authentication TAG and/or IV block(s)
+                                                                                    is/are available for the CPU to
+                                                                                    retrieve. This bit is only asserted
+                                                                                    if the save_context bit is set to 1b.
+                                                                                    The bit is mutually exclusive with
+                                                                                    the context_ready bit. */
+#define AESADV_CPU_INT_IIDX_STAT_CNTXTRDY        ((uint32_t)0x00000004U)         /* !< This bit indicates that the context
+                                                                                    data registers can be overwritten,
+                                                                                    and the CPU is permitted to write new
+                                                                                    context. */
+
+/* AESADV_CPU_INT_IMASK Bits */
+/* AESADV_CPU_INT_IMASK[OUTPUTRDY] Bits */
+#define AESADV_CPU_INT_IMASK_OUTPUTRDY_OFS       (0)                             /* !< OUTPUTRDY Offset */
+#define AESADV_CPU_INT_IMASK_OUTPUTRDY_MASK      ((uint32_t)0x00000001U)         /* !< This indicates that the core has an
+                                                                                    output available to be read out. This
+                                                                                    should not be used if DMA handshake
+                                                                                    is used (AES_DMA_HS.DMA_DATA_ACK set
+                                                                                    to 1) */
+#define AESADV_CPU_INT_IMASK_OUTPUTRDY_CLR       ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_IMASK_OUTPUTRDY_SET       ((uint32_t)0x00000001U)         /* !< Set Interrrupt Mask */
+/* AESADV_CPU_INT_IMASK[INPUTRDY] Bits */
+#define AESADV_CPU_INT_IMASK_INPUTRDY_OFS        (1)                             /* !< INPUTRDY Offset */
+#define AESADV_CPU_INT_IMASK_INPUTRDY_MASK       ((uint32_t)0x00000002U)         /* !< This indicates that the engine can
+                                                                                    take new input. This should not be
+                                                                                    used if DMA handshake is used
+                                                                                    (AES_DMA_HS.DMA_DATA_ACK set to 1) */
+#define AESADV_CPU_INT_IMASK_INPUTRDY_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_IMASK_INPUTRDY_SET        ((uint32_t)0x00000002U)         /* !< Set Interrrupt Mask */
+/* AESADV_CPU_INT_IMASK[SAVEDCNTXTRDY] Bits */
+#define AESADV_CPU_INT_IMASK_SAVEDCNTXTRDY_OFS   (2)                             /* !< SAVEDCNTXTRDY Offset */
+#define AESADV_CPU_INT_IMASK_SAVEDCNTXTRDY_MASK  ((uint32_t)0x00000004U)         /* !< This bit indicates that an AES
+                                                                                    authentication TAG and/or IV block(s)
+                                                                                    is/are available for the CPU to
+                                                                                    retrieve. This bit is only asserted
+                                                                                    if the save_context bit is set to 1b.
+                                                                                    The bit is mutually exclusive with
+                                                                                    the context_ready bit. */
+#define AESADV_CPU_INT_IMASK_SAVEDCNTXTRDY_CLR   ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_IMASK_SAVEDCNTXTRDY_SET   ((uint32_t)0x00000004U)         /* !< Set Interrrupt Mask */
+/* AESADV_CPU_INT_IMASK[CNTXTRDY] Bits */
+#define AESADV_CPU_INT_IMASK_CNTXTRDY_OFS        (3)                             /* !< CNTXTRDY Offset */
+#define AESADV_CPU_INT_IMASK_CNTXTRDY_MASK       ((uint32_t)0x00000008U)         /* !< This bit indicates that the context
+                                                                                    data registers can be overwritten,
+                                                                                    and the CPU is permitted to write
+                                                                                    next context. */
+#define AESADV_CPU_INT_IMASK_CNTXTRDY_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_IMASK_CNTXTRDY_SET        ((uint32_t)0x00000008U)         /* !< Set Interrrupt Mask */
+
+/* AESADV_CPU_INT_RIS Bits */
+/* AESADV_CPU_INT_RIS[OUTPUTRDY] Bits */
+#define AESADV_CPU_INT_RIS_OUTPUTRDY_OFS         (0)                             /* !< OUTPUTRDY Offset */
+#define AESADV_CPU_INT_RIS_OUTPUTRDY_MASK        ((uint32_t)0x00000001U)         /* !< This indicates that the core has an
+                                                                                    output available to be read out. This
+                                                                                    should not be used if DMA handshake
+                                                                                    is used (AES_DMA_HS.DMA_DATA_ACK set
+                                                                                    to 1) */
+#define AESADV_CPU_INT_RIS_OUTPUTRDY_CLR         ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AESADV_CPU_INT_RIS_OUTPUTRDY_SET         ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+/* AESADV_CPU_INT_RIS[INPUTRDY] Bits */
+#define AESADV_CPU_INT_RIS_INPUTRDY_OFS          (1)                             /* !< INPUTRDY Offset */
+#define AESADV_CPU_INT_RIS_INPUTRDY_MASK         ((uint32_t)0x00000002U)         /* !< This indicates that the engine can
+                                                                                    take new input. This should not be
+                                                                                    used if DMA handshake is used
+                                                                                    (AES_DMA_HS.DMA_DATA_ACK set to 1) */
+#define AESADV_CPU_INT_RIS_INPUTRDY_CLR          ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_RIS_INPUTRDY_SET          ((uint32_t)0x00000002U)         /* !< Set Interrrupt Mask */
+/* AESADV_CPU_INT_RIS[SAVEDCNTXTRDY] Bits */
+#define AESADV_CPU_INT_RIS_SAVEDCNTXTRDY_OFS     (2)                             /* !< SAVEDCNTXTRDY Offset */
+#define AESADV_CPU_INT_RIS_SAVEDCNTXTRDY_MASK    ((uint32_t)0x00000004U)         /* !< This bit indicates that an AES
+                                                                                    authentication TAG and/or IV block(s)
+                                                                                    is/are available for the CPU to
+                                                                                    retrieve. This bit is only asserted
+                                                                                    if the save_context bit is set to 1b.
+                                                                                    The bit is mutually exclusive with
+                                                                                    the context_ready bit. */
+#define AESADV_CPU_INT_RIS_SAVEDCNTXTRDY_CLR     ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_RIS_SAVEDCNTXTRDY_SET     ((uint32_t)0x00000004U)         /* !< Set Interrrupt Mask */
+/* AESADV_CPU_INT_RIS[CNTXTRDY] Bits */
+#define AESADV_CPU_INT_RIS_CNTXTRDY_OFS          (3)                             /* !< CNTXTRDY Offset */
+#define AESADV_CPU_INT_RIS_CNTXTRDY_MASK         ((uint32_t)0x00000008U)         /* !< This bit indicates that the context
+                                                                                    data registers can be overwritten,
+                                                                                    and the CPU is permitted to write
+                                                                                    next context. */
+#define AESADV_CPU_INT_RIS_CNTXTRDY_CLR          ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_RIS_CNTXTRDY_SET          ((uint32_t)0x00000008U)         /* !< Set Interrrupt Mask */
+
+/* AESADV_CPU_INT_MIS Bits */
+/* AESADV_CPU_INT_MIS[OUTPUTRDY] Bits */
+#define AESADV_CPU_INT_MIS_OUTPUTRDY_OFS         (0)                             /* !< OUTPUTRDY Offset */
+#define AESADV_CPU_INT_MIS_OUTPUTRDY_MASK        ((uint32_t)0x00000001U)         /* !< This indicates that the core has an
+                                                                                    output available to be read out. This
+                                                                                    should not be used if DMA handshake
+                                                                                    is used (AES_DMA_HS.DMA_DATA_ACK set
+                                                                                    to 1) */
+#define AESADV_CPU_INT_MIS_OUTPUTRDY_CLR         ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define AESADV_CPU_INT_MIS_OUTPUTRDY_SET         ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+/* AESADV_CPU_INT_MIS[INPUTRDY] Bits */
+#define AESADV_CPU_INT_MIS_INPUTRDY_OFS          (1)                             /* !< INPUTRDY Offset */
+#define AESADV_CPU_INT_MIS_INPUTRDY_MASK         ((uint32_t)0x00000002U)         /* !< This indicates that the engine can
+                                                                                    take new input. This should not be
+                                                                                    used if DMA handshake is used
+                                                                                    (AES_DMA_HS.DMA_DATA_ACK set to 1) */
+#define AESADV_CPU_INT_MIS_INPUTRDY_CLR          ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_MIS_INPUTRDY_SET          ((uint32_t)0x00000002U)         /* !< Set Interrrupt Mask */
+/* AESADV_CPU_INT_MIS[SAVEDCNTXTRDY] Bits */
+#define AESADV_CPU_INT_MIS_SAVEDCNTXTRDY_OFS     (2)                             /* !< SAVEDCNTXTRDY Offset */
+#define AESADV_CPU_INT_MIS_SAVEDCNTXTRDY_MASK    ((uint32_t)0x00000004U)         /* !< This bit indicates that an AES
+                                                                                    authentication TAG and/or IV block(s)
+                                                                                    is/are available for the CPU to
+                                                                                    retrieve. This bit is only asserted
+                                                                                    if the save_context bit is set to 1b.
+                                                                                    The bit is mutually exclusive with
+                                                                                    the context_ready bit. */
+#define AESADV_CPU_INT_MIS_SAVEDCNTXTRDY_CLR     ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_MIS_SAVEDCNTXTRDY_SET     ((uint32_t)0x00000004U)         /* !< Set Interrrupt Mask */
+/* AESADV_CPU_INT_MIS[CNTXTRDY] Bits */
+#define AESADV_CPU_INT_MIS_CNTXTRDY_OFS          (3)                             /* !< CNTXTRDY Offset */
+#define AESADV_CPU_INT_MIS_CNTXTRDY_MASK         ((uint32_t)0x00000008U)         /* !< This bit indicates that the context
+                                                                                    data registers can be overwritten,
+                                                                                    and the CPU is permitted to write
+                                                                                    next context. */
+#define AESADV_CPU_INT_MIS_CNTXTRDY_CLR          ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_MIS_CNTXTRDY_SET          ((uint32_t)0x00000008U)         /* !< Set Interrrupt Mask */
+
+/* AESADV_CPU_INT_ISET Bits */
+/* AESADV_CPU_INT_ISET[OUTPUTRDY] Bits */
+#define AESADV_CPU_INT_ISET_OUTPUTRDY_OFS        (0)                             /* !< OUTPUTRDY Offset */
+#define AESADV_CPU_INT_ISET_OUTPUTRDY_MASK       ((uint32_t)0x00000001U)         /* !< This indicates that the core has an
+                                                                                    output available to be read out. This
+                                                                                    should not be used if DMA handshake
+                                                                                    is used (AES_DMA_HS.DMA_DATA_ACK set
+                                                                                    to 1) */
+#define AESADV_CPU_INT_ISET_OUTPUTRDY_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AESADV_CPU_INT_ISET_OUTPUTRDY_SET        ((uint32_t)0x00000001U)         /* !< Set Interrupt */
+/* AESADV_CPU_INT_ISET[INPUTRDY] Bits */
+#define AESADV_CPU_INT_ISET_INPUTRDY_OFS         (1)                             /* !< INPUTRDY Offset */
+#define AESADV_CPU_INT_ISET_INPUTRDY_MASK        ((uint32_t)0x00000002U)         /* !< This indicates that the engine can
+                                                                                    take new input.This should not be
+                                                                                    used if DMA handshake is used
+                                                                                    (AES_DMA_HS.DMA_DATA_ACK set to 1) */
+#define AESADV_CPU_INT_ISET_INPUTRDY_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_ISET_INPUTRDY_SET         ((uint32_t)0x00000002U)         /* !< Set Interrrupt Mask */
+/* AESADV_CPU_INT_ISET[SAVEDCNTXTRDY] Bits */
+#define AESADV_CPU_INT_ISET_SAVEDCNTXTRDY_OFS    (2)                             /* !< SAVEDCNTXTRDY Offset */
+#define AESADV_CPU_INT_ISET_SAVEDCNTXTRDY_MASK   ((uint32_t)0x00000004U)         /* !< This bit indicates that an AES
+                                                                                    authentication TAG and/or IV block(s)
+                                                                                    is/are available for the CPU to
+                                                                                    retrieve. This bit is only asserted
+                                                                                    if the save_context bit is set to 1b.
+                                                                                    The bit is mutually exclusive with
+                                                                                    the context_ready bit. */
+#define AESADV_CPU_INT_ISET_SAVEDCNTXTRDY_CLR    ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_ISET_SAVEDCNTXTRDY_SET    ((uint32_t)0x00000004U)         /* !< Set Interrrupt Mask */
+/* AESADV_CPU_INT_ISET[CNTXTRDY] Bits */
+#define AESADV_CPU_INT_ISET_CNTXTRDY_OFS         (3)                             /* !< CNTXTRDY Offset */
+#define AESADV_CPU_INT_ISET_CNTXTRDY_MASK        ((uint32_t)0x00000008U)         /* !< This bit indicates that the context
+                                                                                    data registers can be overwritten,
+                                                                                    and the CPU is permitted to write
+                                                                                    next context. */
+#define AESADV_CPU_INT_ISET_CNTXTRDY_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_ISET_CNTXTRDY_SET         ((uint32_t)0x00000008U)         /* !< Set Interrrupt Mask */
+
+/* AESADV_CPU_INT_ICLR Bits */
+/* AESADV_CPU_INT_ICLR[OUTPUTRDY] Bits */
+#define AESADV_CPU_INT_ICLR_OUTPUTRDY_OFS        (0)                             /* !< OUTPUTRDY Offset */
+#define AESADV_CPU_INT_ICLR_OUTPUTRDY_MASK       ((uint32_t)0x00000001U)         /* !< This indicates that the core has an
+                                                                                    output available to be read out. This
+                                                                                    should not be used if DMA handshake
+                                                                                    is used (AES_DMA_HS.DMA_DATA_ACK set
+                                                                                    to 1) */
+#define AESADV_CPU_INT_ICLR_OUTPUTRDY_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AESADV_CPU_INT_ICLR_OUTPUTRDY_CLR        ((uint32_t)0x00000001U)         /* !< Clear Interrupt */
+/* AESADV_CPU_INT_ICLR[INPUTRDY] Bits */
+#define AESADV_CPU_INT_ICLR_INPUTRDY_OFS         (1)                             /* !< INPUTRDY Offset */
+#define AESADV_CPU_INT_ICLR_INPUTRDY_MASK        ((uint32_t)0x00000002U)         /* !< This indicates that the engine can
+                                                                                    take new input. This should not be
+                                                                                    used if DMA handshake is used
+                                                                                    (AES_DMA_HS.DMA_DATA_ACK set to 1) */
+#define AESADV_CPU_INT_ICLR_INPUTRDY_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_ICLR_INPUTRDY_SET         ((uint32_t)0x00000002U)         /* !< Set Interrrupt Mask */
+/* AESADV_CPU_INT_ICLR[SAVEDCNTXTRDY] Bits */
+#define AESADV_CPU_INT_ICLR_SAVEDCNTXTRDY_OFS    (2)                             /* !< SAVEDCNTXTRDY Offset */
+#define AESADV_CPU_INT_ICLR_SAVEDCNTXTRDY_MASK   ((uint32_t)0x00000004U)         /* !< This bit indicates that an AES
+                                                                                    authentication TAG and/or IV block(s)
+                                                                                    is/are available for the CPU to
+                                                                                    retrieve. This bit is only asserted
+                                                                                    if the save_context bit is set to 1b.
+                                                                                    The bit is mutually exclusive with
+                                                                                    the context_ready bit. */
+#define AESADV_CPU_INT_ICLR_SAVEDCNTXTRDY_CLR    ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_ICLR_SAVEDCNTXTRDY_SET    ((uint32_t)0x00000004U)         /* !< Set Interrrupt Mask */
+/* AESADV_CPU_INT_ICLR[CNTXTRDY] Bits */
+#define AESADV_CPU_INT_ICLR_CNTXTRDY_OFS         (3)                             /* !< CNTXTRDY Offset */
+#define AESADV_CPU_INT_ICLR_CNTXTRDY_MASK        ((uint32_t)0x00000008U)         /* !< This bit indicates that the context
+                                                                                    data registers can be overwritten,
+                                                                                    and the CPU is permitted to write
+                                                                                    next context. */
+#define AESADV_CPU_INT_ICLR_CNTXTRDY_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define AESADV_CPU_INT_ICLR_CNTXTRDY_SET         ((uint32_t)0x00000008U)         /* !< Set Interrrupt Mask */
+
+/* AESADV_PWREN Bits */
+/* AESADV_PWREN[ENABLE] Bits */
+#define AESADV_PWREN_ENABLE_OFS                  (0)                             /* !< ENABLE Offset */
+#define AESADV_PWREN_ENABLE_MASK                 ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define AESADV_PWREN_ENABLE_DISABLE              ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define AESADV_PWREN_ENABLE_ENABLE               ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* AESADV_PWREN[KEY] Bits */
+#define AESADV_PWREN_KEY_OFS                     (24)                            /* !< KEY Offset */
+#define AESADV_PWREN_KEY_MASK                    ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define AESADV_PWREN_KEY_UNLOCK_W                ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* AESADV_RSTCTL Bits */
+/* AESADV_RSTCTL[RESETSTKYCLR] Bits */
+#define AESADV_RSTCTL_RESETSTKYCLR_OFS           (1)                             /* !< RESETSTKYCLR Offset */
+#define AESADV_RSTCTL_RESETSTKYCLR_MASK          ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define AESADV_RSTCTL_RESETSTKYCLR_NOP           ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AESADV_RSTCTL_RESETSTKYCLR_CLR           ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* AESADV_RSTCTL[RESETASSERT] Bits */
+#define AESADV_RSTCTL_RESETASSERT_OFS            (0)                             /* !< RESETASSERT Offset */
+#define AESADV_RSTCTL_RESETASSERT_MASK           ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define AESADV_RSTCTL_RESETASSERT_NOP            ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define AESADV_RSTCTL_RESETASSERT_ASSERT         ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* AESADV_RSTCTL[KEY] Bits */
+#define AESADV_RSTCTL_KEY_OFS                    (24)                            /* !< KEY Offset */
+#define AESADV_RSTCTL_KEY_MASK                   ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define AESADV_RSTCTL_KEY_UNLOCK_W               ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* AESADV_STAT Bits */
+/* AESADV_STAT[RESETSTKY] Bits */
+#define AESADV_STAT_RESETSTKY_OFS                (16)                            /* !< RESETSTKY Offset */
+#define AESADV_STAT_RESETSTKY_MASK               ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define AESADV_STAT_RESETSTKY_NORES              ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define AESADV_STAT_RESETSTKY_RESET              ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* AESADV_PDBGCTL Bits */
+/* AESADV_PDBGCTL[FREE] Bits */
+#define AESADV_PDBGCTL_FREE_OFS                  (0)                             /* !< FREE Offset */
+#define AESADV_PDBGCTL_FREE_MASK                 ((uint32_t)0x00000001U)         /* !< Free run control */
+#define AESADV_PDBGCTL_FREE_RUN                  ((uint32_t)0x00000001U)         /* !< The peripheral ignores the state of
+                                                                                    the Core Halted input */
+
+/* AESADV_EVT_MODE Bits */
+/* AESADV_EVT_MODE[INT0_CFG] Bits */
+#define AESADV_EVT_MODE_INT0_CFG_OFS             (0)                             /* !< INT0_CFG Offset */
+#define AESADV_EVT_MODE_INT0_CFG_MASK            ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT0] */
+#define AESADV_EVT_MODE_INT0_CFG_DISABLE         ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define AESADV_EVT_MODE_INT0_CFG_SOFTWARE        ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define AESADV_EVT_MODE_INT0_CFG_HARDWARE        ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* AESADV_EVT_MODE[EVT1_CFG] Bits */
+#define AESADV_EVT_MODE_EVT1_CFG_OFS             (2)                             /* !< EVT1_CFG Offset */
+#define AESADV_EVT_MODE_EVT1_CFG_MASK            ((uint32_t)0x0000000CU)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT1] */
+#define AESADV_EVT_MODE_EVT1_CFG_DISABLE         ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define AESADV_EVT_MODE_EVT1_CFG_SOFTWARE        ((uint32_t)0x00000004U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define AESADV_EVT_MODE_EVT1_CFG_HARDWARE        ((uint32_t)0x00000008U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* AESADV_EVT_MODE[EVT2_CFG] Bits */
+#define AESADV_EVT_MODE_EVT2_CFG_OFS             (4)                             /* !< EVT2_CFG Offset */
+#define AESADV_EVT_MODE_EVT2_CFG_MASK            ((uint32_t)0x00000030U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT2] */
+#define AESADV_EVT_MODE_EVT2_CFG_DISABLE         ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define AESADV_EVT_MODE_EVT2_CFG_SOFTWARE        ((uint32_t)0x00000010U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define AESADV_EVT_MODE_EVT2_CFG_HARDWARE        ((uint32_t)0x00000020U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* AESADV_GCMCCM_TAG0 Bits */
+/* AESADV_GCMCCM_TAG0[DATA] Bits */
+#define AESADV_GCMCCM_TAG0_DATA_OFS              (0)                             /* !< DATA Offset */
+#define AESADV_GCMCCM_TAG0_DATA_MASK             ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_GCMCCM_TAG1 Bits */
+/* AESADV_GCMCCM_TAG1[DATA] Bits */
+#define AESADV_GCMCCM_TAG1_DATA_OFS              (0)                             /* !< DATA Offset */
+#define AESADV_GCMCCM_TAG1_DATA_MASK             ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_GCMCCM_TAG2 Bits */
+/* AESADV_GCMCCM_TAG2[DATA] Bits */
+#define AESADV_GCMCCM_TAG2_DATA_OFS              (0)                             /* !< DATA Offset */
+#define AESADV_GCMCCM_TAG2_DATA_MASK             ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_GCMCCM_TAG3 Bits */
+/* AESADV_GCMCCM_TAG3[DATA] Bits */
+#define AESADV_GCMCCM_TAG3_DATA_OFS              (0)                             /* !< DATA Offset */
+#define AESADV_GCMCCM_TAG3_DATA_MASK             ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_GHASH_H0 Bits */
+/* AESADV_GHASH_H0[DATA] Bits */
+#define AESADV_GHASH_H0_DATA_OFS                 (0)                             /* !< DATA Offset */
+#define AESADV_GHASH_H0_DATA_MASK                ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_GHASH_H1 Bits */
+/* AESADV_GHASH_H1[DATA] Bits */
+#define AESADV_GHASH_H1_DATA_OFS                 (0)                             /* !< DATA Offset */
+#define AESADV_GHASH_H1_DATA_MASK                ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_GHASH_H2 Bits */
+/* AESADV_GHASH_H2[DATA] Bits */
+#define AESADV_GHASH_H2_DATA_OFS                 (0)                             /* !< DATA Offset */
+#define AESADV_GHASH_H2_DATA_MASK                ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_GHASH_H3 Bits */
+/* AESADV_GHASH_H3[DATA] Bits */
+#define AESADV_GHASH_H3_DATA_OFS                 (0)                             /* !< DATA Offset */
+#define AESADV_GHASH_H3_DATA_MASK                ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_KEY0 Bits */
+/* AESADV_KEY0[DATA] Bits */
+#define AESADV_KEY0_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define AESADV_KEY0_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_KEY1 Bits */
+/* AESADV_KEY1[DATA] Bits */
+#define AESADV_KEY1_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define AESADV_KEY1_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_KEY2 Bits */
+/* AESADV_KEY2[DATA] Bits */
+#define AESADV_KEY2_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define AESADV_KEY2_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_KEY3 Bits */
+/* AESADV_KEY3[DATA] Bits */
+#define AESADV_KEY3_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define AESADV_KEY3_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_KEY4 Bits */
+/* AESADV_KEY4[DATA] Bits */
+#define AESADV_KEY4_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define AESADV_KEY4_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_KEY5 Bits */
+/* AESADV_KEY5[DATA] Bits */
+#define AESADV_KEY5_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define AESADV_KEY5_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_KEY6 Bits */
+/* AESADV_KEY6[DATA] Bits */
+#define AESADV_KEY6_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define AESADV_KEY6_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_KEY7 Bits */
+/* AESADV_KEY7[DATA] Bits */
+#define AESADV_KEY7_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define AESADV_KEY7_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_IV0 Bits */
+/* AESADV_IV0[DATA] Bits */
+#define AESADV_IV0_DATA_OFS                      (0)                             /* !< DATA Offset */
+#define AESADV_IV0_DATA_MASK                     ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_IV1 Bits */
+/* AESADV_IV1[DATA] Bits */
+#define AESADV_IV1_DATA_OFS                      (0)                             /* !< DATA Offset */
+#define AESADV_IV1_DATA_MASK                     ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_IV2 Bits */
+/* AESADV_IV2[DATA] Bits */
+#define AESADV_IV2_DATA_OFS                      (0)                             /* !< DATA Offset */
+#define AESADV_IV2_DATA_MASK                     ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_IV3 Bits */
+/* AESADV_IV3[DATA] Bits */
+#define AESADV_IV3_DATA_OFS                      (0)                             /* !< DATA Offset */
+#define AESADV_IV3_DATA_MASK                     ((uint32_t)0xFFFFFFFFU)         /* !< Key data */
+
+/* AESADV_CTRL Bits */
+/* AESADV_CTRL[OUTPUT_RDY] Bits */
+#define AESADV_CTRL_OUTPUT_RDY_OFS               (0)                             /* !< OUTPUT_RDY Offset */
+#define AESADV_CTRL_OUTPUT_RDY_MASK              ((uint32_t)0x00000001U)         /* !< Output Ready. If 1b, this read-only
+                                                                                    status bit indicates that an AES
+                                                                                    output block is available for the CPU
+                                                                                    to retrieve. */
+#define AESADV_CTRL_OUTPUT_RDY_NOTREADY          ((uint32_t)0x00000000U)         /* !< Not Ready */
+#define AESADV_CTRL_OUTPUT_RDY_READY             ((uint32_t)0x00000001U)         /* !< Ready */
+/* AESADV_CTRL[INPUT_RDY] Bits */
+#define AESADV_CTRL_INPUT_RDY_OFS                (1)                             /* !< INPUT_RDY Offset */
+#define AESADV_CTRL_INPUT_RDY_MASK               ((uint32_t)0x00000002U)         /* !< Ready for input. If 1b, this
+                                                                                    read-only status bit indicates that
+                                                                                    the 16-byte input buffer is empty,
+                                                                                    and the CPU is permitted to write the
+                                                                                    next block of data. After reset, this
+                                                                                    bit is 0. After writing a context,
+                                                                                    this bit will become 1b. */
+#define AESADV_CTRL_INPUT_RDY_NOTEMPTY           ((uint32_t)0x00000000U)         /* !< Not Ready */
+#define AESADV_CTRL_INPUT_RDY_EMPTY              ((uint32_t)0x00000002U)         /* !< Ready */
+/* AESADV_CTRL[DIR] Bits */
+#define AESADV_CTRL_DIR_OFS                      (2)                             /* !< DIR Offset */
+#define AESADV_CTRL_DIR_MASK                     ((uint32_t)0x00000004U)         /* !< Direction. If set to 1b an encrypt
+                                                                                    operation is performed. If set to 0b
+                                                                                    a decrypt operation is performed.
+                                                                                    Note: This bit must be written with a
+                                                                                    1b when CBC-MAC is selected. */
+#define AESADV_CTRL_DIR_DECRYPT                  ((uint32_t)0x00000000U)         /* !< Decryption */
+#define AESADV_CTRL_DIR_ENCRYPT                  ((uint32_t)0x00000004U)         /* !< Encryption */
+/* AESADV_CTRL[KEYSIZE] Bits */
+#define AESADV_CTRL_KEYSIZE_OFS                  (3)                             /* !< KEYSIZE Offset */
+#define AESADV_CTRL_KEYSIZE_MASK                 ((uint32_t)0x00000018U)         /* !< Specifies the encryption strength /
+                                                                                    key width */
+#define AESADV_CTRL_KEYSIZE_K128                 ((uint32_t)0x00000008U)         /* !< 128-bit key */
+#define AESADV_CTRL_KEYSIZE_K256                 ((uint32_t)0x00000018U)         /* !< 256-bit key */
+/* AESADV_CTRL[CBC] Bits */
+#define AESADV_CTRL_CBC_OFS                      (5)                             /* !< CBC Offset */
+#define AESADV_CTRL_CBC_MASK                     ((uint32_t)0x00000020U)         /* !< If set to 1b, cipher-block-chaining
+                                                                                    (CBC) mode is selected. */
+#define AESADV_CTRL_CBC_DISABLE                  ((uint32_t)0x00000000U)         /* !< Disable CBC mode */
+#define AESADV_CTRL_CBC_ENABLE                   ((uint32_t)0x00000020U)         /* !< Select CBC mode */
+/* AESADV_CTRL[CTR] Bits */
+#define AESADV_CTRL_CTR_OFS                      (6)                             /* !< CTR Offset */
+#define AESADV_CTRL_CTR_MASK                     ((uint32_t)0x00000040U)         /* !< If set to 1b, AES counter mode
+                                                                                    (CTR) is selected. Note: This bit
+                                                                                    must also be set for GCM and CCM,
+                                                                                    when encryption/decryption is
+                                                                                    required. */
+#define AESADV_CTRL_CTR_DISABLE                  ((uint32_t)0x00000000U)         /* !< Disable CBC mode */
+#define AESADV_CTRL_CTR_ENABLE                   ((uint32_t)0x00000040U)         /* !< Select CBC mode */
+/* AESADV_CTRL[CTR_WIDTH] Bits */
+#define AESADV_CTRL_CTR_WIDTH_OFS                (7)                             /* !< CTR_WIDTH Offset */
+#define AESADV_CTRL_CTR_WIDTH_MASK               ((uint32_t)0x00000180U)         /* !< When the CTR bit is set, specifies
+                                                                                    the counter width for AES-CTR mode.
+                                                                                    When the CFB bit is set, specifies
+                                                                                    the CFB mode feedback width: */
+#define AESADV_CTRL_CTR_WIDTH_CTR32              ((uint32_t)0x00000000U)         /* !< 32-bit counter */
+#define AESADV_CTRL_CTR_WIDTH_CFB128             ((uint32_t)0x00000000U)         /* !< CFB-128 mode */
+#define AESADV_CTRL_CTR_WIDTH_CTR64              ((uint32_t)0x00000080U)         /* !< 64-bit counter */
+#define AESADV_CTRL_CTR_WIDTH_CFB1               ((uint32_t)0x00000080U)         /* !< CFB-1 mode */
+#define AESADV_CTRL_CTR_WIDTH_CTR96              ((uint32_t)0x00000100U)         /* !< 96-bit counter */
+#define AESADV_CTRL_CTR_WIDTH_CFB8               ((uint32_t)0x00000100U)         /* !< CFB-8 mode */
+#define AESADV_CTRL_CTR_WIDTH_CTR128             ((uint32_t)0x00000180U)         /* !< 128-bit counter */
+/* AESADV_CTRL[ICM] Bits */
+#define AESADV_CTRL_ICM_OFS                      (9)                             /* !< ICM Offset */
+#define AESADV_CTRL_ICM_MASK                     ((uint32_t)0x00000200U)         /* !< When the CFB bit is set, specifies
+                                                                                    the CFB mode feedback width: */
+#define AESADV_CTRL_ICM_DISABLE                  ((uint32_t)0x00000000U)         /* !< Disable CBC mode */
+#define AESADV_CTRL_ICM_ENABLE                   ((uint32_t)0x00000200U)         /* !< Select CBC mode */
+/* AESADV_CTRL[CFB] Bits */
+#define AESADV_CTRL_CFB_OFS                      (10)                            /* !< CFB Offset */
+#define AESADV_CTRL_CFB_MASK                     ((uint32_t)0x00000400U)         /* !< If set to 1b, AES cipher feedback
+                                                                                    mode CFB is selected. Use the
+                                                                                    ctr_width field to specify the
+                                                                                    feedback width. */
+#define AESADV_CTRL_CFB_DISABLE                  ((uint32_t)0x00000000U)         /* !< Disable CBC mode */
+#define AESADV_CTRL_CFB_ENABLE                   ((uint32_t)0x00000400U)         /* !< Select CBC mode */
+/* AESADV_CTRL[CBCMAC] Bits */
+#define AESADV_CTRL_CBCMAC_OFS                   (15)                            /* !< CBCMAC Offset */
+#define AESADV_CTRL_CBCMAC_MASK                  ((uint32_t)0x00008000U)         /* !< If set to 1b, AES-CBC MAC is
+                                                                                    selected, the Direction bit must be
+                                                                                    set to 1 for this mode. */
+#define AESADV_CTRL_CBCMAC_DISABLE               ((uint32_t)0x00000000U)         /* !< Disable CBC mode */
+#define AESADV_CTRL_CBCMAC_ENABLE                ((uint32_t)0x00008000U)         /* !< Select CBC mode */
+/* AESADV_CTRL[GCM] Bits */
+#define AESADV_CTRL_GCM_OFS                      (16)                            /* !< GCM Offset */
+#define AESADV_CTRL_GCM_MASK                     ((uint32_t)0x00030000U)         /* !< If not set to 00b, AES-GCM mode is
+                                                                                    selected, this is a combined mode,
+                                                                                    using the Galois field multiplier
+                                                                                    GF(2128) for authentication and
+                                                                                    AES-CTR mode for encryption, the bits
+                                                                                    specify the GCM mode: 01b = GHASH
+                                                                                    with H loaded and Y0-encrypted forced
+                                                                                    to zero 10b = GHASH with H loaded and
+                                                                                    Y0-encrypted calculated internally
+                                                                                    11b = Autonomous GHASH (both H and
+                                                                                    Y0-encrypted calculated internally)
+                                                                                    Note: Besides GCM, the CTR mode bits
+                                                                                    must also be set to 1b to enable GCM
+                                                                                    with AES-CTR; if the CTR bit is not
+                                                                                    set a GHASH (authentication) only
+                                                                                    operation is performed. A GHASH only
+                                                                                    operation is only allowed if the GCM
+                                                                                    mode is set to '01b' and the
+                                                                                    direction bit is set to '0b'. Other
+                                                                                    modes may not be selected in
+                                                                                    combination with GCM. Table 14 below
+                                                                                    shows the valid combinations for the
+                                                                                    GCM and CTR mode bits, all other
+                                                                                    options are invalid and must not be
+                                                                                    selected. */
+#define AESADV_CTRL_GCM_FORCE_ZERO               ((uint32_t)0x00010000U)         /* !< GHASH with H loaded and
+                                                                                    Y0-encrypted forced to 0. */
+#define AESADV_CTRL_GCM_LOAD_HASH_KEY            ((uint32_t)0x00020000U)         /* !< GHASH with H loaded and
+                                                                                    Y0-encrypted calculated internally */
+#define AESADV_CTRL_GCM_AUTONOMOUS               ((uint32_t)0x00030000U)         /* !< Autonomous GHASH (both H and
+                                                                                    Y0-encrypted calculated internally) */
+/* AESADV_CTRL[CCM] Bits */
+#define AESADV_CTRL_CCM_OFS                      (18)                            /* !< CCM Offset */
+#define AESADV_CTRL_CCM_MASK                     ((uint32_t)0x00040000U)         /* !< If set to 1b, AES-CCM is selected,
+                                                                                    this is a combined mode, using AES
+                                                                                    for both authentication and
+                                                                                    encryption. In addition to the CCM
+                                                                                    bit, the CTR mode bit must be set
+                                                                                    such that AES-CTR is enabled. Other
+                                                                                    combinations with CCM are invalid. */
+#define AESADV_CTRL_CCM_DISABLE                  ((uint32_t)0x00000000U)         /* !< Disable CBC mode */
+#define AESADV_CTRL_CCM_ENABLE                   ((uint32_t)0x00040000U)         /* !< Select CBC mode */
+/* AESADV_CTRL[CCML] Bits */
+#define AESADV_CTRL_CCML_OFS                     (19)                            /* !< CCML Offset */
+#define AESADV_CTRL_CCML_MASK                    ((uint32_t)0x00380000U)         /* !< Defines L that indicates the width
+                                                                                    of the length field for CCM
+                                                                                    operations; the length field in bytes
+                                                                                    equals the value of CMM-L plus one.
+                                                                                    All values are supported. */
+#define AESADV_CTRL_CCML_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Length is 1 */
+#define AESADV_CTRL_CCML_MAXIMUM                 ((uint32_t)0x00380000U)         /* !< Length is 8 */
+/* AESADV_CTRL[CCMM] Bits */
+#define AESADV_CTRL_CCMM_OFS                     (22)                            /* !< CCMM Offset */
+#define AESADV_CTRL_CCMM_MASK                    ((uint32_t)0x01C00000U)         /* !< Defines M that indicates the length
+                                                                                    of the authentication field for CCM
+                                                                                    operations; the authentication field
+                                                                                    length equals two times (the value of
+                                                                                    CCM-M plus one). Note: The engine
+                                                                                    always returns a 128-bit
+                                                                                    authentication field, of which the M
+                                                                                    least significant bytes are valid.
+                                                                                    All values are supported. */
+#define AESADV_CTRL_CCMM_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Length is 1 */
+#define AESADV_CTRL_CCMM_MAXIMUM                 ((uint32_t)0x01C00000U)         /* !< Length is 8 */
+/* AESADV_CTRL[OFB_GCM_CCM_CONT] Bits */
+#define AESADV_CTRL_OFB_GCM_CCM_CONT_OFS         (26)                            /* !< OFB_GCM_CCM_CONT Offset */
+#define AESADV_CTRL_OFB_GCM_CCM_CONT_MASK        ((uint32_t)0x04000000U)         /* !< This bit has a dual use, depending
+                                                                                    on the selection of CCM/GCM, see bits
+                                                                                    [18:16]. If CCM/GCM is not selected:
+                                                                                    If this bit is set to 1b, full block
+                                                                                    AES output feedback mode (OFB-128) is
+                                                                                    selected. If CCM/GCM is selected:
+                                                                                    Continue processing of an interrupted
+                                                                                    AES-GCM or AES-CCM operation in the
+                                                                                    AAD phase. Set this write-only signal
+                                                                                    to 1b together with the regular mode
+                                                                                    bit settings for a GCM or CCM
+                                                                                    operation, to continue processing
+                                                                                    from the next full AAD block (128
+                                                                                    bits) boundary. Before setting this
+                                                                                    bit all applicable context to resume
+                                                                                    processing must have been loaded into
+                                                                                    the engine: Keys, IV, intermediate
+                                                                                    digest/TAG, block counter and the CCM
+                                                                                    align data word (the latter is for
+                                                                                    CCM mode only). The mode can be
+                                                                                    written together with this bit, as it
+                                                                                    is part of the same register. */
+#define AESADV_CTRL_OFB_GCM_CCM_CONT_OFB         ((uint32_t)0x04000000U)         /* !< Enable OFB */
+#define AESADV_CTRL_OFB_GCM_CCM_CONT_GCM_CCM_CONTINUE ((uint32_t)0x04000000U)         /* !< Continue GCM/CCM processing in AAD
+                                                                                    phase */
+/* AESADV_CTRL[GET_DIGEST] Bits */
+#define AESADV_CTRL_GET_DIGEST_OFS               (27)                            /* !< GET_DIGEST Offset */
+#define AESADV_CTRL_GET_DIGEST_MASK              ((uint32_t)0x08000000U)         /* !< Interrupt processing and generate
+                                                                                    an intermediate digest during an
+                                                                                    AES-GCM or AES-CCM operation. Set
+                                                                                    this write-only signal to 1b to
+                                                                                    interrupt GCM or CCM processing at
+                                                                                    the next full block (128 bits)
+                                                                                    boundary. An intermediate digest may
+                                                                                    be requested during the
+                                                                                    encryption/decryption data phase or
+                                                                                    in the AAD phase. Note: Interruption
+                                                                                    can only be done on full block (128
+                                                                                    bits) boundaries. The minimum number
+                                                                                    of remaining bytes to resume and
+                                                                                    finalize the operation, must be
+                                                                                    greater than or equal to 1. */
+#define AESADV_CTRL_GET_DIGEST_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define AESADV_CTRL_GET_DIGEST_ENABLE            ((uint32_t)0x08000000U)         /* !< Enable */
+/* AESADV_CTRL[GCM_CONT] Bits */
+#define AESADV_CTRL_GCM_CONT_OFS                 (28)                            /* !< GCM_CONT Offset */
+#define AESADV_CTRL_GCM_CONT_MASK                ((uint32_t)0x10000000U)         /* !< Continue processing of an
+                                                                                    interrupted AES-GCM or AES-CCM
+                                                                                    operation in the crypto/payload
+                                                                                    phase. Set this write-only signal to
+                                                                                    1b together with the regular mode bit
+                                                                                    settings for a GCM or CCM operation,
+                                                                                    to continue processing from the next
+                                                                                    full block (128 bits) boundary.
+                                                                                    Before setting this bit all
+                                                                                    applicable context to resume
+                                                                                    processing must have been loaded into
+                                                                                    the engine: Keys, IV, intermediate
+                                                                                    digest/TAG and block counter. The
+                                                                                    mode can be written together with
+                                                                                    this bit, as it is part of the same
+                                                                                    register. */
+#define AESADV_CTRL_GCM_CONT_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define AESADV_CTRL_GCM_CONT_ENABLE              ((uint32_t)0x10000000U)         /* !< Enable */
+/* AESADV_CTRL[SAVE_CNTXT] Bits */
+#define AESADV_CTRL_SAVE_CNTXT_OFS               (29)                            /* !< SAVE_CNTXT Offset */
+#define AESADV_CTRL_SAVE_CNTXT_MASK              ((uint32_t)0x20000000U)         /* !< This bit is used to indicate that
+                                                                                    an authentication TAG or result IV
+                                                                                    needs to be stored as a result
+                                                                                    context. If this bit is set, context
+                                                                                    output DMA and/or interrupt will be
+                                                                                    asserted if the operation is
+                                                                                    finished, and related signals are
+                                                                                    enabled. Typically, this value must
+                                                                                    be set for authentication modes
+                                                                                    returning a TAG (CBC-MAC, GCM and
+                                                                                    CCM), or for basic encryption modes
+                                                                                    that require future continuation with
+                                                                                    the current result IV. If this bit is
+                                                                                    set, the engine will hold its full
+                                                                                    context until the TAG and/or IV
+                                                                                    registers are read. Only after
+                                                                                    reading the TAG or IV, a new DMA
+                                                                                    request for a new (input) context
+                                                                                    will be asserted. If this bit is not
+                                                                                    set, the engine will assert the
+                                                                                    context input DMA request signal
+                                                                                    directly after starting to process
+                                                                                    the last block with the current
+                                                                                    context. */
+#define AESADV_CTRL_SAVE_CNTXT_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define AESADV_CTRL_SAVE_CNTXT_ENABLE            ((uint32_t)0x20000000U)         /* !< Enable */
+/* AESADV_CTRL[SAVED_CNTXT_RDY] Bits */
+#define AESADV_CTRL_SAVED_CNTXT_RDY_OFS          (30)                            /* !< SAVED_CNTXT_RDY Offset */
+#define AESADV_CTRL_SAVED_CNTXT_RDY_MASK         ((uint32_t)0x40000000U)         /* !< If 1b, this read-only status bit
+                                                                                    indicates that an AES authentication
+                                                                                    TAG and/or IV block(s) is/are
+                                                                                    available for the Host to retrieve.
+                                                                                    This bit is only asserted if the
+                                                                                    save_context bit is set to 1b. The
+                                                                                    bit is mutually exclusive with the
+                                                                                    context_ready bit. */
+#define AESADV_CTRL_SAVED_CNTXT_RDY_NOTREADY     ((uint32_t)0x00000000U)         /* !< Not ready */
+#define AESADV_CTRL_SAVED_CNTXT_RDY_READY        ((uint32_t)0x40000000U)         /* !< Ready */
+/* AESADV_CTRL[CNTXT_RDY] Bits */
+#define AESADV_CTRL_CNTXT_RDY_OFS                (31)                            /* !< CNTXT_RDY Offset */
+#define AESADV_CTRL_CNTXT_RDY_MASK               ((uint32_t)0x80000000U)         /* !< If 1b, this read-only status bit
+                                                                                    indicates that the context data
+                                                                                    registers can be overwritten, and the
+                                                                                    CPU is permitted to write the next
+                                                                                    context. */
+#define AESADV_CTRL_CNTXT_RDY_NOTREADY           ((uint32_t)0x00000000U)         /* !< Not ready */
+#define AESADV_CTRL_CNTXT_RDY_READY              ((uint32_t)0x80000000U)         /* !< Ready */
+
+/* AESADV_C_LENGTH_0 Bits */
+/* AESADV_C_LENGTH_0[DATA] Bits */
+#define AESADV_C_LENGTH_0_DATA_OFS               (0)                             /* !< DATA Offset */
+#define AESADV_C_LENGTH_0_DATA_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< Bits [60:0] of the crypto length
+                                                                                    registers (LSW and MSW) store the
+                                                                                    cryptographic data length in bytes
+                                                                                    for all modes. Once processing with
+                                                                                    this context is started, this length
+                                                                                    decrements to zero. Data lengths up
+                                                                                    to (261-1) bytes are allowed. For
+                                                                                    GCM, any value up to 236-32 bytes can
+                                                                                    be used. This is because a 32-bit
+                                                                                    counter mode is used; the maximum
+                                                                                    number of 128-bit blocks is 232-2,
+                                                                                    resulting in a maximum number of
+                                                                                    bytes of 236-32. A write to this
+                                                                                    register triggers the engine to start
+                                                                                    using this context. This is valid for
+                                                                                    all modes except GCM and CCM. Note
+                                                                                    that for the combined modes, this
+                                                                                    length does not include the
+                                                                                    authentication only data; the
+                                                                                    authentication length is specified in
+                                                                                    the AES_AAD_LENGTH register below.
+                                                                                    All modes must have a length > 0. For
+                                                                                    the combined modes, it is allowed to
+                                                                                    have one of the lengths equal to
+                                                                                    zero. For the basic encryption modes
+                                                                                    (ECB/CBC/CTR/ICM/CFB/OFB) it is
+                                                                                    allowed to program zero to the length
+                                                                                    field; in that case the length is
+                                                                                    assumed infinite. All data must be
+                                                                                    byte (8-bit) aligned for stream
+                                                                                    cipher modes; bit aligned data
+                                                                                    streams are not supported. For block
+                                                                                    cipher modes, the data length must be
+                                                                                    programmed in multiples of the block
+                                                                                    cipher size, 16 bytes. */
+
+/* AESADV_C_LENGTH_1 Bits */
+/* AESADV_C_LENGTH_1[DATA] Bits */
+#define AESADV_C_LENGTH_1_DATA_OFS               (0)                             /* !< DATA Offset */
+#define AESADV_C_LENGTH_1_DATA_MASK              ((uint32_t)0x1FFFFFFFU)         /* !< Bits [60:0] of the crypto length
+                                                                                    registers (LSW and MSW) store the
+                                                                                    cryptographic data length in bytes
+                                                                                    for all modes. Once processing with
+                                                                                    this context is started, this length
+                                                                                    decrements to zero. Data lengths up
+                                                                                    to (261-1) bytes are allowed. For
+                                                                                    GCM, any value up to 236-32 bytes can
+                                                                                    be used. This is because a 32-bit
+                                                                                    counter mode is used; the maximum
+                                                                                    number of 128-bit blocks is 232-2,
+                                                                                    resulting in a maximum number of
+                                                                                    bytes of 236-32. A write to this
+                                                                                    register triggers the engine to start
+                                                                                    using this context. This is valid for
+                                                                                    all modes except GCM and CCM. Note
+                                                                                    that for the combined modes, this
+                                                                                    length does not include the
+                                                                                    authentication only data; the
+                                                                                    authentication length is specified in
+                                                                                    the AES_AAD_LENGTH register below.
+                                                                                    All modes must have a length > 0. For
+                                                                                    the combined modes, it is allowed to
+                                                                                    have one of the lengths equal to
+                                                                                    zero. For the basic encryption modes
+                                                                                    (ECB/CBC/CTR/ICM/CFB/OFB) it is
+                                                                                    allowed to program zero to the length
+                                                                                    field; in that case the length is
+                                                                                    assumed infinite. All data must be
+                                                                                    byte (8-bit) aligned for stream
+                                                                                    cipher modes; bit aligned data
+                                                                                    streams are not supported. For block
+                                                                                    cipher modes, the data length must be
+                                                                                    programmed in multiples of the block
+                                                                                    cipher size, 16 bytes. */
+
+/* AESADV_AAD_LENGTH Bits */
+/* AESADV_AAD_LENGTH[DATA] Bits */
+#define AESADV_AAD_LENGTH_DATA_OFS               (0)                             /* !< DATA Offset */
+#define AESADV_AAD_LENGTH_DATA_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< Bits [31:0] of the authentication
+                                                                                    length register store the
+                                                                                    authentication data length in bytes
+                                                                                    for combined modes only (GCM or CCM)
+                                                                                    Supported AAD-lengths for CCM are
+                                                                                    from 0 to (216-28) bytes. For GCM any
+                                                                                    value up to (232-1) bytes can be
+                                                                                    used. Once processing with this
+                                                                                    context is started, this length
+                                                                                    decrements to zero. A write to this
+                                                                                    register triggers the engine to start
+                                                                                    using this context for GCM and CCM. */
+
+/* AESADV_DATA0 Bits */
+/* AESADV_DATA0[DATA] Bits */
+#define AESADV_DATA0_DATA_OFS                    (0)                             /* !< DATA Offset */
+#define AESADV_DATA0_DATA_MASK                   ((uint32_t)0xFFFFFFFFU)         /* !< Data */
+
+/* AESADV_DATA1 Bits */
+/* AESADV_DATA1[DATA] Bits */
+#define AESADV_DATA1_DATA_OFS                    (0)                             /* !< DATA Offset */
+#define AESADV_DATA1_DATA_MASK                   ((uint32_t)0xFFFFFFFFU)         /* !< Data */
+
+/* AESADV_DATA2 Bits */
+/* AESADV_DATA2[DATA] Bits */
+#define AESADV_DATA2_DATA_OFS                    (0)                             /* !< DATA Offset */
+#define AESADV_DATA2_DATA_MASK                   ((uint32_t)0xFFFFFFFFU)         /* !< Data */
+
+/* AESADV_DATA3 Bits */
+/* AESADV_DATA3[DATA] Bits */
+#define AESADV_DATA3_DATA_OFS                    (0)                             /* !< DATA Offset */
+#define AESADV_DATA3_DATA_MASK                   ((uint32_t)0xFFFFFFFFU)         /* !< Data */
+
+/* AESADV_TAG0 Bits */
+/* AESADV_TAG0[DATA] Bits */
+#define AESADV_TAG0_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define AESADV_TAG0_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< For a CPU read operation, these
+                                                                                    registers contain the last 128-bit
+                                                                                    TAG output of the engine; the TAG is
+                                                                                    available until the next context is
+                                                                                    written. This register will only
+                                                                                    contain valid data if the TAG is
+                                                                                    available, when the
+                                                                                    saved_context_ready or get_digest bit
+                                                                                    from AES_CTRL register is set. In
+                                                                                    case of get_digest, the output will
+                                                                                    be an intermediate TAG for CCM or GCM
+                                                                                    operation continuation. During
+                                                                                    processing or for operations/modes
+                                                                                    that do not return a TAG, reads from
+                                                                                    this register returns data from the
+                                                                                    IV register. For operations that do
+                                                                                    return a TAG in the IV register, the
+                                                                                    IV register must be accessed
+                                                                                    directly. */
+
+/* AESADV_TAG1 Bits */
+/* AESADV_TAG1[DATA] Bits */
+#define AESADV_TAG1_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define AESADV_TAG1_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< For a CPU read operation, these
+                                                                                    registers contain the last 128-bit
+                                                                                    TAG output of the engine; the TAG is
+                                                                                    available until the next context is
+                                                                                    written. This register will only
+                                                                                    contain valid data if the TAG is
+                                                                                    available, when the
+                                                                                    saved_context_ready or get_digest bit
+                                                                                    from AES_CTRL register is set. In
+                                                                                    case of get_digest, the output will
+                                                                                    be an intermediate TAG for CCM or GCM
+                                                                                    operation continuation. During
+                                                                                    processing or for operations/modes
+                                                                                    that do not return a TAG, reads from
+                                                                                    this register returns data from the
+                                                                                    IV register. For operations that do
+                                                                                    return a TAG in the IV register, the
+                                                                                    IV register must be accessed
+                                                                                    directly. */
+
+/* AESADV_TAG2 Bits */
+/* AESADV_TAG2[DATA] Bits */
+#define AESADV_TAG2_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define AESADV_TAG2_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< For a CPU read operation, these
+                                                                                    registers contain the last 128-bit
+                                                                                    TAG output of the engine; the TAG is
+                                                                                    available until the next context is
+                                                                                    written. This register will only
+                                                                                    contain valid data if the TAG is
+                                                                                    available, when the
+                                                                                    saved_context_ready or get_digest bit
+                                                                                    from AES_CTRL register is set. In
+                                                                                    case of get_digest, the output will
+                                                                                    be an intermediate TAG for CCM or GCM
+                                                                                    operation continuation. During
+                                                                                    processing or for operations/modes
+                                                                                    that do not return a TAG, reads from
+                                                                                    this register returns data from the
+                                                                                    IV register. For operations that do
+                                                                                    return a TAG in the IV register, the
+                                                                                    IV register must be accessed
+                                                                                    directly. */
+
+/* AESADV_TAG3 Bits */
+/* AESADV_TAG3[DATA] Bits */
+#define AESADV_TAG3_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define AESADV_TAG3_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< For a CPU read operation, these
+                                                                                    registers contain the last 128-bit
+                                                                                    TAG output of the engine; the TAG is
+                                                                                    available until the next context is
+                                                                                    written. This register will only
+                                                                                    contain valid data if the TAG is
+                                                                                    available, when the
+                                                                                    saved_context_ready or get_digest bit
+                                                                                    from AES_CTRL register is set. In
+                                                                                    case of get_digest, the output will
+                                                                                    be an intermediate TAG for CCM or GCM
+                                                                                    operation continuation. During
+                                                                                    processing or for operations/modes
+                                                                                    that do not return a TAG, reads from
+                                                                                    this register returns data from the
+                                                                                    IV register. For operations that do
+                                                                                    return a TAG in the IV register, the
+                                                                                    IV register must be accessed
+                                                                                    directly. */
+
+/* AESADV_STATUS Bits */
+/* AESADV_STATUS[KEYWR] Bits */
+#define AESADV_STATUS_KEYWR_OFS                  (0)                             /* !< KEYWR Offset */
+#define AESADV_STATUS_KEYWR_MASK                 ((uint32_t)0x00000001U)         /* !< Key write status. 0 - user write to
+                                                                                    KEY register is allowed. 1 - user
+                                                                                    write to KEY register is ignored. In
+                                                                                    order to allow user write, perform a
+                                                                                    module reset. */
+#define AESADV_STATUS_KEYWR_ENABLED              ((uint32_t)0x00000000U)         /* !< User write to KEY MMR is allowed */
+#define AESADV_STATUS_KEYWR_DISABLED             ((uint32_t)0x00000001U)         /* !< User write to KEY MMR is disabled.
+                                                                                    Writing has no effect. */
+
+/* AESADV_DATA_IN Bits */
+/* AESADV_DATA_IN[DATA] Bits */
+#define AESADV_DATA_IN_DATA_OFS                  (0)                             /* !< DATA Offset */
+#define AESADV_DATA_IN_DATA_MASK                 ((uint32_t)0xFFFFFFFFU)         /* !< Data input word */
+
+/* AESADV_DATA_OUT Bits */
+/* AESADV_DATA_OUT[DATA] Bits */
+#define AESADV_DATA_OUT_DATA_OFS                 (0)                             /* !< DATA Offset */
+#define AESADV_DATA_OUT_DATA_MASK                ((uint32_t)0xFFFFFFFFU)         /* !< Data output word */
+
+/* AESADV_FORCE_IN_AV Bits */
+/* AESADV_FORCE_IN_AV[DATA] Bits */
+#define AESADV_FORCE_IN_AV_DATA_OFS              (0)                             /* !< DATA Offset */
+#define AESADV_FORCE_IN_AV_DATA_MASK             ((uint32_t)0xFFFFFFFFU)         /* !< Any write to this register forces
+                                                                                    the input data buffer to valid and
+                                                                                    will force the engine to start
+                                                                                    processing this data. The data
+                                                                                    written here is not used. The core
+                                                                                    must be configured to have input and
+                                                                                    output data acknowledge be I/O
+                                                                                    register based */
+
+/* AESADV_CCM_ALN_WRD Bits */
+/* AESADV_CCM_ALN_WRD[DATA] Bits */
+#define AESADV_CCM_ALN_WRD_DATA_OFS              (0)                             /* !< DATA Offset */
+#define AESADV_CCM_ALN_WRD_DATA_MASK             ((uint32_t)0xFFFFFFFFU)         /* !< This register provides a means to
+                                                                                    access an internal register that
+                                                                                    stores alignment data bytes during
+                                                                                    the AAD phase of AES-CCM processing.
+                                                                                    This register needs to be read and
+                                                                                    stored when an AES-CCM operation is
+                                                                                    interrupted during the AAD phase.
+                                                                                    This value needs to be restored by
+                                                                                    writing this register, when resuming
+                                                                                    that AES-CCM operation in a later
+                                                                                    session. */
+
+/* AESADV_BLK_CNT0 Bits */
+/* AESADV_BLK_CNT0[DATA] Bits */
+#define AESADV_BLK_CNT0_DATA_OFS                 (0)                             /* !< DATA Offset */
+#define AESADV_BLK_CNT0_DATA_MASK                ((uint32_t)0xFFFFFFFFU)         /* !< Internal block counter for AES GCM
+                                                                                    and CCM operations. These bits read
+                                                                                    the block count value that represents
+                                                                                    the number of blocks to go. This
+                                                                                    value is valid with
+                                                                                    saved_context_ready after a request
+                                                                                    for an intermediate GCM/CCM digest.
+                                                                                    Writing these registers will restore
+                                                                                    the internal block counter to the
+                                                                                    programmed value. This only needs to
+                                                                                    be done to prepare the engine to
+                                                                                    continue processing of an interrupted
+                                                                                    GCM or CCM operation. Also refer to
+                                                                                    the get_digest and gcm_ccm_continue
+                                                                                    bits in AES_CTRL register. */
+
+/* AESADV_BLK_CNT1 Bits */
+/* AESADV_BLK_CNT1[DATA] Bits */
+#define AESADV_BLK_CNT1_DATA_OFS                 (0)                             /* !< DATA Offset */
+#define AESADV_BLK_CNT1_DATA_MASK                ((uint32_t)0x00FFFFFFU)         /* !< Internal block counter for AES GCM
+                                                                                    and CCM operations. These bits read
+                                                                                    the block count value that represents
+                                                                                    the number of blocks to go. This
+                                                                                    value is valid with
+                                                                                    saved_context_ready after a request
+                                                                                    for an intermediate GCM/CCM digest.
+                                                                                    Writing these registers will restore
+                                                                                    the internal block counter to the
+                                                                                    programmed value. This only needs to
+                                                                                    be done to prepare the engine to
+                                                                                    continue processing of an interrupted
+                                                                                    GCM or CCM operation. Also refer to
+                                                                                    the get_digest and gcm_ccm_continue
+                                                                                    bits in AES_CTRL register. */
+
+/* AESADV_DMA_HS Bits */
+/* AESADV_DMA_HS[DMA_DATA_ACK] Bits */
+#define AESADV_DMA_HS_DMA_DATA_ACK_OFS           (0)                             /* !< DMA_DATA_ACK Offset */
+#define AESADV_DMA_HS_DMA_DATA_ACK_MASK          ((uint32_t)0x00000001U)         /* !< When this bit is 0b, input and
+                                                                                    output data acknowledge is I/O
+                                                                                    register based, as specified in the
+                                                                                    description of the AES_DATA_IN_n /
+                                                                                    AES_DATA_OUT_n registers. When this
+                                                                                    bit is 1b, input and ouput data
+                                                                                    acknowledge is based on DMA handshake
+                                                                                    signals. */
+#define AESADV_DMA_HS_DMA_DATA_ACK_DMA_DISABLE   ((uint32_t)0x00000000U)         /* !< Disable DMA based data handshake */
+#define AESADV_DMA_HS_DMA_DATA_ACK_DMA_ENABLE    ((uint32_t)0x00000001U)         /* !< Enables DMA based handshake */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_aesadv__include */
+

--- a/mspm0/source/ti/devices/msp/peripherals/hw_comp.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_comp.h
@@ -1,0 +1,825 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_comp__include
+#define ti_devices_msp_peripherals_hw_comp__include
+
+/* Filename: hw_comp.h */
+/* Revised: 2023-05-10 21:23:38 */
+/* Revision: 5c29864c187960f76e656cbc0f0f844cdb69a263 */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* COMP Registers
+******************************************************************************/
+#define COMP_GEN_EVENT_OFS                       ((uint32_t)0x00001050U)
+#define COMP_CPU_INT_OFS                         ((uint32_t)0x00001020U)
+#define COMP_GPRCM_OFS                           ((uint32_t)0x00000800U)
+
+
+/** @addtogroup COMP_GEN_EVENT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001050) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001058) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001060) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001068) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001070) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001078) Interrupt clear */
+} COMP_GEN_EVENT_Regs;
+
+/*@}*/ /* end of group COMP_GEN_EVENT */
+
+/** @addtogroup COMP_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} COMP_CPU_INT_Regs;
+
+/*@}*/ /* end of group COMP_CPU_INT */
+
+/** @addtogroup COMP_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00000808) Peripheral Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} COMP_GPRCM_Regs;
+
+/*@}*/ /* end of group COMP_GPRCM */
+
+/** @addtogroup COMP
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[256];
+  __IO uint32_t FSUB_0;                            /* !< (@ 0x00000400) Subscriber Port 0 */
+  __IO uint32_t FSUB_1;                            /* !< (@ 0x00000404) Subscriber Port 1 */
+       uint32_t RESERVED1[15];
+  __IO uint32_t FPUB_1;                            /* !< (@ 0x00000444) Publisher port 1 */
+       uint32_t RESERVED2[238];
+  COMP_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED3[514];
+  COMP_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED4;
+  COMP_GEN_EVENT_Regs  GEN_EVENT;                         /* !< (@ 0x00001050) */
+       uint32_t RESERVED5[25];
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED6[6];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Module Description */
+  __IO uint32_t CTL0;                              /* !< (@ 0x00001100) Control 0 */
+  __IO uint32_t CTL1;                              /* !< (@ 0x00001104) Control 1 */
+  __IO uint32_t CTL2;                              /* !< (@ 0x00001108) Control 2 */
+  __IO uint32_t CTL3;                              /* !< (@ 0x0000110C) Control 3 */
+       uint32_t RESERVED7[4];
+  __I  uint32_t STAT;                              /* !< (@ 0x00001120) Status */
+} COMP_Regs;
+
+/*@}*/ /* end of group COMP */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* COMP Register Control Bits
+******************************************************************************/
+
+/* COMP_GEN_EVENT_IIDX Bits */
+/* COMP_GEN_EVENT_IIDX[STAT] Bits */
+#define COMP_GEN_EVENT_IIDX_STAT_OFS             (0)                             /* !< STAT Offset */
+#define COMP_GEN_EVENT_IIDX_STAT_MASK            ((uint32_t)0x00000003U)         /* !< Interrupt index status */
+#define COMP_GEN_EVENT_IIDX_STAT_NO_INTR         ((uint32_t)0x00000000U)         /* !< No pending interrupt */
+#define COMP_GEN_EVENT_IIDX_STAT_COMPIFG         ((uint32_t)0x00000002U)         /* !< Comparator output interrupt */
+#define COMP_GEN_EVENT_IIDX_STAT_COMPINVIFG      ((uint32_t)0x00000003U)         /* !< Comparator output inverted
+                                                                                    interrupt */
+#define COMP_GEN_EVENT_IIDX_STAT_OUTRDYIFG       ((uint32_t)0x00000004U)         /* !< Comparator output ready interrupt */
+
+/* COMP_GEN_EVENT_IMASK Bits */
+/* COMP_GEN_EVENT_IMASK[COMPIFG] Bits */
+#define COMP_GEN_EVENT_IMASK_COMPIFG_OFS         (1)                             /* !< COMPIFG Offset */
+#define COMP_GEN_EVENT_IMASK_COMPIFG_MASK        ((uint32_t)0x00000002U)         /* !< Masks COMPIFG */
+#define COMP_GEN_EVENT_IMASK_COMPIFG_CLR         ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define COMP_GEN_EVENT_IMASK_COMPIFG_SET         ((uint32_t)0x00000002U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* COMP_GEN_EVENT_IMASK[COMPINVIFG] Bits */
+#define COMP_GEN_EVENT_IMASK_COMPINVIFG_OFS      (2)                             /* !< COMPINVIFG Offset */
+#define COMP_GEN_EVENT_IMASK_COMPINVIFG_MASK     ((uint32_t)0x00000004U)         /* !< Masks COMPINVIFG */
+#define COMP_GEN_EVENT_IMASK_COMPINVIFG_CLR      ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define COMP_GEN_EVENT_IMASK_COMPINVIFG_SET      ((uint32_t)0x00000004U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* COMP_GEN_EVENT_IMASK[OUTRDYIFG] Bits */
+#define COMP_GEN_EVENT_IMASK_OUTRDYIFG_OFS       (3)                             /* !< OUTRDYIFG Offset */
+#define COMP_GEN_EVENT_IMASK_OUTRDYIFG_MASK      ((uint32_t)0x00000008U)         /* !< Masks OUTRDYIFG */
+#define COMP_GEN_EVENT_IMASK_OUTRDYIFG_CLR       ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define COMP_GEN_EVENT_IMASK_OUTRDYIFG_SET       ((uint32_t)0x00000008U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+
+/* COMP_GEN_EVENT_RIS Bits */
+/* COMP_GEN_EVENT_RIS[COMPIFG] Bits */
+#define COMP_GEN_EVENT_RIS_COMPIFG_OFS           (1)                             /* !< COMPIFG Offset */
+#define COMP_GEN_EVENT_RIS_COMPIFG_MASK          ((uint32_t)0x00000002U)         /* !< Raw interrupt status for comparator
+                                                                                    output interrupt flag. The IES bit
+                                                                                    defines the transition of the
+                                                                                    comparator output setting this bit. */
+#define COMP_GEN_EVENT_RIS_COMPIFG_CLR           ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define COMP_GEN_EVENT_RIS_COMPIFG_SET           ((uint32_t)0x00000002U)         /* !< Interrupt pending */
+/* COMP_GEN_EVENT_RIS[COMPINVIFG] Bits */
+#define COMP_GEN_EVENT_RIS_COMPINVIFG_OFS        (2)                             /* !< COMPINVIFG Offset */
+#define COMP_GEN_EVENT_RIS_COMPINVIFG_MASK       ((uint32_t)0x00000004U)         /* !< Raw interrupt status for comparator
+                                                                                    output inverted interrupt flag. The
+                                                                                    IES bit defines the transition of the
+                                                                                    comparator output setting this bit. */
+#define COMP_GEN_EVENT_RIS_COMPINVIFG_CLR        ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define COMP_GEN_EVENT_RIS_COMPINVIFG_SET        ((uint32_t)0x00000004U)         /* !< Interrupt pending */
+/* COMP_GEN_EVENT_RIS[OUTRDYIFG] Bits */
+#define COMP_GEN_EVENT_RIS_OUTRDYIFG_OFS         (3)                             /* !< OUTRDYIFG Offset */
+#define COMP_GEN_EVENT_RIS_OUTRDYIFG_MASK        ((uint32_t)0x00000008U)         /* !< Raw interrupt status for comparator
+                                                                                    output ready interrupt flag. This bit
+                                                                                    is set when the comparator output is
+                                                                                    valid. */
+#define COMP_GEN_EVENT_RIS_OUTRDYIFG_CLR         ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define COMP_GEN_EVENT_RIS_OUTRDYIFG_SET         ((uint32_t)0x00000008U)         /* !< Interrupt pending */
+
+/* COMP_GEN_EVENT_MIS Bits */
+/* COMP_GEN_EVENT_MIS[COMPIFG] Bits */
+#define COMP_GEN_EVENT_MIS_COMPIFG_OFS           (1)                             /* !< COMPIFG Offset */
+#define COMP_GEN_EVENT_MIS_COMPIFG_MASK          ((uint32_t)0x00000002U)         /* !< Masked interrupt status for COMPIFG */
+#define COMP_GEN_EVENT_MIS_COMPIFG_CLR           ((uint32_t)0x00000000U)         /* !< COMPIFG does not request an
+                                                                                    interrupt service routine */
+#define COMP_GEN_EVENT_MIS_COMPIFG_SET           ((uint32_t)0x00000002U)         /* !< COMPIFG requests an interrupt
+                                                                                    service routine */
+/* COMP_GEN_EVENT_MIS[COMPINVIFG] Bits */
+#define COMP_GEN_EVENT_MIS_COMPINVIFG_OFS        (2)                             /* !< COMPINVIFG Offset */
+#define COMP_GEN_EVENT_MIS_COMPINVIFG_MASK       ((uint32_t)0x00000004U)         /* !< Masked interrupt status for
+                                                                                    COMPINVIFG */
+#define COMP_GEN_EVENT_MIS_COMPINVIFG_CLR        ((uint32_t)0x00000000U)         /* !< COMPINVIFG does not request an
+                                                                                    interrupt service routine */
+#define COMP_GEN_EVENT_MIS_COMPINVIFG_SET        ((uint32_t)0x00000004U)         /* !< COMPINVIFG requests an interrupt
+                                                                                    service routine */
+/* COMP_GEN_EVENT_MIS[OUTRDYIFG] Bits */
+#define COMP_GEN_EVENT_MIS_OUTRDYIFG_OFS         (3)                             /* !< OUTRDYIFG Offset */
+#define COMP_GEN_EVENT_MIS_OUTRDYIFG_MASK        ((uint32_t)0x00000008U)         /* !< Masked interrupt status for
+                                                                                    OUTRDYIFG */
+#define COMP_GEN_EVENT_MIS_OUTRDYIFG_CLR         ((uint32_t)0x00000000U)         /* !< OUTRDYIFG does not request an
+                                                                                    interrupt service routine */
+#define COMP_GEN_EVENT_MIS_OUTRDYIFG_SET         ((uint32_t)0x00000008U)         /* !< OUTRDYIFG requests an interrupt
+                                                                                    service routine */
+
+/* COMP_GEN_EVENT_ISET Bits */
+/* COMP_GEN_EVENT_ISET[COMPIFG] Bits */
+#define COMP_GEN_EVENT_ISET_COMPIFG_OFS          (1)                             /* !< COMPIFG Offset */
+#define COMP_GEN_EVENT_ISET_COMPIFG_MASK         ((uint32_t)0x00000002U)         /* !< Sets COMPIFG in RIS register */
+#define COMP_GEN_EVENT_ISET_COMPIFG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define COMP_GEN_EVENT_ISET_COMPIFG_SET          ((uint32_t)0x00000002U)         /* !< RIS bit corresponding to COMPIFG is
+                                                                                    set */
+/* COMP_GEN_EVENT_ISET[COMPINVIFG] Bits */
+#define COMP_GEN_EVENT_ISET_COMPINVIFG_OFS       (2)                             /* !< COMPINVIFG Offset */
+#define COMP_GEN_EVENT_ISET_COMPINVIFG_MASK      ((uint32_t)0x00000004U)         /* !< Sets COMPINVIFG in RIS register */
+#define COMP_GEN_EVENT_ISET_COMPINVIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define COMP_GEN_EVENT_ISET_COMPINVIFG_SET       ((uint32_t)0x00000004U)         /* !< RIS bit corresponding to COMPINVIFG
+                                                                                    is set */
+/* COMP_GEN_EVENT_ISET[OUTRDYIFG] Bits */
+#define COMP_GEN_EVENT_ISET_OUTRDYIFG_OFS        (3)                             /* !< OUTRDYIFG Offset */
+#define COMP_GEN_EVENT_ISET_OUTRDYIFG_MASK       ((uint32_t)0x00000008U)         /* !< Sets OUTRDYIFG in RIS register */
+#define COMP_GEN_EVENT_ISET_OUTRDYIFG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define COMP_GEN_EVENT_ISET_OUTRDYIFG_SET        ((uint32_t)0x00000008U)         /* !< RIS bit corresponding to OUTRDYIFG
+                                                                                    is set */
+
+/* COMP_GEN_EVENT_ICLR Bits */
+/* COMP_GEN_EVENT_ICLR[COMPIFG] Bits */
+#define COMP_GEN_EVENT_ICLR_COMPIFG_OFS          (1)                             /* !< COMPIFG Offset */
+#define COMP_GEN_EVENT_ICLR_COMPIFG_MASK         ((uint32_t)0x00000002U)         /* !< Clears COMPIFG in RIS register */
+#define COMP_GEN_EVENT_ICLR_COMPIFG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define COMP_GEN_EVENT_ICLR_COMPIFG_CLR          ((uint32_t)0x00000002U)         /* !< RIS bit corresponding to COMPIFG is
+                                                                                    cleared */
+/* COMP_GEN_EVENT_ICLR[COMPINVIFG] Bits */
+#define COMP_GEN_EVENT_ICLR_COMPINVIFG_OFS       (2)                             /* !< COMPINVIFG Offset */
+#define COMP_GEN_EVENT_ICLR_COMPINVIFG_MASK      ((uint32_t)0x00000004U)         /* !< Clears COMPINVIFG in RIS register */
+#define COMP_GEN_EVENT_ICLR_COMPINVIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define COMP_GEN_EVENT_ICLR_COMPINVIFG_CLR       ((uint32_t)0x00000004U)         /* !< RIS bit corresponding to COMPINVIFG
+                                                                                    is cleared */
+/* COMP_GEN_EVENT_ICLR[OUTRDYIFG] Bits */
+#define COMP_GEN_EVENT_ICLR_OUTRDYIFG_OFS        (3)                             /* !< OUTRDYIFG Offset */
+#define COMP_GEN_EVENT_ICLR_OUTRDYIFG_MASK       ((uint32_t)0x00000008U)         /* !< Clears OUTRDYIFG in RIS register */
+#define COMP_GEN_EVENT_ICLR_OUTRDYIFG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define COMP_GEN_EVENT_ICLR_OUTRDYIFG_CLR        ((uint32_t)0x00000008U)         /* !< RIS bit corresponding to OUTRDYIFG
+                                                                                    is cleared */
+
+/* COMP_CPU_INT_IIDX Bits */
+/* COMP_CPU_INT_IIDX[STAT] Bits */
+#define COMP_CPU_INT_IIDX_STAT_OFS               (0)                             /* !< STAT Offset */
+#define COMP_CPU_INT_IIDX_STAT_MASK              ((uint32_t)0x00000003U)         /* !< Interrupt index status */
+#define COMP_CPU_INT_IIDX_STAT_NO_INTR           ((uint32_t)0x00000000U)         /* !< No pending interrupt */
+#define COMP_CPU_INT_IIDX_STAT_COMPIFG           ((uint32_t)0x00000002U)         /* !< Comparator output interrupt */
+#define COMP_CPU_INT_IIDX_STAT_COMPINVIFG        ((uint32_t)0x00000003U)         /* !< Comparator output inverted
+                                                                                    interrupt */
+#define COMP_CPU_INT_IIDX_STAT_OUTRDYIFG         ((uint32_t)0x00000004U)         /* !< Comparator output ready interrupt */
+
+/* COMP_CPU_INT_IMASK Bits */
+/* COMP_CPU_INT_IMASK[COMPIFG] Bits */
+#define COMP_CPU_INT_IMASK_COMPIFG_OFS           (1)                             /* !< COMPIFG Offset */
+#define COMP_CPU_INT_IMASK_COMPIFG_MASK          ((uint32_t)0x00000002U)         /* !< Masks COMPIFG */
+#define COMP_CPU_INT_IMASK_COMPIFG_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define COMP_CPU_INT_IMASK_COMPIFG_SET           ((uint32_t)0x00000002U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* COMP_CPU_INT_IMASK[COMPINVIFG] Bits */
+#define COMP_CPU_INT_IMASK_COMPINVIFG_OFS        (2)                             /* !< COMPINVIFG Offset */
+#define COMP_CPU_INT_IMASK_COMPINVIFG_MASK       ((uint32_t)0x00000004U)         /* !< Masks COMPINVIFG */
+#define COMP_CPU_INT_IMASK_COMPINVIFG_CLR        ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define COMP_CPU_INT_IMASK_COMPINVIFG_SET        ((uint32_t)0x00000004U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* COMP_CPU_INT_IMASK[OUTRDYIFG] Bits */
+#define COMP_CPU_INT_IMASK_OUTRDYIFG_OFS         (3)                             /* !< OUTRDYIFG Offset */
+#define COMP_CPU_INT_IMASK_OUTRDYIFG_MASK        ((uint32_t)0x00000008U)         /* !< Masks OUTRDYIFG */
+#define COMP_CPU_INT_IMASK_OUTRDYIFG_CLR         ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define COMP_CPU_INT_IMASK_OUTRDYIFG_SET         ((uint32_t)0x00000008U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+
+/* COMP_CPU_INT_RIS Bits */
+/* COMP_CPU_INT_RIS[COMPIFG] Bits */
+#define COMP_CPU_INT_RIS_COMPIFG_OFS             (1)                             /* !< COMPIFG Offset */
+#define COMP_CPU_INT_RIS_COMPIFG_MASK            ((uint32_t)0x00000002U)         /* !< Raw interrupt status for comparator
+                                                                                    output interrupt flag. The IES bit
+                                                                                    defines the transition of the
+                                                                                    comparator output setting this bit. */
+#define COMP_CPU_INT_RIS_COMPIFG_CLR             ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define COMP_CPU_INT_RIS_COMPIFG_SET             ((uint32_t)0x00000002U)         /* !< Interrupt pending */
+/* COMP_CPU_INT_RIS[COMPINVIFG] Bits */
+#define COMP_CPU_INT_RIS_COMPINVIFG_OFS          (2)                             /* !< COMPINVIFG Offset */
+#define COMP_CPU_INT_RIS_COMPINVIFG_MASK         ((uint32_t)0x00000004U)         /* !< Raw interrupt status for comparator
+                                                                                    output inverted interrupt flag. The
+                                                                                    IES bit defines the transition of the
+                                                                                    comparator output setting this bit. */
+#define COMP_CPU_INT_RIS_COMPINVIFG_CLR          ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define COMP_CPU_INT_RIS_COMPINVIFG_SET          ((uint32_t)0x00000004U)         /* !< Interrupt pending */
+/* COMP_CPU_INT_RIS[OUTRDYIFG] Bits */
+#define COMP_CPU_INT_RIS_OUTRDYIFG_OFS           (3)                             /* !< OUTRDYIFG Offset */
+#define COMP_CPU_INT_RIS_OUTRDYIFG_MASK          ((uint32_t)0x00000008U)         /* !< Raw interrupt status for comparator
+                                                                                    output ready interrupt flag. This bit
+                                                                                    is set when the comparator output is
+                                                                                    valid. */
+#define COMP_CPU_INT_RIS_OUTRDYIFG_CLR           ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define COMP_CPU_INT_RIS_OUTRDYIFG_SET           ((uint32_t)0x00000008U)         /* !< Interrupt pending */
+
+/* COMP_CPU_INT_MIS Bits */
+/* COMP_CPU_INT_MIS[COMPIFG] Bits */
+#define COMP_CPU_INT_MIS_COMPIFG_OFS             (1)                             /* !< COMPIFG Offset */
+#define COMP_CPU_INT_MIS_COMPIFG_MASK            ((uint32_t)0x00000002U)         /* !< Masked interrupt status for COMPIFG */
+#define COMP_CPU_INT_MIS_COMPIFG_CLR             ((uint32_t)0x00000000U)         /* !< COMPIFG does not request an
+                                                                                    interrupt service routine */
+#define COMP_CPU_INT_MIS_COMPIFG_SET             ((uint32_t)0x00000002U)         /* !< COMPIFG requests an interrupt
+                                                                                    service routine */
+/* COMP_CPU_INT_MIS[COMPINVIFG] Bits */
+#define COMP_CPU_INT_MIS_COMPINVIFG_OFS          (2)                             /* !< COMPINVIFG Offset */
+#define COMP_CPU_INT_MIS_COMPINVIFG_MASK         ((uint32_t)0x00000004U)         /* !< Masked interrupt status for
+                                                                                    COMPINVIFG */
+#define COMP_CPU_INT_MIS_COMPINVIFG_CLR          ((uint32_t)0x00000000U)         /* !< COMPINVIFG does not request an
+                                                                                    interrupt service routine */
+#define COMP_CPU_INT_MIS_COMPINVIFG_SET          ((uint32_t)0x00000004U)         /* !< COMPINVIFG requests an interrupt
+                                                                                    service routine */
+/* COMP_CPU_INT_MIS[OUTRDYIFG] Bits */
+#define COMP_CPU_INT_MIS_OUTRDYIFG_OFS           (3)                             /* !< OUTRDYIFG Offset */
+#define COMP_CPU_INT_MIS_OUTRDYIFG_MASK          ((uint32_t)0x00000008U)         /* !< Masked interrupt status for
+                                                                                    OUTRDYIFG */
+#define COMP_CPU_INT_MIS_OUTRDYIFG_CLR           ((uint32_t)0x00000000U)         /* !< OUTRDYIFG does not request an
+                                                                                    interrupt service routine */
+#define COMP_CPU_INT_MIS_OUTRDYIFG_SET           ((uint32_t)0x00000008U)         /* !< OUTRDYIFG requests an interrupt
+                                                                                    service routine */
+
+/* COMP_CPU_INT_ISET Bits */
+/* COMP_CPU_INT_ISET[COMPIFG] Bits */
+#define COMP_CPU_INT_ISET_COMPIFG_OFS            (1)                             /* !< COMPIFG Offset */
+#define COMP_CPU_INT_ISET_COMPIFG_MASK           ((uint32_t)0x00000002U)         /* !< Sets COMPIFG in RIS register */
+#define COMP_CPU_INT_ISET_COMPIFG_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define COMP_CPU_INT_ISET_COMPIFG_SET            ((uint32_t)0x00000002U)         /* !< RIS bit corresponding to COMPIFG is
+                                                                                    set */
+/* COMP_CPU_INT_ISET[COMPINVIFG] Bits */
+#define COMP_CPU_INT_ISET_COMPINVIFG_OFS         (2)                             /* !< COMPINVIFG Offset */
+#define COMP_CPU_INT_ISET_COMPINVIFG_MASK        ((uint32_t)0x00000004U)         /* !< Sets COMPINVIFG in RIS register */
+#define COMP_CPU_INT_ISET_COMPINVIFG_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define COMP_CPU_INT_ISET_COMPINVIFG_SET         ((uint32_t)0x00000004U)         /* !< RIS bit corresponding to COMPINVIFG
+                                                                                    is set */
+/* COMP_CPU_INT_ISET[OUTRDYIFG] Bits */
+#define COMP_CPU_INT_ISET_OUTRDYIFG_OFS          (3)                             /* !< OUTRDYIFG Offset */
+#define COMP_CPU_INT_ISET_OUTRDYIFG_MASK         ((uint32_t)0x00000008U)         /* !< Sets OUTRDYIFG in RIS register */
+#define COMP_CPU_INT_ISET_OUTRDYIFG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define COMP_CPU_INT_ISET_OUTRDYIFG_SET          ((uint32_t)0x00000008U)         /* !< RIS bit corresponding to OUTRDYIFG
+                                                                                    is set */
+
+/* COMP_CPU_INT_ICLR Bits */
+/* COMP_CPU_INT_ICLR[COMPIFG] Bits */
+#define COMP_CPU_INT_ICLR_COMPIFG_OFS            (1)                             /* !< COMPIFG Offset */
+#define COMP_CPU_INT_ICLR_COMPIFG_MASK           ((uint32_t)0x00000002U)         /* !< Clears COMPIFG in RIS register */
+#define COMP_CPU_INT_ICLR_COMPIFG_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define COMP_CPU_INT_ICLR_COMPIFG_CLR            ((uint32_t)0x00000002U)         /* !< RIS bit corresponding to COMPIFG is
+                                                                                    cleared */
+/* COMP_CPU_INT_ICLR[COMPINVIFG] Bits */
+#define COMP_CPU_INT_ICLR_COMPINVIFG_OFS         (2)                             /* !< COMPINVIFG Offset */
+#define COMP_CPU_INT_ICLR_COMPINVIFG_MASK        ((uint32_t)0x00000004U)         /* !< Clears COMPINVIFG in RIS register */
+#define COMP_CPU_INT_ICLR_COMPINVIFG_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define COMP_CPU_INT_ICLR_COMPINVIFG_CLR         ((uint32_t)0x00000004U)         /* !< RIS bit corresponding to COMPINVIFG
+                                                                                    is cleared */
+/* COMP_CPU_INT_ICLR[OUTRDYIFG] Bits */
+#define COMP_CPU_INT_ICLR_OUTRDYIFG_OFS          (3)                             /* !< OUTRDYIFG Offset */
+#define COMP_CPU_INT_ICLR_OUTRDYIFG_MASK         ((uint32_t)0x00000008U)         /* !< Clears OUTRDYIFG in RIS register */
+#define COMP_CPU_INT_ICLR_OUTRDYIFG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define COMP_CPU_INT_ICLR_OUTRDYIFG_CLR          ((uint32_t)0x00000008U)         /* !< RIS bit corresponding to OUTRDYIFG
+                                                                                    is cleared */
+
+/* COMP_PWREN Bits */
+/* COMP_PWREN[ENABLE] Bits */
+#define COMP_PWREN_ENABLE_OFS                    (0)                             /* !< ENABLE Offset */
+#define COMP_PWREN_ENABLE_MASK                   ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define COMP_PWREN_ENABLE_DISABLE                ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define COMP_PWREN_ENABLE_ENABLE                 ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* COMP_PWREN[KEY] Bits */
+#define COMP_PWREN_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define COMP_PWREN_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define COMP_PWREN_KEY_UNLOCK_W                  ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* COMP_RSTCTL Bits */
+/* COMP_RSTCTL[RESETSTKYCLR] Bits */
+#define COMP_RSTCTL_RESETSTKYCLR_OFS             (1)                             /* !< RESETSTKYCLR Offset */
+#define COMP_RSTCTL_RESETSTKYCLR_MASK            ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define COMP_RSTCTL_RESETSTKYCLR_NOP             ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define COMP_RSTCTL_RESETSTKYCLR_CLR             ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* COMP_RSTCTL[RESETASSERT] Bits */
+#define COMP_RSTCTL_RESETASSERT_OFS              (0)                             /* !< RESETASSERT Offset */
+#define COMP_RSTCTL_RESETASSERT_MASK             ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define COMP_RSTCTL_RESETASSERT_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define COMP_RSTCTL_RESETASSERT_ASSERT           ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* COMP_RSTCTL[KEY] Bits */
+#define COMP_RSTCTL_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define COMP_RSTCTL_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define COMP_RSTCTL_KEY_UNLOCK_W                 ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* COMP_CLKCFG Bits */
+/* COMP_CLKCFG[KEY] Bits */
+#define COMP_CLKCFG_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define COMP_CLKCFG_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define COMP_CLKCFG_KEY_UNLOCK                   ((uint32_t)0xA9000000U)         /* !< Key value to be used in writing to
+                                                                                    this register for the write to take
+                                                                                    effect. */
+/* COMP_CLKCFG[BLOCKASYNC] Bits */
+#define COMP_CLKCFG_BLOCKASYNC_OFS               (8)                             /* !< BLOCKASYNC Offset */
+#define COMP_CLKCFG_BLOCKASYNC_MASK              ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define COMP_CLKCFG_BLOCKASYNC_DISABLE           ((uint32_t)0x00000000U)         /* !< disable COMP to request SYSOSC */
+#define COMP_CLKCFG_BLOCKASYNC_ENABLE            ((uint32_t)0x00000100U)         /* !< enable COMP to request SYSOSC */
+
+/* COMP_GPRCM_STAT Bits */
+/* COMP_GPRCM_STAT[RESETSTKY] Bits */
+#define COMP_GPRCM_STAT_RESETSTKY_OFS            (16)                            /* !< RESETSTKY Offset */
+#define COMP_GPRCM_STAT_RESETSTKY_MASK           ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define COMP_GPRCM_STAT_RESETSTKY_NORES          ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define COMP_GPRCM_STAT_RESETSTKY_RESET          ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* COMP_FSUB_0 Bits */
+/* COMP_FSUB_0[CHANID] Bits */
+#define COMP_FSUB_0_CHANID_OFS                   (0)                             /* !< CHANID Offset */
+#define COMP_FSUB_0_CHANID_MASK                  ((uint32_t)0x00007FFFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define COMP_FSUB_0_CHANID_MNIMUM                ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define COMP_FSUB_0_CHANID_UNCONNECTED           ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define COMP_FSUB_0_CHANID_MAXIMUM               ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* COMP_FSUB_1 Bits */
+/* COMP_FSUB_1[CHANID] Bits */
+#define COMP_FSUB_1_CHANID_OFS                   (0)                             /* !< CHANID Offset */
+#define COMP_FSUB_1_CHANID_MASK                  ((uint32_t)0x00007FFFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define COMP_FSUB_1_CHANID_MNIMUM                ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define COMP_FSUB_1_CHANID_UNCONNECTED           ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define COMP_FSUB_1_CHANID_MAXIMUM               ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* COMP_FPUB_1 Bits */
+/* COMP_FPUB_1[CHANID] Bits */
+#define COMP_FPUB_1_CHANID_OFS                   (0)                             /* !< CHANID Offset */
+#define COMP_FPUB_1_CHANID_MASK                  ((uint32_t)0x00007FFFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define COMP_FPUB_1_CHANID_MNIMUM                ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define COMP_FPUB_1_CHANID_UNCONNECTED           ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define COMP_FPUB_1_CHANID_MAXIMUM               ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* COMP_EVT_MODE Bits */
+/* COMP_EVT_MODE[INT0_CFG] Bits */
+#define COMP_EVT_MODE_INT0_CFG_OFS               (0)                             /* !< INT0_CFG Offset */
+#define COMP_EVT_MODE_INT0_CFG_MASK              ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to CPU_INT */
+#define COMP_EVT_MODE_INT0_CFG_DISABLE           ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define COMP_EVT_MODE_INT0_CFG_SOFTWARE          ((uint32_t)0x00000001U)         /* !< Event handled by software. Software
+                                                                                    must clear the associated RIS flag. */
+#define COMP_EVT_MODE_INT0_CFG_HARDWARE          ((uint32_t)0x00000002U)         /* !< Event handled by hardware. The
+                                                                                    hardware (another module) clears
+                                                                                    automatically the associated RIS
+                                                                                    flag. */
+/* COMP_EVT_MODE[EVT1_CFG] Bits */
+#define COMP_EVT_MODE_EVT1_CFG_OFS               (2)                             /* !< EVT1_CFG Offset */
+#define COMP_EVT_MODE_EVT1_CFG_MASK              ((uint32_t)0x0000000CU)         /* !< Event line mode select for event
+                                                                                    corresponding to GEN_EVENT */
+#define COMP_EVT_MODE_EVT1_CFG_DISABLE           ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define COMP_EVT_MODE_EVT1_CFG_SOFTWARE          ((uint32_t)0x00000004U)         /* !< Event handled by software. Software
+                                                                                    must clear the associated RIS flag. */
+#define COMP_EVT_MODE_EVT1_CFG_HARDWARE          ((uint32_t)0x00000008U)         /* !< Event handled by hardware. The
+                                                                                    hardware (another module) clears
+                                                                                    automatically the associated RIS
+                                                                                    flag. */
+
+/* COMP_DESC Bits */
+/* COMP_DESC[MINREV] Bits */
+#define COMP_DESC_MINREV_OFS                     (0)                             /* !< MINREV Offset */
+#define COMP_DESC_MINREV_MASK                    ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+/* COMP_DESC[MAJREV] Bits */
+#define COMP_DESC_MAJREV_OFS                     (4)                             /* !< MAJREV Offset */
+#define COMP_DESC_MAJREV_MASK                    ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+/* COMP_DESC[FEATUREVER] Bits */
+#define COMP_DESC_FEATUREVER_OFS                 (12)                            /* !< FEATUREVER Offset */
+#define COMP_DESC_FEATUREVER_MASK                ((uint32_t)0x0000F000U)         /* !< Feature Set for the module
+                                                                                    *instance* */
+/* COMP_DESC[MODULEID] Bits */
+#define COMP_DESC_MODULEID_OFS                   (16)                            /* !< MODULEID Offset */
+#define COMP_DESC_MODULEID_MASK                  ((uint32_t)0xFFFF0000U)         /* !< Module identification contains a
+                                                                                    unique peripheral identification
+                                                                                    number. The assignments are
+                                                                                    maintained in a central database for
+                                                                                    all of the platform modules to ensure
+                                                                                    uniqueness. */
+
+/* COMP_CTL0 Bits */
+/* COMP_CTL0[IPSEL] Bits */
+#define COMP_CTL0_IPSEL_OFS                      (0)                             /* !< IPSEL Offset */
+#define COMP_CTL0_IPSEL_MASK                     ((uint32_t)0x00000007U)         /* !< Channel input selected for the
+                                                                                    positive terminal of the comparator
+                                                                                    if IPEN is set to 1. */
+#define COMP_CTL0_IPSEL_CH_0                     ((uint32_t)0x00000000U)         /* !< Channel 0 selected */
+#define COMP_CTL0_IPSEL_CH_1                     ((uint32_t)0x00000001U)         /* !< Channel 1 selected */
+#define COMP_CTL0_IPSEL_CH_2                     ((uint32_t)0x00000002U)         /* !< Channel 2 selected */
+#define COMP_CTL0_IPSEL_CH_3                     ((uint32_t)0x00000003U)         /* !< Channel 3 selected */
+#define COMP_CTL0_IPSEL_CH_4                     ((uint32_t)0x00000004U)         /* !< Channel 4 selected */
+#define COMP_CTL0_IPSEL_CH_5                     ((uint32_t)0x00000005U)         /* !< Channel 5 selected */
+#define COMP_CTL0_IPSEL_CH_6                     ((uint32_t)0x00000006U)         /* !< Channel 6 selected */
+#define COMP_CTL0_IPSEL_CH_7                     ((uint32_t)0x00000007U)         /* !< Channel 7  selected */
+/* COMP_CTL0[IPEN] Bits */
+#define COMP_CTL0_IPEN_OFS                       (15)                            /* !< IPEN Offset */
+#define COMP_CTL0_IPEN_MASK                      ((uint32_t)0x00008000U)         /* !< Channel input enable for the
+                                                                                    positive terminal of the comparator. */
+#define COMP_CTL0_IPEN_DISABLE                   ((uint32_t)0x00000000U)         /* !< Selected analog input channel for
+                                                                                    positive terminal is disabled */
+#define COMP_CTL0_IPEN_ENABLE                    ((uint32_t)0x00008000U)         /* !< Selected analog input channel for
+                                                                                    positive terminal is enabled */
+/* COMP_CTL0[IMEN] Bits */
+#define COMP_CTL0_IMEN_OFS                       (31)                            /* !< IMEN Offset */
+#define COMP_CTL0_IMEN_MASK                      ((uint32_t)0x80000000U)         /* !< Channel input enable for the
+                                                                                    negative terminal of the comparator. */
+#define COMP_CTL0_IMEN_DISABLE                   ((uint32_t)0x00000000U)         /* !< Selected analog input channel for
+                                                                                    negative terminal is disabled */
+#define COMP_CTL0_IMEN_ENABLE                    ((uint32_t)0x80000000U)         /* !< Selected analog input channel for
+                                                                                    negative terminal is enabled */
+/* COMP_CTL0[IMSEL] Bits */
+#define COMP_CTL0_IMSEL_OFS                      (16)                            /* !< IMSEL Offset */
+#define COMP_CTL0_IMSEL_MASK                     ((uint32_t)0x00070000U)         /* !< Channel input selected for the
+                                                                                    negative terminal of the comparator
+                                                                                    if IMEN is set to 1. */
+#define COMP_CTL0_IMSEL_CH_0                     ((uint32_t)0x00000000U)         /* !< Channel 0 selected */
+#define COMP_CTL0_IMSEL_CH_1                     ((uint32_t)0x00010000U)         /* !< Channel 1 selected */
+#define COMP_CTL0_IMSEL_CH_2                     ((uint32_t)0x00020000U)         /* !< Channel 2 selected */
+#define COMP_CTL0_IMSEL_CH_3                     ((uint32_t)0x00030000U)         /* !< Channel 3 selected */
+#define COMP_CTL0_IMSEL_CH_4                     ((uint32_t)0x00040000U)         /* !< Channel 4 selected */
+#define COMP_CTL0_IMSEL_CH_5                     ((uint32_t)0x00050000U)         /* !< Channel 5 selected */
+#define COMP_CTL0_IMSEL_CH_6                     ((uint32_t)0x00060000U)         /* !< Channel 6 selected */
+#define COMP_CTL0_IMSEL_CH_7                     ((uint32_t)0x00070000U)         /* !< Channel 7 selected */
+
+/* COMP_CTL1 Bits */
+/* COMP_CTL1[ENABLE] Bits */
+#define COMP_CTL1_ENABLE_OFS                     (0)                             /* !< ENABLE Offset */
+#define COMP_CTL1_ENABLE_MASK                    ((uint32_t)0x00000001U)         /* !< This bit turns on the comparator.
+                                                                                    When the comparator is turned off it
+                                                                                    consumes no power. */
+#define COMP_CTL1_ENABLE_OFF                     ((uint32_t)0x00000000U)         /* !< Comparator is off */
+#define COMP_CTL1_ENABLE_ON                      ((uint32_t)0x00000001U)         /* !< Comparator is on */
+/* COMP_CTL1[MODE] Bits */
+#define COMP_CTL1_MODE_OFS                       (1)                             /* !< MODE Offset */
+#define COMP_CTL1_MODE_MASK                      ((uint32_t)0x00000002U)         /* !< This bit selects the comparator
+                                                                                    operating mode. */
+#define COMP_CTL1_MODE_FAST                      ((uint32_t)0x00000000U)         /* !< Comparator is in fast mode */
+#define COMP_CTL1_MODE_ULP                       ((uint32_t)0x00000002U)         /* !< Comparator is in ultra-low power
+                                                                                    mode */
+/* COMP_CTL1[EXCH] Bits */
+#define COMP_CTL1_EXCH_OFS                       (2)                             /* !< EXCH Offset */
+#define COMP_CTL1_EXCH_MASK                      ((uint32_t)0x00000004U)         /* !< This bit exchanges the comparator
+                                                                                    inputs and inverts the comparator
+                                                                                    output. */
+#define COMP_CTL1_EXCH_NO_EXC                    ((uint32_t)0x00000000U)         /* !< Comparator inputs not exchanged and
+                                                                                    output not inverted */
+#define COMP_CTL1_EXCH_EXC                       ((uint32_t)0x00000004U)         /* !< Comparator inputs exchanged and
+                                                                                    output inverted */
+/* COMP_CTL1[SHORT] Bits */
+#define COMP_CTL1_SHORT_OFS                      (3)                             /* !< SHORT Offset */
+#define COMP_CTL1_SHORT_MASK                     ((uint32_t)0x00000008U)         /* !< This bit shorts the positive and
+                                                                                    negative input terminals of the
+                                                                                    comparator. */
+#define COMP_CTL1_SHORT_NO_SHT                   ((uint32_t)0x00000000U)         /* !< Comparator positive and negative
+                                                                                    input terminals are not shorted */
+#define COMP_CTL1_SHORT_SHT                      ((uint32_t)0x00000008U)         /* !< Comparator positive and negative
+                                                                                    input terminals are shorted */
+/* COMP_CTL1[IES] Bits */
+#define COMP_CTL1_IES_OFS                        (4)                             /* !< IES Offset */
+#define COMP_CTL1_IES_MASK                       ((uint32_t)0x00000010U)         /* !< This bit selected the interrupt
+                                                                                    edge for COMPIFG and COMPINVIFG. */
+#define COMP_CTL1_IES_RISING                     ((uint32_t)0x00000000U)         /* !< Rising edge sets COMPIFG and
+                                                                                    falling edge sets COMPINVIFG */
+#define COMP_CTL1_IES_FALLING                    ((uint32_t)0x00000010U)         /* !< Falling edge sets COMPIFG and
+                                                                                    rising edge sets COMPINVIFG */
+/* COMP_CTL1[HYST] Bits */
+#define COMP_CTL1_HYST_OFS                       (5)                             /* !< HYST Offset */
+#define COMP_CTL1_HYST_MASK                      ((uint32_t)0x00000060U)         /* !< These bits select the hysteresis
+                                                                                    setting of the comparator. */
+#define COMP_CTL1_HYST_NO_HYS                    ((uint32_t)0x00000000U)         /* !< No hysteresis */
+#define COMP_CTL1_HYST_LOW_HYS                   ((uint32_t)0x00000020U)         /* !< Low hysteresis, typical 10mV */
+#define COMP_CTL1_HYST_MED_HYS                   ((uint32_t)0x00000040U)         /* !< Medium hysteresis, typical 20mV */
+#define COMP_CTL1_HYST_HIGH_HYS                  ((uint32_t)0x00000060U)         /* !< High hysteresis, typical 30mV */
+/* COMP_CTL1[OUTPOL] Bits */
+#define COMP_CTL1_OUTPOL_OFS                     (7)                             /* !< OUTPOL Offset */
+#define COMP_CTL1_OUTPOL_MASK                    ((uint32_t)0x00000080U)         /* !< This bit selects the comparator
+                                                                                    output polarity. */
+#define COMP_CTL1_OUTPOL_NON_INV                 ((uint32_t)0x00000000U)         /* !< Comparator output is non-inverted */
+#define COMP_CTL1_OUTPOL_INV                     ((uint32_t)0x00000080U)         /* !< Comparator output is inverted */
+/* COMP_CTL1[FLTEN] Bits */
+#define COMP_CTL1_FLTEN_OFS                      (8)                             /* !< FLTEN Offset */
+#define COMP_CTL1_FLTEN_MASK                     ((uint32_t)0x00000100U)         /* !< This bit enables the analog filter
+                                                                                    at comparator output. */
+#define COMP_CTL1_FLTEN_DISABLE                  ((uint32_t)0x00000000U)         /* !< Comparator output filter is
+                                                                                    disabled */
+#define COMP_CTL1_FLTEN_ENABLE                   ((uint32_t)0x00000100U)         /* !< Comparator output filter is enabled */
+/* COMP_CTL1[FLTDLY] Bits */
+#define COMP_CTL1_FLTDLY_OFS                     (9)                             /* !< FLTDLY Offset */
+#define COMP_CTL1_FLTDLY_MASK                    ((uint32_t)0x00000600U)         /* !< These bits select the comparator
+                                                                                    output filter delay. See the
+                                                                                    device-specific data sheet for
+                                                                                    specific values on comparator
+                                                                                    propagation delay for different
+                                                                                    filter delay settings. */
+#define COMP_CTL1_FLTDLY_DLY_0                   ((uint32_t)0x00000000U)         /* !< Typical filter delay of 70 ns */
+#define COMP_CTL1_FLTDLY_DLY_1                   ((uint32_t)0x00000200U)         /* !< Typical filter delay of 500 ns */
+#define COMP_CTL1_FLTDLY_DLY_2                   ((uint32_t)0x00000400U)         /* !< Typical filter delay of 1200 ns */
+#define COMP_CTL1_FLTDLY_DLY_3                   ((uint32_t)0x00000600U)         /* !< Typical filter delay of 2700 ns */
+/* COMP_CTL1[WINCOMPEN] Bits */
+#define COMP_CTL1_WINCOMPEN_OFS                  (12)                            /* !< WINCOMPEN Offset */
+#define COMP_CTL1_WINCOMPEN_MASK                 ((uint32_t)0x00001000U)         /* !< This bit enables window comparator
+                                                                                    operation of comparator. */
+#define COMP_CTL1_WINCOMPEN_OFF                  ((uint32_t)0x00000000U)         /* !< window comparator is disable */
+#define COMP_CTL1_WINCOMPEN_ON                   ((uint32_t)0x00001000U)         /* !< window comparator is enable */
+
+/* COMP_CTL2 Bits */
+/* COMP_CTL2[REFMODE] Bits */
+#define COMP_CTL2_REFMODE_OFS                    (0)                             /* !< REFMODE Offset */
+#define COMP_CTL2_REFMODE_MASK                   ((uint32_t)0x00000001U)         /* !< This bit requests ULP_REF bandgap
+                                                                                    operation in fast mode(static) or low
+                                                                                    power mode (sampled). The local
+                                                                                    reference buffer and 8-bit DAC inside
+                                                                                    comparator module are also configured
+                                                                                    accordingly.  Fast mode operation
+                                                                                    offers higher accuracy but consumes
+                                                                                    higher current. Low power operation
+                                                                                    consumes lower current but with
+                                                                                    relaxed reference voltage accuracy.
+                                                                                    Comparator requests for reference
+                                                                                    voltage from ULP_REF only when REFLVL
+                                                                                    > 0. */
+#define COMP_CTL2_REFMODE_STATIC                 ((uint32_t)0x00000000U)         /* !< ULP_REF bandgap, local reference
+                                                                                    buffer and 8-bit DAC inside
+                                                                                    comparator operate in static mode. */
+#define COMP_CTL2_REFMODE_SAMPLED                ((uint32_t)0x00000001U)         /* !< ULP_REF bandgap, local reference
+                                                                                    buffer and 8-bit DAC inside
+                                                                                    comparator operate in sampled mode. */
+/* COMP_CTL2[REFSRC] Bits */
+#define COMP_CTL2_REFSRC_OFS                     (3)                             /* !< REFSRC Offset */
+#define COMP_CTL2_REFSRC_MASK                    ((uint32_t)0x00000038U)         /* !< These bits select the reference
+                                                                                    source for the comparator. */
+#define COMP_CTL2_REFSRC_OFF                     ((uint32_t)0x00000000U)         /* !< Reference voltage generator is
+                                                                                    disabled (local reference buffer as
+                                                                                    well as DAC). */
+#define COMP_CTL2_REFSRC_VDDA_DAC                ((uint32_t)0x00000008U)         /* !< VDDA selected as the reference
+                                                                                    source to DAC and DAC output applied
+                                                                                    as reference to comparator. */
+#define COMP_CTL2_REFSRC_VREF_DAC                ((uint32_t)0x00000010U)         /* !< VREF selected as reference to DAC
+                                                                                    and DAC output applied as reference
+                                                                                    to comparator. */
+#define COMP_CTL2_REFSRC_VREF                    ((uint32_t)0x00000018U)         /* !< In devices where internal VREF is
+                                                                                    buffered and hookedup to extrernal
+                                                                                    VREF pin, VREF applied as reference
+                                                                                    to comparator. DAC is switched off.
+                                                                                    Note: In LEGO_A3, DAC is turned off
+                                                                                    in this selection, in other deviced
+                                                                                    DAC is kept on. */
+#define COMP_CTL2_REFSRC_VDDA                    ((uint32_t)0x00000028U)         /* !< VDDA is used as comparator
+                                                                                    reference. Note: In LEGO_A3, DAC is
+                                                                                    turned off in this selection, in
+                                                                                    other deviced DAC is kept on. */
+#define COMP_CTL2_REFSRC_INTVREF_DAC             ((uint32_t)0x00000030U)         /* !< Internal reference selected as the
+                                                                                    reference source to DAC and DAC
+                                                                                    output applied as reference to
+                                                                                    comparator. */
+#define COMP_CTL2_REFSRC_INTVREF                 ((uint32_t)0x00000038U)         /* !< Internal VREF is used as the source
+                                                                                    of comparator. Not all devices will
+                                                                                    have this option. */
+/* COMP_CTL2[REFSEL] Bits */
+#define COMP_CTL2_REFSEL_OFS                     (7)                             /* !< REFSEL Offset */
+#define COMP_CTL2_REFSEL_MASK                    ((uint32_t)0x00000080U)         /* !< This bit selects if the selected
+                                                                                    reference voltage is applied to
+                                                                                    positive or negative terminal of the
+                                                                                    comparator. */
+#define COMP_CTL2_REFSEL_POSITIVE                ((uint32_t)0x00000000U)         /* !< If EXCH bit is 0, the selected
+                                                                                    reference is applied to positive
+                                                                                    terminal. If EXCH bit is 1, the
+                                                                                    selected reference is applied to
+                                                                                    negative terminal. */
+#define COMP_CTL2_REFSEL_NEGATIVE                ((uint32_t)0x00000080U)         /* !< If EXCH bit is 0, the selected
+                                                                                    reference is applied to negative
+                                                                                    terminal. If EXCH bit is 1, the
+                                                                                    selected reference is applied to
+                                                                                    positive terminal. */
+/* COMP_CTL2[DACCTL] Bits */
+#define COMP_CTL2_DACCTL_OFS                     (16)                            /* !< DACCTL Offset */
+#define COMP_CTL2_DACCTL_MASK                    ((uint32_t)0x00010000U)         /* !< This bit determines if the
+                                                                                    comparator output or DACSW bit
+                                                                                    controls the selection between
+                                                                                    DACCODE0 and DACCODE1. */
+#define COMP_CTL2_DACCTL_COMPOUT_SEL             ((uint32_t)0x00000000U)         /* !< Comparator output controls
+                                                                                    selection between DACCODE0 and
+                                                                                    DACCODE1 */
+#define COMP_CTL2_DACCTL_DACSW_SEL               ((uint32_t)0x00010000U)         /* !< DACSW bit controls selection
+                                                                                    between DACCODE0 and DACCODE1 */
+/* COMP_CTL2[DACSW] Bits */
+#define COMP_CTL2_DACSW_OFS                      (17)                            /* !< DACSW Offset */
+#define COMP_CTL2_DACSW_MASK                     ((uint32_t)0x00020000U)         /* !< This bit selects between DACCODE0
+                                                                                    and DACCODE1 to 8-bit DAC when DACCTL
+                                                                                    bit is 1. */
+#define COMP_CTL2_DACSW_DACCODE0_SEL             ((uint32_t)0x00000000U)         /* !< DACCODE0 selected for 8-bit DAC */
+#define COMP_CTL2_DACSW_DACCODE1_SEL             ((uint32_t)0x00020000U)         /* !< DACCODE1 selected for 8-bit DAC */
+/* COMP_CTL2[BLANKSRC] Bits */
+#define COMP_CTL2_BLANKSRC_OFS                   (8)                             /* !< BLANKSRC Offset */
+#define COMP_CTL2_BLANKSRC_MASK                  ((uint32_t)0x00000700U)         /* !< These bits select the blanking
+                                                                                    source for the comparator. */
+#define COMP_CTL2_BLANKSRC_DISABLE               ((uint32_t)0x00000000U)         /* !< Blanking source disabled */
+#define COMP_CTL2_BLANKSRC_BLANKSRC1             ((uint32_t)0x00000100U)         /* !< Select Blanking Source 1 */
+#define COMP_CTL2_BLANKSRC_BLANKSRC2             ((uint32_t)0x00000200U)         /* !< Select Blanking Source 2 */
+#define COMP_CTL2_BLANKSRC_BLANKSRC3             ((uint32_t)0x00000300U)         /* !< Select Blanking Source 3 */
+#define COMP_CTL2_BLANKSRC_BLANKSRC4             ((uint32_t)0x00000400U)         /* !< Select Blanking Source 4 */
+#define COMP_CTL2_BLANKSRC_BLANKSRC5             ((uint32_t)0x00000500U)         /* !< Select Blanking Source 5 */
+#define COMP_CTL2_BLANKSRC_BLANKSRC6             ((uint32_t)0x00000600U)         /* !< Select Blanking Source 6 */
+/* COMP_CTL2[SAMPMODE] Bits */
+#define COMP_CTL2_SAMPMODE_OFS                   (24)                            /* !< SAMPMODE Offset */
+#define COMP_CTL2_SAMPMODE_MASK                  ((uint32_t)0x01000000U)         /* !< Enable sampled mode of comparator. */
+#define COMP_CTL2_SAMPMODE_DISABLE               ((uint32_t)0x00000000U)         /* !< Sampled mode disabled */
+#define COMP_CTL2_SAMPMODE_ENABLE                ((uint32_t)0x01000000U)         /* !< Sampled mode enabled */
+
+/* COMP_CTL3 Bits */
+/* COMP_CTL3[DACCODE0] Bits */
+#define COMP_CTL3_DACCODE0_OFS                   (0)                             /* !< DACCODE0 Offset */
+#define COMP_CTL3_DACCODE0_MASK                  ((uint32_t)0x000000FFU)         /* !< This is the first 8-bit DAC code.
+                                                                                    When the DAC code is 0x0 the DAC
+                                                                                    output will be 0 V. When the DAC code
+                                                                                    is 0xFF the DAC output will be
+                                                                                    selected reference voltage x 255/256. */
+#define COMP_CTL3_DACCODE0_MNIMUM                ((uint32_t)0x00000000U)         /* !< Minimum DAC code value */
+#define COMP_CTL3_DACCODE0_MAXIMUM               ((uint32_t)0x000000FFU)         /* !< Minimum DAC code value */
+/* COMP_CTL3[DACCODE1] Bits */
+#define COMP_CTL3_DACCODE1_OFS                   (16)                            /* !< DACCODE1 Offset */
+#define COMP_CTL3_DACCODE1_MASK                  ((uint32_t)0x00FF0000U)         /* !< This is the second 8-bit DAC code.
+                                                                                    When the DAC code is 0x0 the DAC
+                                                                                    output will be 0 V. When the DAC code
+                                                                                    is 0xFF the DAC output will be
+                                                                                    selected reference voltage x 255/256. */
+#define COMP_CTL3_DACCODE1_MNIMUM                ((uint32_t)0x00000000U)         /* !< Minimum DAC code value */
+#define COMP_CTL3_DACCODE1_MAXIMUM               ((uint32_t)0x00FF0000U)         /* !< Minimum DAC code value */
+
+/* COMP_STAT Bits */
+/* COMP_STAT[OUT] Bits */
+#define COMP_STAT_OUT_OFS                        (0)                             /* !< OUT Offset */
+#define COMP_STAT_OUT_MASK                       ((uint32_t)0x00000001U)         /* !< This bit reflects the value of the
+                                                                                    comparator output. Writing to this
+                                                                                    bit has no effect on the comparator
+                                                                                    output. */
+#define COMP_STAT_OUT_LOW                        ((uint32_t)0x00000000U)         /* !< Comparator output is low */
+#define COMP_STAT_OUT_HIGH                       ((uint32_t)0x00000001U)         /* !< Comparator output is high */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_comp__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_crc.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_crc.h
@@ -1,0 +1,300 @@
+/*****************************************************************************
+
+  Copyright (C) 2022 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_crc__include
+#define ti_devices_msp_peripherals_hw_crc__include
+
+/* This preliminary header file does not have a version number */
+/* MMR repo: https://bitbucket.itg.ti.com/projects/cmcu_msp65ip/repos/f65mspcrc */
+/* MMR revision: 3dcce9f1dec4d9cd7395689f4e4c8a92d2dd7f5b */
+/* Generator revision: 77992b62fb4e9926f5a9143aae1e89fec6a84738
+   (MInT: ec7ec7482a60c6871be32db8b378ec27aa4771f6) */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* CRC Registers
+******************************************************************************/
+#define CRC_GPRCM_OFS                            ((uint32_t)0x00000800U)
+
+
+/** @addtogroup CRC_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} CRC_GPRCM_Regs;
+
+/*@}*/ /* end of group CRC_GPRCM */
+
+/** @addtogroup CRC
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  CRC_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED1[507];
+  __I  uint32_t CLKSEL;                            /* !< (@ 0x00001004) Clock Select */
+       uint32_t RESERVED2[61];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Module Description */
+  __IO uint32_t CRCCTRL;                           /* !< (@ 0x00001100) CRC Control Register */
+  __O  uint32_t CRCSEED;                           /* !< (@ 0x00001104) CRC Seed Register */
+  __O  uint32_t CRCIN;                             /* !< (@ 0x00001108) CRC Input Data Register */
+  __I  uint32_t CRCOUT;                            /* !< (@ 0x0000110C) CRC Output Result Register */
+       uint32_t RESERVED3[444];
+  __O  uint32_t CRCIN_IDX[512];                    /* !< (@ 0x00001800) CRC Input Data Array Register */
+} CRC_Regs;
+
+/*@}*/ /* end of group CRC */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* CRC Register Control Bits
+******************************************************************************/
+
+/* CRC_PWREN Bits */
+/* CRC_PWREN[ENABLE] Bits */
+#define CRC_PWREN_ENABLE_OFS                     (0)                             /* !< ENABLE Offset */
+#define CRC_PWREN_ENABLE_MASK                    ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define CRC_PWREN_ENABLE_DISABLE                 ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define CRC_PWREN_ENABLE_ENABLE                  ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* CRC_PWREN[KEY] Bits */
+#define CRC_PWREN_KEY_OFS                        (24)                            /* !< KEY Offset */
+#define CRC_PWREN_KEY_MASK                       ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define CRC_PWREN_KEY_UNLOCK_W                   ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* CRC_RSTCTL Bits */
+/* CRC_RSTCTL[RESETSTKYCLR] Bits */
+#define CRC_RSTCTL_RESETSTKYCLR_OFS              (1)                             /* !< RESETSTKYCLR Offset */
+#define CRC_RSTCTL_RESETSTKYCLR_MASK             ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define CRC_RSTCTL_RESETSTKYCLR_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define CRC_RSTCTL_RESETSTKYCLR_CLR              ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* CRC_RSTCTL[RESETASSERT] Bits */
+#define CRC_RSTCTL_RESETASSERT_OFS               (0)                             /* !< RESETASSERT Offset */
+#define CRC_RSTCTL_RESETASSERT_MASK              ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define CRC_RSTCTL_RESETASSERT_NOP               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define CRC_RSTCTL_RESETASSERT_ASSERT            ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* CRC_RSTCTL[KEY] Bits */
+#define CRC_RSTCTL_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define CRC_RSTCTL_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define CRC_RSTCTL_KEY_UNLOCK_W                  ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* CRC_STAT Bits */
+/* CRC_STAT[RESETSTKY] Bits */
+#define CRC_STAT_RESETSTKY_OFS                   (16)                            /* !< RESETSTKY Offset */
+#define CRC_STAT_RESETSTKY_MASK                  ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define CRC_STAT_RESETSTKY_NORES                 ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define CRC_STAT_RESETSTKY_RESET                 ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* CRC_CLKSEL Bits */
+/* CRC_CLKSEL[MCLK_SEL] Bits */
+#define CRC_CLKSEL_MCLK_SEL_OFS                  (0)                             /* !< MCLK_SEL Offset */
+#define CRC_CLKSEL_MCLK_SEL_MASK                 ((uint32_t)0x00000001U)         /* !< Selects main clock (MCLK) if
+                                                                                    enabled */
+#define CRC_CLKSEL_MCLK_SEL_DISABLE              ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define CRC_CLKSEL_MCLK_SEL_ENABLE               ((uint32_t)0x00000001U)         /* !< Select this clock as a source */
+
+/* CRC_DESC Bits */
+/* CRC_DESC[MINREV] Bits */
+#define CRC_DESC_MINREV_OFS                      (0)                             /* !< MINREV Offset */
+#define CRC_DESC_MINREV_MASK                     ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+#define CRC_DESC_MINREV_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define CRC_DESC_MINREV_MAXIMUM                  ((uint32_t)0x0000000FU)         /* !< Highest possible value */
+/* CRC_DESC[MAJREV] Bits */
+#define CRC_DESC_MAJREV_OFS                      (4)                             /* !< MAJREV Offset */
+#define CRC_DESC_MAJREV_MASK                     ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+#define CRC_DESC_MAJREV_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define CRC_DESC_MAJREV_MAXIMUM                  ((uint32_t)0x000000F0U)         /* !< Highest possible value */
+/* CRC_DESC[INSTNUM] Bits */
+#define CRC_DESC_INSTNUM_OFS                     (8)                             /* !< INSTNUM Offset */
+#define CRC_DESC_INSTNUM_MASK                    ((uint32_t)0x00000F00U)         /* !< Instance Number within the device.
+                                                                                    This will be a parameter to the RTL
+                                                                                    for modules that can have multiple
+                                                                                    instances */
+#define CRC_DESC_INSTNUM_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define CRC_DESC_INSTNUM_MAXIMUM                 ((uint32_t)0x00000F00U)         /* !< Highest possible value */
+/* CRC_DESC[FEATUREVER] Bits */
+#define CRC_DESC_FEATUREVER_OFS                  (12)                            /* !< FEATUREVER Offset */
+#define CRC_DESC_FEATUREVER_MASK                 ((uint32_t)0x0000F000U)         /* !< Feature Set for the module
+                                                                                    *instance* */
+#define CRC_DESC_FEATUREVER_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define CRC_DESC_FEATUREVER_MAXIMUM              ((uint32_t)0x0000F000U)         /* !< Highest possible value */
+/* CRC_DESC[MODULEID] Bits */
+#define CRC_DESC_MODULEID_OFS                    (16)                            /* !< MODULEID Offset */
+#define CRC_DESC_MODULEID_MASK                   ((uint32_t)0xFFFF0000U)         /* !< Module identification contains a
+                                                                                    unique peripheral identification
+                                                                                    number. The assignments are
+                                                                                    maintained in a central database for
+                                                                                    all of the platform modules to ensure
+                                                                                    uniqueness. */
+#define CRC_DESC_MODULEID_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define CRC_DESC_MODULEID_MAXIMUM                ((uint32_t)0xFFFF0000U)         /* !< Highest possible value */
+
+/* CRC_CRCCTRL Bits */
+/* CRC_CRCCTRL[POLYSIZE] Bits */
+#define CRC_CRCCTRL_POLYSIZE_OFS                 (0)                             /* !< POLYSIZE Offset */
+#define CRC_CRCCTRL_POLYSIZE_MASK                ((uint32_t)0x00000001U)         /* !< This bit indicates which CRC
+                                                                                    calculation is performed by the
+                                                                                    generator. */
+#define CRC_CRCCTRL_POLYSIZE_CRC32               ((uint32_t)0x00000000U)         /* !< CRC-32 ISO-3309 calculation is
+                                                                                    performed */
+#define CRC_CRCCTRL_POLYSIZE_CRC16               ((uint32_t)0x00000001U)         /* !< CRC-16 CCITT is performed */
+/* CRC_CRCCTRL[BITREVERSE] Bits */
+#define CRC_CRCCTRL_BITREVERSE_OFS               (1)                             /* !< BITREVERSE Offset */
+#define CRC_CRCCTRL_BITREVERSE_MASK              ((uint32_t)0x00000002U)         /* !< CRC Bit Input and output Reverse.
+                                                                                    This bit indicates that the bit order
+                                                                                    of each input byte used for the CRC
+                                                                                    calculation is reversed before it is
+                                                                                    passed to the generator, and that the
+                                                                                    bit order of the calculated CRC is be
+                                                                                    reversed when read from CRC_RESULT. */
+#define CRC_CRCCTRL_BITREVERSE_NOT_REVERSED      ((uint32_t)0x00000000U)         /* !< Bit order is not reversed. */
+#define CRC_CRCCTRL_BITREVERSE_REVERSED          ((uint32_t)0x00000002U)         /* !< Bit order is reversed. */
+/* CRC_CRCCTRL[INPUT_ENDIANNESS] Bits */
+#define CRC_CRCCTRL_INPUT_ENDIANNESS_OFS         (2)                             /* !< INPUT_ENDIANNESS Offset */
+#define CRC_CRCCTRL_INPUT_ENDIANNESS_MASK        ((uint32_t)0x00000004U)         /* !< CRC Endian. This bit indicates the
+                                                                                    byte order within a word or half word
+                                                                                    of input data. */
+#define CRC_CRCCTRL_INPUT_ENDIANNESS_LITTLE_ENDIAN ((uint32_t)0x00000000U)         /* !< LSB is lowest memory address and
+                                                                                    first to be processed. */
+#define CRC_CRCCTRL_INPUT_ENDIANNESS_BIG_ENDIAN  ((uint32_t)0x00000004U)         /* !< LSB is highest memory address and
+                                                                                    last to be processed. */
+/* CRC_CRCCTRL[OUTPUT_BYTESWAP] Bits */
+#define CRC_CRCCTRL_OUTPUT_BYTESWAP_OFS          (4)                             /* !< OUTPUT_BYTESWAP Offset */
+#define CRC_CRCCTRL_OUTPUT_BYTESWAP_MASK         ((uint32_t)0x00000010U)         /* !< CRC Output Byteswap Enable. This
+                                                                                    bit controls whether the output is
+                                                                                    byte-swapped upon a read of the
+                                                                                    CRCOUT register. If CRCOUT is
+                                                                                    accessed as a half-word, and the
+                                                                                    OUTPUT_BYTESWAP is set to to 1, then
+                                                                                    the two bytes in the 16-bit access
+                                                                                    are swapped and returned. B1 is
+                                                                                    returned as B0 B0 is returned as B1
+                                                                                    If CRCOUT is accessed as a word, and
+                                                                                    the OUTPUT_BYTESWAP is set to 1, then
+                                                                                    the four bytes in the 32-bit read are
+                                                                                    swapped. B3 is returned as B0 B2 is
+                                                                                    returned as B1 B1 is returned as B2
+                                                                                    B0 is returned as B3  Note that if
+                                                                                    the CRC POLYSIZE is 16-bit and a
+                                                                                    32-bit read of CRCOUT is performed
+                                                                                    with OUTPUT_BYTESWAP enabled,  then
+                                                                                    the output is: MSB                LSB
+                                                                                    0x0   0x0   B0   B1  If the CRC
+                                                                                    POLYSIZE is 16-bit and a 32-bit read
+                                                                                    of CRCOUT is performed with
+                                                                                    OUTPUT_BYTESWAP disabled,  then the
+                                                                                    output is: MSB                LSB 0x0
+                                                                                    0x0   B1   B0 */
+#define CRC_CRCCTRL_OUTPUT_BYTESWAP_DISABLE      ((uint32_t)0x00000000U)         /* !< Output byteswapping is disabled */
+#define CRC_CRCCTRL_OUTPUT_BYTESWAP_ENABLE       ((uint32_t)0x00000010U)         /* !< Output byteswapping is enabled. */
+
+/* CRC_CRCSEED Bits */
+/* CRC_CRCSEED[SEED] Bits */
+#define CRC_CRCSEED_SEED_OFS                     (0)                             /* !< SEED Offset */
+#define CRC_CRCSEED_SEED_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< Seed Data */
+#define CRC_CRCSEED_SEED_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define CRC_CRCSEED_SEED_MAXIMUM                 ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value */
+
+/* CRC_CRCIN Bits */
+/* CRC_CRCIN[DATA] Bits */
+#define CRC_CRCIN_DATA_OFS                       (0)                             /* !< DATA Offset */
+#define CRC_CRCIN_DATA_MASK                      ((uint32_t)0xFFFFFFFFU)         /* !< Input Data */
+#define CRC_CRCIN_DATA_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define CRC_CRCIN_DATA_MAXIMUM                   ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value */
+
+/* CRC_CRCOUT Bits */
+/* CRC_CRCOUT[RESULT] Bits */
+#define CRC_CRCOUT_RESULT_OFS                    (0)                             /* !< RESULT Offset */
+#define CRC_CRCOUT_RESULT_MASK                   ((uint32_t)0xFFFFFFFFU)         /* !< Result */
+#define CRC_CRCOUT_RESULT_MINIMUM                ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define CRC_CRCOUT_RESULT_MAXIMUM                ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value */
+
+/* CRC_CRCIN_IDX Bits */
+/* CRC_CRCIN_IDX[DATA] Bits */
+#define CRC_CRCIN_IDX_DATA_OFS                   (0)                             /* !< DATA Offset */
+#define CRC_CRCIN_IDX_DATA_MASK                  ((uint32_t)0xFFFFFFFFU)         /* !< Input Data */
+#define CRC_CRCIN_IDX_DATA_MINIMUM               ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define CRC_CRCIN_IDX_DATA_MAXIMUM               ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_crc__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_crcp.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_crcp.h
@@ -1,0 +1,306 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_crcp__include
+#define ti_devices_msp_peripherals_hw_crcp__include
+
+/* This preliminary header file does not have a version number */
+/* MMR repo: https://bitbucket.itg.ti.com/projects/cmcu_msp65ip/repos/f65mspcrcp */
+/* MMR revision: c7a923985b92a7b6b96f570800afdbf6fa370b4e */
+/* Generator revision: 0afd252131372f6ff2599f3ff4321e731df2364d
+   (MInT: ec7ec7482a60c6871be32db8b378ec27aa4771f6) */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* CRCP Registers
+******************************************************************************/
+#define CRCP_GPRCM_OFS                           ((uint32_t)0x00000800U)
+
+
+/** @addtogroup CRCP_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} CRCP_GPRCM_Regs;
+
+/*@}*/ /* end of group CRCP_GPRCM */
+
+/** @addtogroup CRCP
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  CRCP_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED1[507];
+  __I  uint32_t CLKSEL;                            /* !< (@ 0x00001004) Clock Select */
+       uint32_t RESERVED2[61];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Module Description */
+  __IO uint32_t CRCCTRL;                           /* !< (@ 0x00001100) CRC Control Register */
+  __O  uint32_t CRCSEED;                           /* !< (@ 0x00001104) CRC Seed Register */
+  __O  uint32_t CRCIN;                             /* !< (@ 0x00001108) CRC Input Data Register */
+  __I  uint32_t CRCOUT;                            /* !< (@ 0x0000110C) CRC Output Result Register */
+  __IO uint32_t CRCPOLY;                           /* !< (@ 0x00001110) CRC Polynomial configuration register */
+       uint32_t RESERVED3[443];
+  __O  uint32_t CRCIN_IDX[512];                    /* !< (@ 0x00001800) CRC Input Data Array Register */
+} CRCP_Regs;
+
+/*@}*/ /* end of group CRCP */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* CRCP Register Control Bits
+******************************************************************************/
+
+/* CRCP_PWREN Bits */
+/* CRCP_PWREN[ENABLE] Bits */
+#define CRCP_PWREN_ENABLE_OFS                    (0)                             /* !< ENABLE Offset */
+#define CRCP_PWREN_ENABLE_MASK                   ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define CRCP_PWREN_ENABLE_DISABLE                ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define CRCP_PWREN_ENABLE_ENABLE                 ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* CRCP_PWREN[KEY] Bits */
+#define CRCP_PWREN_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define CRCP_PWREN_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define CRCP_PWREN_KEY_UNLOCK_W                  ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* CRCP_RSTCTL Bits */
+/* CRCP_RSTCTL[RESETSTKYCLR] Bits */
+#define CRCP_RSTCTL_RESETSTKYCLR_OFS             (1)                             /* !< RESETSTKYCLR Offset */
+#define CRCP_RSTCTL_RESETSTKYCLR_MASK            ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define CRCP_RSTCTL_RESETSTKYCLR_NOP             ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define CRCP_RSTCTL_RESETSTKYCLR_CLR             ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* CRCP_RSTCTL[RESETASSERT] Bits */
+#define CRCP_RSTCTL_RESETASSERT_OFS              (0)                             /* !< RESETASSERT Offset */
+#define CRCP_RSTCTL_RESETASSERT_MASK             ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define CRCP_RSTCTL_RESETASSERT_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define CRCP_RSTCTL_RESETASSERT_ASSERT           ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* CRCP_RSTCTL[KEY] Bits */
+#define CRCP_RSTCTL_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define CRCP_RSTCTL_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define CRCP_RSTCTL_KEY_UNLOCK_W                 ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* CRCP_STAT Bits */
+/* CRCP_STAT[RESETSTKY] Bits */
+#define CRCP_STAT_RESETSTKY_OFS                  (16)                            /* !< RESETSTKY Offset */
+#define CRCP_STAT_RESETSTKY_MASK                 ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define CRCP_STAT_RESETSTKY_NORES                ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define CRCP_STAT_RESETSTKY_RESET                ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* CRCP_CLKSEL Bits */
+/* CRCP_CLKSEL[MCLK_SEL] Bits */
+#define CRCP_CLKSEL_MCLK_SEL_OFS                 (0)                             /* !< MCLK_SEL Offset */
+#define CRCP_CLKSEL_MCLK_SEL_MASK                ((uint32_t)0x00000001U)         /* !< Selects main clock (MCLK) if
+                                                                                    enabled */
+#define CRCP_CLKSEL_MCLK_SEL_DISABLE             ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define CRCP_CLKSEL_MCLK_SEL_ENABLE              ((uint32_t)0x00000001U)         /* !< Select this clock as a source */
+
+/* CRCP_DESC Bits */
+/* CRCP_DESC[MINREV] Bits */
+#define CRCP_DESC_MINREV_OFS                     (0)                             /* !< MINREV Offset */
+#define CRCP_DESC_MINREV_MASK                    ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+#define CRCP_DESC_MINREV_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define CRCP_DESC_MINREV_MAXIMUM                 ((uint32_t)0x0000000FU)         /* !< Highest possible value */
+/* CRCP_DESC[MAJREV] Bits */
+#define CRCP_DESC_MAJREV_OFS                     (4)                             /* !< MAJREV Offset */
+#define CRCP_DESC_MAJREV_MASK                    ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+#define CRCP_DESC_MAJREV_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define CRCP_DESC_MAJREV_MAXIMUM                 ((uint32_t)0x000000F0U)         /* !< Highest possible value */
+/* CRCP_DESC[INSTNUM] Bits */
+#define CRCP_DESC_INSTNUM_OFS                    (8)                             /* !< INSTNUM Offset */
+#define CRCP_DESC_INSTNUM_MASK                   ((uint32_t)0x00000F00U)         /* !< Instance Number within the device.
+                                                                                    This will be a parameter to the RTL
+                                                                                    for modules that can have multiple
+                                                                                    instances */
+#define CRCP_DESC_INSTNUM_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define CRCP_DESC_INSTNUM_MAXIMUM                ((uint32_t)0x00000F00U)         /* !< Highest possible value */
+/* CRCP_DESC[FEATUREVER] Bits */
+#define CRCP_DESC_FEATUREVER_OFS                 (12)                            /* !< FEATUREVER Offset */
+#define CRCP_DESC_FEATUREVER_MASK                ((uint32_t)0x0000F000U)         /* !< Feature Set for the module
+                                                                                    *instance* */
+#define CRCP_DESC_FEATUREVER_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define CRCP_DESC_FEATUREVER_MAXIMUM             ((uint32_t)0x0000F000U)         /* !< Highest possible value */
+/* CRCP_DESC[MODULEID] Bits */
+#define CRCP_DESC_MODULEID_OFS                   (16)                            /* !< MODULEID Offset */
+#define CRCP_DESC_MODULEID_MASK                  ((uint32_t)0xFFFF0000U)         /* !< Module identification contains a
+                                                                                    unique peripheral identification
+                                                                                    number. The assignments are
+                                                                                    maintained in a central database for
+                                                                                    all of the platform modules to ensure
+                                                                                    uniqueness. */
+#define CRCP_DESC_MODULEID_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define CRCP_DESC_MODULEID_MAXIMUM               ((uint32_t)0xFFFF0000U)         /* !< Highest possible value */
+
+/* CRCP_CRCCTRL Bits */
+/* CRCP_CRCCTRL[POLYSIZE] Bits */
+#define CRCP_CRCCTRL_POLYSIZE_OFS                (0)                             /* !< POLYSIZE Offset */
+#define CRCP_CRCCTRL_POLYSIZE_MASK               ((uint32_t)0x00000001U)         /* !< This bit indicates which CRC
+                                                                                    calculation is performed by the
+                                                                                    generator. */
+#define CRCP_CRCCTRL_POLYSIZE_CRC32              ((uint32_t)0x00000000U)         /* !< CRC-32 ISO-3309 calulation is
+                                                                                    performed */
+#define CRCP_CRCCTRL_POLYSIZE_CRC16              ((uint32_t)0x00000001U)         /* !< CRC-16 CCITT is performed */
+/* CRCP_CRCCTRL[BITREVERSE] Bits */
+#define CRCP_CRCCTRL_BITREVERSE_OFS              (1)                             /* !< BITREVERSE Offset */
+#define CRCP_CRCCTRL_BITREVERSE_MASK             ((uint32_t)0x00000002U)         /* !< CRC Bit Input and output Reverse.
+                                                                                    This bit indictes that the bit order
+                                                                                    of each input byte used for the CRC
+                                                                                    calculation is reversed before it is
+                                                                                    passed to the generator, and that the
+                                                                                    bit order of the calculated CRC is be
+                                                                                    reversed when read from CRC_RESULT. */
+#define CRCP_CRCCTRL_BITREVERSE_NOT_REVERSED     ((uint32_t)0x00000000U)         /* !< Bit order is not reversed. */
+#define CRCP_CRCCTRL_BITREVERSE_REVERSED         ((uint32_t)0x00000002U)         /* !< Bit order is reversed. */
+/* CRCP_CRCCTRL[INPUT_ENDIANNESS] Bits */
+#define CRCP_CRCCTRL_INPUT_ENDIANNESS_OFS        (2)                             /* !< INPUT_ENDIANNESS Offset */
+#define CRCP_CRCCTRL_INPUT_ENDIANNESS_MASK       ((uint32_t)0x00000004U)         /* !< CRC Endian. This bit indicates the
+                                                                                    byte order within a word or half word
+                                                                                    of input data. */
+#define CRCP_CRCCTRL_INPUT_ENDIANNESS_LITTLE_ENDIAN ((uint32_t)0x00000000U)         /* !< LSB is lowest memory address and
+                                                                                    first to be processed. */
+#define CRCP_CRCCTRL_INPUT_ENDIANNESS_BIG_ENDIAN ((uint32_t)0x00000004U)         /* !< LSB is highest memory address and
+                                                                                    last to be processed. */
+/* CRCP_CRCCTRL[OUTPUT_BYTESWAP] Bits */
+#define CRCP_CRCCTRL_OUTPUT_BYTESWAP_OFS         (4)                             /* !< OUTPUT_BYTESWAP Offset */
+#define CRCP_CRCCTRL_OUTPUT_BYTESWAP_MASK        ((uint32_t)0x00000010U)         /* !< CRC Output Byteswap Enable. This
+                                                                                    bit controls whether the output is
+                                                                                    byte-swapped upon a read of the
+                                                                                    CRCOUT register. If CRCOUT is
+                                                                                    accessed as a half-word, and the
+                                                                                    OUTPUT_BYTESWAP is set to to 1, then
+                                                                                    the two bytes in the 16-bit access
+                                                                                    are swapped and returned. B1 is
+                                                                                    returned as B0 B0 is returned as B1
+                                                                                    If CRCOUT is accessed as a word, and
+                                                                                    the OUTPUT_BYTESWAP is set to 1, then
+                                                                                    the four bytes in the 32-bit read are
+                                                                                    swapped. B3 is returned as B0 B2 is
+                                                                                    returned as B1 B1 is returned as B2
+                                                                                    B0 is returned as B3  Note that if
+                                                                                    the CRC POLYSIZE is 16-bit and a
+                                                                                    32-bit read of CRCOUT is performed
+                                                                                    with OUTPUT_BYTESWAP enabled,  then
+                                                                                    the output is: MSB                LSB
+                                                                                    0x0   0x0   B0   B1  If the CRC
+                                                                                    POLYSIZE is 16-bit and a 32-bit read
+                                                                                    of CRCOUT is performed with
+                                                                                    OUTPUT_BYTESWAP disabled,  then the
+                                                                                    output is: MSB                LSB 0x0
+                                                                                    0x0   B1   B0 */
+#define CRCP_CRCCTRL_OUTPUT_BYTESWAP_DISABLE     ((uint32_t)0x00000000U)         /* !< Output byteswapping is disabled */
+#define CRCP_CRCCTRL_OUTPUT_BYTESWAP_ENABLE      ((uint32_t)0x00000010U)         /* !< Output byteswapping is enabled. */
+
+/* CRCP_CRCSEED Bits */
+/* CRCP_CRCSEED[SEED] Bits */
+#define CRCP_CRCSEED_SEED_OFS                    (0)                             /* !< SEED Offset */
+#define CRCP_CRCSEED_SEED_MASK                   ((uint32_t)0xFFFFFFFFU)         /* !< Seed Data */
+#define CRCP_CRCSEED_SEED_MINIMUM                ((uint32_t)0x00000000U)         /* !< Mnimum value */
+#define CRCP_CRCSEED_SEED_MAXIMUM                ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value */
+
+/* CRCP_CRCIN Bits */
+/* CRCP_CRCIN[DATA] Bits */
+#define CRCP_CRCIN_DATA_OFS                      (0)                             /* !< DATA Offset */
+#define CRCP_CRCIN_DATA_MASK                     ((uint32_t)0xFFFFFFFFU)         /* !< Input Data */
+#define CRCP_CRCIN_DATA_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Mnimum value */
+#define CRCP_CRCIN_DATA_MAXIMUM                  ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value */
+
+/* CRCP_CRCOUT Bits */
+/* CRCP_CRCOUT[RESULT] Bits */
+#define CRCP_CRCOUT_RESULT_OFS                   (0)                             /* !< RESULT Offset */
+#define CRCP_CRCOUT_RESULT_MASK                  ((uint32_t)0xFFFFFFFFU)         /* !< Result */
+#define CRCP_CRCOUT_RESULT_MINIMUM               ((uint32_t)0x00000000U)         /* !< Mnimum value */
+#define CRCP_CRCOUT_RESULT_MAXIMUM               ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value */
+
+/* CRCP_CRCPOLY Bits */
+/* CRCP_CRCPOLY[DATA] Bits */
+#define CRCP_CRCPOLY_DATA_OFS                    (0)                             /* !< DATA Offset */
+#define CRCP_CRCPOLY_DATA_MASK                   ((uint32_t)0xFFFFFFFFU)         /* !< Polynomial definition */
+
+/* CRCP_CRCIN_IDX Bits */
+/* CRCP_CRCIN_IDX[DATA] Bits */
+#define CRCP_CRCIN_IDX_DATA_OFS                  (0)                             /* !< DATA Offset */
+#define CRCP_CRCIN_IDX_DATA_MASK                 ((uint32_t)0xFFFFFFFFU)         /* !< Input Data */
+#define CRCP_CRCIN_IDX_DATA_MINIMUM              ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define CRCP_CRCIN_IDX_DATA_MAXIMUM              ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_crcp__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_dac12.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_dac12.h
@@ -1,0 +1,1063 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_dac12__include
+#define ti_devices_msp_peripherals_hw_dac12__include
+
+/* Filename: hw_dac12.h */
+/* Revised: 2023-05-23 20:53:14 */
+/* Revision: ca7bbc3215c1e62bd43f32ecfdd7c7ce7f9b65b3 */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* DAC12 Registers
+******************************************************************************/
+#define DAC12_GEN_EVENT_OFS                      ((uint32_t)0x00001050U)
+#define DAC12_CPU_INT_OFS                        ((uint32_t)0x00001020U)
+#define DAC12_GPRCM_OFS                          ((uint32_t)0x00000800U)
+
+
+/** @addtogroup DAC12_GEN_EVENT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001050) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001058) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001060) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001068) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001070) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001078) Interrupt clear */
+} DAC12_GEN_EVENT_Regs;
+
+/*@}*/ /* end of group DAC12_GEN_EVENT */
+
+/** @addtogroup DAC12_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} DAC12_CPU_INT_Regs;
+
+/*@}*/ /* end of group DAC12_CPU_INT */
+
+/** @addtogroup DAC12_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} DAC12_GPRCM_Regs;
+
+/*@}*/ /* end of group DAC12_GPRCM */
+
+/** @addtogroup DAC12
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[256];
+  __IO uint32_t FSUB_0;                            /* !< (@ 0x00000400) Subscriber Port 0 */
+       uint32_t RESERVED1[16];
+  __IO uint32_t FPUB_1;                            /* !< (@ 0x00000444) Publisher port 1 */
+       uint32_t RESERVED2[238];
+  DAC12_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED3[514];
+  DAC12_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED4;
+  DAC12_GEN_EVENT_Regs  GEN_EVENT;                         /* !< (@ 0x00001050) */
+       uint32_t RESERVED5[25];
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED6[6];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Module Description */
+  __IO uint32_t CTL0;                              /* !< (@ 0x00001100) Control 0 */
+       uint32_t RESERVED7[3];
+  __IO uint32_t CTL1;                              /* !< (@ 0x00001110) Control 1 */
+       uint32_t RESERVED8[3];
+  __IO uint32_t CTL2;                              /* !< (@ 0x00001120) Control 2 */
+       uint32_t RESERVED9[3];
+  __IO uint32_t CTL3;                              /* !< (@ 0x00001130) Control 3 */
+       uint32_t RESERVED10[3];
+  __IO uint32_t CALCTL;                            /* !< (@ 0x00001140) Calibration control */
+       uint32_t RESERVED11[7];
+  __I  uint32_t CALDATA;                           /* !< (@ 0x00001160) Calibration data */
+       uint32_t RESERVED12[39];
+  __IO uint32_t DATA0;                             /* !< (@ 0x00001200) Data 0 */
+} DAC12_Regs;
+
+/*@}*/ /* end of group DAC12 */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* DAC12 Register Control Bits
+******************************************************************************/
+
+/* DAC12_GEN_EVENT_IIDX Bits */
+/* DAC12_GEN_EVENT_IIDX[STAT] Bits */
+#define DAC12_GEN_EVENT_IIDX_STAT_OFS            (0)                             /* !< STAT Offset */
+#define DAC12_GEN_EVENT_IIDX_STAT_MASK           ((uint32_t)0x0000000FU)         /* !< Interrupt index status */
+#define DAC12_GEN_EVENT_IIDX_STAT_NO_INTR        ((uint32_t)0x00000000U)         /* !< No pending interrupt */
+#define DAC12_GEN_EVENT_IIDX_STAT_MODRDYIFG      ((uint32_t)0x00000002U)         /* !< Module ready interrupt */
+#define DAC12_GEN_EVENT_IIDX_STAT_FIFOFULLIFG    ((uint32_t)0x00000009U)         /* !< FIFO full interrupt */
+#define DAC12_GEN_EVENT_IIDX_STAT_FIFO1B4IFG     ((uint32_t)0x0000000AU)         /* !< FIFO one fourth empty interrupt */
+#define DAC12_GEN_EVENT_IIDX_STAT_FIFO1B2IFG     ((uint32_t)0x0000000BU)         /* !< FIFO half empty interrupt */
+#define DAC12_GEN_EVENT_IIDX_STAT_FIFO3B4IFG     ((uint32_t)0x0000000CU)         /* !< FIFO three fourth empty interrupt */
+#define DAC12_GEN_EVENT_IIDX_STAT_FIFOEMPTYIFG   ((uint32_t)0x0000000DU)         /* !< FIFO empty interrupt */
+#define DAC12_GEN_EVENT_IIDX_STAT_FIFOURUNIFG    ((uint32_t)0x0000000EU)         /* !< FIFO underrun interrupt */
+#define DAC12_GEN_EVENT_IIDX_STAT_DMADONEIFG     ((uint32_t)0x0000000FU)         /* !< DMA done interrupt */
+
+/* DAC12_GEN_EVENT_IMASK Bits */
+/* DAC12_GEN_EVENT_IMASK[MODRDYIFG] Bits */
+#define DAC12_GEN_EVENT_IMASK_MODRDYIFG_OFS      (1)                             /* !< MODRDYIFG Offset */
+#define DAC12_GEN_EVENT_IMASK_MODRDYIFG_MASK     ((uint32_t)0x00000002U)         /* !< Masks MODRDYIFG */
+#define DAC12_GEN_EVENT_IMASK_MODRDYIFG_CLR      ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_GEN_EVENT_IMASK_MODRDYIFG_SET      ((uint32_t)0x00000002U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_GEN_EVENT_IMASK[FIFO1B2IFG] Bits */
+#define DAC12_GEN_EVENT_IMASK_FIFO1B2IFG_OFS     (10)                            /* !< FIFO1B2IFG Offset */
+#define DAC12_GEN_EVENT_IMASK_FIFO1B2IFG_MASK    ((uint32_t)0x00000400U)         /* !< Masks FIFO1B2IFG */
+#define DAC12_GEN_EVENT_IMASK_FIFO1B2IFG_CLR     ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_GEN_EVENT_IMASK_FIFO1B2IFG_SET     ((uint32_t)0x00000400U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_GEN_EVENT_IMASK[FIFOEMPTYIFG] Bits */
+#define DAC12_GEN_EVENT_IMASK_FIFOEMPTYIFG_OFS   (12)                            /* !< FIFOEMPTYIFG Offset */
+#define DAC12_GEN_EVENT_IMASK_FIFOEMPTYIFG_MASK  ((uint32_t)0x00001000U)         /* !< Masks FIFOEMPTYIFG */
+#define DAC12_GEN_EVENT_IMASK_FIFOEMPTYIFG_CLR   ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_GEN_EVENT_IMASK_FIFOEMPTYIFG_SET   ((uint32_t)0x00001000U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_GEN_EVENT_IMASK[FIFO1B4IFG] Bits */
+#define DAC12_GEN_EVENT_IMASK_FIFO1B4IFG_OFS     (9)                             /* !< FIFO1B4IFG Offset */
+#define DAC12_GEN_EVENT_IMASK_FIFO1B4IFG_MASK    ((uint32_t)0x00000200U)         /* !< Masks FIFO1B4IFG */
+#define DAC12_GEN_EVENT_IMASK_FIFO1B4IFG_CLR     ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_GEN_EVENT_IMASK_FIFO1B4IFG_SET     ((uint32_t)0x00000200U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_GEN_EVENT_IMASK[FIFO3B4IFG] Bits */
+#define DAC12_GEN_EVENT_IMASK_FIFO3B4IFG_OFS     (11)                            /* !< FIFO3B4IFG Offset */
+#define DAC12_GEN_EVENT_IMASK_FIFO3B4IFG_MASK    ((uint32_t)0x00000800U)         /* !< Masks FIFO3B4IFG */
+#define DAC12_GEN_EVENT_IMASK_FIFO3B4IFG_CLR     ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_GEN_EVENT_IMASK_FIFO3B4IFG_SET     ((uint32_t)0x00000800U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_GEN_EVENT_IMASK[FIFOFULLIFG] Bits */
+#define DAC12_GEN_EVENT_IMASK_FIFOFULLIFG_OFS    (8)                             /* !< FIFOFULLIFG Offset */
+#define DAC12_GEN_EVENT_IMASK_FIFOFULLIFG_MASK   ((uint32_t)0x00000100U)         /* !< Masks FIFOFULLIFG */
+#define DAC12_GEN_EVENT_IMASK_FIFOFULLIFG_CLR    ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_GEN_EVENT_IMASK_FIFOFULLIFG_SET    ((uint32_t)0x00000100U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_GEN_EVENT_IMASK[FIFOURUNIFG] Bits */
+#define DAC12_GEN_EVENT_IMASK_FIFOURUNIFG_OFS    (13)                            /* !< FIFOURUNIFG Offset */
+#define DAC12_GEN_EVENT_IMASK_FIFOURUNIFG_MASK   ((uint32_t)0x00002000U)         /* !< Masks FIFOURUNIFG */
+#define DAC12_GEN_EVENT_IMASK_FIFOURUNIFG_CLR    ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_GEN_EVENT_IMASK_FIFOURUNIFG_SET    ((uint32_t)0x00002000U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_GEN_EVENT_IMASK[DMADONEIFG] Bits */
+#define DAC12_GEN_EVENT_IMASK_DMADONEIFG_OFS     (14)                            /* !< DMADONEIFG Offset */
+#define DAC12_GEN_EVENT_IMASK_DMADONEIFG_MASK    ((uint32_t)0x00004000U)         /* !< Masks DMADONEIFG */
+#define DAC12_GEN_EVENT_IMASK_DMADONEIFG_CLR     ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_GEN_EVENT_IMASK_DMADONEIFG_SET     ((uint32_t)0x00004000U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+
+/* DAC12_GEN_EVENT_RIS Bits */
+/* DAC12_GEN_EVENT_RIS[MODRDYIFG] Bits */
+#define DAC12_GEN_EVENT_RIS_MODRDYIFG_OFS        (1)                             /* !< MODRDYIFG Offset */
+#define DAC12_GEN_EVENT_RIS_MODRDYIFG_MASK       ((uint32_t)0x00000002U)         /* !< Raw interrupt status for MODRDYIFG */
+#define DAC12_GEN_EVENT_RIS_MODRDYIFG_CLR        ((uint32_t)0x00000000U)         /* !< DAC module ready event did not
+                                                                                    occur */
+#define DAC12_GEN_EVENT_RIS_MODRDYIFG_SET        ((uint32_t)0x00000002U)         /* !< DAC module ready event occurred */
+/* DAC12_GEN_EVENT_RIS[FIFOEMPTYIFG] Bits */
+#define DAC12_GEN_EVENT_RIS_FIFOEMPTYIFG_OFS     (12)                            /* !< FIFOEMPTYIFG Offset */
+#define DAC12_GEN_EVENT_RIS_FIFOEMPTYIFG_MASK    ((uint32_t)0x00001000U)         /* !< Raw interrupt status for
+                                                                                    FIFOEMPTYIFG */
+#define DAC12_GEN_EVENT_RIS_FIFOEMPTYIFG_CLR     ((uint32_t)0x00000000U)         /* !< FIFO empty condition did not occur */
+#define DAC12_GEN_EVENT_RIS_FIFOEMPTYIFG_SET     ((uint32_t)0x00001000U)         /* !< FIFO empty condition occurred */
+/* DAC12_GEN_EVENT_RIS[FIFO1B4IFG] Bits */
+#define DAC12_GEN_EVENT_RIS_FIFO1B4IFG_OFS       (9)                             /* !< FIFO1B4IFG Offset */
+#define DAC12_GEN_EVENT_RIS_FIFO1B4IFG_MASK      ((uint32_t)0x00000200U)         /* !< Raw interrupt status for FIFO1B4IFG */
+#define DAC12_GEN_EVENT_RIS_FIFO1B4IFG_CLR       ((uint32_t)0x00000000U)         /* !< FIFO one fourth empty condition did
+                                                                                    not occur */
+#define DAC12_GEN_EVENT_RIS_FIFO1B4IFG_SET       ((uint32_t)0x00000200U)         /* !< FIFO one fourth empty condition
+                                                                                    occurred */
+/* DAC12_GEN_EVENT_RIS[FIFO1B2IFG] Bits */
+#define DAC12_GEN_EVENT_RIS_FIFO1B2IFG_OFS       (10)                            /* !< FIFO1B2IFG Offset */
+#define DAC12_GEN_EVENT_RIS_FIFO1B2IFG_MASK      ((uint32_t)0x00000400U)         /* !< Raw interrupt status for FIFO1B2IFG */
+#define DAC12_GEN_EVENT_RIS_FIFO1B2IFG_CLR       ((uint32_t)0x00000000U)         /* !< FIFO half empty condition did not
+                                                                                    occur */
+#define DAC12_GEN_EVENT_RIS_FIFO1B2IFG_SET       ((uint32_t)0x00000400U)         /* !< FIFO half empty condition occurred */
+/* DAC12_GEN_EVENT_RIS[FIFO3B4IFG] Bits */
+#define DAC12_GEN_EVENT_RIS_FIFO3B4IFG_OFS       (11)                            /* !< FIFO3B4IFG Offset */
+#define DAC12_GEN_EVENT_RIS_FIFO3B4IFG_MASK      ((uint32_t)0x00000800U)         /* !< Raw interrupt status for FIFO3B4IFG */
+#define DAC12_GEN_EVENT_RIS_FIFO3B4IFG_CLR       ((uint32_t)0x00000000U)         /* !< FIFO three fourth empty condition
+                                                                                    did not occur */
+#define DAC12_GEN_EVENT_RIS_FIFO3B4IFG_SET       ((uint32_t)0x00000800U)         /* !< FIFO three fourth empty condition
+                                                                                    occurred */
+/* DAC12_GEN_EVENT_RIS[FIFOFULLIFG] Bits */
+#define DAC12_GEN_EVENT_RIS_FIFOFULLIFG_OFS      (8)                             /* !< FIFOFULLIFG Offset */
+#define DAC12_GEN_EVENT_RIS_FIFOFULLIFG_MASK     ((uint32_t)0x00000100U)         /* !< Raw interrupt status for
+                                                                                    FIFOFULLIFG */
+#define DAC12_GEN_EVENT_RIS_FIFOFULLIFG_CLR      ((uint32_t)0x00000000U)         /* !< FIFO full condition did not occur */
+#define DAC12_GEN_EVENT_RIS_FIFOFULLIFG_SET      ((uint32_t)0x00000100U)         /* !< FIFO full condition occurred */
+/* DAC12_GEN_EVENT_RIS[FIFOURUNIFG] Bits */
+#define DAC12_GEN_EVENT_RIS_FIFOURUNIFG_OFS      (13)                            /* !< FIFOURUNIFG Offset */
+#define DAC12_GEN_EVENT_RIS_FIFOURUNIFG_MASK     ((uint32_t)0x00002000U)         /* !< Raw interrupt status for
+                                                                                    FIFOURUNIFG */
+#define DAC12_GEN_EVENT_RIS_FIFOURUNIFG_CLR      ((uint32_t)0x00000000U)         /* !< FIFO underrun condition did not
+                                                                                    occur */
+#define DAC12_GEN_EVENT_RIS_FIFOURUNIFG_SET      ((uint32_t)0x00002000U)         /* !< FIFO underrun condition occurred */
+/* DAC12_GEN_EVENT_RIS[DMADONEIFG] Bits */
+#define DAC12_GEN_EVENT_RIS_DMADONEIFG_OFS       (14)                            /* !< DMADONEIFG Offset */
+#define DAC12_GEN_EVENT_RIS_DMADONEIFG_MASK      ((uint32_t)0x00004000U)         /* !< Raw interrupt status for DMADONEIFG */
+#define DAC12_GEN_EVENT_RIS_DMADONEIFG_CLR       ((uint32_t)0x00000000U)         /* !< DMA done condition did not occur */
+#define DAC12_GEN_EVENT_RIS_DMADONEIFG_SET       ((uint32_t)0x00004000U)         /* !< DMA done condition occurred */
+
+/* DAC12_GEN_EVENT_MIS Bits */
+/* DAC12_GEN_EVENT_MIS[MODRDYIFG] Bits */
+#define DAC12_GEN_EVENT_MIS_MODRDYIFG_OFS        (1)                             /* !< MODRDYIFG Offset */
+#define DAC12_GEN_EVENT_MIS_MODRDYIFG_MASK       ((uint32_t)0x00000002U)         /* !< Masked interrupt status for
+                                                                                    MODRDYIFG */
+#define DAC12_GEN_EVENT_MIS_MODRDYIFG_CLR        ((uint32_t)0x00000000U)         /* !< MODRDYIFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_GEN_EVENT_MIS_MODRDYIFG_SET        ((uint32_t)0x00000002U)         /* !< MODRDYIFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_GEN_EVENT_MIS[FIFOEMPTYIFG] Bits */
+#define DAC12_GEN_EVENT_MIS_FIFOEMPTYIFG_OFS     (12)                            /* !< FIFOEMPTYIFG Offset */
+#define DAC12_GEN_EVENT_MIS_FIFOEMPTYIFG_MASK    ((uint32_t)0x00001000U)         /* !< Masked interrupt status for
+                                                                                    FIFOEMPTYIFG */
+#define DAC12_GEN_EVENT_MIS_FIFOEMPTYIFG_CLR     ((uint32_t)0x00000000U)         /* !< FIFOEMPTYIFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_GEN_EVENT_MIS_FIFOEMPTYIFG_SET     ((uint32_t)0x00001000U)         /* !< FIFOEMPTYIFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_GEN_EVENT_MIS[FIFO1B4IFG] Bits */
+#define DAC12_GEN_EVENT_MIS_FIFO1B4IFG_OFS       (9)                             /* !< FIFO1B4IFG Offset */
+#define DAC12_GEN_EVENT_MIS_FIFO1B4IFG_MASK      ((uint32_t)0x00000200U)         /* !< Masked interrupt status for
+                                                                                    FIFO1B4IFG */
+#define DAC12_GEN_EVENT_MIS_FIFO1B4IFG_CLR       ((uint32_t)0x00000000U)         /* !< FIFO1B4IFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_GEN_EVENT_MIS_FIFO1B4IFG_SET       ((uint32_t)0x00000200U)         /* !< FIFO1B4IFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_GEN_EVENT_MIS[FIFO1B2IFG] Bits */
+#define DAC12_GEN_EVENT_MIS_FIFO1B2IFG_OFS       (10)                            /* !< FIFO1B2IFG Offset */
+#define DAC12_GEN_EVENT_MIS_FIFO1B2IFG_MASK      ((uint32_t)0x00000400U)         /* !< Masked interrupt status for
+                                                                                    FIFO1B2IFG */
+#define DAC12_GEN_EVENT_MIS_FIFO1B2IFG_CLR       ((uint32_t)0x00000000U)         /* !< FIFO1B2IFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_GEN_EVENT_MIS_FIFO1B2IFG_SET       ((uint32_t)0x00000400U)         /* !< FIFO1B2IFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_GEN_EVENT_MIS[FIFO3B4IFG] Bits */
+#define DAC12_GEN_EVENT_MIS_FIFO3B4IFG_OFS       (11)                            /* !< FIFO3B4IFG Offset */
+#define DAC12_GEN_EVENT_MIS_FIFO3B4IFG_MASK      ((uint32_t)0x00000800U)         /* !< Masked interrupt status for
+                                                                                    FIFO3B4IFG */
+#define DAC12_GEN_EVENT_MIS_FIFO3B4IFG_CLR       ((uint32_t)0x00000000U)         /* !< FIFO3B4IFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_GEN_EVENT_MIS_FIFO3B4IFG_SET       ((uint32_t)0x00000800U)         /* !< FIFO3B4IFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_GEN_EVENT_MIS[FIFOFULLIFG] Bits */
+#define DAC12_GEN_EVENT_MIS_FIFOFULLIFG_OFS      (8)                             /* !< FIFOFULLIFG Offset */
+#define DAC12_GEN_EVENT_MIS_FIFOFULLIFG_MASK     ((uint32_t)0x00000100U)         /* !< Masked interrupt status for
+                                                                                    FIFOFULLIFG */
+#define DAC12_GEN_EVENT_MIS_FIFOFULLIFG_CLR      ((uint32_t)0x00000000U)         /* !< FIFOFULLIFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_GEN_EVENT_MIS_FIFOFULLIFG_SET      ((uint32_t)0x00000100U)         /* !< FIFOFULLIFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_GEN_EVENT_MIS[FIFOURUNIFG] Bits */
+#define DAC12_GEN_EVENT_MIS_FIFOURUNIFG_OFS      (13)                            /* !< FIFOURUNIFG Offset */
+#define DAC12_GEN_EVENT_MIS_FIFOURUNIFG_MASK     ((uint32_t)0x00002000U)         /* !< Masked interrupt status for
+                                                                                    FIFOURUNIFG */
+#define DAC12_GEN_EVENT_MIS_FIFOURUNIFG_CLR      ((uint32_t)0x00000000U)         /* !< FIFOURUNIFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_GEN_EVENT_MIS_FIFOURUNIFG_SET      ((uint32_t)0x00002000U)         /* !< FIFOURUNIFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_GEN_EVENT_MIS[DMADONEIFG] Bits */
+#define DAC12_GEN_EVENT_MIS_DMADONEIFG_OFS       (14)                            /* !< DMADONEIFG Offset */
+#define DAC12_GEN_EVENT_MIS_DMADONEIFG_MASK      ((uint32_t)0x00004000U)         /* !< Masked interrupt status for
+                                                                                    DMADONEIFG */
+#define DAC12_GEN_EVENT_MIS_DMADONEIFG_CLR       ((uint32_t)0x00000000U)         /* !< DMADONEIFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_GEN_EVENT_MIS_DMADONEIFG_SET       ((uint32_t)0x00004000U)         /* !< DMADONEIFG requests an interrupt
+                                                                                    service routine */
+
+/* DAC12_GEN_EVENT_ISET Bits */
+/* DAC12_GEN_EVENT_ISET[MODRDYIFG] Bits */
+#define DAC12_GEN_EVENT_ISET_MODRDYIFG_OFS       (1)                             /* !< MODRDYIFG Offset */
+#define DAC12_GEN_EVENT_ISET_MODRDYIFG_MASK      ((uint32_t)0x00000002U)         /* !< Sets MODRDYIFG in RIS register */
+#define DAC12_GEN_EVENT_ISET_MODRDYIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ISET_MODRDYIFG_SET       ((uint32_t)0x00000002U)         /* !< RIS bit corresponding to MODRDYIFG
+                                                                                    is set */
+/* DAC12_GEN_EVENT_ISET[FIFOEMPTYIFG] Bits */
+#define DAC12_GEN_EVENT_ISET_FIFOEMPTYIFG_OFS    (12)                            /* !< FIFOEMPTYIFG Offset */
+#define DAC12_GEN_EVENT_ISET_FIFOEMPTYIFG_MASK   ((uint32_t)0x00001000U)         /* !< Sets FIFOEMPTYIFG in RIS register */
+#define DAC12_GEN_EVENT_ISET_FIFOEMPTYIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ISET_FIFOEMPTYIFG_SET    ((uint32_t)0x00001000U)         /* !< RIS bit corresponding to
+                                                                                    FIFOEMPTYIFG is set */
+/* DAC12_GEN_EVENT_ISET[FIFO1B4IFG] Bits */
+#define DAC12_GEN_EVENT_ISET_FIFO1B4IFG_OFS      (9)                             /* !< FIFO1B4IFG Offset */
+#define DAC12_GEN_EVENT_ISET_FIFO1B4IFG_MASK     ((uint32_t)0x00000200U)         /* !< Sets FIFO1B4IFG in RIS register */
+#define DAC12_GEN_EVENT_ISET_FIFO1B4IFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ISET_FIFO1B4IFG_SET      ((uint32_t)0x00000200U)         /* !< RIS bit corresponding to FIFO1B4IFG
+                                                                                    is set */
+/* DAC12_GEN_EVENT_ISET[FIFO1B2IFG] Bits */
+#define DAC12_GEN_EVENT_ISET_FIFO1B2IFG_OFS      (10)                            /* !< FIFO1B2IFG Offset */
+#define DAC12_GEN_EVENT_ISET_FIFO1B2IFG_MASK     ((uint32_t)0x00000400U)         /* !< Sets FIFO1B2IFG in RIS register */
+#define DAC12_GEN_EVENT_ISET_FIFO1B2IFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ISET_FIFO1B2IFG_SET      ((uint32_t)0x00000400U)         /* !< RIS bit corresponding to FIFO1B2IFG
+                                                                                    is set */
+/* DAC12_GEN_EVENT_ISET[FIFO3B4IFG] Bits */
+#define DAC12_GEN_EVENT_ISET_FIFO3B4IFG_OFS      (11)                            /* !< FIFO3B4IFG Offset */
+#define DAC12_GEN_EVENT_ISET_FIFO3B4IFG_MASK     ((uint32_t)0x00000800U)         /* !< Sets FIFO3B4IFG in RIS register */
+#define DAC12_GEN_EVENT_ISET_FIFO3B4IFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ISET_FIFO3B4IFG_SET      ((uint32_t)0x00000800U)         /* !< RIS bit corresponding to FIFO3B4IFG
+                                                                                    is set */
+/* DAC12_GEN_EVENT_ISET[FIFOFULLIFG] Bits */
+#define DAC12_GEN_EVENT_ISET_FIFOFULLIFG_OFS     (8)                             /* !< FIFOFULLIFG Offset */
+#define DAC12_GEN_EVENT_ISET_FIFOFULLIFG_MASK    ((uint32_t)0x00000100U)         /* !< Sets FIFOFULLIFG in RIS register */
+#define DAC12_GEN_EVENT_ISET_FIFOFULLIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ISET_FIFOFULLIFG_SET     ((uint32_t)0x00000100U)         /* !< RIS bit corresponding to
+                                                                                    FIFOFULLIFG is set */
+/* DAC12_GEN_EVENT_ISET[FIFOURUNIFG] Bits */
+#define DAC12_GEN_EVENT_ISET_FIFOURUNIFG_OFS     (13)                            /* !< FIFOURUNIFG Offset */
+#define DAC12_GEN_EVENT_ISET_FIFOURUNIFG_MASK    ((uint32_t)0x00002000U)         /* !< Sets FIFOURUNIFG in RIS register */
+#define DAC12_GEN_EVENT_ISET_FIFOURUNIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ISET_FIFOURUNIFG_SET     ((uint32_t)0x00002000U)         /* !< RIS bit corresponding to
+                                                                                    FIFOURUNIFG is set */
+/* DAC12_GEN_EVENT_ISET[DMADONEIFG] Bits */
+#define DAC12_GEN_EVENT_ISET_DMADONEIFG_OFS      (14)                            /* !< DMADONEIFG Offset */
+#define DAC12_GEN_EVENT_ISET_DMADONEIFG_MASK     ((uint32_t)0x00004000U)         /* !< Sets DMADONEIFG in RIS register */
+#define DAC12_GEN_EVENT_ISET_DMADONEIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ISET_DMADONEIFG_SET      ((uint32_t)0x00004000U)         /* !< RIS bit corresponding to DMADONEIFG
+                                                                                    is set */
+
+/* DAC12_GEN_EVENT_ICLR Bits */
+/* DAC12_GEN_EVENT_ICLR[MODRDYIFG] Bits */
+#define DAC12_GEN_EVENT_ICLR_MODRDYIFG_OFS       (1)                             /* !< MODRDYIFG Offset */
+#define DAC12_GEN_EVENT_ICLR_MODRDYIFG_MASK      ((uint32_t)0x00000002U)         /* !< Clears MODRDYIFG in RIS register */
+#define DAC12_GEN_EVENT_ICLR_MODRDYIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ICLR_MODRDYIFG_CLR       ((uint32_t)0x00000002U)         /* !< RIS bit corresponding to MODRDYIFG
+                                                                                    is cleared */
+/* DAC12_GEN_EVENT_ICLR[FIFOEMPTYIFG] Bits */
+#define DAC12_GEN_EVENT_ICLR_FIFOEMPTYIFG_OFS    (12)                            /* !< FIFOEMPTYIFG Offset */
+#define DAC12_GEN_EVENT_ICLR_FIFOEMPTYIFG_MASK   ((uint32_t)0x00001000U)         /* !< Clears FIFOEMPTYIFG in RIS register */
+#define DAC12_GEN_EVENT_ICLR_FIFOEMPTYIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ICLR_FIFOEMPTYIFG_CLR    ((uint32_t)0x00001000U)         /* !< RIS bit corresponding to
+                                                                                    FIFOEMPTYIFG is cleared */
+/* DAC12_GEN_EVENT_ICLR[FIFO1B4IFG] Bits */
+#define DAC12_GEN_EVENT_ICLR_FIFO1B4IFG_OFS      (9)                             /* !< FIFO1B4IFG Offset */
+#define DAC12_GEN_EVENT_ICLR_FIFO1B4IFG_MASK     ((uint32_t)0x00000200U)         /* !< Clears FIFO1B4IFG in RIS register */
+#define DAC12_GEN_EVENT_ICLR_FIFO1B4IFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ICLR_FIFO1B4IFG_CLR      ((uint32_t)0x00000200U)         /* !< RIS bit corresponding to FIFO1B4IFG
+                                                                                    is cleared */
+/* DAC12_GEN_EVENT_ICLR[FIFO1B2IFG] Bits */
+#define DAC12_GEN_EVENT_ICLR_FIFO1B2IFG_OFS      (10)                            /* !< FIFO1B2IFG Offset */
+#define DAC12_GEN_EVENT_ICLR_FIFO1B2IFG_MASK     ((uint32_t)0x00000400U)         /* !< Clears FIFO1B2IFG in RIS register */
+#define DAC12_GEN_EVENT_ICLR_FIFO1B2IFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ICLR_FIFO1B2IFG_CLR      ((uint32_t)0x00000400U)         /* !< RIS bit corresponding to FIFO1B2IFG
+                                                                                    is cleared */
+/* DAC12_GEN_EVENT_ICLR[FIFO3B4IFG] Bits */
+#define DAC12_GEN_EVENT_ICLR_FIFO3B4IFG_OFS      (11)                            /* !< FIFO3B4IFG Offset */
+#define DAC12_GEN_EVENT_ICLR_FIFO3B4IFG_MASK     ((uint32_t)0x00000800U)         /* !< Clears FIFO3B4IFG in RIS register */
+#define DAC12_GEN_EVENT_ICLR_FIFO3B4IFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ICLR_FIFO3B4IFG_CLR      ((uint32_t)0x00000800U)         /* !< RIS bit corresponding to FIFO3B4IFG
+                                                                                    is cleared */
+/* DAC12_GEN_EVENT_ICLR[FIFOFULLIFG] Bits */
+#define DAC12_GEN_EVENT_ICLR_FIFOFULLIFG_OFS     (8)                             /* !< FIFOFULLIFG Offset */
+#define DAC12_GEN_EVENT_ICLR_FIFOFULLIFG_MASK    ((uint32_t)0x00000100U)         /* !< Clears FIFOFULLIFG in RIS register */
+#define DAC12_GEN_EVENT_ICLR_FIFOFULLIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ICLR_FIFOFULLIFG_CLR     ((uint32_t)0x00000100U)         /* !< RIS bit corresponding to
+                                                                                    FIFOFULLIFG is cleared */
+/* DAC12_GEN_EVENT_ICLR[FIFOURUNIFG] Bits */
+#define DAC12_GEN_EVENT_ICLR_FIFOURUNIFG_OFS     (13)                            /* !< FIFOURUNIFG Offset */
+#define DAC12_GEN_EVENT_ICLR_FIFOURUNIFG_MASK    ((uint32_t)0x00002000U)         /* !< Clears FIFOURUNIFG in RIS register */
+#define DAC12_GEN_EVENT_ICLR_FIFOURUNIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ICLR_FIFOURUNIFG_CLR     ((uint32_t)0x00002000U)         /* !< RIS bit corresponding to
+                                                                                    FIFOURUNIFG is cleared */
+/* DAC12_GEN_EVENT_ICLR[DMADONEIFG] Bits */
+#define DAC12_GEN_EVENT_ICLR_DMADONEIFG_OFS      (14)                            /* !< DMADONEIFG Offset */
+#define DAC12_GEN_EVENT_ICLR_DMADONEIFG_MASK     ((uint32_t)0x00004000U)         /* !< Clears DMADONEIFG in RIS register */
+#define DAC12_GEN_EVENT_ICLR_DMADONEIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_GEN_EVENT_ICLR_DMADONEIFG_CLR      ((uint32_t)0x00004000U)         /* !< RIS bit corresponding to DMADONEIFG
+                                                                                    is cleared */
+
+/* DAC12_CPU_INT_IIDX Bits */
+/* DAC12_CPU_INT_IIDX[STAT] Bits */
+#define DAC12_CPU_INT_IIDX_STAT_OFS              (0)                             /* !< STAT Offset */
+#define DAC12_CPU_INT_IIDX_STAT_MASK             ((uint32_t)0x0000000FU)         /* !< Interrupt index status */
+#define DAC12_CPU_INT_IIDX_STAT_NO_INTR          ((uint32_t)0x00000000U)         /* !< No pending interrupt */
+#define DAC12_CPU_INT_IIDX_STAT_MODRDYIFG        ((uint32_t)0x00000002U)         /* !< Module ready interrupt */
+#define DAC12_CPU_INT_IIDX_STAT_FIFOFULLIFG      ((uint32_t)0x00000009U)         /* !< FIFO full interrupt */
+#define DAC12_CPU_INT_IIDX_STAT_FIFO1B4IFG       ((uint32_t)0x0000000AU)         /* !< FIFO one fourth empty interrupt */
+#define DAC12_CPU_INT_IIDX_STAT_FIFO1B2IFG       ((uint32_t)0x0000000BU)         /* !< FIFO half empty interrupt */
+#define DAC12_CPU_INT_IIDX_STAT_FIFO3B4IFG       ((uint32_t)0x0000000CU)         /* !< FIFO three fourth empty interrupt */
+#define DAC12_CPU_INT_IIDX_STAT_FIFOEMPTYIFG     ((uint32_t)0x0000000DU)         /* !< FIFO empty interrupt */
+#define DAC12_CPU_INT_IIDX_STAT_FIFOURUNIFG      ((uint32_t)0x0000000EU)         /* !< FIFO underrun interrupt */
+#define DAC12_CPU_INT_IIDX_STAT_DMADONEIFG       ((uint32_t)0x0000000FU)         /* !< DMA done interrupt */
+
+/* DAC12_CPU_INT_IMASK Bits */
+/* DAC12_CPU_INT_IMASK[MODRDYIFG] Bits */
+#define DAC12_CPU_INT_IMASK_MODRDYIFG_OFS        (1)                             /* !< MODRDYIFG Offset */
+#define DAC12_CPU_INT_IMASK_MODRDYIFG_MASK       ((uint32_t)0x00000002U)         /* !< Masks MODRDYIFG */
+#define DAC12_CPU_INT_IMASK_MODRDYIFG_CLR        ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_CPU_INT_IMASK_MODRDYIFG_SET        ((uint32_t)0x00000002U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_CPU_INT_IMASK[FIFO1B2IFG] Bits */
+#define DAC12_CPU_INT_IMASK_FIFO1B2IFG_OFS       (10)                            /* !< FIFO1B2IFG Offset */
+#define DAC12_CPU_INT_IMASK_FIFO1B2IFG_MASK      ((uint32_t)0x00000400U)         /* !< Masks FIFO1B2IFG */
+#define DAC12_CPU_INT_IMASK_FIFO1B2IFG_CLR       ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_CPU_INT_IMASK_FIFO1B2IFG_SET       ((uint32_t)0x00000400U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_CPU_INT_IMASK[FIFOEMPTYIFG] Bits */
+#define DAC12_CPU_INT_IMASK_FIFOEMPTYIFG_OFS     (12)                            /* !< FIFOEMPTYIFG Offset */
+#define DAC12_CPU_INT_IMASK_FIFOEMPTYIFG_MASK    ((uint32_t)0x00001000U)         /* !< Masks FIFOEMPTYIFG */
+#define DAC12_CPU_INT_IMASK_FIFOEMPTYIFG_CLR     ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_CPU_INT_IMASK_FIFOEMPTYIFG_SET     ((uint32_t)0x00001000U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_CPU_INT_IMASK[FIFO1B4IFG] Bits */
+#define DAC12_CPU_INT_IMASK_FIFO1B4IFG_OFS       (9)                             /* !< FIFO1B4IFG Offset */
+#define DAC12_CPU_INT_IMASK_FIFO1B4IFG_MASK      ((uint32_t)0x00000200U)         /* !< Masks FIFO1B4IFG */
+#define DAC12_CPU_INT_IMASK_FIFO1B4IFG_CLR       ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_CPU_INT_IMASK_FIFO1B4IFG_SET       ((uint32_t)0x00000200U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_CPU_INT_IMASK[FIFO3B4IFG] Bits */
+#define DAC12_CPU_INT_IMASK_FIFO3B4IFG_OFS       (11)                            /* !< FIFO3B4IFG Offset */
+#define DAC12_CPU_INT_IMASK_FIFO3B4IFG_MASK      ((uint32_t)0x00000800U)         /* !< Masks FIFO3B4IFG */
+#define DAC12_CPU_INT_IMASK_FIFO3B4IFG_CLR       ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_CPU_INT_IMASK_FIFO3B4IFG_SET       ((uint32_t)0x00000800U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_CPU_INT_IMASK[FIFOFULLIFG] Bits */
+#define DAC12_CPU_INT_IMASK_FIFOFULLIFG_OFS      (8)                             /* !< FIFOFULLIFG Offset */
+#define DAC12_CPU_INT_IMASK_FIFOFULLIFG_MASK     ((uint32_t)0x00000100U)         /* !< Masks FIFOFULLIFG */
+#define DAC12_CPU_INT_IMASK_FIFOFULLIFG_CLR      ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_CPU_INT_IMASK_FIFOFULLIFG_SET      ((uint32_t)0x00000100U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_CPU_INT_IMASK[FIFOURUNIFG] Bits */
+#define DAC12_CPU_INT_IMASK_FIFOURUNIFG_OFS      (13)                            /* !< FIFOURUNIFG Offset */
+#define DAC12_CPU_INT_IMASK_FIFOURUNIFG_MASK     ((uint32_t)0x00002000U)         /* !< Masks FIFOURUNIFG */
+#define DAC12_CPU_INT_IMASK_FIFOURUNIFG_CLR      ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_CPU_INT_IMASK_FIFOURUNIFG_SET      ((uint32_t)0x00002000U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DAC12_CPU_INT_IMASK[DMADONEIFG] Bits */
+#define DAC12_CPU_INT_IMASK_DMADONEIFG_OFS       (14)                            /* !< DMADONEIFG Offset */
+#define DAC12_CPU_INT_IMASK_DMADONEIFG_MASK      ((uint32_t)0x00004000U)         /* !< Masks DMADONEIFG */
+#define DAC12_CPU_INT_IMASK_DMADONEIFG_CLR       ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DAC12_CPU_INT_IMASK_DMADONEIFG_SET       ((uint32_t)0x00004000U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+
+/* DAC12_CPU_INT_RIS Bits */
+/* DAC12_CPU_INT_RIS[MODRDYIFG] Bits */
+#define DAC12_CPU_INT_RIS_MODRDYIFG_OFS          (1)                             /* !< MODRDYIFG Offset */
+#define DAC12_CPU_INT_RIS_MODRDYIFG_MASK         ((uint32_t)0x00000002U)         /* !< Raw interrupt status for MODRDYIFG */
+#define DAC12_CPU_INT_RIS_MODRDYIFG_CLR          ((uint32_t)0x00000000U)         /* !< DAC module ready event did not
+                                                                                    occur */
+#define DAC12_CPU_INT_RIS_MODRDYIFG_SET          ((uint32_t)0x00000002U)         /* !< DAC module ready event occurred */
+/* DAC12_CPU_INT_RIS[FIFOEMPTYIFG] Bits */
+#define DAC12_CPU_INT_RIS_FIFOEMPTYIFG_OFS       (12)                            /* !< FIFOEMPTYIFG Offset */
+#define DAC12_CPU_INT_RIS_FIFOEMPTYIFG_MASK      ((uint32_t)0x00001000U)         /* !< Raw interrupt status for
+                                                                                    FIFOEMPTYIFG */
+#define DAC12_CPU_INT_RIS_FIFOEMPTYIFG_CLR       ((uint32_t)0x00000000U)         /* !< FIFO empty condition did not occur */
+#define DAC12_CPU_INT_RIS_FIFOEMPTYIFG_SET       ((uint32_t)0x00001000U)         /* !< FIFO empty condition occurred */
+/* DAC12_CPU_INT_RIS[FIFO1B4IFG] Bits */
+#define DAC12_CPU_INT_RIS_FIFO1B4IFG_OFS         (9)                             /* !< FIFO1B4IFG Offset */
+#define DAC12_CPU_INT_RIS_FIFO1B4IFG_MASK        ((uint32_t)0x00000200U)         /* !< Raw interrupt status for FIFO1B4IFG */
+#define DAC12_CPU_INT_RIS_FIFO1B4IFG_CLR         ((uint32_t)0x00000000U)         /* !< FIFO one fourth empty condition did
+                                                                                    not occur */
+#define DAC12_CPU_INT_RIS_FIFO1B4IFG_SET         ((uint32_t)0x00000200U)         /* !< FIFO one fourth empty condition
+                                                                                    occurred */
+/* DAC12_CPU_INT_RIS[FIFO1B2IFG] Bits */
+#define DAC12_CPU_INT_RIS_FIFO1B2IFG_OFS         (10)                            /* !< FIFO1B2IFG Offset */
+#define DAC12_CPU_INT_RIS_FIFO1B2IFG_MASK        ((uint32_t)0x00000400U)         /* !< Raw interrupt status for FIFO1B2IFG */
+#define DAC12_CPU_INT_RIS_FIFO1B2IFG_CLR         ((uint32_t)0x00000000U)         /* !< FIFO half empty condition did not
+                                                                                    occur */
+#define DAC12_CPU_INT_RIS_FIFO1B2IFG_SET         ((uint32_t)0x00000400U)         /* !< FIFO half empty condition occurred */
+/* DAC12_CPU_INT_RIS[FIFO3B4IFG] Bits */
+#define DAC12_CPU_INT_RIS_FIFO3B4IFG_OFS         (11)                            /* !< FIFO3B4IFG Offset */
+#define DAC12_CPU_INT_RIS_FIFO3B4IFG_MASK        ((uint32_t)0x00000800U)         /* !< Raw interrupt status for FIFO3B4IFG */
+#define DAC12_CPU_INT_RIS_FIFO3B4IFG_CLR         ((uint32_t)0x00000000U)         /* !< FIFO three fourth empty condition
+                                                                                    did not occur */
+#define DAC12_CPU_INT_RIS_FIFO3B4IFG_SET         ((uint32_t)0x00000800U)         /* !< FIFO three fourth empty condition
+                                                                                    occurred */
+/* DAC12_CPU_INT_RIS[FIFOFULLIFG] Bits */
+#define DAC12_CPU_INT_RIS_FIFOFULLIFG_OFS        (8)                             /* !< FIFOFULLIFG Offset */
+#define DAC12_CPU_INT_RIS_FIFOFULLIFG_MASK       ((uint32_t)0x00000100U)         /* !< Raw interrupt status for
+                                                                                    FIFOFULLIFG */
+#define DAC12_CPU_INT_RIS_FIFOFULLIFG_CLR        ((uint32_t)0x00000000U)         /* !< FIFO full condition did not occur */
+#define DAC12_CPU_INT_RIS_FIFOFULLIFG_SET        ((uint32_t)0x00000100U)         /* !< FIFO full condition occurred */
+/* DAC12_CPU_INT_RIS[FIFOURUNIFG] Bits */
+#define DAC12_CPU_INT_RIS_FIFOURUNIFG_OFS        (13)                            /* !< FIFOURUNIFG Offset */
+#define DAC12_CPU_INT_RIS_FIFOURUNIFG_MASK       ((uint32_t)0x00002000U)         /* !< Raw interrupt status for
+                                                                                    FIFOURUNIFG */
+#define DAC12_CPU_INT_RIS_FIFOURUNIFG_CLR        ((uint32_t)0x00000000U)         /* !< FIFO underrun condition did not
+                                                                                    occur */
+#define DAC12_CPU_INT_RIS_FIFOURUNIFG_SET        ((uint32_t)0x00002000U)         /* !< FIFO underrun condition occurred */
+/* DAC12_CPU_INT_RIS[DMADONEIFG] Bits */
+#define DAC12_CPU_INT_RIS_DMADONEIFG_OFS         (14)                            /* !< DMADONEIFG Offset */
+#define DAC12_CPU_INT_RIS_DMADONEIFG_MASK        ((uint32_t)0x00004000U)         /* !< Raw interrupt status for DMADONEIFG */
+#define DAC12_CPU_INT_RIS_DMADONEIFG_CLR         ((uint32_t)0x00000000U)         /* !< DMA done condition did not occur */
+#define DAC12_CPU_INT_RIS_DMADONEIFG_SET         ((uint32_t)0x00004000U)         /* !< DMA done condition occurred */
+
+/* DAC12_CPU_INT_MIS Bits */
+/* DAC12_CPU_INT_MIS[MODRDYIFG] Bits */
+#define DAC12_CPU_INT_MIS_MODRDYIFG_OFS          (1)                             /* !< MODRDYIFG Offset */
+#define DAC12_CPU_INT_MIS_MODRDYIFG_MASK         ((uint32_t)0x00000002U)         /* !< Masked interrupt status for
+                                                                                    MODRDYIFG */
+#define DAC12_CPU_INT_MIS_MODRDYIFG_CLR          ((uint32_t)0x00000000U)         /* !< MODRDYIFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_CPU_INT_MIS_MODRDYIFG_SET          ((uint32_t)0x00000002U)         /* !< MODRDYIFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_CPU_INT_MIS[FIFOEMPTYIFG] Bits */
+#define DAC12_CPU_INT_MIS_FIFOEMPTYIFG_OFS       (12)                            /* !< FIFOEMPTYIFG Offset */
+#define DAC12_CPU_INT_MIS_FIFOEMPTYIFG_MASK      ((uint32_t)0x00001000U)         /* !< Masked interrupt status for
+                                                                                    FIFOEMPTYIFG */
+#define DAC12_CPU_INT_MIS_FIFOEMPTYIFG_CLR       ((uint32_t)0x00000000U)         /* !< FIFOEMPTYIFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_CPU_INT_MIS_FIFOEMPTYIFG_SET       ((uint32_t)0x00001000U)         /* !< FIFOEMPTYIFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_CPU_INT_MIS[FIFO1B4IFG] Bits */
+#define DAC12_CPU_INT_MIS_FIFO1B4IFG_OFS         (9)                             /* !< FIFO1B4IFG Offset */
+#define DAC12_CPU_INT_MIS_FIFO1B4IFG_MASK        ((uint32_t)0x00000200U)         /* !< Masked interrupt status for
+                                                                                    FIFO1B4IFG */
+#define DAC12_CPU_INT_MIS_FIFO1B4IFG_CLR         ((uint32_t)0x00000000U)         /* !< FIFO1B4IFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_CPU_INT_MIS_FIFO1B4IFG_SET         ((uint32_t)0x00000200U)         /* !< FIFO1B4IFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_CPU_INT_MIS[FIFO1B2IFG] Bits */
+#define DAC12_CPU_INT_MIS_FIFO1B2IFG_OFS         (10)                            /* !< FIFO1B2IFG Offset */
+#define DAC12_CPU_INT_MIS_FIFO1B2IFG_MASK        ((uint32_t)0x00000400U)         /* !< Masked interrupt status for
+                                                                                    FIFO1B2IFG */
+#define DAC12_CPU_INT_MIS_FIFO1B2IFG_CLR         ((uint32_t)0x00000000U)         /* !< FIFO1B2IFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_CPU_INT_MIS_FIFO1B2IFG_SET         ((uint32_t)0x00000400U)         /* !< FIFO1B2IFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_CPU_INT_MIS[FIFO3B4IFG] Bits */
+#define DAC12_CPU_INT_MIS_FIFO3B4IFG_OFS         (11)                            /* !< FIFO3B4IFG Offset */
+#define DAC12_CPU_INT_MIS_FIFO3B4IFG_MASK        ((uint32_t)0x00000800U)         /* !< Masked interrupt status for
+                                                                                    FIFO3B4IFG */
+#define DAC12_CPU_INT_MIS_FIFO3B4IFG_CLR         ((uint32_t)0x00000000U)         /* !< FIFO3B4IFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_CPU_INT_MIS_FIFO3B4IFG_SET         ((uint32_t)0x00000800U)         /* !< FIFO3B4IFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_CPU_INT_MIS[FIFOFULLIFG] Bits */
+#define DAC12_CPU_INT_MIS_FIFOFULLIFG_OFS        (8)                             /* !< FIFOFULLIFG Offset */
+#define DAC12_CPU_INT_MIS_FIFOFULLIFG_MASK       ((uint32_t)0x00000100U)         /* !< Masked interrupt status for
+                                                                                    FIFOFULLIFG */
+#define DAC12_CPU_INT_MIS_FIFOFULLIFG_CLR        ((uint32_t)0x00000000U)         /* !< FIFOFULLIFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_CPU_INT_MIS_FIFOFULLIFG_SET        ((uint32_t)0x00000100U)         /* !< FIFOFULLIFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_CPU_INT_MIS[FIFOURUNIFG] Bits */
+#define DAC12_CPU_INT_MIS_FIFOURUNIFG_OFS        (13)                            /* !< FIFOURUNIFG Offset */
+#define DAC12_CPU_INT_MIS_FIFOURUNIFG_MASK       ((uint32_t)0x00002000U)         /* !< Masked interrupt status for
+                                                                                    FIFOURUNIFG */
+#define DAC12_CPU_INT_MIS_FIFOURUNIFG_CLR        ((uint32_t)0x00000000U)         /* !< FIFOURUNIFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_CPU_INT_MIS_FIFOURUNIFG_SET        ((uint32_t)0x00002000U)         /* !< FIFOURUNIFG requests an interrupt
+                                                                                    service routine */
+/* DAC12_CPU_INT_MIS[DMADONEIFG] Bits */
+#define DAC12_CPU_INT_MIS_DMADONEIFG_OFS         (14)                            /* !< DMADONEIFG Offset */
+#define DAC12_CPU_INT_MIS_DMADONEIFG_MASK        ((uint32_t)0x00004000U)         /* !< Masked interrupt status for
+                                                                                    DMADONEIFG */
+#define DAC12_CPU_INT_MIS_DMADONEIFG_CLR         ((uint32_t)0x00000000U)         /* !< DMADONEIFG does not request an
+                                                                                    interrupt service routine */
+#define DAC12_CPU_INT_MIS_DMADONEIFG_SET         ((uint32_t)0x00004000U)         /* !< DMADONEIFG requests an interrupt
+                                                                                    service routine */
+
+/* DAC12_CPU_INT_ISET Bits */
+/* DAC12_CPU_INT_ISET[MODRDYIFG] Bits */
+#define DAC12_CPU_INT_ISET_MODRDYIFG_OFS         (1)                             /* !< MODRDYIFG Offset */
+#define DAC12_CPU_INT_ISET_MODRDYIFG_MASK        ((uint32_t)0x00000002U)         /* !< Sets MODRDYIFG in RIS register */
+#define DAC12_CPU_INT_ISET_MODRDYIFG_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ISET_MODRDYIFG_SET         ((uint32_t)0x00000002U)         /* !< RIS bit corresponding to MODRDYIFG
+                                                                                    is set */
+/* DAC12_CPU_INT_ISET[FIFOEMPTYIFG] Bits */
+#define DAC12_CPU_INT_ISET_FIFOEMPTYIFG_OFS      (12)                            /* !< FIFOEMPTYIFG Offset */
+#define DAC12_CPU_INT_ISET_FIFOEMPTYIFG_MASK     ((uint32_t)0x00001000U)         /* !< Sets FIFOEMPTYIFG in RIS register */
+#define DAC12_CPU_INT_ISET_FIFOEMPTYIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ISET_FIFOEMPTYIFG_SET      ((uint32_t)0x00001000U)         /* !< RIS bit corresponding to
+                                                                                    FIFOEMPTYIFG is set */
+/* DAC12_CPU_INT_ISET[FIFO1B4IFG] Bits */
+#define DAC12_CPU_INT_ISET_FIFO1B4IFG_OFS        (9)                             /* !< FIFO1B4IFG Offset */
+#define DAC12_CPU_INT_ISET_FIFO1B4IFG_MASK       ((uint32_t)0x00000200U)         /* !< Sets FIFO1B4IFG in RIS register */
+#define DAC12_CPU_INT_ISET_FIFO1B4IFG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ISET_FIFO1B4IFG_SET        ((uint32_t)0x00000200U)         /* !< RIS bit corresponding to FIFO1B4IFG
+                                                                                    is set */
+/* DAC12_CPU_INT_ISET[FIFO1B2IFG] Bits */
+#define DAC12_CPU_INT_ISET_FIFO1B2IFG_OFS        (10)                            /* !< FIFO1B2IFG Offset */
+#define DAC12_CPU_INT_ISET_FIFO1B2IFG_MASK       ((uint32_t)0x00000400U)         /* !< Sets FIFO1B2IFG in RIS register */
+#define DAC12_CPU_INT_ISET_FIFO1B2IFG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ISET_FIFO1B2IFG_SET        ((uint32_t)0x00000400U)         /* !< RIS bit corresponding to FIFO1B2IFG
+                                                                                    is set */
+/* DAC12_CPU_INT_ISET[FIFO3B4IFG] Bits */
+#define DAC12_CPU_INT_ISET_FIFO3B4IFG_OFS        (11)                            /* !< FIFO3B4IFG Offset */
+#define DAC12_CPU_INT_ISET_FIFO3B4IFG_MASK       ((uint32_t)0x00000800U)         /* !< Sets FIFO3B4IFG in RIS register */
+#define DAC12_CPU_INT_ISET_FIFO3B4IFG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ISET_FIFO3B4IFG_SET        ((uint32_t)0x00000800U)         /* !< RIS bit corresponding to FIFO3B4IFG
+                                                                                    is set */
+/* DAC12_CPU_INT_ISET[FIFOFULLIFG] Bits */
+#define DAC12_CPU_INT_ISET_FIFOFULLIFG_OFS       (8)                             /* !< FIFOFULLIFG Offset */
+#define DAC12_CPU_INT_ISET_FIFOFULLIFG_MASK      ((uint32_t)0x00000100U)         /* !< Sets FIFOFULLIFG in RIS register */
+#define DAC12_CPU_INT_ISET_FIFOFULLIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ISET_FIFOFULLIFG_SET       ((uint32_t)0x00000100U)         /* !< RIS bit corresponding to
+                                                                                    FIFOFULLIFG is set */
+/* DAC12_CPU_INT_ISET[FIFOURUNIFG] Bits */
+#define DAC12_CPU_INT_ISET_FIFOURUNIFG_OFS       (13)                            /* !< FIFOURUNIFG Offset */
+#define DAC12_CPU_INT_ISET_FIFOURUNIFG_MASK      ((uint32_t)0x00002000U)         /* !< Sets FIFOURUNIFG in RIS register */
+#define DAC12_CPU_INT_ISET_FIFOURUNIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ISET_FIFOURUNIFG_SET       ((uint32_t)0x00002000U)         /* !< RIS bit corresponding to
+                                                                                    FIFOURUNIFG is set */
+/* DAC12_CPU_INT_ISET[DMADONEIFG] Bits */
+#define DAC12_CPU_INT_ISET_DMADONEIFG_OFS        (14)                            /* !< DMADONEIFG Offset */
+#define DAC12_CPU_INT_ISET_DMADONEIFG_MASK       ((uint32_t)0x00004000U)         /* !< Sets DMADONEIFG in RIS register */
+#define DAC12_CPU_INT_ISET_DMADONEIFG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ISET_DMADONEIFG_SET        ((uint32_t)0x00004000U)         /* !< RIS bit corresponding to DMADONEIFG
+                                                                                    is set */
+
+/* DAC12_CPU_INT_ICLR Bits */
+/* DAC12_CPU_INT_ICLR[MODRDYIFG] Bits */
+#define DAC12_CPU_INT_ICLR_MODRDYIFG_OFS         (1)                             /* !< MODRDYIFG Offset */
+#define DAC12_CPU_INT_ICLR_MODRDYIFG_MASK        ((uint32_t)0x00000002U)         /* !< Clears MODRDYIFG in RIS register */
+#define DAC12_CPU_INT_ICLR_MODRDYIFG_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ICLR_MODRDYIFG_CLR         ((uint32_t)0x00000002U)         /* !< RIS bit corresponding to MODRDYIFG
+                                                                                    is cleared */
+/* DAC12_CPU_INT_ICLR[FIFOEMPTYIFG] Bits */
+#define DAC12_CPU_INT_ICLR_FIFOEMPTYIFG_OFS      (12)                            /* !< FIFOEMPTYIFG Offset */
+#define DAC12_CPU_INT_ICLR_FIFOEMPTYIFG_MASK     ((uint32_t)0x00001000U)         /* !< Clears FIFOEMPTYIFG in RIS register */
+#define DAC12_CPU_INT_ICLR_FIFOEMPTYIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ICLR_FIFOEMPTYIFG_CLR      ((uint32_t)0x00001000U)         /* !< RIS bit corresponding to
+                                                                                    FIFOEMPTYIFG is cleared */
+/* DAC12_CPU_INT_ICLR[FIFO1B4IFG] Bits */
+#define DAC12_CPU_INT_ICLR_FIFO1B4IFG_OFS        (9)                             /* !< FIFO1B4IFG Offset */
+#define DAC12_CPU_INT_ICLR_FIFO1B4IFG_MASK       ((uint32_t)0x00000200U)         /* !< Clears FIFO1B4IFG in RIS register */
+#define DAC12_CPU_INT_ICLR_FIFO1B4IFG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ICLR_FIFO1B4IFG_CLR        ((uint32_t)0x00000200U)         /* !< RIS bit corresponding to FIFO1B4IFG
+                                                                                    is cleared */
+/* DAC12_CPU_INT_ICLR[FIFO1B2IFG] Bits */
+#define DAC12_CPU_INT_ICLR_FIFO1B2IFG_OFS        (10)                            /* !< FIFO1B2IFG Offset */
+#define DAC12_CPU_INT_ICLR_FIFO1B2IFG_MASK       ((uint32_t)0x00000400U)         /* !< Clears FIFO1B2IFG in RIS register */
+#define DAC12_CPU_INT_ICLR_FIFO1B2IFG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ICLR_FIFO1B2IFG_CLR        ((uint32_t)0x00000400U)         /* !< RIS bit corresponding to FIFO1B2IFG
+                                                                                    is cleared */
+/* DAC12_CPU_INT_ICLR[FIFO3B4IFG] Bits */
+#define DAC12_CPU_INT_ICLR_FIFO3B4IFG_OFS        (11)                            /* !< FIFO3B4IFG Offset */
+#define DAC12_CPU_INT_ICLR_FIFO3B4IFG_MASK       ((uint32_t)0x00000800U)         /* !< Clears FIFO3B4IFG in RIS register */
+#define DAC12_CPU_INT_ICLR_FIFO3B4IFG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ICLR_FIFO3B4IFG_CLR        ((uint32_t)0x00000800U)         /* !< RIS bit corresponding to FIFO3B4IFG
+                                                                                    is cleared */
+/* DAC12_CPU_INT_ICLR[FIFOFULLIFG] Bits */
+#define DAC12_CPU_INT_ICLR_FIFOFULLIFG_OFS       (8)                             /* !< FIFOFULLIFG Offset */
+#define DAC12_CPU_INT_ICLR_FIFOFULLIFG_MASK      ((uint32_t)0x00000100U)         /* !< Clears FIFOFULLIFG in RIS register */
+#define DAC12_CPU_INT_ICLR_FIFOFULLIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ICLR_FIFOFULLIFG_CLR       ((uint32_t)0x00000100U)         /* !< RIS bit corresponding to
+                                                                                    FIFOFULLIFG is cleared */
+/* DAC12_CPU_INT_ICLR[FIFOURUNIFG] Bits */
+#define DAC12_CPU_INT_ICLR_FIFOURUNIFG_OFS       (13)                            /* !< FIFOURUNIFG Offset */
+#define DAC12_CPU_INT_ICLR_FIFOURUNIFG_MASK      ((uint32_t)0x00002000U)         /* !< Clears FIFOURUNIFG in RIS register */
+#define DAC12_CPU_INT_ICLR_FIFOURUNIFG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ICLR_FIFOURUNIFG_CLR       ((uint32_t)0x00002000U)         /* !< RIS bit corresponding to
+                                                                                    FIFOURUNIFG is cleared */
+/* DAC12_CPU_INT_ICLR[DMADONEIFG] Bits */
+#define DAC12_CPU_INT_ICLR_DMADONEIFG_OFS        (14)                            /* !< DMADONEIFG Offset */
+#define DAC12_CPU_INT_ICLR_DMADONEIFG_MASK       ((uint32_t)0x00004000U)         /* !< Clears DMADONEIFG in RIS register */
+#define DAC12_CPU_INT_ICLR_DMADONEIFG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DAC12_CPU_INT_ICLR_DMADONEIFG_CLR        ((uint32_t)0x00004000U)         /* !< RIS bit corresponding to DMADONEIFG
+                                                                                    is cleared */
+
+/* DAC12_PWREN Bits */
+/* DAC12_PWREN[ENABLE] Bits */
+#define DAC12_PWREN_ENABLE_OFS                   (0)                             /* !< ENABLE Offset */
+#define DAC12_PWREN_ENABLE_MASK                  ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define DAC12_PWREN_ENABLE_DISABLE               ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define DAC12_PWREN_ENABLE_ENABLE                ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* DAC12_PWREN[KEY] Bits */
+#define DAC12_PWREN_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define DAC12_PWREN_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define DAC12_PWREN_KEY_UNLOCK_W                 ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* DAC12_RSTCTL Bits */
+/* DAC12_RSTCTL[RESETSTKYCLR] Bits */
+#define DAC12_RSTCTL_RESETSTKYCLR_OFS            (1)                             /* !< RESETSTKYCLR Offset */
+#define DAC12_RSTCTL_RESETSTKYCLR_MASK           ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define DAC12_RSTCTL_RESETSTKYCLR_NOP            ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DAC12_RSTCTL_RESETSTKYCLR_CLR            ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* DAC12_RSTCTL[RESETASSERT] Bits */
+#define DAC12_RSTCTL_RESETASSERT_OFS             (0)                             /* !< RESETASSERT Offset */
+#define DAC12_RSTCTL_RESETASSERT_MASK            ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define DAC12_RSTCTL_RESETASSERT_NOP             ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DAC12_RSTCTL_RESETASSERT_ASSERT          ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* DAC12_RSTCTL[KEY] Bits */
+#define DAC12_RSTCTL_KEY_OFS                     (24)                            /* !< KEY Offset */
+#define DAC12_RSTCTL_KEY_MASK                    ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define DAC12_RSTCTL_KEY_UNLOCK_W                ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* DAC12_STAT Bits */
+/* DAC12_STAT[RESETSTKY] Bits */
+#define DAC12_STAT_RESETSTKY_OFS                 (16)                            /* !< RESETSTKY Offset */
+#define DAC12_STAT_RESETSTKY_MASK                ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define DAC12_STAT_RESETSTKY_NORES               ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define DAC12_STAT_RESETSTKY_RESET               ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* DAC12_FSUB_0 Bits */
+/* DAC12_FSUB_0[CHANID] Bits */
+#define DAC12_FSUB_0_CHANID_OFS                  (0)                             /* !< CHANID Offset */
+#define DAC12_FSUB_0_CHANID_MASK                 ((uint32_t)0x00007FFFU)         /* !< 0 = disconnected. others =
+                                                                                    connected to channel_ID = CHANID. */
+#define DAC12_FSUB_0_CHANID_MNIMUM               ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define DAC12_FSUB_0_CHANID_UNCONNECTED          ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define DAC12_FSUB_0_CHANID_MAXIMUM              ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* DAC12_FPUB_1 Bits */
+/* DAC12_FPUB_1[CHANID] Bits */
+#define DAC12_FPUB_1_CHANID_OFS                  (0)                             /* !< CHANID Offset */
+#define DAC12_FPUB_1_CHANID_MASK                 ((uint32_t)0x00007FFFU)         /* !< 0 = disconnected. others =
+                                                                                    connected to channel_ID = CHANID. */
+#define DAC12_FPUB_1_CHANID_MNIMUM               ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define DAC12_FPUB_1_CHANID_UNCONNECTED          ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define DAC12_FPUB_1_CHANID_MAXIMUM              ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* DAC12_EVT_MODE Bits */
+/* DAC12_EVT_MODE[INT0_CFG] Bits */
+#define DAC12_EVT_MODE_INT0_CFG_OFS              (0)                             /* !< INT0_CFG Offset */
+#define DAC12_EVT_MODE_INT0_CFG_MASK             ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT][0] */
+#define DAC12_EVT_MODE_INT0_CFG_DISABLE          ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define DAC12_EVT_MODE_INT0_CFG_SOFTWARE         ((uint32_t)0x00000001U)         /* !< Event handled by software. Software
+                                                                                    must clear the associated RIS flag. */
+#define DAC12_EVT_MODE_INT0_CFG_HARDWARE         ((uint32_t)0x00000002U)         /* !< Event handled by hardware. The
+                                                                                    hardware (another module) clears
+                                                                                    automatically the associated RIS
+                                                                                    flag. */
+/* DAC12_EVT_MODE[EVT1_CFG] Bits */
+#define DAC12_EVT_MODE_EVT1_CFG_OFS              (2)                             /* !< EVT1_CFG Offset */
+#define DAC12_EVT_MODE_EVT1_CFG_MASK             ((uint32_t)0x0000000CU)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT][0] */
+#define DAC12_EVT_MODE_EVT1_CFG_DISABLE          ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define DAC12_EVT_MODE_EVT1_CFG_SOFTWARE         ((uint32_t)0x00000004U)         /* !< Event handled by software. Software
+                                                                                    must clear the associated RIS flag. */
+#define DAC12_EVT_MODE_EVT1_CFG_HARDWARE         ((uint32_t)0x00000008U)         /* !< Event handled by hardware. The
+                                                                                    hardware (another module) clears
+                                                                                    automatically the associated RIS
+                                                                                    flag. */
+
+/* DAC12_DESC Bits */
+/* DAC12_DESC[MINREV] Bits */
+#define DAC12_DESC_MINREV_OFS                    (0)                             /* !< MINREV Offset */
+#define DAC12_DESC_MINREV_MASK                   ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+/* DAC12_DESC[MAJREV] Bits */
+#define DAC12_DESC_MAJREV_OFS                    (4)                             /* !< MAJREV Offset */
+#define DAC12_DESC_MAJREV_MASK                   ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+/* DAC12_DESC[FEATUREVER] Bits */
+#define DAC12_DESC_FEATUREVER_OFS                (12)                            /* !< FEATUREVER Offset */
+#define DAC12_DESC_FEATUREVER_MASK               ((uint32_t)0x0000F000U)         /* !< Feature Set for the module
+                                                                                    *instance* */
+/* DAC12_DESC[MODULEID] Bits */
+#define DAC12_DESC_MODULEID_OFS                  (16)                            /* !< MODULEID Offset */
+#define DAC12_DESC_MODULEID_MASK                 ((uint32_t)0xFFFF0000U)         /* !< Module identification contains a
+                                                                                    unique peripheral identification
+                                                                                    number. The assignments are
+                                                                                    maintained in a central database for
+                                                                                    all of the platform modules to ensure
+                                                                                    uniqueness. */
+
+/* DAC12_CTL0 Bits */
+/* DAC12_CTL0[DFM] Bits */
+#define DAC12_CTL0_DFM_OFS                       (16)                            /* !< DFM Offset */
+#define DAC12_CTL0_DFM_MASK                      ((uint32_t)0x00010000U)         /* !< This bit defines the DAC input data
+                                                                                    format. */
+#define DAC12_CTL0_DFM_BINARY                    ((uint32_t)0x00000000U)         /* !< Straight binary */
+#define DAC12_CTL0_DFM_TWOS_COMP                 ((uint32_t)0x00010000U)         /* !< Twos complement */
+/* DAC12_CTL0[ENABLE] Bits */
+#define DAC12_CTL0_ENABLE_OFS                    (0)                             /* !< ENABLE Offset */
+#define DAC12_CTL0_ENABLE_MASK                   ((uint32_t)0x00000001U)         /* !< This bit enables the DAC module. */
+#define DAC12_CTL0_ENABLE_CLR                    ((uint32_t)0x00000000U)         /* !< DAC is disabled */
+#define DAC12_CTL0_ENABLE_SET                    ((uint32_t)0x00000001U)         /* !< DAC is enabled */
+/* DAC12_CTL0[RES] Bits */
+#define DAC12_CTL0_RES_OFS                       (8)                             /* !< RES Offset */
+#define DAC12_CTL0_RES_MASK                      ((uint32_t)0x00000100U)         /* !< These bits define the DAC output
+                                                                                    voltage resolution. */
+#define DAC12_CTL0_RES__8BITS                    ((uint32_t)0x00000000U)         /* !< 8-bits resolution */
+#define DAC12_CTL0_RES__12BITS                   ((uint32_t)0x00000100U)         /* !< 12-bit resolution */
+
+/* DAC12_CTL1 Bits */
+/* DAC12_CTL1[AMPEN] Bits */
+#define DAC12_CTL1_AMPEN_OFS                     (0)                             /* !< AMPEN Offset */
+#define DAC12_CTL1_AMPEN_MASK                    ((uint32_t)0x00000001U)         /* !< AMP_EN - output amplifier enabled
+                                                                                    or disabled 0 : disabled  1 : enabled */
+#define DAC12_CTL1_AMPEN_DISABLE                 ((uint32_t)0x00000000U)         /* !< disable */
+#define DAC12_CTL1_AMPEN_ENABLE                  ((uint32_t)0x00000001U)         /* !< enable */
+/* DAC12_CTL1[REFSP] Bits */
+#define DAC12_CTL1_REFSP_OFS                     (8)                             /* !< REFSP Offset */
+#define DAC12_CTL1_REFSP_MASK                    ((uint32_t)0x00000100U)         /* !< This bit selects the DAC voltage
+                                                                                    reference source + input. */
+#define DAC12_CTL1_REFSP_VDDA                    ((uint32_t)0x00000000U)         /* !< Analog supply (VDDA) as VR+ */
+#define DAC12_CTL1_REFSP_VEREFP                  ((uint32_t)0x00000100U)         /* !< VEREFP pin as VR+ */
+/* DAC12_CTL1[OPS] Bits */
+#define DAC12_CTL1_OPS_OFS                       (24)                            /* !< OPS Offset */
+#define DAC12_CTL1_OPS_MASK                      ((uint32_t)0x01000000U)         /* !< These bits select the DAC output on
+                                                                                    device pin. */
+#define DAC12_CTL1_OPS_NOC0                      ((uint32_t)0x00000000U)         /* !< No connect. Both DAC output
+                                                                                    switches are open. */
+#define DAC12_CTL1_OPS_OUT0                      ((uint32_t)0x01000000U)         /* !< OUT0 output is selected */
+/* DAC12_CTL1[REFSN] Bits */
+#define DAC12_CTL1_REFSN_OFS                     (9)                             /* !< REFSN Offset */
+#define DAC12_CTL1_REFSN_MASK                    ((uint32_t)0x00000200U)         /* !< This bit selects the DAC voltage
+                                                                                    reference source + input. */
+#define DAC12_CTL1_REFSN_VEREFN                  ((uint32_t)0x00000000U)         /* !< VEREFN pin as VR- */
+#define DAC12_CTL1_REFSN_VSSA                    ((uint32_t)0x00000200U)         /* !< Analog supply (VSSA) as VR- */
+/* DAC12_CTL1[AMPHIZ] Bits */
+#define DAC12_CTL1_AMPHIZ_OFS                    (1)                             /* !< AMPHIZ Offset */
+#define DAC12_CTL1_AMPHIZ_MASK                   ((uint32_t)0x00000002U)         /* !< AMPHIZ - amplifier output value  0
+                                                                                    : amplifier output is high impedance
+                                                                                    1 : amplifier output is pulled down
+                                                                                    to ground */
+#define DAC12_CTL1_AMPHIZ_HIZ                    ((uint32_t)0x00000000U)         /* !< HiZ when disable */
+#define DAC12_CTL1_AMPHIZ_PULLDOWN               ((uint32_t)0x00000002U)         /* !< dacout pulldown when disable */
+
+/* DAC12_CTL2 Bits */
+/* DAC12_CTL2[FIFOEN] Bits */
+#define DAC12_CTL2_FIFOEN_OFS                    (0)                             /* !< FIFOEN Offset */
+#define DAC12_CTL2_FIFOEN_MASK                   ((uint32_t)0x00000001U)         /* !< This bit enables the FIFO and the
+                                                                                    FIFO hardware control state machine. */
+#define DAC12_CTL2_FIFOEN_CLR                    ((uint32_t)0x00000000U)         /* !< FIFO is disabled */
+#define DAC12_CTL2_FIFOEN_SET                    ((uint32_t)0x00000001U)         /* !< FIFO is enabled */
+/* DAC12_CTL2[FIFOTH] Bits */
+#define DAC12_CTL2_FIFOTH_OFS                    (8)                             /* !< FIFOTH Offset */
+#define DAC12_CTL2_FIFOTH_MASK                   ((uint32_t)0x00000300U)         /* !< These bits determine the FIFO
+                                                                                    threshold. In case of DMA based
+                                                                                    operation, DAC generates new DMA
+                                                                                    trigger when the number of empty
+                                                                                    locations in FIFO match the selected
+                                                                                    FIFO threshold level.  In case of CPU
+                                                                                    based operation, the FIFO threshold
+                                                                                    bits are don't care and FIFO level is
+                                                                                    directly indicated through the
+                                                                                    respective bits in the RIS register. */
+#define DAC12_CTL2_FIFOTH_LOW                    ((uint32_t)0x00000000U)         /* !< One fourth of the FIFO locations
+                                                                                    are empty */
+#define DAC12_CTL2_FIFOTH_MED                    ((uint32_t)0x00000100U)         /* !< Half of the FIFO locations are
+                                                                                    empty */
+#define DAC12_CTL2_FIFOTH_HIGH                   ((uint32_t)0x00000200U)         /* !< Three fourth of the FIFO locations
+                                                                                    are empty */
+#define DAC12_CTL2_FIFOTH_SPARE                  ((uint32_t)0x00000300U)         /* !< Reserved value. Defaults to same
+                                                                                    effect as FIFOTH = 0 (One fourth of
+                                                                                    the FIFO locations are empty). */
+/* DAC12_CTL2[FIFOTRIGSEL] Bits */
+#define DAC12_CTL2_FIFOTRIGSEL_OFS               (16)                            /* !< FIFOTRIGSEL Offset */
+#define DAC12_CTL2_FIFOTRIGSEL_MASK              ((uint32_t)0x00030000U)         /* !< These bits select the source for
+                                                                                    FIFO read trigger. When the selected
+                                                                                    FIFO read trigger is asserted, the
+                                                                                    data from FIFO (as indicated by read
+                                                                                    pointer) is moved into internal DAC
+                                                                                    data register. */
+#define DAC12_CTL2_FIFOTRIGSEL_STIM              ((uint32_t)0x00000000U)         /* !< Sample time generator output */
+#define DAC12_CTL2_FIFOTRIGSEL_TRIG0             ((uint32_t)0x00010000U)         /* !< Hardware trigger-0 from event
+                                                                                    fabric */
+#define DAC12_CTL2_FIFOTRIGSEL_SPARE1            ((uint32_t)0x00020000U)         /* !< Reserved - unimplemented */
+#define DAC12_CTL2_FIFOTRIGSEL_SPARE2            ((uint32_t)0x00030000U)         /* !< Reserved - unimplemented */
+/* DAC12_CTL2[DMATRIGEN] Bits */
+#define DAC12_CTL2_DMATRIGEN_OFS                 (24)                            /* !< DMATRIGEN Offset */
+#define DAC12_CTL2_DMATRIGEN_MASK                ((uint32_t)0x01000000U)         /* !< This bit enables the DMA trigger
+                                                                                    generation mechanism. When this bit
+                                                                                    is set along with FIFOEN, the DMA
+                                                                                    trigger is generated based on the
+                                                                                    empty FIFO locations qualified by
+                                                                                    FIFOTH settings. This bit should be
+                                                                                    cleared by software to stop further
+                                                                                    DMA triggers. */
+#define DAC12_CTL2_DMATRIGEN_CLR                 ((uint32_t)0x00000000U)         /* !< DMA trigger generation mechanism is
+                                                                                    disabled */
+#define DAC12_CTL2_DMATRIGEN_SET                 ((uint32_t)0x01000000U)         /* !< DMA trigger generation mechanism is
+                                                                                    enabled */
+
+/* DAC12_CTL3 Bits */
+/* DAC12_CTL3[STIMEN] Bits */
+#define DAC12_CTL3_STIMEN_OFS                    (0)                             /* !< STIMEN Offset */
+#define DAC12_CTL3_STIMEN_MASK                   ((uint32_t)0x00000001U)         /* !< This bit enables the sample time
+                                                                                    generator. */
+#define DAC12_CTL3_STIMEN_CLR                    ((uint32_t)0x00000000U)         /* !< Sample time generator is disabled */
+#define DAC12_CTL3_STIMEN_SET                    ((uint32_t)0x00000001U)         /* !< Sample time generator is enabled */
+/* DAC12_CTL3[STIMCONFIG] Bits */
+#define DAC12_CTL3_STIMCONFIG_OFS                (8)                             /* !< STIMCONFIG Offset */
+#define DAC12_CTL3_STIMCONFIG_MASK               ((uint32_t)0x00000F00U)         /* !< These bits are used to configure
+                                                                                    the trigger rate from the sample time
+                                                                                    generator. The STIMCONFIG values 10
+                                                                                    to 15 are reserved and default to
+                                                                                    same effect as value 0 (500SPS). */
+#define DAC12_CTL3_STIMCONFIG__500SPS            ((uint32_t)0x00000000U)         /* !< Trigger rate is 500 sps (clock
+                                                                                    divide value is 4000) */
+#define DAC12_CTL3_STIMCONFIG__1KSPS             ((uint32_t)0x00000100U)         /* !< Trigger rate is 1 ksps (clock
+                                                                                    divide value is 2000) */
+#define DAC12_CTL3_STIMCONFIG__2KSPS             ((uint32_t)0x00000200U)         /* !< Trigger rate is 2 ksps (clock
+                                                                                    divide value is 1000) */
+#define DAC12_CTL3_STIMCONFIG__4KSPS             ((uint32_t)0x00000300U)         /* !< Trigger rate is 4 ksps (clock
+                                                                                    divide value is 500) */
+#define DAC12_CTL3_STIMCONFIG__8KSPS             ((uint32_t)0x00000400U)         /* !< Trigger rate is 8 ksps (clock
+                                                                                    divide value is 250) */
+#define DAC12_CTL3_STIMCONFIG__16KSPS            ((uint32_t)0x00000500U)         /* !< Trigger rate is 16 ksps (clock
+                                                                                    divide value is 125) */
+#define DAC12_CTL3_STIMCONFIG__100KSPS           ((uint32_t)0x00000600U)         /* !< Trigger rate is 100 ksps (clock
+                                                                                    divide value is 20) */
+#define DAC12_CTL3_STIMCONFIG__200KSPS           ((uint32_t)0x00000700U)         /* !< Trigger rate is 200 ksps (clock
+                                                                                    divide value is 10) */
+#define DAC12_CTL3_STIMCONFIG__500KSPS           ((uint32_t)0x00000800U)         /* !< Trigger rate is 500 ksps (clock
+                                                                                    divide value is 4) */
+#define DAC12_CTL3_STIMCONFIG__1MSPS             ((uint32_t)0x00000900U)         /* !< Trigger rate is 1 Msps (clock
+                                                                                    divide value is 2) */
+
+/* DAC12_CALCTL Bits */
+/* DAC12_CALCTL[CALON] Bits */
+#define DAC12_CALCTL_CALON_OFS                   (0)                             /* !< CALON Offset */
+#define DAC12_CALCTL_CALON_MASK                  ((uint32_t)0x00000001U)         /* !< This bit when set initiates the DAC
+                                                                                    offset error calibration sequence and
+                                                                                    is automatically reset when the
+                                                                                    offset error calibration completes. */
+#define DAC12_CALCTL_CALON_INACTIVE              ((uint32_t)0x00000000U)         /* !< Offset error calibration is not
+                                                                                    active */
+#define DAC12_CALCTL_CALON_ACTIVE                ((uint32_t)0x00000001U)         /* !< Initiate offset error calibration
+                                                                                    or offset error calibration is
+                                                                                    already in progress */
+/* DAC12_CALCTL[CALSEL] Bits */
+#define DAC12_CALCTL_CALSEL_OFS                  (1)                             /* !< CALSEL Offset */
+#define DAC12_CALCTL_CALSEL_MASK                 ((uint32_t)0x00000002U)         /* !< This bit is used to select between
+                                                                                    factory trim or self calibration
+                                                                                    trim. */
+#define DAC12_CALCTL_CALSEL_FACTORYTRIM          ((uint32_t)0x00000000U)         /* !< Factory Trim Calibration Values are
+                                                                                    used when calibration is enabled */
+#define DAC12_CALCTL_CALSEL_SELFCALIBRATIONTRIM  ((uint32_t)0x00000002U)         /* !< Self Calibration Trim Values are
+                                                                                    used when calibration is enabled */
+
+/* DAC12_CALDATA Bits */
+/* DAC12_CALDATA[DATA] Bits */
+#define DAC12_CALDATA_DATA_OFS                   (0)                             /* !< DATA Offset */
+#define DAC12_CALDATA_DATA_MASK                  ((uint32_t)0x0000007FU)         /* !< DAC offset error calibration data.
+                                                                                    The DAC offset error calibration data
+                                                                                    is represented in twos complement
+                                                                                    format providing a range of 64 to
+                                                                                    +63. This is read-only bit,
+                                                                                    reflecting the calibration data.
+                                                                                    Writing to this register will have no
+                                                                                    effect, it will not change the
+                                                                                    calibration value. */
+
+/* DAC12_DATA0 Bits */
+/* DAC12_DATA0[DATA_VALUE] Bits */
+#define DAC12_DATA0_DATA_VALUE_OFS               (0)                             /* !< DATA_VALUE Offset */
+#define DAC12_DATA0_DATA_VALUE_MASK              ((uint32_t)0x00000FFFU)         /* !< This is the data written for
+                                                                                    digital to analog conversion. */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_dac12__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_dma.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_dma.h
@@ -1,0 +1,2382 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_dma__include
+#define ti_devices_msp_peripherals_hw_dma__include
+
+/* Filename: hw_dma.h */
+/* Revised: 2023-05-10 21:25:55 */
+/* Revision: fd45ad6f4da46c901da2f4bc9007f7b90b448408 */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* DMA Registers
+******************************************************************************/
+#define DMA_DMACHAN_OFS                          ((uint32_t)0x00001200U)
+#define DMA_DMATRIG_OFS                          ((uint32_t)0x00001110U)
+#define DMA_GEN_EVENT_OFS                        ((uint32_t)0x00001050U)
+#define DMA_CPU_INT_OFS                          ((uint32_t)0x00001020U)
+
+
+/** @addtogroup DMA_DMACHAN
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t DMACTL;                            /* !< (@ 0x00001200) DMA Channel Control */
+  __IO uint32_t DMASA;                             /* !< (@ 0x00001204) DMA Channel Source Address */
+  __IO uint32_t DMADA;                             /* !< (@ 0x00001208) DMA Channel Destination Address */
+  __IO uint32_t DMASZ;                             /* !< (@ 0x0000120C) DMA Channel Size */
+} DMA_DMACHAN_Regs;
+
+/*@}*/ /* end of group DMA_DMACHAN */
+
+/** @addtogroup DMA_DMATRIG
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t DMATCTL;                           /* !< (@ 0x00001110) DMA Trigger Select */
+} DMA_DMATRIG_Regs;
+
+/*@}*/ /* end of group DMA_DMATRIG */
+
+/** @addtogroup DMA_GEN_EVENT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001050) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001058) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001060) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001068) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001070) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001078) Interrupt clear */
+} DMA_GEN_EVENT_Regs;
+
+/*@}*/ /* end of group DMA_GEN_EVENT */
+
+/** @addtogroup DMA_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} DMA_CPU_INT_Regs;
+
+/*@}*/ /* end of group DMA_CPU_INT */
+
+/** @addtogroup DMA
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[256];
+  __IO uint32_t FSUB_0;                            /* !< (@ 0x00000400) Subscriber Port 0 */
+  __IO uint32_t FSUB_1;                            /* !< (@ 0x00000404) Subscriber Port 1 */
+       uint32_t RESERVED1[15];
+  __IO uint32_t FPUB_1;                            /* !< (@ 0x00000444) Publisher Port 0 */
+       uint32_t RESERVED2[756];
+  __IO uint32_t PDBGCTL;                           /* !< (@ 0x00001018) Peripheral Debug Control */
+       uint32_t RESERVED3;
+  DMA_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED4;
+  DMA_GEN_EVENT_Regs  GEN_EVENT;                         /* !< (@ 0x00001050) */
+       uint32_t RESERVED5[25];
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED6[6];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Module Description */
+  __IO uint32_t DMAPRIO;                           /* !< (@ 0x00001100) DMA Channel Priority Control */
+       uint32_t RESERVED7[3];
+  DMA_DMATRIG_Regs  DMATRIG[16];                       /* !< (@ 0x00001110) */
+       uint32_t RESERVED8[44];
+  DMA_DMACHAN_Regs  DMACHAN[16];                       /* !< (@ 0x00001200) */
+} DMA_Regs;
+
+/*@}*/ /* end of group DMA */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* DMA Register Control Bits
+******************************************************************************/
+
+/* DMA_DMACTL Bits */
+/* DMA_DMACTL[DMAREQ] Bits */
+#define DMA_DMACTL_DMAREQ_OFS                    (0)                             /* !< DMAREQ Offset */
+#define DMA_DMACTL_DMAREQ_MASK                   ((uint32_t)0x00000001U)         /* !< DMA request. Software-controlled
+                                                                                    DMA start. DMAREQ is reset
+                                                                                    automatically. */
+#define DMA_DMACTL_DMAREQ_IDLE                   ((uint32_t)0x00000000U)         /* !< Default read value */
+#define DMA_DMACTL_DMAREQ_REQUEST                ((uint32_t)0x00000001U)         /* !< DMA transfer request (start DMA) */
+/* DMA_DMACTL[DMAEN] Bits */
+#define DMA_DMACTL_DMAEN_OFS                     (1)                             /* !< DMAEN Offset */
+#define DMA_DMACTL_DMAEN_MASK                    ((uint32_t)0x00000002U)         /* !< DMA enable */
+#define DMA_DMACTL_DMAEN_DISABLE                 ((uint32_t)0x00000000U)         /* !< DMA channel disabled */
+#define DMA_DMACTL_DMAEN_ENABLE                  ((uint32_t)0x00000002U)         /* !< DMA channel enabled */
+/* DMA_DMACTL[DMASRCWDTH] Bits */
+#define DMA_DMACTL_DMASRCWDTH_OFS                (8)                             /* !< DMASRCWDTH Offset */
+#define DMA_DMACTL_DMASRCWDTH_MASK               ((uint32_t)0x00000300U)         /* !< DMA source width. This bit selects
+                                                                                    the source data width as a byte, half
+                                                                                    word, word or long word. */
+#define DMA_DMACTL_DMASRCWDTH_BYTE               ((uint32_t)0x00000000U)         /* !< Source data width is BYTE (8-bit) */
+#define DMA_DMACTL_DMASRCWDTH_HALF               ((uint32_t)0x00000100U)         /* !< Source data width is HALF-WORD
+                                                                                    (16-bit) */
+#define DMA_DMACTL_DMASRCWDTH_WORD               ((uint32_t)0x00000200U)         /* !< Source data width is WORD (32-bit) */
+#define DMA_DMACTL_DMASRCWDTH_LONG               ((uint32_t)0x00000300U)         /* !< Source data width is LONG-WORD
+                                                                                    (64-bit) */
+/* DMA_DMACTL[DMADSTWDTH] Bits */
+#define DMA_DMACTL_DMADSTWDTH_OFS                (12)                            /* !< DMADSTWDTH Offset */
+#define DMA_DMACTL_DMADSTWDTH_MASK               ((uint32_t)0x00003000U)         /* !< DMA destination width. This bit
+                                                                                    selects the destination as a byte,
+                                                                                    half word, word or long word. */
+#define DMA_DMACTL_DMADSTWDTH_BYTE               ((uint32_t)0x00000000U)         /* !< Destination data width is BYTE
+                                                                                    (8-bit) */
+#define DMA_DMACTL_DMADSTWDTH_HALF               ((uint32_t)0x00001000U)         /* !< Destination data width is HALF-WORD
+                                                                                    (16-bit) */
+#define DMA_DMACTL_DMADSTWDTH_WORD               ((uint32_t)0x00002000U)         /* !< Destination data width is WORD
+                                                                                    (32-bit) */
+#define DMA_DMACTL_DMADSTWDTH_LONG               ((uint32_t)0x00003000U)         /* !< Destination data width is LONG-WORD
+                                                                                    (64-bit) */
+/* DMA_DMACTL[DMASRCINCR] Bits */
+#define DMA_DMACTL_DMASRCINCR_OFS                (16)                            /* !< DMASRCINCR Offset */
+#define DMA_DMACTL_DMASRCINCR_MASK               ((uint32_t)0x000F0000U)         /* !< DMA source increment. This bit
+                                                                                    selects automatic incrementing or
+                                                                                    decrementing of the source address
+                                                                                    DMASA for each transfer. The amount
+                                                                                    of change to the DMASA is based on
+                                                                                    the definitin in the DMASRCWDTH. For
+                                                                                    example an increment of 1 (+1) on a
+                                                                                    WORD transfer will increment the
+                                                                                    DMASA by 4. */
+#define DMA_DMACTL_DMASRCINCR_UNCHANGED          ((uint32_t)0x00000000U)         /* !< Address is unchanged (+0) */
+#define DMA_DMACTL_DMASRCINCR_DECREMENT          ((uint32_t)0x00020000U)         /* !< Decremented by 1 (-1 * DMASRCWDTH) */
+#define DMA_DMACTL_DMASRCINCR_INCREMENT          ((uint32_t)0x00030000U)         /* !< Incremented by 1 (+1 * DMASRCWDTH) */
+#define DMA_DMACTL_DMASRCINCR_STRIDE_2           ((uint32_t)0x00080000U)         /* !< Stride size 2 (+2 * DMASRCWDTH) */
+#define DMA_DMACTL_DMASRCINCR_STRIDE_3           ((uint32_t)0x00090000U)         /* !< Stride size 3 (+3 * DMASRCWDTH) */
+#define DMA_DMACTL_DMASRCINCR_STRIDE_4           ((uint32_t)0x000A0000U)         /* !< Stride size 4 (+4 * DMASRCWDTH) */
+#define DMA_DMACTL_DMASRCINCR_STRIDE_5           ((uint32_t)0x000B0000U)         /* !< Stride size 5 (+5 * DMASRCWDTH) */
+#define DMA_DMACTL_DMASRCINCR_STRIDE_6           ((uint32_t)0x000C0000U)         /* !< Stride size 6 (+6 * DMASRCWDTH) */
+#define DMA_DMACTL_DMASRCINCR_STRIDE_7           ((uint32_t)0x000D0000U)         /* !< Stride size 7 (+7 * DMASRCWDTH) */
+#define DMA_DMACTL_DMASRCINCR_STRIDE_8           ((uint32_t)0x000E0000U)         /* !< Stride size 8 (+8 * DMASRCWDTH) */
+#define DMA_DMACTL_DMASRCINCR_STRIDE_9           ((uint32_t)0x000F0000U)         /* !< Stride size 9 (+9 * DMASRCWDTH) */
+/* DMA_DMACTL[DMADSTINCR] Bits */
+#define DMA_DMACTL_DMADSTINCR_OFS                (20)                            /* !< DMADSTINCR Offset */
+#define DMA_DMACTL_DMADSTINCR_MASK               ((uint32_t)0x00F00000U)         /* !< DMA destination increment. This bit
+                                                                                    selects automatic incrementing or
+                                                                                    decrementing of the destination
+                                                                                    address DMADA for each transfer. The
+                                                                                    amount of change to the DMADA is
+                                                                                    based on the definitin in the
+                                                                                    DMADSTWDTH. For example an increment
+                                                                                    of 1 (+1) on a WORD transfer will
+                                                                                    increment the DMADA by 4. */
+#define DMA_DMACTL_DMADSTINCR_UNCHANGED          ((uint32_t)0x00000000U)         /* !< Address is unchanged (+0) */
+#define DMA_DMACTL_DMADSTINCR_DECREMENT          ((uint32_t)0x00200000U)         /* !< Decremented by 1 (-1 * DMADSTWDTH) */
+#define DMA_DMACTL_DMADSTINCR_INCREMENT          ((uint32_t)0x00300000U)         /* !< Incremented by 1 (+1 * DMADSTWDTH) */
+#define DMA_DMACTL_DMADSTINCR_STRIDE_2           ((uint32_t)0x00800000U)         /* !< Stride size 2 (+2 * DMADSTWDTH) */
+#define DMA_DMACTL_DMADSTINCR_STRIDE_3           ((uint32_t)0x00900000U)         /* !< Stride size 3 (+3 * DMADSTWDTH) */
+#define DMA_DMACTL_DMADSTINCR_STRIDE_4           ((uint32_t)0x00A00000U)         /* !< Stride size 4 (+4 * DMADSTWDTH) */
+#define DMA_DMACTL_DMADSTINCR_STRIDE_5           ((uint32_t)0x00B00000U)         /* !< Stride size 5 (+5 * DMADSTWDTH) */
+#define DMA_DMACTL_DMADSTINCR_STRIDE_6           ((uint32_t)0x00C00000U)         /* !< Stride size 6 (+6 * DMADSTWDTH) */
+#define DMA_DMACTL_DMADSTINCR_STRIDE_7           ((uint32_t)0x00D00000U)         /* !< Stride size 7 (+7 * DMADSTWDTH) */
+#define DMA_DMACTL_DMADSTINCR_STRIDE_8           ((uint32_t)0x00E00000U)         /* !< Stride size 8 (+8 * DMADSTWDTH) */
+#define DMA_DMACTL_DMADSTINCR_STRIDE_9           ((uint32_t)0x00F00000U)         /* !< Stride size 9 (+9 * DMADSTWDTH) */
+/* DMA_DMACTL[DMATM] Bits */
+#define DMA_DMACTL_DMATM_OFS                     (28)                            /* !< DMATM Offset */
+#define DMA_DMACTL_DMATM_MASK                    ((uint32_t)0x30000000U)         /* !< DMA transfer mode register  Note:
+                                                                                    The repeat-single (2h) and
+                                                                                    repeat-block (3h) transfer are only
+                                                                                    available in a FULL-channel
+                                                                                    configuration. Please consult the
+                                                                                    datasheet of the specific device to
+                                                                                    map which channel number has FULL or
+                                                                                    BASIC capability. In a BASIC channel
+                                                                                    configuration only the values for
+                                                                                    single (0h) and block (1h) transfer
+                                                                                    can be set. */
+#define DMA_DMACTL_DMATM_SINGLE                  ((uint32_t)0x00000000U)         /* !< Single transfer. Each transfers
+                                                                                    requires a new trigger. When the
+                                                                                    DMASZ counts down to zero an event
+                                                                                    can be generated and the DMAEN is
+                                                                                    cleared. */
+#define DMA_DMACTL_DMATM_BLOCK                   ((uint32_t)0x10000000U)         /* !< Block transfer. Each trigger
+                                                                                    transfers the complete block defined
+                                                                                    in DMASZ. After the transfer is
+                                                                                    complete an event can be generated
+                                                                                    and the DMAEN is cleared. */
+#define DMA_DMACTL_DMATM_RPTSNGL                 ((uint32_t)0x20000000U)         /* !< Repeated single transfer. Each
+                                                                                    transfers requires a new trigger.
+                                                                                    When the DMASZ counts down to zero an
+                                                                                    event can be generated. After the
+                                                                                    last transfer the DMASA, DMADA, DAMSZ
+                                                                                    registers are restored to its initial
+                                                                                    value and the DMAEN stays enabled. */
+#define DMA_DMACTL_DMATM_RPTBLCK                 ((uint32_t)0x30000000U)         /* !< Repeated block transfer. Each
+                                                                                    trigger transfers the complete block
+                                                                                    defined in DMASZ. After the last
+                                                                                    transfer the DMASA, DMADA, DAMSZ
+                                                                                    registers are restored to its initial
+                                                                                    value and the DMAEN stays enabled. */
+/* DMA_DMACTL[DMAEM] Bits */
+#define DMA_DMACTL_DMAEM_OFS                     (24)                            /* !< DMAEM Offset */
+#define DMA_DMACTL_DMAEM_MASK                    ((uint32_t)0x03000000U)         /* !< DMA extended mode  Note: The
+                                                                                    extended transfer modes are only
+                                                                                    available in a FULL-channel
+                                                                                    configuration. Please consult the
+                                                                                    datasheet of the specific device to
+                                                                                    map which channel number has FULL or
+                                                                                    BASIC capability. In a BASIC channel
+                                                                                    configuration this register is a
+                                                                                    read-only register and reads 0x0. */
+#define DMA_DMACTL_DMAEM_NORMAL                  ((uint32_t)0x00000000U)         /* !< Normal mode is related to transfers
+                                                                                    from SRC to DST */
+#define DMA_DMACTL_DMAEM_FILLMODE                ((uint32_t)0x02000000U)         /* !< Fill mode will copy the SA register
+                                                                                    content as data to DA */
+#define DMA_DMACTL_DMAEM_TABLEMODE               ((uint32_t)0x03000000U)         /* !< Table mode will read an address and
+                                                                                    data value from SA and write the data
+                                                                                    to address */
+/* DMA_DMACTL[DMAPREIRQ] Bits */
+#define DMA_DMACTL_DMAPREIRQ_OFS                 (4)                             /* !< DMAPREIRQ Offset */
+#define DMA_DMACTL_DMAPREIRQ_MASK                ((uint32_t)0x00000070U)         /* !< Enable an early IRQ event. This can
+                                                                                    help software to react quicker to and
+                                                                                    DMA done event or allows some
+                                                                                    additional configuration before the
+                                                                                    channel is complete.   Note: This
+                                                                                    register is only available in a
+                                                                                    FULL-channel configuration. Please
+                                                                                    consult the datasheet of the specific
+                                                                                    device to map which channel number
+                                                                                    has FULL or BASIC capability. In a
+                                                                                    BASIC configuration this register is
+                                                                                    a read only value and always reads as
+                                                                                    0x0. */
+#define DMA_DMACTL_DMAPREIRQ_PREIRQ_DISABLE      ((uint32_t)0x00000000U)         /* !< Pre-IRQ event disabled. */
+#define DMA_DMACTL_DMAPREIRQ_PREIRQ_1            ((uint32_t)0x00000010U)         /* !< Issure Pre-IRQ event when DMASZ=1 */
+#define DMA_DMACTL_DMAPREIRQ_PREIRQ_2            ((uint32_t)0x00000020U)         /* !< Issure Pre-IRQ event when DMASZ=2 */
+#define DMA_DMACTL_DMAPREIRQ_PREIRQ_4            ((uint32_t)0x00000030U)         /* !< Issure Pre-IRQ event when DMASZ=4 */
+#define DMA_DMACTL_DMAPREIRQ_PREIRQ_8            ((uint32_t)0x00000040U)         /* !< Issure Pre-IRQ event when DMASZ=8 */
+#define DMA_DMACTL_DMAPREIRQ_PREIRQ_32           ((uint32_t)0x00000050U)         /* !< Issure Pre-IRQ event when DMASZ=32 */
+#define DMA_DMACTL_DMAPREIRQ_PREIRQ_64           ((uint32_t)0x00000060U)         /* !< Issure Pre-IRQ event when DMASZ=64 */
+#define DMA_DMACTL_DMAPREIRQ_PREIRQ_HALF         ((uint32_t)0x00000070U)         /* !< Issure Pre-IRQ event when DMASZ
+                                                                                    reached the half size point of the
+                                                                                    original transfer size */
+
+/* DMA_DMASA Bits */
+/* DMA_DMASA[ADDR] Bits */
+#define DMA_DMASA_ADDR_OFS                       (0)                             /* !< ADDR Offset */
+#define DMA_DMASA_ADDR_MASK                      ((uint32_t)0xFFFFFFFFU)         /* !< DMA Channel Source Address */
+#define DMA_DMASA_ADDR_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define DMA_DMASA_ADDR_MAXIMUM                   ((uint32_t)0xFFFFFFFFU)         /* !< Highest possible value */
+
+/* DMA_DMADA Bits */
+/* DMA_DMADA[ADDR] Bits */
+#define DMA_DMADA_ADDR_OFS                       (0)                             /* !< ADDR Offset */
+#define DMA_DMADA_ADDR_MASK                      ((uint32_t)0xFFFFFFFFU)         /* !< DMA Channel Destination Address */
+#define DMA_DMADA_ADDR_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define DMA_DMADA_ADDR_MAXIMUM                   ((uint32_t)0xFFFFFFFFU)         /* !< Highest possible value */
+
+/* DMA_DMASZ Bits */
+/* DMA_DMASZ[SIZE] Bits */
+#define DMA_DMASZ_SIZE_OFS                       (0)                             /* !< SIZE Offset */
+#define DMA_DMASZ_SIZE_MASK                      ((uint32_t)0x0000FFFFU)         /* !< DMA Channel Size in number of
+                                                                                    transfers */
+#define DMA_DMASZ_SIZE_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define DMA_DMASZ_SIZE_MAXIMUM                   ((uint32_t)0x0000FFFFU)         /* !< Highest possible value */
+
+/* DMA_DMATCTL Bits */
+/* DMA_DMATCTL[DMATSEL] Bits */
+#define DMA_DMATCTL_DMATSEL_OFS                  (0)                             /* !< DMATSEL Offset */
+#define DMA_DMATCTL_DMATSEL_MASK                 ((uint32_t)0x0000003FU)         /* !< DMA Trigger Select   Note:
+                                                                                    Reference the datasheet of the device
+                                                                                    to see the specific trigger mapping. */
+#define DMA_DMATCTL_DMATSEL_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define DMA_DMATCTL_DMATSEL_DMAREQ               ((uint32_t)0x00000000U)         /* !< Software trigger request */
+#define DMA_DMATCTL_DMATSEL_MAXIMUM              ((uint32_t)0x0000003FU)         /* !< Highest possible value */
+/* DMA_DMATCTL[DMATINT] Bits */
+#define DMA_DMATCTL_DMATINT_OFS                  (7)                             /* !< DMATINT Offset */
+#define DMA_DMATCTL_DMATINT_MASK                 ((uint32_t)0x00000080U)         /* !< DMA Trigger by Internal Channel */
+#define DMA_DMATCTL_DMATINT_EXTERNAL             ((uint32_t)0x00000000U)         /* !< DMATSEL will define external
+                                                                                    trigger select as transfer trigger. */
+#define DMA_DMATCTL_DMATINT_INTERNAL             ((uint32_t)0x00000080U)         /* !< DMATSEL will define internal
+                                                                                    channel as transfer trigger select.
+                                                                                    0-> Channel0-done, 1-> Channel1-done,
+                                                                                    ... */
+
+/* DMA_GEN_EVENT_IIDX Bits */
+/* DMA_GEN_EVENT_IIDX[STAT] Bits */
+#define DMA_GEN_EVENT_IIDX_STAT_OFS              (0)                             /* !< STAT Offset */
+#define DMA_GEN_EVENT_IIDX_STAT_MASK             ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define DMA_GEN_EVENT_IIDX_STAT_NO_INTR          ((uint32_t)0x00000000U)         /* !< No bit is set means there is no
+                                                                                    pending interrupt request */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH0           ((uint32_t)0x00000001U)         /* !< DMA Channel 0 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH1           ((uint32_t)0x00000002U)         /* !< DMA Channel 1 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH2           ((uint32_t)0x00000003U)         /* !< DMA Channel 2 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH3           ((uint32_t)0x00000004U)         /* !< DMA Channel 3 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH4           ((uint32_t)0x00000005U)         /* !< DMA Channel 4 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH5           ((uint32_t)0x00000006U)         /* !< DMA Channel 5 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH6           ((uint32_t)0x00000007U)         /* !< DMA Channel 6 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH7           ((uint32_t)0x00000008U)         /* !< DMA Channel 7 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH8           ((uint32_t)0x00000009U)         /* !< DMA Channel 8 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH9           ((uint32_t)0x0000000AU)         /* !< DMA Channel 9 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH10          ((uint32_t)0x0000000BU)         /* !< DMA Channel 10 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH11          ((uint32_t)0x0000000CU)         /* !< DMA Channel 11 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH12          ((uint32_t)0x0000000DU)         /* !< DMA Channel 12 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH13          ((uint32_t)0x0000000EU)         /* !< DMA Channel 13 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH14          ((uint32_t)0x0000000FU)         /* !< DMA Channel 14 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_DMACH15          ((uint32_t)0x00000010U)         /* !< DMA Channel 15 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IIDX_STAT_PREIRQCH0        ((uint32_t)0x00000011U)         /* !< PRE-IRQ event for DMA Channel 0. */
+#define DMA_GEN_EVENT_IIDX_STAT_PREIRQCH1        ((uint32_t)0x00000012U)         /* !< PRE-IRQ event for DMA Channel 1. */
+#define DMA_GEN_EVENT_IIDX_STAT_PREIRQCH2        ((uint32_t)0x00000013U)         /* !< PRE-IRQ event for DMA Channel 2. */
+#define DMA_GEN_EVENT_IIDX_STAT_PREIRQCH3        ((uint32_t)0x00000014U)         /* !< PRE-IRQ event for DMA Channel 3. */
+#define DMA_GEN_EVENT_IIDX_STAT_PREIRQCH4        ((uint32_t)0x00000015U)         /* !< PRE-IRQ event for DMA Channel 4. */
+#define DMA_GEN_EVENT_IIDX_STAT_PREIRQCH5        ((uint32_t)0x00000016U)         /* !< PRE-IRQ event for DMA Channel 5. */
+#define DMA_GEN_EVENT_IIDX_STAT_PREIRQCH6        ((uint32_t)0x00000017U)         /* !< PRE-IRQ event for DMA Channel 6. */
+#define DMA_GEN_EVENT_IIDX_STAT_PREIRQCH7        ((uint32_t)0x00000018U)         /* !< PRE-IRQ event for DMA Channel 7. */
+#define DMA_GEN_EVENT_IIDX_STAT_ADDRERR          ((uint32_t)0x00000019U)         /* !< DMA address error, SRC address not
+                                                                                    reachable. */
+#define DMA_GEN_EVENT_IIDX_STAT_DATAERR          ((uint32_t)0x0000001AU)         /* !< DMA data error, SRC data might be
+                                                                                    corrupted (PAR or ECC error). */
+
+/* DMA_GEN_EVENT_IMASK Bits */
+/* DMA_GEN_EVENT_IMASK[DMACH0] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH0_OFS           (0)                             /* !< DMACH0 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH0_MASK          ((uint32_t)0x00000001U)         /* !< DMA Channel 0 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH0_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH0_SET           ((uint32_t)0x00000001U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH1] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH1_OFS           (1)                             /* !< DMACH1 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH1_MASK          ((uint32_t)0x00000002U)         /* !< DMA Channel 1 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH1_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH1_SET           ((uint32_t)0x00000002U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH2] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH2_OFS           (2)                             /* !< DMACH2 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH2_MASK          ((uint32_t)0x00000004U)         /* !< DMA Channel 2 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH2_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH2_SET           ((uint32_t)0x00000004U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH3] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH3_OFS           (3)                             /* !< DMACH3 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH3_MASK          ((uint32_t)0x00000008U)         /* !< DMA Channel 3 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH3_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH3_SET           ((uint32_t)0x00000008U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH4] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH4_OFS           (4)                             /* !< DMACH4 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH4_MASK          ((uint32_t)0x00000010U)         /* !< DMA Channel 4 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH4_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH4_SET           ((uint32_t)0x00000010U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH5] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH5_OFS           (5)                             /* !< DMACH5 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH5_MASK          ((uint32_t)0x00000020U)         /* !< DMA Channel 5 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH5_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH5_SET           ((uint32_t)0x00000020U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH6] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH6_OFS           (6)                             /* !< DMACH6 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH6_MASK          ((uint32_t)0x00000040U)         /* !< DMA Channel 6 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH6_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH6_SET           ((uint32_t)0x00000040U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH7] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH7_OFS           (7)                             /* !< DMACH7 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH7_MASK          ((uint32_t)0x00000080U)         /* !< DMA Channel 7 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH7_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH7_SET           ((uint32_t)0x00000080U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH8] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH8_OFS           (8)                             /* !< DMACH8 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH8_MASK          ((uint32_t)0x00000100U)         /* !< DMA Channel 8 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH8_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH8_SET           ((uint32_t)0x00000100U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH9] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH9_OFS           (9)                             /* !< DMACH9 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH9_MASK          ((uint32_t)0x00000200U)         /* !< DMA Channel 9 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH9_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH9_SET           ((uint32_t)0x00000200U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH10] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH10_OFS          (10)                            /* !< DMACH10 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH10_MASK         ((uint32_t)0x00000400U)         /* !< DMA Channel 10 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH10_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH10_SET          ((uint32_t)0x00000400U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH11] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH11_OFS          (11)                            /* !< DMACH11 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH11_MASK         ((uint32_t)0x00000800U)         /* !< DMA Channel 11 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH11_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH11_SET          ((uint32_t)0x00000800U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH12] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH12_OFS          (12)                            /* !< DMACH12 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH12_MASK         ((uint32_t)0x00001000U)         /* !< DMA Channel 12 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH12_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH12_SET          ((uint32_t)0x00001000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH13] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH13_OFS          (13)                            /* !< DMACH13 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH13_MASK         ((uint32_t)0x00002000U)         /* !< DMA Channel 13 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH13_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH13_SET          ((uint32_t)0x00002000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH14] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH14_OFS          (14)                            /* !< DMACH14 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH14_MASK         ((uint32_t)0x00004000U)         /* !< DMA Channel 14 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH14_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH14_SET          ((uint32_t)0x00004000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DMACH15] Bits */
+#define DMA_GEN_EVENT_IMASK_DMACH15_OFS          (15)                            /* !< DMACH15 Offset */
+#define DMA_GEN_EVENT_IMASK_DMACH15_MASK         ((uint32_t)0x00008000U)         /* !< DMA Channel 15 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_GEN_EVENT_IMASK_DMACH15_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DMACH15_SET          ((uint32_t)0x00008000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[PREIRQCH0] Bits */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH0_OFS        (16)                            /* !< PREIRQCH0 Offset */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH0_MASK       ((uint32_t)0x00010000U)         /* !< Pre-IRQ for Channel 0. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH0_CLR        ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH0_SET        ((uint32_t)0x00010000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[PREIRQCH1] Bits */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH1_OFS        (17)                            /* !< PREIRQCH1 Offset */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH1_MASK       ((uint32_t)0x00020000U)         /* !< Pre-IRQ for Channel 1. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH1_CLR        ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH1_SET        ((uint32_t)0x00020000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[PREIRQCH2] Bits */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH2_OFS        (18)                            /* !< PREIRQCH2 Offset */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH2_MASK       ((uint32_t)0x00040000U)         /* !< Pre-IRQ for Channel 2. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH2_CLR        ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH2_SET        ((uint32_t)0x00040000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[PREIRQCH3] Bits */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH3_OFS        (19)                            /* !< PREIRQCH3 Offset */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH3_MASK       ((uint32_t)0x00080000U)         /* !< Pre-IRQ for Channel 3. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH3_CLR        ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH3_SET        ((uint32_t)0x00080000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[PREIRQCH4] Bits */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH4_OFS        (20)                            /* !< PREIRQCH4 Offset */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH4_MASK       ((uint32_t)0x00100000U)         /* !< Pre-IRQ for Channel 4. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH4_CLR        ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH4_SET        ((uint32_t)0x00100000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[PREIRQCH5] Bits */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH5_OFS        (21)                            /* !< PREIRQCH5 Offset */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH5_MASK       ((uint32_t)0x00200000U)         /* !< Pre-IRQ for Channel 5. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH5_CLR        ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH5_SET        ((uint32_t)0x00200000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[PREIRQCH6] Bits */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH6_OFS        (22)                            /* !< PREIRQCH6 Offset */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH6_MASK       ((uint32_t)0x00400000U)         /* !< Pre-IRQ for Channel 6. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH6_CLR        ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH6_SET        ((uint32_t)0x00400000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[PREIRQCH7] Bits */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH7_OFS        (23)                            /* !< PREIRQCH7 Offset */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH7_MASK       ((uint32_t)0x00800000U)         /* !< Pre-IRQ for Channel 7. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH7_CLR        ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_PREIRQCH7_SET        ((uint32_t)0x00800000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[ADDRERR] Bits */
+#define DMA_GEN_EVENT_IMASK_ADDRERR_OFS          (24)                            /* !< ADDRERR Offset */
+#define DMA_GEN_EVENT_IMASK_ADDRERR_MASK         ((uint32_t)0x01000000U)         /* !< DMA address error, SRC address not
+                                                                                    reachable. */
+#define DMA_GEN_EVENT_IMASK_ADDRERR_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_ADDRERR_SET          ((uint32_t)0x01000000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_IMASK[DATAERR] Bits */
+#define DMA_GEN_EVENT_IMASK_DATAERR_OFS          (25)                            /* !< DATAERR Offset */
+#define DMA_GEN_EVENT_IMASK_DATAERR_MASK         ((uint32_t)0x02000000U)         /* !< DMA data error, SRC data might be
+                                                                                    corrupted (PAR or ECC error). */
+#define DMA_GEN_EVENT_IMASK_DATAERR_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_IMASK_DATAERR_SET          ((uint32_t)0x02000000U)         /* !< Set interrupt mask bit */
+
+/* DMA_GEN_EVENT_RIS Bits */
+/* DMA_GEN_EVENT_RIS[DMACH0] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH0_OFS             (0)                             /* !< DMACH0 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH0_MASK            ((uint32_t)0x00000001U)         /* !< DMA Channel 0 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH0_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH0_SET             ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH1] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH1_OFS             (1)                             /* !< DMACH1 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH1_MASK            ((uint32_t)0x00000002U)         /* !< DMA Channel 1 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH1_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH1_SET             ((uint32_t)0x00000002U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH2] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH2_OFS             (2)                             /* !< DMACH2 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH2_MASK            ((uint32_t)0x00000004U)         /* !< DMA Channel 2 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH2_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH2_SET             ((uint32_t)0x00000004U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH3] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH3_OFS             (3)                             /* !< DMACH3 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH3_MASK            ((uint32_t)0x00000008U)         /* !< DMA Channel 3 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH3_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH3_SET             ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH4] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH4_OFS             (4)                             /* !< DMACH4 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH4_MASK            ((uint32_t)0x00000010U)         /* !< DMA Channel 4 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH4_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH4_SET             ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH5] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH5_OFS             (5)                             /* !< DMACH5 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH5_MASK            ((uint32_t)0x00000020U)         /* !< DMA Channel 5 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH5_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH5_SET             ((uint32_t)0x00000020U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH6] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH6_OFS             (6)                             /* !< DMACH6 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH6_MASK            ((uint32_t)0x00000040U)         /* !< DMA Channel 6 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH6_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH6_SET             ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH7] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH7_OFS             (7)                             /* !< DMACH7 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH7_MASK            ((uint32_t)0x00000080U)         /* !< DMA Channel 7 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH7_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH7_SET             ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH8] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH8_OFS             (8)                             /* !< DMACH8 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH8_MASK            ((uint32_t)0x00000100U)         /* !< DMA Channel 8 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH8_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH8_SET             ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH9] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH9_OFS             (9)                             /* !< DMACH9 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH9_MASK            ((uint32_t)0x00000200U)         /* !< DMA Channel 9 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH9_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH9_SET             ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH10] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH10_OFS            (10)                            /* !< DMACH10 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH10_MASK           ((uint32_t)0x00000400U)         /* !< DMA Channel 10 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH10_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH10_SET            ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH11] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH11_OFS            (11)                            /* !< DMACH11 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH11_MASK           ((uint32_t)0x00000800U)         /* !< DMA Channel 11 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH11_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH11_SET            ((uint32_t)0x00000800U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH12] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH12_OFS            (12)                            /* !< DMACH12 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH12_MASK           ((uint32_t)0x00001000U)         /* !< DMA Channel 12 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH12_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH12_SET            ((uint32_t)0x00001000U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH13] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH13_OFS            (13)                            /* !< DMACH13 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH13_MASK           ((uint32_t)0x00002000U)         /* !< DMA Channel 13 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH13_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH13_SET            ((uint32_t)0x00002000U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH14] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH14_OFS            (14)                            /* !< DMACH14 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH14_MASK           ((uint32_t)0x00004000U)         /* !< DMA Channel 14 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH14_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH14_SET            ((uint32_t)0x00004000U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[DMACH15] Bits */
+#define DMA_GEN_EVENT_RIS_DMACH15_OFS            (15)                            /* !< DMACH15 Offset */
+#define DMA_GEN_EVENT_RIS_DMACH15_MASK           ((uint32_t)0x00008000U)         /* !< DMA Channel 15 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_RIS_DMACH15_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_GEN_EVENT_RIS_DMACH15_SET            ((uint32_t)0x00008000U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_RIS[PREIRQCH0] Bits */
+#define DMA_GEN_EVENT_RIS_PREIRQCH0_OFS          (16)                            /* !< PREIRQCH0 Offset */
+#define DMA_GEN_EVENT_RIS_PREIRQCH0_MASK         ((uint32_t)0x00010000U)         /* !< Pre-IRQ for Channel 0. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_RIS_PREIRQCH0_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_RIS_PREIRQCH0_SET          ((uint32_t)0x00010000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_RIS[PREIRQCH1] Bits */
+#define DMA_GEN_EVENT_RIS_PREIRQCH1_OFS          (17)                            /* !< PREIRQCH1 Offset */
+#define DMA_GEN_EVENT_RIS_PREIRQCH1_MASK         ((uint32_t)0x00020000U)         /* !< Pre-IRQ for Channel 1. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_RIS_PREIRQCH1_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_RIS_PREIRQCH1_SET          ((uint32_t)0x00020000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_RIS[PREIRQCH2] Bits */
+#define DMA_GEN_EVENT_RIS_PREIRQCH2_OFS          (18)                            /* !< PREIRQCH2 Offset */
+#define DMA_GEN_EVENT_RIS_PREIRQCH2_MASK         ((uint32_t)0x00040000U)         /* !< Pre-IRQ for Channel 2. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_RIS_PREIRQCH2_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_RIS_PREIRQCH2_SET          ((uint32_t)0x00040000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_RIS[PREIRQCH3] Bits */
+#define DMA_GEN_EVENT_RIS_PREIRQCH3_OFS          (19)                            /* !< PREIRQCH3 Offset */
+#define DMA_GEN_EVENT_RIS_PREIRQCH3_MASK         ((uint32_t)0x00080000U)         /* !< Pre-IRQ for Channel 3. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_RIS_PREIRQCH3_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_RIS_PREIRQCH3_SET          ((uint32_t)0x00080000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_RIS[PREIRQCH4] Bits */
+#define DMA_GEN_EVENT_RIS_PREIRQCH4_OFS          (20)                            /* !< PREIRQCH4 Offset */
+#define DMA_GEN_EVENT_RIS_PREIRQCH4_MASK         ((uint32_t)0x00100000U)         /* !< Pre-IRQ for Channel 4. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_RIS_PREIRQCH4_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_RIS_PREIRQCH4_SET          ((uint32_t)0x00100000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_RIS[PREIRQCH5] Bits */
+#define DMA_GEN_EVENT_RIS_PREIRQCH5_OFS          (21)                            /* !< PREIRQCH5 Offset */
+#define DMA_GEN_EVENT_RIS_PREIRQCH5_MASK         ((uint32_t)0x00200000U)         /* !< Pre-IRQ for Channel 5. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_RIS_PREIRQCH5_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_RIS_PREIRQCH5_SET          ((uint32_t)0x00200000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_RIS[PREIRQCH6] Bits */
+#define DMA_GEN_EVENT_RIS_PREIRQCH6_OFS          (22)                            /* !< PREIRQCH6 Offset */
+#define DMA_GEN_EVENT_RIS_PREIRQCH6_MASK         ((uint32_t)0x00400000U)         /* !< Pre-IRQ for Channel 6. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_RIS_PREIRQCH6_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_RIS_PREIRQCH6_SET          ((uint32_t)0x00400000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_RIS[PREIRQCH7] Bits */
+#define DMA_GEN_EVENT_RIS_PREIRQCH7_OFS          (23)                            /* !< PREIRQCH7 Offset */
+#define DMA_GEN_EVENT_RIS_PREIRQCH7_MASK         ((uint32_t)0x00800000U)         /* !< Pre-IRQ for Channel 7. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_RIS_PREIRQCH7_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_RIS_PREIRQCH7_SET          ((uint32_t)0x00800000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_RIS[ADDRERR] Bits */
+#define DMA_GEN_EVENT_RIS_ADDRERR_OFS            (24)                            /* !< ADDRERR Offset */
+#define DMA_GEN_EVENT_RIS_ADDRERR_MASK           ((uint32_t)0x01000000U)         /* !< DMA address error, SRC address not
+                                                                                    reachable. */
+#define DMA_GEN_EVENT_RIS_ADDRERR_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_RIS_ADDRERR_SET            ((uint32_t)0x01000000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_RIS[DATAERR] Bits */
+#define DMA_GEN_EVENT_RIS_DATAERR_OFS            (25)                            /* !< DATAERR Offset */
+#define DMA_GEN_EVENT_RIS_DATAERR_MASK           ((uint32_t)0x02000000U)         /* !< DMA data error, SRC data might be
+                                                                                    corrupted (PAR or ECC error). */
+#define DMA_GEN_EVENT_RIS_DATAERR_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_RIS_DATAERR_SET            ((uint32_t)0x02000000U)         /* !< Set interrupt mask bit */
+
+/* DMA_GEN_EVENT_MIS Bits */
+/* DMA_GEN_EVENT_MIS[DMACH0] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH0_OFS             (0)                             /* !< DMACH0 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH0_MASK            ((uint32_t)0x00000001U)         /* !< DMA Channel 0 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH0_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH0_SET             ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH1] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH1_OFS             (1)                             /* !< DMACH1 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH1_MASK            ((uint32_t)0x00000002U)         /* !< DMA Channel 1 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH1_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH1_SET             ((uint32_t)0x00000002U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH2] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH2_OFS             (2)                             /* !< DMACH2 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH2_MASK            ((uint32_t)0x00000004U)         /* !< DMA Channel 2 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH2_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH2_SET             ((uint32_t)0x00000004U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH3] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH3_OFS             (3)                             /* !< DMACH3 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH3_MASK            ((uint32_t)0x00000008U)         /* !< DMA Channel 3 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH3_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH3_SET             ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH4] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH4_OFS             (4)                             /* !< DMACH4 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH4_MASK            ((uint32_t)0x00000010U)         /* !< DMA Channel 4 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH4_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH4_SET             ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH5] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH5_OFS             (5)                             /* !< DMACH5 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH5_MASK            ((uint32_t)0x00000020U)         /* !< DMA Channel 5 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH5_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH5_SET             ((uint32_t)0x00000020U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH6] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH6_OFS             (6)                             /* !< DMACH6 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH6_MASK            ((uint32_t)0x00000040U)         /* !< DMA Channel 6 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH6_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH6_SET             ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH7] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH7_OFS             (7)                             /* !< DMACH7 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH7_MASK            ((uint32_t)0x00000080U)         /* !< DMA Channel 7 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH7_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH7_SET             ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH8] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH8_OFS             (8)                             /* !< DMACH8 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH8_MASK            ((uint32_t)0x00000100U)         /* !< DMA Channel 8 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH8_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH8_SET             ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH9] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH9_OFS             (9)                             /* !< DMACH9 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH9_MASK            ((uint32_t)0x00000200U)         /* !< DMA Channel 9 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH9_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH9_SET             ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH10] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH10_OFS            (10)                            /* !< DMACH10 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH10_MASK           ((uint32_t)0x00000400U)         /* !< DMA Channel 10 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH10_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH10_SET            ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH11] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH11_OFS            (11)                            /* !< DMACH11 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH11_MASK           ((uint32_t)0x00000800U)         /* !< DMA Channel 11 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH11_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH11_SET            ((uint32_t)0x00000800U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH12] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH12_OFS            (12)                            /* !< DMACH12 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH12_MASK           ((uint32_t)0x00001000U)         /* !< DMA Channel 12 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH12_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH12_SET            ((uint32_t)0x00001000U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH13] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH13_OFS            (13)                            /* !< DMACH13 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH13_MASK           ((uint32_t)0x00002000U)         /* !< DMA Channel 13 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH13_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH13_SET            ((uint32_t)0x00002000U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH14] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH14_OFS            (14)                            /* !< DMACH14 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH14_MASK           ((uint32_t)0x00004000U)         /* !< DMA Channel 14 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH14_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH14_SET            ((uint32_t)0x00004000U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[DMACH15] Bits */
+#define DMA_GEN_EVENT_MIS_DMACH15_OFS            (15)                            /* !< DMACH15 Offset */
+#define DMA_GEN_EVENT_MIS_DMACH15_MASK           ((uint32_t)0x00008000U)         /* !< DMA Channel 15 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_MIS_DMACH15_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_GEN_EVENT_MIS_DMACH15_SET            ((uint32_t)0x00008000U)         /* !< Interrupt occurred */
+/* DMA_GEN_EVENT_MIS[PREIRQCH0] Bits */
+#define DMA_GEN_EVENT_MIS_PREIRQCH0_OFS          (16)                            /* !< PREIRQCH0 Offset */
+#define DMA_GEN_EVENT_MIS_PREIRQCH0_MASK         ((uint32_t)0x00010000U)         /* !< Pre-IRQ for Channel 0. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_MIS_PREIRQCH0_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_MIS_PREIRQCH0_SET          ((uint32_t)0x00010000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_MIS[PREIRQCH1] Bits */
+#define DMA_GEN_EVENT_MIS_PREIRQCH1_OFS          (17)                            /* !< PREIRQCH1 Offset */
+#define DMA_GEN_EVENT_MIS_PREIRQCH1_MASK         ((uint32_t)0x00020000U)         /* !< Pre-IRQ for Channel 1. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_MIS_PREIRQCH1_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_MIS_PREIRQCH1_SET          ((uint32_t)0x00020000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_MIS[PREIRQCH2] Bits */
+#define DMA_GEN_EVENT_MIS_PREIRQCH2_OFS          (18)                            /* !< PREIRQCH2 Offset */
+#define DMA_GEN_EVENT_MIS_PREIRQCH2_MASK         ((uint32_t)0x00040000U)         /* !< Pre-IRQ for Channel 2. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_MIS_PREIRQCH2_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_MIS_PREIRQCH2_SET          ((uint32_t)0x00040000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_MIS[PREIRQCH3] Bits */
+#define DMA_GEN_EVENT_MIS_PREIRQCH3_OFS          (19)                            /* !< PREIRQCH3 Offset */
+#define DMA_GEN_EVENT_MIS_PREIRQCH3_MASK         ((uint32_t)0x00080000U)         /* !< Pre-IRQ for Channel 3. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_MIS_PREIRQCH3_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_MIS_PREIRQCH3_SET          ((uint32_t)0x00080000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_MIS[PREIRQCH4] Bits */
+#define DMA_GEN_EVENT_MIS_PREIRQCH4_OFS          (20)                            /* !< PREIRQCH4 Offset */
+#define DMA_GEN_EVENT_MIS_PREIRQCH4_MASK         ((uint32_t)0x00100000U)         /* !< Pre-IRQ for Channel 4. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_MIS_PREIRQCH4_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_MIS_PREIRQCH4_SET          ((uint32_t)0x00100000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_MIS[PREIRQCH5] Bits */
+#define DMA_GEN_EVENT_MIS_PREIRQCH5_OFS          (21)                            /* !< PREIRQCH5 Offset */
+#define DMA_GEN_EVENT_MIS_PREIRQCH5_MASK         ((uint32_t)0x00200000U)         /* !< Pre-IRQ for Channel 5. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_MIS_PREIRQCH5_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_MIS_PREIRQCH5_SET          ((uint32_t)0x00200000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_MIS[PREIRQCH6] Bits */
+#define DMA_GEN_EVENT_MIS_PREIRQCH6_OFS          (22)                            /* !< PREIRQCH6 Offset */
+#define DMA_GEN_EVENT_MIS_PREIRQCH6_MASK         ((uint32_t)0x00400000U)         /* !< Pre-IRQ for Channel 6. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_MIS_PREIRQCH6_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_MIS_PREIRQCH6_SET          ((uint32_t)0x00400000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_MIS[PREIRQCH7] Bits */
+#define DMA_GEN_EVENT_MIS_PREIRQCH7_OFS          (23)                            /* !< PREIRQCH7 Offset */
+#define DMA_GEN_EVENT_MIS_PREIRQCH7_MASK         ((uint32_t)0x00800000U)         /* !< Pre-IRQ for Channel 7. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_MIS_PREIRQCH7_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_MIS_PREIRQCH7_SET          ((uint32_t)0x00800000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_MIS[ADDRERR] Bits */
+#define DMA_GEN_EVENT_MIS_ADDRERR_OFS            (24)                            /* !< ADDRERR Offset */
+#define DMA_GEN_EVENT_MIS_ADDRERR_MASK           ((uint32_t)0x01000000U)         /* !< DMA address error, SRC address not
+                                                                                    reachable. */
+#define DMA_GEN_EVENT_MIS_ADDRERR_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_MIS_ADDRERR_SET            ((uint32_t)0x01000000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_MIS[DATAERR] Bits */
+#define DMA_GEN_EVENT_MIS_DATAERR_OFS            (25)                            /* !< DATAERR Offset */
+#define DMA_GEN_EVENT_MIS_DATAERR_MASK           ((uint32_t)0x02000000U)         /* !< DMA data error, SRC data might be
+                                                                                    corrupted (PAR or ECC error). */
+#define DMA_GEN_EVENT_MIS_DATAERR_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_MIS_DATAERR_SET            ((uint32_t)0x02000000U)         /* !< Set interrupt mask bit */
+
+/* DMA_GEN_EVENT_ISET Bits */
+/* DMA_GEN_EVENT_ISET[DMACH0] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH0_OFS            (0)                             /* !< DMACH0 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH0_MASK           ((uint32_t)0x00000001U)         /* !< DMA Channel 0 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH0_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH0_SET            ((uint32_t)0x00000001U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH1] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH1_OFS            (1)                             /* !< DMACH1 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH1_MASK           ((uint32_t)0x00000002U)         /* !< DMA Channel 1 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH1_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH1_SET            ((uint32_t)0x00000002U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH2] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH2_OFS            (2)                             /* !< DMACH2 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH2_MASK           ((uint32_t)0x00000004U)         /* !< DMA Channel 2 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH2_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH2_SET            ((uint32_t)0x00000004U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH3] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH3_OFS            (3)                             /* !< DMACH3 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH3_MASK           ((uint32_t)0x00000008U)         /* !< DMA Channel 3 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH3_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH3_SET            ((uint32_t)0x00000008U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH4] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH4_OFS            (4)                             /* !< DMACH4 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH4_MASK           ((uint32_t)0x00000010U)         /* !< DMA Channel 4 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH4_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH4_SET            ((uint32_t)0x00000010U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH5] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH5_OFS            (5)                             /* !< DMACH5 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH5_MASK           ((uint32_t)0x00000020U)         /* !< DMA Channel 5 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH5_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH5_SET            ((uint32_t)0x00000020U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH6] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH6_OFS            (6)                             /* !< DMACH6 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH6_MASK           ((uint32_t)0x00000040U)         /* !< DMA Channel 6 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH6_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH6_SET            ((uint32_t)0x00000040U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH7] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH7_OFS            (7)                             /* !< DMACH7 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH7_MASK           ((uint32_t)0x00000080U)         /* !< DMA Channel 7 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH7_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH7_SET            ((uint32_t)0x00000080U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH8] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH8_OFS            (8)                             /* !< DMACH8 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH8_MASK           ((uint32_t)0x00000100U)         /* !< DMA Channel 8 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH8_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH8_SET            ((uint32_t)0x00000100U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH9] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH9_OFS            (9)                             /* !< DMACH9 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH9_MASK           ((uint32_t)0x00000200U)         /* !< DMA Channel 9 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH9_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH9_SET            ((uint32_t)0x00000200U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH10] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH10_OFS           (10)                            /* !< DMACH10 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH10_MASK          ((uint32_t)0x00000400U)         /* !< DMA Channel 0 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH10_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH10_SET           ((uint32_t)0x00000400U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH11] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH11_OFS           (11)                            /* !< DMACH11 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH11_MASK          ((uint32_t)0x00000800U)         /* !< DMA Channel 11 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH11_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH11_SET           ((uint32_t)0x00000800U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH12] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH12_OFS           (12)                            /* !< DMACH12 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH12_MASK          ((uint32_t)0x00001000U)         /* !< DMA Channel 12 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH12_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH12_SET           ((uint32_t)0x00001000U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH13] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH13_OFS           (13)                            /* !< DMACH13 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH13_MASK          ((uint32_t)0x00002000U)         /* !< DMA Channel 13 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH13_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH13_SET           ((uint32_t)0x00002000U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH14] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH14_OFS           (14)                            /* !< DMACH14 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH14_MASK          ((uint32_t)0x00004000U)         /* !< DMA Channel 14 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH14_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH14_SET           ((uint32_t)0x00004000U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[DMACH15] Bits */
+#define DMA_GEN_EVENT_ISET_DMACH15_OFS           (15)                            /* !< DMACH15 Offset */
+#define DMA_GEN_EVENT_ISET_DMACH15_MASK          ((uint32_t)0x00008000U)         /* !< DMA Channel 0 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ISET_DMACH15_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ISET_DMACH15_SET           ((uint32_t)0x00008000U)         /* !< Set interrupt */
+/* DMA_GEN_EVENT_ISET[PREIRQCH0] Bits */
+#define DMA_GEN_EVENT_ISET_PREIRQCH0_OFS         (16)                            /* !< PREIRQCH0 Offset */
+#define DMA_GEN_EVENT_ISET_PREIRQCH0_MASK        ((uint32_t)0x00010000U)         /* !< Pre-IRQ for Channel 0. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ISET_PREIRQCH0_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ISET_PREIRQCH0_SET         ((uint32_t)0x00010000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ISET[PREIRQCH1] Bits */
+#define DMA_GEN_EVENT_ISET_PREIRQCH1_OFS         (17)                            /* !< PREIRQCH1 Offset */
+#define DMA_GEN_EVENT_ISET_PREIRQCH1_MASK        ((uint32_t)0x00020000U)         /* !< Pre-IRQ for Channel 1. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ISET_PREIRQCH1_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ISET_PREIRQCH1_SET         ((uint32_t)0x00020000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ISET[PREIRQCH2] Bits */
+#define DMA_GEN_EVENT_ISET_PREIRQCH2_OFS         (18)                            /* !< PREIRQCH2 Offset */
+#define DMA_GEN_EVENT_ISET_PREIRQCH2_MASK        ((uint32_t)0x00040000U)         /* !< Pre-IRQ for Channel 2. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ISET_PREIRQCH2_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ISET_PREIRQCH2_SET         ((uint32_t)0x00040000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ISET[PREIRQCH3] Bits */
+#define DMA_GEN_EVENT_ISET_PREIRQCH3_OFS         (19)                            /* !< PREIRQCH3 Offset */
+#define DMA_GEN_EVENT_ISET_PREIRQCH3_MASK        ((uint32_t)0x00080000U)         /* !< Pre-IRQ for Channel 3. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ISET_PREIRQCH3_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ISET_PREIRQCH3_SET         ((uint32_t)0x00080000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ISET[PREIRQCH4] Bits */
+#define DMA_GEN_EVENT_ISET_PREIRQCH4_OFS         (20)                            /* !< PREIRQCH4 Offset */
+#define DMA_GEN_EVENT_ISET_PREIRQCH4_MASK        ((uint32_t)0x00100000U)         /* !< Pre-IRQ for Channel 4. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ISET_PREIRQCH4_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ISET_PREIRQCH4_SET         ((uint32_t)0x00100000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ISET[PREIRQCH5] Bits */
+#define DMA_GEN_EVENT_ISET_PREIRQCH5_OFS         (21)                            /* !< PREIRQCH5 Offset */
+#define DMA_GEN_EVENT_ISET_PREIRQCH5_MASK        ((uint32_t)0x00200000U)         /* !< Pre-IRQ for Channel 5. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ISET_PREIRQCH5_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ISET_PREIRQCH5_SET         ((uint32_t)0x00200000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ISET[PREIRQCH6] Bits */
+#define DMA_GEN_EVENT_ISET_PREIRQCH6_OFS         (22)                            /* !< PREIRQCH6 Offset */
+#define DMA_GEN_EVENT_ISET_PREIRQCH6_MASK        ((uint32_t)0x00400000U)         /* !< Pre-IRQ for Channel 6. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ISET_PREIRQCH6_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ISET_PREIRQCH6_SET         ((uint32_t)0x00400000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ISET[PREIRQCH7] Bits */
+#define DMA_GEN_EVENT_ISET_PREIRQCH7_OFS         (23)                            /* !< PREIRQCH7 Offset */
+#define DMA_GEN_EVENT_ISET_PREIRQCH7_MASK        ((uint32_t)0x00800000U)         /* !< Pre-IRQ for Channel 7. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ISET_PREIRQCH7_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ISET_PREIRQCH7_SET         ((uint32_t)0x00800000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ISET[ADDRERR] Bits */
+#define DMA_GEN_EVENT_ISET_ADDRERR_OFS           (24)                            /* !< ADDRERR Offset */
+#define DMA_GEN_EVENT_ISET_ADDRERR_MASK          ((uint32_t)0x01000000U)         /* !< DMA address error, SRC address not
+                                                                                    reachable. */
+#define DMA_GEN_EVENT_ISET_ADDRERR_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ISET_ADDRERR_SET           ((uint32_t)0x01000000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ISET[DATAERR] Bits */
+#define DMA_GEN_EVENT_ISET_DATAERR_OFS           (25)                            /* !< DATAERR Offset */
+#define DMA_GEN_EVENT_ISET_DATAERR_MASK          ((uint32_t)0x02000000U)         /* !< DMA data error, SRC data might be
+                                                                                    corrupted (PAR or ECC error). */
+#define DMA_GEN_EVENT_ISET_DATAERR_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ISET_DATAERR_SET           ((uint32_t)0x02000000U)         /* !< Set interrupt mask bit */
+
+/* DMA_GEN_EVENT_ICLR Bits */
+/* DMA_GEN_EVENT_ICLR[DMACH0] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH0_OFS            (0)                             /* !< DMACH0 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH0_MASK           ((uint32_t)0x00000001U)         /* !< DMA Channel 0 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH0_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH0_CLR            ((uint32_t)0x00000001U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH1] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH1_OFS            (1)                             /* !< DMACH1 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH1_MASK           ((uint32_t)0x00000002U)         /* !< DMA Channel 1 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH1_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH1_CLR            ((uint32_t)0x00000002U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH2] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH2_OFS            (2)                             /* !< DMACH2 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH2_MASK           ((uint32_t)0x00000004U)         /* !< DMA Channel 2 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH2_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH2_CLR            ((uint32_t)0x00000004U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH3] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH3_OFS            (3)                             /* !< DMACH3 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH3_MASK           ((uint32_t)0x00000008U)         /* !< DMA Channel 3 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH3_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH3_CLR            ((uint32_t)0x00000008U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH4] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH4_OFS            (4)                             /* !< DMACH4 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH4_MASK           ((uint32_t)0x00000010U)         /* !< DMA Channel 4 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH4_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH4_CLR            ((uint32_t)0x00000010U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH5] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH5_OFS            (5)                             /* !< DMACH5 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH5_MASK           ((uint32_t)0x00000020U)         /* !< DMA Channel 5 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH5_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH5_CLR            ((uint32_t)0x00000020U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH6] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH6_OFS            (6)                             /* !< DMACH6 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH6_MASK           ((uint32_t)0x00000040U)         /* !< DMA Channel 6 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH6_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH6_CLR            ((uint32_t)0x00000040U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH7] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH7_OFS            (7)                             /* !< DMACH7 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH7_MASK           ((uint32_t)0x00000080U)         /* !< DMA Channel 7 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH7_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH7_CLR            ((uint32_t)0x00000080U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH8] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH8_OFS            (8)                             /* !< DMACH8 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH8_MASK           ((uint32_t)0x00000100U)         /* !< DMA Channel 8 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH8_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH8_CLR            ((uint32_t)0x00000100U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH9] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH9_OFS            (9)                             /* !< DMACH9 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH9_MASK           ((uint32_t)0x00000200U)         /* !< DMA Channel 9 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH9_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH9_CLR            ((uint32_t)0x00000200U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH10] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH10_OFS           (10)                            /* !< DMACH10 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH10_MASK          ((uint32_t)0x00000400U)         /* !< DMA Channel 10 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH10_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH10_CLR           ((uint32_t)0x00000400U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH11] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH11_OFS           (11)                            /* !< DMACH11 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH11_MASK          ((uint32_t)0x00000800U)         /* !< DMA Channel 11 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH11_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH11_CLR           ((uint32_t)0x00000800U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH12] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH12_OFS           (12)                            /* !< DMACH12 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH12_MASK          ((uint32_t)0x00001000U)         /* !< DMA Channel 12 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH12_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH12_CLR           ((uint32_t)0x00001000U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH13] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH13_OFS           (13)                            /* !< DMACH13 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH13_MASK          ((uint32_t)0x00002000U)         /* !< DMA Channel 13 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH13_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH13_CLR           ((uint32_t)0x00002000U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH14] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH14_OFS           (14)                            /* !< DMACH14 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH14_MASK          ((uint32_t)0x00004000U)         /* !< DMA Channel 14 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH14_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH14_CLR           ((uint32_t)0x00004000U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[DMACH15] Bits */
+#define DMA_GEN_EVENT_ICLR_DMACH15_OFS           (15)                            /* !< DMACH15 Offset */
+#define DMA_GEN_EVENT_ICLR_DMACH15_MASK          ((uint32_t)0x00008000U)         /* !< DMA Channel 15 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_GEN_EVENT_ICLR_DMACH15_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_GEN_EVENT_ICLR_DMACH15_CLR           ((uint32_t)0x00008000U)         /* !< Clear interrupt */
+/* DMA_GEN_EVENT_ICLR[PREIRQCH0] Bits */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH0_OFS         (16)                            /* !< PREIRQCH0 Offset */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH0_MASK        ((uint32_t)0x00010000U)         /* !< Pre-IRQ for Channel 0. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH0_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH0_SET         ((uint32_t)0x00010000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ICLR[PREIRQCH1] Bits */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH1_OFS         (17)                            /* !< PREIRQCH1 Offset */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH1_MASK        ((uint32_t)0x00020000U)         /* !< Pre-IRQ for Channel 1. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH1_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH1_SET         ((uint32_t)0x00020000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ICLR[PREIRQCH2] Bits */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH2_OFS         (18)                            /* !< PREIRQCH2 Offset */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH2_MASK        ((uint32_t)0x00040000U)         /* !< Pre-IRQ for Channel 2. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH2_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH2_SET         ((uint32_t)0x00040000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ICLR[PREIRQCH3] Bits */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH3_OFS         (19)                            /* !< PREIRQCH3 Offset */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH3_MASK        ((uint32_t)0x00080000U)         /* !< Pre-IRQ for Channel 3. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH3_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH3_SET         ((uint32_t)0x00080000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ICLR[PREIRQCH4] Bits */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH4_OFS         (20)                            /* !< PREIRQCH4 Offset */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH4_MASK        ((uint32_t)0x00100000U)         /* !< Pre-IRQ for Channel 4. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH4_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH4_SET         ((uint32_t)0x00100000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ICLR[PREIRQCH5] Bits */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH5_OFS         (21)                            /* !< PREIRQCH5 Offset */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH5_MASK        ((uint32_t)0x00200000U)         /* !< Pre-IRQ for Channel 5. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH5_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH5_SET         ((uint32_t)0x00200000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ICLR[PREIRQCH6] Bits */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH6_OFS         (22)                            /* !< PREIRQCH6 Offset */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH6_MASK        ((uint32_t)0x00400000U)         /* !< Pre-IRQ for Channel 6. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH6_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH6_SET         ((uint32_t)0x00400000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ICLR[PREIRQCH7] Bits */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH7_OFS         (23)                            /* !< PREIRQCH7 Offset */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH7_MASK        ((uint32_t)0x00800000U)         /* !< Pre-IRQ for Channel 7. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH7_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ICLR_PREIRQCH7_SET         ((uint32_t)0x00800000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ICLR[ADDRERR] Bits */
+#define DMA_GEN_EVENT_ICLR_ADDRERR_OFS           (24)                            /* !< ADDRERR Offset */
+#define DMA_GEN_EVENT_ICLR_ADDRERR_MASK          ((uint32_t)0x01000000U)         /* !< DMA address error, SRC address not
+                                                                                    reachable. */
+#define DMA_GEN_EVENT_ICLR_ADDRERR_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ICLR_ADDRERR_SET           ((uint32_t)0x01000000U)         /* !< Set interrupt mask bit */
+/* DMA_GEN_EVENT_ICLR[DATAERR] Bits */
+#define DMA_GEN_EVENT_ICLR_DATAERR_OFS           (25)                            /* !< DATAERR Offset */
+#define DMA_GEN_EVENT_ICLR_DATAERR_MASK          ((uint32_t)0x02000000U)         /* !< DMA data error, SRC data might be
+                                                                                    corrupted (PAR or ECC error). */
+#define DMA_GEN_EVENT_ICLR_DATAERR_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_GEN_EVENT_ICLR_DATAERR_SET           ((uint32_t)0x02000000U)         /* !< Set interrupt mask bit */
+
+/* DMA_CPU_INT_IIDX Bits */
+/* DMA_CPU_INT_IIDX[STAT] Bits */
+#define DMA_CPU_INT_IIDX_STAT_OFS                (0)                             /* !< STAT Offset */
+#define DMA_CPU_INT_IIDX_STAT_MASK               ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define DMA_CPU_INT_IIDX_STAT_NO_INTR            ((uint32_t)0x00000000U)         /* !< No bit is set means there is no
+                                                                                    pending interrupt request */
+#define DMA_CPU_INT_IIDX_STAT_DMACH0             ((uint32_t)0x00000001U)         /* !< DMA Channel 0 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH1             ((uint32_t)0x00000002U)         /* !< DMA Channel 1 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH2             ((uint32_t)0x00000003U)         /* !< DMA Channel 2 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH3             ((uint32_t)0x00000004U)         /* !< DMA Channel 3 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH4             ((uint32_t)0x00000005U)         /* !< DMA Channel 4 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH5             ((uint32_t)0x00000006U)         /* !< DMA Channel 5 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH6             ((uint32_t)0x00000007U)         /* !< DMA Channel 6 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH7             ((uint32_t)0x00000008U)         /* !< DMA Channel 7 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH8             ((uint32_t)0x00000009U)         /* !< DMA Channel 8 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH9             ((uint32_t)0x0000000AU)         /* !< DMA Channel 9 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH10            ((uint32_t)0x0000000BU)         /* !< DMA Channel 10 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH11            ((uint32_t)0x0000000CU)         /* !< DMA Channel 11 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH12            ((uint32_t)0x0000000DU)         /* !< DMA Channel 12 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH13            ((uint32_t)0x0000000EU)         /* !< DMA Channel 13 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH14            ((uint32_t)0x0000000FU)         /* !< DMA Channel 14 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_DMACH15            ((uint32_t)0x00000010U)         /* !< DMA Channel 15 size counter reached
+                                                                                    zero (DMASZ=0). */
+#define DMA_CPU_INT_IIDX_STAT_PREIRQCH0          ((uint32_t)0x00000011U)         /* !< PRE-IRQ event for DMA Channel 0. */
+#define DMA_CPU_INT_IIDX_STAT_PREIRQCH1          ((uint32_t)0x00000012U)         /* !< PRE-IRQ event for DMA Channel 1. */
+#define DMA_CPU_INT_IIDX_STAT_PREIRQCH2          ((uint32_t)0x00000013U)         /* !< PRE-IRQ event for DMA Channel 2. */
+#define DMA_CPU_INT_IIDX_STAT_PREIRQCH3          ((uint32_t)0x00000014U)         /* !< PRE-IRQ event for DMA Channel 3. */
+#define DMA_CPU_INT_IIDX_STAT_PREIRQCH4          ((uint32_t)0x00000015U)         /* !< PRE-IRQ event for DMA Channel 4. */
+#define DMA_CPU_INT_IIDX_STAT_PREIRQCH5          ((uint32_t)0x00000016U)         /* !< PRE-IRQ event for DMA Channel 5. */
+#define DMA_CPU_INT_IIDX_STAT_PREIRQCH6          ((uint32_t)0x00000017U)         /* !< PRE-IRQ event for DMA Channel 6. */
+#define DMA_CPU_INT_IIDX_STAT_PREIRQCH7          ((uint32_t)0x00000018U)         /* !< PRE-IRQ event for DMA Channel 7. */
+#define DMA_CPU_INT_IIDX_STAT_ADDRERR            ((uint32_t)0x00000019U)         /* !< DMA address error, SRC address not
+                                                                                    reachable. */
+#define DMA_CPU_INT_IIDX_STAT_DATAERR            ((uint32_t)0x0000001AU)         /* !< DMA data error, SRC data might be
+                                                                                    corrupted (PAR or ECC error). */
+
+/* DMA_CPU_INT_IMASK Bits */
+/* DMA_CPU_INT_IMASK[DMACH0] Bits */
+#define DMA_CPU_INT_IMASK_DMACH0_OFS             (0)                             /* !< DMACH0 Offset */
+#define DMA_CPU_INT_IMASK_DMACH0_MASK            ((uint32_t)0x00000001U)         /* !< DMA Channel 0 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH0_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH0_SET             ((uint32_t)0x00000001U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH1] Bits */
+#define DMA_CPU_INT_IMASK_DMACH1_OFS             (1)                             /* !< DMACH1 Offset */
+#define DMA_CPU_INT_IMASK_DMACH1_MASK            ((uint32_t)0x00000002U)         /* !< DMA Channel 1 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH1_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH1_SET             ((uint32_t)0x00000002U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH2] Bits */
+#define DMA_CPU_INT_IMASK_DMACH2_OFS             (2)                             /* !< DMACH2 Offset */
+#define DMA_CPU_INT_IMASK_DMACH2_MASK            ((uint32_t)0x00000004U)         /* !< DMA Channel 2 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH2_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH2_SET             ((uint32_t)0x00000004U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH3] Bits */
+#define DMA_CPU_INT_IMASK_DMACH3_OFS             (3)                             /* !< DMACH3 Offset */
+#define DMA_CPU_INT_IMASK_DMACH3_MASK            ((uint32_t)0x00000008U)         /* !< DMA Channel 3 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH3_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH3_SET             ((uint32_t)0x00000008U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH4] Bits */
+#define DMA_CPU_INT_IMASK_DMACH4_OFS             (4)                             /* !< DMACH4 Offset */
+#define DMA_CPU_INT_IMASK_DMACH4_MASK            ((uint32_t)0x00000010U)         /* !< DMA Channel 4 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH4_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH4_SET             ((uint32_t)0x00000010U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH5] Bits */
+#define DMA_CPU_INT_IMASK_DMACH5_OFS             (5)                             /* !< DMACH5 Offset */
+#define DMA_CPU_INT_IMASK_DMACH5_MASK            ((uint32_t)0x00000020U)         /* !< DMA Channel 5 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH5_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH5_SET             ((uint32_t)0x00000020U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH6] Bits */
+#define DMA_CPU_INT_IMASK_DMACH6_OFS             (6)                             /* !< DMACH6 Offset */
+#define DMA_CPU_INT_IMASK_DMACH6_MASK            ((uint32_t)0x00000040U)         /* !< DMA Channel 6 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH6_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH6_SET             ((uint32_t)0x00000040U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH7] Bits */
+#define DMA_CPU_INT_IMASK_DMACH7_OFS             (7)                             /* !< DMACH7 Offset */
+#define DMA_CPU_INT_IMASK_DMACH7_MASK            ((uint32_t)0x00000080U)         /* !< DMA Channel 7 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH7_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH7_SET             ((uint32_t)0x00000080U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH8] Bits */
+#define DMA_CPU_INT_IMASK_DMACH8_OFS             (8)                             /* !< DMACH8 Offset */
+#define DMA_CPU_INT_IMASK_DMACH8_MASK            ((uint32_t)0x00000100U)         /* !< DMA Channel 8 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH8_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH8_SET             ((uint32_t)0x00000100U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH9] Bits */
+#define DMA_CPU_INT_IMASK_DMACH9_OFS             (9)                             /* !< DMACH9 Offset */
+#define DMA_CPU_INT_IMASK_DMACH9_MASK            ((uint32_t)0x00000200U)         /* !< DMA Channel 9 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH9_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH9_SET             ((uint32_t)0x00000200U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH10] Bits */
+#define DMA_CPU_INT_IMASK_DMACH10_OFS            (10)                            /* !< DMACH10 Offset */
+#define DMA_CPU_INT_IMASK_DMACH10_MASK           ((uint32_t)0x00000400U)         /* !< DMA Channel 10 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH10_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH10_SET            ((uint32_t)0x00000400U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH11] Bits */
+#define DMA_CPU_INT_IMASK_DMACH11_OFS            (11)                            /* !< DMACH11 Offset */
+#define DMA_CPU_INT_IMASK_DMACH11_MASK           ((uint32_t)0x00000800U)         /* !< DMA Channel 11 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH11_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH11_SET            ((uint32_t)0x00000800U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH12] Bits */
+#define DMA_CPU_INT_IMASK_DMACH12_OFS            (12)                            /* !< DMACH12 Offset */
+#define DMA_CPU_INT_IMASK_DMACH12_MASK           ((uint32_t)0x00001000U)         /* !< DMA Channel 12 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH12_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH12_SET            ((uint32_t)0x00001000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH13] Bits */
+#define DMA_CPU_INT_IMASK_DMACH13_OFS            (13)                            /* !< DMACH13 Offset */
+#define DMA_CPU_INT_IMASK_DMACH13_MASK           ((uint32_t)0x00002000U)         /* !< DMA Channel 13 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH13_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH13_SET            ((uint32_t)0x00002000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH14] Bits */
+#define DMA_CPU_INT_IMASK_DMACH14_OFS            (14)                            /* !< DMACH14 Offset */
+#define DMA_CPU_INT_IMASK_DMACH14_MASK           ((uint32_t)0x00004000U)         /* !< DMA Channel 14 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH14_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH14_SET            ((uint32_t)0x00004000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DMACH15] Bits */
+#define DMA_CPU_INT_IMASK_DMACH15_OFS            (15)                            /* !< DMACH15 Offset */
+#define DMA_CPU_INT_IMASK_DMACH15_MASK           ((uint32_t)0x00008000U)         /* !< DMA Channel 15 interrupt signal.
+                                                                                    Size counter reached zero (DMASZ=0). */
+#define DMA_CPU_INT_IMASK_DMACH15_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DMACH15_SET            ((uint32_t)0x00008000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[PREIRQCH0] Bits */
+#define DMA_CPU_INT_IMASK_PREIRQCH0_OFS          (16)                            /* !< PREIRQCH0 Offset */
+#define DMA_CPU_INT_IMASK_PREIRQCH0_MASK         ((uint32_t)0x00010000U)         /* !< Pre-IRQ for Channel 0. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_IMASK_PREIRQCH0_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_PREIRQCH0_SET          ((uint32_t)0x00010000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[PREIRQCH1] Bits */
+#define DMA_CPU_INT_IMASK_PREIRQCH1_OFS          (17)                            /* !< PREIRQCH1 Offset */
+#define DMA_CPU_INT_IMASK_PREIRQCH1_MASK         ((uint32_t)0x00020000U)         /* !< Pre-IRQ for Channel 1. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_IMASK_PREIRQCH1_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_PREIRQCH1_SET          ((uint32_t)0x00020000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[PREIRQCH2] Bits */
+#define DMA_CPU_INT_IMASK_PREIRQCH2_OFS          (18)                            /* !< PREIRQCH2 Offset */
+#define DMA_CPU_INT_IMASK_PREIRQCH2_MASK         ((uint32_t)0x00040000U)         /* !< Pre-IRQ for Channel 2. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_IMASK_PREIRQCH2_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_PREIRQCH2_SET          ((uint32_t)0x00040000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[PREIRQCH3] Bits */
+#define DMA_CPU_INT_IMASK_PREIRQCH3_OFS          (19)                            /* !< PREIRQCH3 Offset */
+#define DMA_CPU_INT_IMASK_PREIRQCH3_MASK         ((uint32_t)0x00080000U)         /* !< Pre-IRQ for Channel 3. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_IMASK_PREIRQCH3_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_PREIRQCH3_SET          ((uint32_t)0x00080000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[PREIRQCH4] Bits */
+#define DMA_CPU_INT_IMASK_PREIRQCH4_OFS          (20)                            /* !< PREIRQCH4 Offset */
+#define DMA_CPU_INT_IMASK_PREIRQCH4_MASK         ((uint32_t)0x00100000U)         /* !< Pre-IRQ for Channel 4. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_IMASK_PREIRQCH4_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_PREIRQCH4_SET          ((uint32_t)0x00100000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[PREIRQCH5] Bits */
+#define DMA_CPU_INT_IMASK_PREIRQCH5_OFS          (21)                            /* !< PREIRQCH5 Offset */
+#define DMA_CPU_INT_IMASK_PREIRQCH5_MASK         ((uint32_t)0x00200000U)         /* !< Pre-IRQ for Channel 5. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_IMASK_PREIRQCH5_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_PREIRQCH5_SET          ((uint32_t)0x00200000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[PREIRQCH6] Bits */
+#define DMA_CPU_INT_IMASK_PREIRQCH6_OFS          (22)                            /* !< PREIRQCH6 Offset */
+#define DMA_CPU_INT_IMASK_PREIRQCH6_MASK         ((uint32_t)0x00400000U)         /* !< Pre-IRQ for Channel 6. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_IMASK_PREIRQCH6_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_PREIRQCH6_SET          ((uint32_t)0x00400000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[PREIRQCH7] Bits */
+#define DMA_CPU_INT_IMASK_PREIRQCH7_OFS          (23)                            /* !< PREIRQCH7 Offset */
+#define DMA_CPU_INT_IMASK_PREIRQCH7_MASK         ((uint32_t)0x00800000U)         /* !< Pre-IRQ for Channel 7. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_IMASK_PREIRQCH7_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_PREIRQCH7_SET          ((uint32_t)0x00800000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[ADDRERR] Bits */
+#define DMA_CPU_INT_IMASK_ADDRERR_OFS            (24)                            /* !< ADDRERR Offset */
+#define DMA_CPU_INT_IMASK_ADDRERR_MASK           ((uint32_t)0x01000000U)         /* !< DMA address error, SRC address not
+                                                                                    reachable. */
+#define DMA_CPU_INT_IMASK_ADDRERR_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_ADDRERR_SET            ((uint32_t)0x01000000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_IMASK[DATAERR] Bits */
+#define DMA_CPU_INT_IMASK_DATAERR_OFS            (25)                            /* !< DATAERR Offset */
+#define DMA_CPU_INT_IMASK_DATAERR_MASK           ((uint32_t)0x02000000U)         /* !< DMA data error, SRC data might be
+                                                                                    corrupted (PAR or ECC error). */
+#define DMA_CPU_INT_IMASK_DATAERR_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_IMASK_DATAERR_SET            ((uint32_t)0x02000000U)         /* !< Set interrupt mask bit */
+
+/* DMA_CPU_INT_RIS Bits */
+/* DMA_CPU_INT_RIS[DMACH0] Bits */
+#define DMA_CPU_INT_RIS_DMACH0_OFS               (0)                             /* !< DMACH0 Offset */
+#define DMA_CPU_INT_RIS_DMACH0_MASK              ((uint32_t)0x00000001U)         /* !< DMA Channel 0 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH0_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH0_SET               ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH1] Bits */
+#define DMA_CPU_INT_RIS_DMACH1_OFS               (1)                             /* !< DMACH1 Offset */
+#define DMA_CPU_INT_RIS_DMACH1_MASK              ((uint32_t)0x00000002U)         /* !< DMA Channel 1 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH1_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH1_SET               ((uint32_t)0x00000002U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH2] Bits */
+#define DMA_CPU_INT_RIS_DMACH2_OFS               (2)                             /* !< DMACH2 Offset */
+#define DMA_CPU_INT_RIS_DMACH2_MASK              ((uint32_t)0x00000004U)         /* !< DMA Channel 2 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH2_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH2_SET               ((uint32_t)0x00000004U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH3] Bits */
+#define DMA_CPU_INT_RIS_DMACH3_OFS               (3)                             /* !< DMACH3 Offset */
+#define DMA_CPU_INT_RIS_DMACH3_MASK              ((uint32_t)0x00000008U)         /* !< DMA Channel 3 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH3_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH3_SET               ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH4] Bits */
+#define DMA_CPU_INT_RIS_DMACH4_OFS               (4)                             /* !< DMACH4 Offset */
+#define DMA_CPU_INT_RIS_DMACH4_MASK              ((uint32_t)0x00000010U)         /* !< DMA Channel 4 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH4_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH4_SET               ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH5] Bits */
+#define DMA_CPU_INT_RIS_DMACH5_OFS               (5)                             /* !< DMACH5 Offset */
+#define DMA_CPU_INT_RIS_DMACH5_MASK              ((uint32_t)0x00000020U)         /* !< DMA Channel 5 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH5_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH5_SET               ((uint32_t)0x00000020U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH6] Bits */
+#define DMA_CPU_INT_RIS_DMACH6_OFS               (6)                             /* !< DMACH6 Offset */
+#define DMA_CPU_INT_RIS_DMACH6_MASK              ((uint32_t)0x00000040U)         /* !< DMA Channel 6 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH6_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH6_SET               ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH7] Bits */
+#define DMA_CPU_INT_RIS_DMACH7_OFS               (7)                             /* !< DMACH7 Offset */
+#define DMA_CPU_INT_RIS_DMACH7_MASK              ((uint32_t)0x00000080U)         /* !< DMA Channel 7 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH7_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH7_SET               ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH8] Bits */
+#define DMA_CPU_INT_RIS_DMACH8_OFS               (8)                             /* !< DMACH8 Offset */
+#define DMA_CPU_INT_RIS_DMACH8_MASK              ((uint32_t)0x00000100U)         /* !< DMA Channel 8 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH8_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH8_SET               ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH9] Bits */
+#define DMA_CPU_INT_RIS_DMACH9_OFS               (9)                             /* !< DMACH9 Offset */
+#define DMA_CPU_INT_RIS_DMACH9_MASK              ((uint32_t)0x00000200U)         /* !< DMA Channel 9 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH9_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH9_SET               ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH10] Bits */
+#define DMA_CPU_INT_RIS_DMACH10_OFS              (10)                            /* !< DMACH10 Offset */
+#define DMA_CPU_INT_RIS_DMACH10_MASK             ((uint32_t)0x00000400U)         /* !< DMA Channel 10 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH10_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH10_SET              ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH11] Bits */
+#define DMA_CPU_INT_RIS_DMACH11_OFS              (11)                            /* !< DMACH11 Offset */
+#define DMA_CPU_INT_RIS_DMACH11_MASK             ((uint32_t)0x00000800U)         /* !< DMA Channel 11 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH11_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH11_SET              ((uint32_t)0x00000800U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH12] Bits */
+#define DMA_CPU_INT_RIS_DMACH12_OFS              (12)                            /* !< DMACH12 Offset */
+#define DMA_CPU_INT_RIS_DMACH12_MASK             ((uint32_t)0x00001000U)         /* !< DMA Channel 12 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH12_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH12_SET              ((uint32_t)0x00001000U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH13] Bits */
+#define DMA_CPU_INT_RIS_DMACH13_OFS              (13)                            /* !< DMACH13 Offset */
+#define DMA_CPU_INT_RIS_DMACH13_MASK             ((uint32_t)0x00002000U)         /* !< DMA Channel 13 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH13_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH13_SET              ((uint32_t)0x00002000U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH14] Bits */
+#define DMA_CPU_INT_RIS_DMACH14_OFS              (14)                            /* !< DMACH14 Offset */
+#define DMA_CPU_INT_RIS_DMACH14_MASK             ((uint32_t)0x00004000U)         /* !< DMA Channel 14 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH14_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH14_SET              ((uint32_t)0x00004000U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[DMACH15] Bits */
+#define DMA_CPU_INT_RIS_DMACH15_OFS              (15)                            /* !< DMACH15 Offset */
+#define DMA_CPU_INT_RIS_DMACH15_MASK             ((uint32_t)0x00008000U)         /* !< DMA Channel 15 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_RIS_DMACH15_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define DMA_CPU_INT_RIS_DMACH15_SET              ((uint32_t)0x00008000U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_RIS[PREIRQCH0] Bits */
+#define DMA_CPU_INT_RIS_PREIRQCH0_OFS            (16)                            /* !< PREIRQCH0 Offset */
+#define DMA_CPU_INT_RIS_PREIRQCH0_MASK           ((uint32_t)0x00010000U)         /* !< Pre-IRQ for Channel 0. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_RIS_PREIRQCH0_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_RIS_PREIRQCH0_SET            ((uint32_t)0x00010000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_RIS[PREIRQCH1] Bits */
+#define DMA_CPU_INT_RIS_PREIRQCH1_OFS            (17)                            /* !< PREIRQCH1 Offset */
+#define DMA_CPU_INT_RIS_PREIRQCH1_MASK           ((uint32_t)0x00020000U)         /* !< Pre-IRQ for Channel 1. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_RIS_PREIRQCH1_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_RIS_PREIRQCH1_SET            ((uint32_t)0x00020000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_RIS[PREIRQCH2] Bits */
+#define DMA_CPU_INT_RIS_PREIRQCH2_OFS            (18)                            /* !< PREIRQCH2 Offset */
+#define DMA_CPU_INT_RIS_PREIRQCH2_MASK           ((uint32_t)0x00040000U)         /* !< Pre-IRQ for Channel 2. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_RIS_PREIRQCH2_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_RIS_PREIRQCH2_SET            ((uint32_t)0x00040000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_RIS[PREIRQCH3] Bits */
+#define DMA_CPU_INT_RIS_PREIRQCH3_OFS            (19)                            /* !< PREIRQCH3 Offset */
+#define DMA_CPU_INT_RIS_PREIRQCH3_MASK           ((uint32_t)0x00080000U)         /* !< Pre-IRQ for Channel 3. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_RIS_PREIRQCH3_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_RIS_PREIRQCH3_SET            ((uint32_t)0x00080000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_RIS[PREIRQCH4] Bits */
+#define DMA_CPU_INT_RIS_PREIRQCH4_OFS            (20)                            /* !< PREIRQCH4 Offset */
+#define DMA_CPU_INT_RIS_PREIRQCH4_MASK           ((uint32_t)0x00100000U)         /* !< Pre-IRQ for Channel 4. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_RIS_PREIRQCH4_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_RIS_PREIRQCH4_SET            ((uint32_t)0x00100000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_RIS[PREIRQCH5] Bits */
+#define DMA_CPU_INT_RIS_PREIRQCH5_OFS            (21)                            /* !< PREIRQCH5 Offset */
+#define DMA_CPU_INT_RIS_PREIRQCH5_MASK           ((uint32_t)0x00200000U)         /* !< Pre-IRQ for Channel 5. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_RIS_PREIRQCH5_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_RIS_PREIRQCH5_SET            ((uint32_t)0x00200000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_RIS[PREIRQCH6] Bits */
+#define DMA_CPU_INT_RIS_PREIRQCH6_OFS            (22)                            /* !< PREIRQCH6 Offset */
+#define DMA_CPU_INT_RIS_PREIRQCH6_MASK           ((uint32_t)0x00400000U)         /* !< Pre-IRQ for Channel 6. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_RIS_PREIRQCH6_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_RIS_PREIRQCH6_SET            ((uint32_t)0x00400000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_RIS[PREIRQCH7] Bits */
+#define DMA_CPU_INT_RIS_PREIRQCH7_OFS            (23)                            /* !< PREIRQCH7 Offset */
+#define DMA_CPU_INT_RIS_PREIRQCH7_MASK           ((uint32_t)0x00800000U)         /* !< Pre-IRQ for Channel 7. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_RIS_PREIRQCH7_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_RIS_PREIRQCH7_SET            ((uint32_t)0x00800000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_RIS[ADDRERR] Bits */
+#define DMA_CPU_INT_RIS_ADDRERR_OFS              (24)                            /* !< ADDRERR Offset */
+#define DMA_CPU_INT_RIS_ADDRERR_MASK             ((uint32_t)0x01000000U)         /* !< DMA address error, SRC address not
+                                                                                    reachable. */
+#define DMA_CPU_INT_RIS_ADDRERR_CLR              ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_RIS_ADDRERR_SET              ((uint32_t)0x01000000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_RIS[DATAERR] Bits */
+#define DMA_CPU_INT_RIS_DATAERR_OFS              (25)                            /* !< DATAERR Offset */
+#define DMA_CPU_INT_RIS_DATAERR_MASK             ((uint32_t)0x02000000U)         /* !< DMA data error, SRC data might be
+                                                                                    corrupted (PAR or ECC error). */
+#define DMA_CPU_INT_RIS_DATAERR_CLR              ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_RIS_DATAERR_SET              ((uint32_t)0x02000000U)         /* !< Set interrupt mask bit */
+
+/* DMA_CPU_INT_MIS Bits */
+/* DMA_CPU_INT_MIS[DMACH0] Bits */
+#define DMA_CPU_INT_MIS_DMACH0_OFS               (0)                             /* !< DMACH0 Offset */
+#define DMA_CPU_INT_MIS_DMACH0_MASK              ((uint32_t)0x00000001U)         /* !< DMA Channel 0 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH0_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH0_SET               ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH1] Bits */
+#define DMA_CPU_INT_MIS_DMACH1_OFS               (1)                             /* !< DMACH1 Offset */
+#define DMA_CPU_INT_MIS_DMACH1_MASK              ((uint32_t)0x00000002U)         /* !< DMA Channel 1 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH1_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH1_SET               ((uint32_t)0x00000002U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH2] Bits */
+#define DMA_CPU_INT_MIS_DMACH2_OFS               (2)                             /* !< DMACH2 Offset */
+#define DMA_CPU_INT_MIS_DMACH2_MASK              ((uint32_t)0x00000004U)         /* !< DMA Channel 2 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH2_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH2_SET               ((uint32_t)0x00000004U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH3] Bits */
+#define DMA_CPU_INT_MIS_DMACH3_OFS               (3)                             /* !< DMACH3 Offset */
+#define DMA_CPU_INT_MIS_DMACH3_MASK              ((uint32_t)0x00000008U)         /* !< DMA Channel 3 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH3_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH3_SET               ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH4] Bits */
+#define DMA_CPU_INT_MIS_DMACH4_OFS               (4)                             /* !< DMACH4 Offset */
+#define DMA_CPU_INT_MIS_DMACH4_MASK              ((uint32_t)0x00000010U)         /* !< DMA Channel 4 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH4_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH4_SET               ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH5] Bits */
+#define DMA_CPU_INT_MIS_DMACH5_OFS               (5)                             /* !< DMACH5 Offset */
+#define DMA_CPU_INT_MIS_DMACH5_MASK              ((uint32_t)0x00000020U)         /* !< DMA Channel 5 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH5_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH5_SET               ((uint32_t)0x00000020U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH6] Bits */
+#define DMA_CPU_INT_MIS_DMACH6_OFS               (6)                             /* !< DMACH6 Offset */
+#define DMA_CPU_INT_MIS_DMACH6_MASK              ((uint32_t)0x00000040U)         /* !< DMA Channel 6 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH6_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH6_SET               ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH7] Bits */
+#define DMA_CPU_INT_MIS_DMACH7_OFS               (7)                             /* !< DMACH7 Offset */
+#define DMA_CPU_INT_MIS_DMACH7_MASK              ((uint32_t)0x00000080U)         /* !< DMA Channel 7 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH7_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH7_SET               ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH8] Bits */
+#define DMA_CPU_INT_MIS_DMACH8_OFS               (8)                             /* !< DMACH8 Offset */
+#define DMA_CPU_INT_MIS_DMACH8_MASK              ((uint32_t)0x00000100U)         /* !< DMA Channel 8 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH8_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH8_SET               ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH9] Bits */
+#define DMA_CPU_INT_MIS_DMACH9_OFS               (9)                             /* !< DMACH9 Offset */
+#define DMA_CPU_INT_MIS_DMACH9_MASK              ((uint32_t)0x00000200U)         /* !< DMA Channel 9 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH9_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH9_SET               ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH10] Bits */
+#define DMA_CPU_INT_MIS_DMACH10_OFS              (10)                            /* !< DMACH10 Offset */
+#define DMA_CPU_INT_MIS_DMACH10_MASK             ((uint32_t)0x00000400U)         /* !< DMA Channel 10 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH10_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH10_SET              ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH11] Bits */
+#define DMA_CPU_INT_MIS_DMACH11_OFS              (11)                            /* !< DMACH11 Offset */
+#define DMA_CPU_INT_MIS_DMACH11_MASK             ((uint32_t)0x00000800U)         /* !< DMA Channel 11 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH11_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH11_SET              ((uint32_t)0x00000800U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH12] Bits */
+#define DMA_CPU_INT_MIS_DMACH12_OFS              (12)                            /* !< DMACH12 Offset */
+#define DMA_CPU_INT_MIS_DMACH12_MASK             ((uint32_t)0x00001000U)         /* !< DMA Channel 12 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH12_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH12_SET              ((uint32_t)0x00001000U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH13] Bits */
+#define DMA_CPU_INT_MIS_DMACH13_OFS              (13)                            /* !< DMACH13 Offset */
+#define DMA_CPU_INT_MIS_DMACH13_MASK             ((uint32_t)0x00002000U)         /* !< DMA Channel 13 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH13_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH13_SET              ((uint32_t)0x00002000U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH14] Bits */
+#define DMA_CPU_INT_MIS_DMACH14_OFS              (14)                            /* !< DMACH14 Offset */
+#define DMA_CPU_INT_MIS_DMACH14_MASK             ((uint32_t)0x00004000U)         /* !< DMA Channel 14 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH14_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH14_SET              ((uint32_t)0x00004000U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[DMACH15] Bits */
+#define DMA_CPU_INT_MIS_DMACH15_OFS              (15)                            /* !< DMACH15 Offset */
+#define DMA_CPU_INT_MIS_DMACH15_MASK             ((uint32_t)0x00008000U)         /* !< DMA Channel 15 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_MIS_DMACH15_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define DMA_CPU_INT_MIS_DMACH15_SET              ((uint32_t)0x00008000U)         /* !< Interrupt occurred */
+/* DMA_CPU_INT_MIS[PREIRQCH0] Bits */
+#define DMA_CPU_INT_MIS_PREIRQCH0_OFS            (16)                            /* !< PREIRQCH0 Offset */
+#define DMA_CPU_INT_MIS_PREIRQCH0_MASK           ((uint32_t)0x00010000U)         /* !< Pre-IRQ for Channel 0. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_MIS_PREIRQCH0_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_MIS_PREIRQCH0_SET            ((uint32_t)0x00010000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_MIS[PREIRQCH1] Bits */
+#define DMA_CPU_INT_MIS_PREIRQCH1_OFS            (17)                            /* !< PREIRQCH1 Offset */
+#define DMA_CPU_INT_MIS_PREIRQCH1_MASK           ((uint32_t)0x00020000U)         /* !< Pre-IRQ for Channel 1. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_MIS_PREIRQCH1_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_MIS_PREIRQCH1_SET            ((uint32_t)0x00020000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_MIS[PREIRQCH2] Bits */
+#define DMA_CPU_INT_MIS_PREIRQCH2_OFS            (18)                            /* !< PREIRQCH2 Offset */
+#define DMA_CPU_INT_MIS_PREIRQCH2_MASK           ((uint32_t)0x00040000U)         /* !< Pre-IRQ for Channel 2. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_MIS_PREIRQCH2_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_MIS_PREIRQCH2_SET            ((uint32_t)0x00040000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_MIS[PREIRQCH3] Bits */
+#define DMA_CPU_INT_MIS_PREIRQCH3_OFS            (19)                            /* !< PREIRQCH3 Offset */
+#define DMA_CPU_INT_MIS_PREIRQCH3_MASK           ((uint32_t)0x00080000U)         /* !< Pre-IRQ for Channel 3. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_MIS_PREIRQCH3_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_MIS_PREIRQCH3_SET            ((uint32_t)0x00080000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_MIS[PREIRQCH4] Bits */
+#define DMA_CPU_INT_MIS_PREIRQCH4_OFS            (20)                            /* !< PREIRQCH4 Offset */
+#define DMA_CPU_INT_MIS_PREIRQCH4_MASK           ((uint32_t)0x00100000U)         /* !< Pre-IRQ for Channel 4. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_MIS_PREIRQCH4_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_MIS_PREIRQCH4_SET            ((uint32_t)0x00100000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_MIS[PREIRQCH5] Bits */
+#define DMA_CPU_INT_MIS_PREIRQCH5_OFS            (21)                            /* !< PREIRQCH5 Offset */
+#define DMA_CPU_INT_MIS_PREIRQCH5_MASK           ((uint32_t)0x00200000U)         /* !< Pre-IRQ for Channel 5. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_MIS_PREIRQCH5_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_MIS_PREIRQCH5_SET            ((uint32_t)0x00200000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_MIS[PREIRQCH6] Bits */
+#define DMA_CPU_INT_MIS_PREIRQCH6_OFS            (22)                            /* !< PREIRQCH6 Offset */
+#define DMA_CPU_INT_MIS_PREIRQCH6_MASK           ((uint32_t)0x00400000U)         /* !< Pre-IRQ for Channel 6. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_MIS_PREIRQCH6_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_MIS_PREIRQCH6_SET            ((uint32_t)0x00400000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_MIS[PREIRQCH7] Bits */
+#define DMA_CPU_INT_MIS_PREIRQCH7_OFS            (23)                            /* !< PREIRQCH7 Offset */
+#define DMA_CPU_INT_MIS_PREIRQCH7_MASK           ((uint32_t)0x00800000U)         /* !< Pre-IRQ for Channel 7. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_MIS_PREIRQCH7_CLR            ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_MIS_PREIRQCH7_SET            ((uint32_t)0x00800000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_MIS[ADDRERR] Bits */
+#define DMA_CPU_INT_MIS_ADDRERR_OFS              (24)                            /* !< ADDRERR Offset */
+#define DMA_CPU_INT_MIS_ADDRERR_MASK             ((uint32_t)0x01000000U)         /* !< DMA address error, SRC address not
+                                                                                    reachable. */
+#define DMA_CPU_INT_MIS_ADDRERR_CLR              ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_MIS_ADDRERR_SET              ((uint32_t)0x01000000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_MIS[DATAERR] Bits */
+#define DMA_CPU_INT_MIS_DATAERR_OFS              (25)                            /* !< DATAERR Offset */
+#define DMA_CPU_INT_MIS_DATAERR_MASK             ((uint32_t)0x02000000U)         /* !< DMA data error, SRC data might be
+                                                                                    corrupted (PAR or ECC error). */
+#define DMA_CPU_INT_MIS_DATAERR_CLR              ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_MIS_DATAERR_SET              ((uint32_t)0x02000000U)         /* !< Set interrupt mask bit */
+
+/* DMA_CPU_INT_ISET Bits */
+/* DMA_CPU_INT_ISET[DMACH0] Bits */
+#define DMA_CPU_INT_ISET_DMACH0_OFS              (0)                             /* !< DMACH0 Offset */
+#define DMA_CPU_INT_ISET_DMACH0_MASK             ((uint32_t)0x00000001U)         /* !< DMA Channel 0 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH0_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH0_SET              ((uint32_t)0x00000001U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH1] Bits */
+#define DMA_CPU_INT_ISET_DMACH1_OFS              (1)                             /* !< DMACH1 Offset */
+#define DMA_CPU_INT_ISET_DMACH1_MASK             ((uint32_t)0x00000002U)         /* !< DMA Channel 1 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH1_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH1_SET              ((uint32_t)0x00000002U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH2] Bits */
+#define DMA_CPU_INT_ISET_DMACH2_OFS              (2)                             /* !< DMACH2 Offset */
+#define DMA_CPU_INT_ISET_DMACH2_MASK             ((uint32_t)0x00000004U)         /* !< DMA Channel 2 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH2_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH2_SET              ((uint32_t)0x00000004U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH3] Bits */
+#define DMA_CPU_INT_ISET_DMACH3_OFS              (3)                             /* !< DMACH3 Offset */
+#define DMA_CPU_INT_ISET_DMACH3_MASK             ((uint32_t)0x00000008U)         /* !< DMA Channel 3 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH3_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH3_SET              ((uint32_t)0x00000008U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH4] Bits */
+#define DMA_CPU_INT_ISET_DMACH4_OFS              (4)                             /* !< DMACH4 Offset */
+#define DMA_CPU_INT_ISET_DMACH4_MASK             ((uint32_t)0x00000010U)         /* !< DMA Channel 4 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH4_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH4_SET              ((uint32_t)0x00000010U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH5] Bits */
+#define DMA_CPU_INT_ISET_DMACH5_OFS              (5)                             /* !< DMACH5 Offset */
+#define DMA_CPU_INT_ISET_DMACH5_MASK             ((uint32_t)0x00000020U)         /* !< DMA Channel 5 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH5_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH5_SET              ((uint32_t)0x00000020U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH6] Bits */
+#define DMA_CPU_INT_ISET_DMACH6_OFS              (6)                             /* !< DMACH6 Offset */
+#define DMA_CPU_INT_ISET_DMACH6_MASK             ((uint32_t)0x00000040U)         /* !< DMA Channel 6 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH6_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH6_SET              ((uint32_t)0x00000040U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH7] Bits */
+#define DMA_CPU_INT_ISET_DMACH7_OFS              (7)                             /* !< DMACH7 Offset */
+#define DMA_CPU_INT_ISET_DMACH7_MASK             ((uint32_t)0x00000080U)         /* !< DMA Channel 7 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH7_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH7_SET              ((uint32_t)0x00000080U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH8] Bits */
+#define DMA_CPU_INT_ISET_DMACH8_OFS              (8)                             /* !< DMACH8 Offset */
+#define DMA_CPU_INT_ISET_DMACH8_MASK             ((uint32_t)0x00000100U)         /* !< DMA Channel 8 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH8_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH8_SET              ((uint32_t)0x00000100U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH9] Bits */
+#define DMA_CPU_INT_ISET_DMACH9_OFS              (9)                             /* !< DMACH9 Offset */
+#define DMA_CPU_INT_ISET_DMACH9_MASK             ((uint32_t)0x00000200U)         /* !< DMA Channel 9 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH9_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH9_SET              ((uint32_t)0x00000200U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH10] Bits */
+#define DMA_CPU_INT_ISET_DMACH10_OFS             (10)                            /* !< DMACH10 Offset */
+#define DMA_CPU_INT_ISET_DMACH10_MASK            ((uint32_t)0x00000400U)         /* !< DMA Channel 0 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH10_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH10_SET             ((uint32_t)0x00000400U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH11] Bits */
+#define DMA_CPU_INT_ISET_DMACH11_OFS             (11)                            /* !< DMACH11 Offset */
+#define DMA_CPU_INT_ISET_DMACH11_MASK            ((uint32_t)0x00000800U)         /* !< DMA Channel 11 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH11_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH11_SET             ((uint32_t)0x00000800U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH12] Bits */
+#define DMA_CPU_INT_ISET_DMACH12_OFS             (12)                            /* !< DMACH12 Offset */
+#define DMA_CPU_INT_ISET_DMACH12_MASK            ((uint32_t)0x00001000U)         /* !< DMA Channel 12 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH12_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH12_SET             ((uint32_t)0x00001000U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH13] Bits */
+#define DMA_CPU_INT_ISET_DMACH13_OFS             (13)                            /* !< DMACH13 Offset */
+#define DMA_CPU_INT_ISET_DMACH13_MASK            ((uint32_t)0x00002000U)         /* !< DMA Channel 13 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH13_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH13_SET             ((uint32_t)0x00002000U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH14] Bits */
+#define DMA_CPU_INT_ISET_DMACH14_OFS             (14)                            /* !< DMACH14 Offset */
+#define DMA_CPU_INT_ISET_DMACH14_MASK            ((uint32_t)0x00004000U)         /* !< DMA Channel 14 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH14_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH14_SET             ((uint32_t)0x00004000U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[DMACH15] Bits */
+#define DMA_CPU_INT_ISET_DMACH15_OFS             (15)                            /* !< DMACH15 Offset */
+#define DMA_CPU_INT_ISET_DMACH15_MASK            ((uint32_t)0x00008000U)         /* !< DMA Channel 0 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ISET_DMACH15_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ISET_DMACH15_SET             ((uint32_t)0x00008000U)         /* !< Set interrupt */
+/* DMA_CPU_INT_ISET[PREIRQCH0] Bits */
+#define DMA_CPU_INT_ISET_PREIRQCH0_OFS           (16)                            /* !< PREIRQCH0 Offset */
+#define DMA_CPU_INT_ISET_PREIRQCH0_MASK          ((uint32_t)0x00010000U)         /* !< Pre-IRQ for Channel 0. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ISET_PREIRQCH0_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ISET_PREIRQCH0_SET           ((uint32_t)0x00010000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ISET[PREIRQCH1] Bits */
+#define DMA_CPU_INT_ISET_PREIRQCH1_OFS           (17)                            /* !< PREIRQCH1 Offset */
+#define DMA_CPU_INT_ISET_PREIRQCH1_MASK          ((uint32_t)0x00020000U)         /* !< Pre-IRQ for Channel 1. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ISET_PREIRQCH1_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ISET_PREIRQCH1_SET           ((uint32_t)0x00020000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ISET[PREIRQCH2] Bits */
+#define DMA_CPU_INT_ISET_PREIRQCH2_OFS           (18)                            /* !< PREIRQCH2 Offset */
+#define DMA_CPU_INT_ISET_PREIRQCH2_MASK          ((uint32_t)0x00040000U)         /* !< Pre-IRQ for Channel 2. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ISET_PREIRQCH2_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ISET_PREIRQCH2_SET           ((uint32_t)0x00040000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ISET[PREIRQCH3] Bits */
+#define DMA_CPU_INT_ISET_PREIRQCH3_OFS           (19)                            /* !< PREIRQCH3 Offset */
+#define DMA_CPU_INT_ISET_PREIRQCH3_MASK          ((uint32_t)0x00080000U)         /* !< Pre-IRQ for Channel 3. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ISET_PREIRQCH3_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ISET_PREIRQCH3_SET           ((uint32_t)0x00080000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ISET[PREIRQCH4] Bits */
+#define DMA_CPU_INT_ISET_PREIRQCH4_OFS           (20)                            /* !< PREIRQCH4 Offset */
+#define DMA_CPU_INT_ISET_PREIRQCH4_MASK          ((uint32_t)0x00100000U)         /* !< Pre-IRQ for Channel 4. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ISET_PREIRQCH4_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ISET_PREIRQCH4_SET           ((uint32_t)0x00100000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ISET[PREIRQCH5] Bits */
+#define DMA_CPU_INT_ISET_PREIRQCH5_OFS           (21)                            /* !< PREIRQCH5 Offset */
+#define DMA_CPU_INT_ISET_PREIRQCH5_MASK          ((uint32_t)0x00200000U)         /* !< Pre-IRQ for Channel 5. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ISET_PREIRQCH5_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ISET_PREIRQCH5_SET           ((uint32_t)0x00200000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ISET[PREIRQCH6] Bits */
+#define DMA_CPU_INT_ISET_PREIRQCH6_OFS           (22)                            /* !< PREIRQCH6 Offset */
+#define DMA_CPU_INT_ISET_PREIRQCH6_MASK          ((uint32_t)0x00400000U)         /* !< Pre-IRQ for Channel 6. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ISET_PREIRQCH6_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ISET_PREIRQCH6_SET           ((uint32_t)0x00400000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ISET[PREIRQCH7] Bits */
+#define DMA_CPU_INT_ISET_PREIRQCH7_OFS           (23)                            /* !< PREIRQCH7 Offset */
+#define DMA_CPU_INT_ISET_PREIRQCH7_MASK          ((uint32_t)0x00800000U)         /* !< Pre-IRQ for Channel 7. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ISET_PREIRQCH7_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ISET_PREIRQCH7_SET           ((uint32_t)0x00800000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ISET[ADDRERR] Bits */
+#define DMA_CPU_INT_ISET_ADDRERR_OFS             (24)                            /* !< ADDRERR Offset */
+#define DMA_CPU_INT_ISET_ADDRERR_MASK            ((uint32_t)0x01000000U)         /* !< DMA address error, SRC address not
+                                                                                    reachable. */
+#define DMA_CPU_INT_ISET_ADDRERR_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ISET_ADDRERR_SET             ((uint32_t)0x01000000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ISET[DATAERR] Bits */
+#define DMA_CPU_INT_ISET_DATAERR_OFS             (25)                            /* !< DATAERR Offset */
+#define DMA_CPU_INT_ISET_DATAERR_MASK            ((uint32_t)0x02000000U)         /* !< DMA data error, SRC data might be
+                                                                                    corrupted (PAR or ECC error). */
+#define DMA_CPU_INT_ISET_DATAERR_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ISET_DATAERR_SET             ((uint32_t)0x02000000U)         /* !< Set interrupt mask bit */
+
+/* DMA_CPU_INT_ICLR Bits */
+/* DMA_CPU_INT_ICLR[DMACH0] Bits */
+#define DMA_CPU_INT_ICLR_DMACH0_OFS              (0)                             /* !< DMACH0 Offset */
+#define DMA_CPU_INT_ICLR_DMACH0_MASK             ((uint32_t)0x00000001U)         /* !< DMA Channel 0 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH0_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH0_CLR              ((uint32_t)0x00000001U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH1] Bits */
+#define DMA_CPU_INT_ICLR_DMACH1_OFS              (1)                             /* !< DMACH1 Offset */
+#define DMA_CPU_INT_ICLR_DMACH1_MASK             ((uint32_t)0x00000002U)         /* !< DMA Channel 1 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH1_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH1_CLR              ((uint32_t)0x00000002U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH2] Bits */
+#define DMA_CPU_INT_ICLR_DMACH2_OFS              (2)                             /* !< DMACH2 Offset */
+#define DMA_CPU_INT_ICLR_DMACH2_MASK             ((uint32_t)0x00000004U)         /* !< DMA Channel 2 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH2_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH2_CLR              ((uint32_t)0x00000004U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH3] Bits */
+#define DMA_CPU_INT_ICLR_DMACH3_OFS              (3)                             /* !< DMACH3 Offset */
+#define DMA_CPU_INT_ICLR_DMACH3_MASK             ((uint32_t)0x00000008U)         /* !< DMA Channel 3 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH3_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH3_CLR              ((uint32_t)0x00000008U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH4] Bits */
+#define DMA_CPU_INT_ICLR_DMACH4_OFS              (4)                             /* !< DMACH4 Offset */
+#define DMA_CPU_INT_ICLR_DMACH4_MASK             ((uint32_t)0x00000010U)         /* !< DMA Channel 4 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH4_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH4_CLR              ((uint32_t)0x00000010U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH5] Bits */
+#define DMA_CPU_INT_ICLR_DMACH5_OFS              (5)                             /* !< DMACH5 Offset */
+#define DMA_CPU_INT_ICLR_DMACH5_MASK             ((uint32_t)0x00000020U)         /* !< DMA Channel 5 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH5_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH5_CLR              ((uint32_t)0x00000020U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH6] Bits */
+#define DMA_CPU_INT_ICLR_DMACH6_OFS              (6)                             /* !< DMACH6 Offset */
+#define DMA_CPU_INT_ICLR_DMACH6_MASK             ((uint32_t)0x00000040U)         /* !< DMA Channel 6 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH6_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH6_CLR              ((uint32_t)0x00000040U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH7] Bits */
+#define DMA_CPU_INT_ICLR_DMACH7_OFS              (7)                             /* !< DMACH7 Offset */
+#define DMA_CPU_INT_ICLR_DMACH7_MASK             ((uint32_t)0x00000080U)         /* !< DMA Channel 7 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH7_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH7_CLR              ((uint32_t)0x00000080U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH8] Bits */
+#define DMA_CPU_INT_ICLR_DMACH8_OFS              (8)                             /* !< DMACH8 Offset */
+#define DMA_CPU_INT_ICLR_DMACH8_MASK             ((uint32_t)0x00000100U)         /* !< DMA Channel 8 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH8_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH8_CLR              ((uint32_t)0x00000100U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH9] Bits */
+#define DMA_CPU_INT_ICLR_DMACH9_OFS              (9)                             /* !< DMACH9 Offset */
+#define DMA_CPU_INT_ICLR_DMACH9_MASK             ((uint32_t)0x00000200U)         /* !< DMA Channel 9 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH9_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH9_CLR              ((uint32_t)0x00000200U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH10] Bits */
+#define DMA_CPU_INT_ICLR_DMACH10_OFS             (10)                            /* !< DMACH10 Offset */
+#define DMA_CPU_INT_ICLR_DMACH10_MASK            ((uint32_t)0x00000400U)         /* !< DMA Channel 10 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH10_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH10_CLR             ((uint32_t)0x00000400U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH11] Bits */
+#define DMA_CPU_INT_ICLR_DMACH11_OFS             (11)                            /* !< DMACH11 Offset */
+#define DMA_CPU_INT_ICLR_DMACH11_MASK            ((uint32_t)0x00000800U)         /* !< DMA Channel 11 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH11_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH11_CLR             ((uint32_t)0x00000800U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH12] Bits */
+#define DMA_CPU_INT_ICLR_DMACH12_OFS             (12)                            /* !< DMACH12 Offset */
+#define DMA_CPU_INT_ICLR_DMACH12_MASK            ((uint32_t)0x00001000U)         /* !< DMA Channel 12 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH12_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH12_CLR             ((uint32_t)0x00001000U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH13] Bits */
+#define DMA_CPU_INT_ICLR_DMACH13_OFS             (13)                            /* !< DMACH13 Offset */
+#define DMA_CPU_INT_ICLR_DMACH13_MASK            ((uint32_t)0x00002000U)         /* !< DMA Channel 13 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH13_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH13_CLR             ((uint32_t)0x00002000U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH14] Bits */
+#define DMA_CPU_INT_ICLR_DMACH14_OFS             (14)                            /* !< DMACH14 Offset */
+#define DMA_CPU_INT_ICLR_DMACH14_MASK            ((uint32_t)0x00004000U)         /* !< DMA Channel 14 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH14_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH14_CLR             ((uint32_t)0x00004000U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[DMACH15] Bits */
+#define DMA_CPU_INT_ICLR_DMACH15_OFS             (15)                            /* !< DMACH15 Offset */
+#define DMA_CPU_INT_ICLR_DMACH15_MASK            ((uint32_t)0x00008000U)         /* !< DMA Channel 15 interrupt signals
+                                                                                    that size counter reached zero
+                                                                                    (DMASZ=0). */
+#define DMA_CPU_INT_ICLR_DMACH15_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define DMA_CPU_INT_ICLR_DMACH15_CLR             ((uint32_t)0x00008000U)         /* !< Clear interrupt */
+/* DMA_CPU_INT_ICLR[PREIRQCH0] Bits */
+#define DMA_CPU_INT_ICLR_PREIRQCH0_OFS           (16)                            /* !< PREIRQCH0 Offset */
+#define DMA_CPU_INT_ICLR_PREIRQCH0_MASK          ((uint32_t)0x00010000U)         /* !< Pre-IRQ for Channel 0. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ICLR_PREIRQCH0_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ICLR_PREIRQCH0_SET           ((uint32_t)0x00010000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ICLR[PREIRQCH1] Bits */
+#define DMA_CPU_INT_ICLR_PREIRQCH1_OFS           (17)                            /* !< PREIRQCH1 Offset */
+#define DMA_CPU_INT_ICLR_PREIRQCH1_MASK          ((uint32_t)0x00020000U)         /* !< Pre-IRQ for Channel 1. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ICLR_PREIRQCH1_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ICLR_PREIRQCH1_SET           ((uint32_t)0x00020000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ICLR[PREIRQCH2] Bits */
+#define DMA_CPU_INT_ICLR_PREIRQCH2_OFS           (18)                            /* !< PREIRQCH2 Offset */
+#define DMA_CPU_INT_ICLR_PREIRQCH2_MASK          ((uint32_t)0x00040000U)         /* !< Pre-IRQ for Channel 2. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ICLR_PREIRQCH2_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ICLR_PREIRQCH2_SET           ((uint32_t)0x00040000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ICLR[PREIRQCH3] Bits */
+#define DMA_CPU_INT_ICLR_PREIRQCH3_OFS           (19)                            /* !< PREIRQCH3 Offset */
+#define DMA_CPU_INT_ICLR_PREIRQCH3_MASK          ((uint32_t)0x00080000U)         /* !< Pre-IRQ for Channel 3. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ICLR_PREIRQCH3_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ICLR_PREIRQCH3_SET           ((uint32_t)0x00080000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ICLR[PREIRQCH4] Bits */
+#define DMA_CPU_INT_ICLR_PREIRQCH4_OFS           (20)                            /* !< PREIRQCH4 Offset */
+#define DMA_CPU_INT_ICLR_PREIRQCH4_MASK          ((uint32_t)0x00100000U)         /* !< Pre-IRQ for Channel 4. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ICLR_PREIRQCH4_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ICLR_PREIRQCH4_SET           ((uint32_t)0x00100000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ICLR[PREIRQCH5] Bits */
+#define DMA_CPU_INT_ICLR_PREIRQCH5_OFS           (21)                            /* !< PREIRQCH5 Offset */
+#define DMA_CPU_INT_ICLR_PREIRQCH5_MASK          ((uint32_t)0x00200000U)         /* !< Pre-IRQ for Channel 5. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ICLR_PREIRQCH5_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ICLR_PREIRQCH5_SET           ((uint32_t)0x00200000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ICLR[PREIRQCH6] Bits */
+#define DMA_CPU_INT_ICLR_PREIRQCH6_OFS           (22)                            /* !< PREIRQCH6 Offset */
+#define DMA_CPU_INT_ICLR_PREIRQCH6_MASK          ((uint32_t)0x00400000U)         /* !< Pre-IRQ for Channel 6. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ICLR_PREIRQCH6_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ICLR_PREIRQCH6_SET           ((uint32_t)0x00400000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ICLR[PREIRQCH7] Bits */
+#define DMA_CPU_INT_ICLR_PREIRQCH7_OFS           (23)                            /* !< PREIRQCH7 Offset */
+#define DMA_CPU_INT_ICLR_PREIRQCH7_MASK          ((uint32_t)0x00800000U)         /* !< Pre-IRQ for Channel 7. Size counter
+                                                                                    reached Pre-IRQ threshold. */
+#define DMA_CPU_INT_ICLR_PREIRQCH7_CLR           ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ICLR_PREIRQCH7_SET           ((uint32_t)0x00800000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ICLR[ADDRERR] Bits */
+#define DMA_CPU_INT_ICLR_ADDRERR_OFS             (24)                            /* !< ADDRERR Offset */
+#define DMA_CPU_INT_ICLR_ADDRERR_MASK            ((uint32_t)0x01000000U)         /* !< DMA address error, SRC address not
+                                                                                    reachable. */
+#define DMA_CPU_INT_ICLR_ADDRERR_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ICLR_ADDRERR_SET             ((uint32_t)0x01000000U)         /* !< Set interrupt mask bit */
+/* DMA_CPU_INT_ICLR[DATAERR] Bits */
+#define DMA_CPU_INT_ICLR_DATAERR_OFS             (25)                            /* !< DATAERR Offset */
+#define DMA_CPU_INT_ICLR_DATAERR_MASK            ((uint32_t)0x02000000U)         /* !< DMA data error, SRC data might be
+                                                                                    corrupted (PAR or ECC error). */
+#define DMA_CPU_INT_ICLR_DATAERR_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask bit */
+#define DMA_CPU_INT_ICLR_DATAERR_SET             ((uint32_t)0x02000000U)         /* !< Set interrupt mask bit */
+
+/* DMA_FSUB_0 Bits */
+/* DMA_FSUB_0[CHANID] Bits */
+#define DMA_FSUB_0_CHANID_OFS                    (0)                             /* !< CHANID Offset */
+#define DMA_FSUB_0_CHANID_MASK                   ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-255 = connected
+                                                                                    to channelID = CHANID. */
+#define DMA_FSUB_0_CHANID_MNIMUM                 ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define DMA_FSUB_0_CHANID_UNCONNECTED            ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define DMA_FSUB_0_CHANID_MAXIMUM                ((uint32_t)0x000000FFU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 255. */
+
+/* DMA_FSUB_1 Bits */
+/* DMA_FSUB_1[CHANID] Bits */
+#define DMA_FSUB_1_CHANID_OFS                    (0)                             /* !< CHANID Offset */
+#define DMA_FSUB_1_CHANID_MASK                   ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-255 = connected
+                                                                                    to channelID = CHANID. */
+#define DMA_FSUB_1_CHANID_MNIMUM                 ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define DMA_FSUB_1_CHANID_UNCONNECTED            ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define DMA_FSUB_1_CHANID_MAXIMUM                ((uint32_t)0x000000FFU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 255. */
+
+/* DMA_FPUB_1 Bits */
+/* DMA_FPUB_1[CHANID] Bits */
+#define DMA_FPUB_1_CHANID_OFS                    (0)                             /* !< CHANID Offset */
+#define DMA_FPUB_1_CHANID_MASK                   ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-255 = connected
+                                                                                    to channelID = CHANID. */
+#define DMA_FPUB_1_CHANID_MNIMUM                 ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define DMA_FPUB_1_CHANID_UNCONNECTED            ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define DMA_FPUB_1_CHANID_MAXIMUM                ((uint32_t)0x000000FFU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 255. */
+
+/* DMA_PDBGCTL Bits */
+/* DMA_PDBGCTL[FREE] Bits */
+#define DMA_PDBGCTL_FREE_OFS                     (0)                             /* !< FREE Offset */
+#define DMA_PDBGCTL_FREE_MASK                    ((uint32_t)0x00000001U)         /* !< Free run control */
+#define DMA_PDBGCTL_FREE_STOP                    ((uint32_t)0x00000000U)         /* !< The peripheral freezes
+                                                                                    functionality while the Core Halted
+                                                                                    input is asserted and resumes when it
+                                                                                    is deasserted. */
+#define DMA_PDBGCTL_FREE_RUN                     ((uint32_t)0x00000001U)         /* !< The peripheral ignores the state of
+                                                                                    the Core Halted input */
+/* DMA_PDBGCTL[SOFT] Bits */
+#define DMA_PDBGCTL_SOFT_OFS                     (1)                             /* !< SOFT Offset */
+#define DMA_PDBGCTL_SOFT_MASK                    ((uint32_t)0x00000002U)         /* !< Soft halt boundary control. This
+                                                                                    function is only available, if [FREE]
+                                                                                    is set to 'STOP' */
+#define DMA_PDBGCTL_SOFT_IMMEDIATE               ((uint32_t)0x00000000U)         /* !< The peripheral will halt
+                                                                                    immediately, even if the resultant
+                                                                                    state will result in corruption if
+                                                                                    the system is restarted */
+#define DMA_PDBGCTL_SOFT_DELAYED                 ((uint32_t)0x00000002U)         /* !< The peripheral blocks the debug
+                                                                                    freeze until it has reached a
+                                                                                    boundary where it can resume without
+                                                                                    corruption */
+
+/* DMA_EVT_MODE Bits */
+/* DMA_EVT_MODE[INT0_CFG] Bits */
+#define DMA_EVT_MODE_INT0_CFG_OFS                (0)                             /* !< INT0_CFG Offset */
+#define DMA_EVT_MODE_INT0_CFG_MASK               ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to interrupt event
+                                                                                    INT_EVENT[0] */
+#define DMA_EVT_MODE_INT0_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define DMA_EVT_MODE_INT0_CFG_SOFTWARE           ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define DMA_EVT_MODE_INT0_CFG_HARDWARE           ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* DMA_EVT_MODE[EVT1_CFG] Bits */
+#define DMA_EVT_MODE_EVT1_CFG_OFS                (2)                             /* !< EVT1_CFG Offset */
+#define DMA_EVT_MODE_EVT1_CFG_MASK               ((uint32_t)0x0000000CU)         /* !< Event line mode select for event
+                                                                                    corresponding to generic event
+                                                                                    INT_EVENT[1] */
+#define DMA_EVT_MODE_EVT1_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define DMA_EVT_MODE_EVT1_CFG_SOFTWARE           ((uint32_t)0x00000004U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define DMA_EVT_MODE_EVT1_CFG_HARDWARE           ((uint32_t)0x00000008U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* DMA_DESC Bits */
+/* DMA_DESC[MINREV] Bits */
+#define DMA_DESC_MINREV_OFS                      (0)                             /* !< MINREV Offset */
+#define DMA_DESC_MINREV_MASK                     ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+#define DMA_DESC_MINREV_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define DMA_DESC_MINREV_MAXIMUM                  ((uint32_t)0x0000000FU)         /* !< Highest possible value */
+/* DMA_DESC[MAJREV] Bits */
+#define DMA_DESC_MAJREV_OFS                      (4)                             /* !< MAJREV Offset */
+#define DMA_DESC_MAJREV_MASK                     ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+#define DMA_DESC_MAJREV_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define DMA_DESC_MAJREV_MAXIMUM                  ((uint32_t)0x000000F0U)         /* !< Highest possible value */
+/* DMA_DESC[FEATUREVER] Bits */
+#define DMA_DESC_FEATUREVER_OFS                  (12)                            /* !< FEATUREVER Offset */
+#define DMA_DESC_FEATUREVER_MASK                 ((uint32_t)0x0000F000U)         /* !< Feature Set for the DMA: number of
+                                                                                    DMA channel minus one  (e.g. 0->1ch,
+                                                                                    2->3ch, 15->16ch). */
+#define DMA_DESC_FEATUREVER_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value (1 channel) */
+#define DMA_DESC_FEATUREVER_MAXIMUM              ((uint32_t)0x0000F000U)         /* !< Highest value (16 channel) */
+/* DMA_DESC[MODULEID] Bits */
+#define DMA_DESC_MODULEID_OFS                    (16)                            /* !< MODULEID Offset */
+#define DMA_DESC_MODULEID_MASK                   ((uint32_t)0xFFFF0000U)         /* !< Module identification contains a
+                                                                                    unique peripheral identification
+                                                                                    number. The assignments are
+                                                                                    maintained in a central database for
+                                                                                    all of the platform modules to ensure
+                                                                                    uniqueness. */
+#define DMA_DESC_MODULEID_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define DMA_DESC_MODULEID_MAXIMUM                ((uint32_t)0xFFFF0000U)         /* !< Highest possible value */
+
+/* DMA_DMAPRIO Bits */
+/* DMA_DMAPRIO[ROUNDROBIN] Bits */
+#define DMA_DMAPRIO_ROUNDROBIN_OFS               (0)                             /* !< ROUNDROBIN Offset */
+#define DMA_DMAPRIO_ROUNDROBIN_MASK              ((uint32_t)0x00000001U)         /* !< Round robin. This bit enables the
+                                                                                    round-robin DMA channel priorities. */
+#define DMA_DMAPRIO_ROUNDROBIN_DISABLE           ((uint32_t)0x00000000U)         /* !< Roundrobin priority disabled, DMA
+                                                                                    channel priority is fixed:
+                                                                                    DMA0-DMA1-DMA2-...-DMA16 */
+#define DMA_DMAPRIO_ROUNDROBIN_ENABLE            ((uint32_t)0x00000001U)         /* !< Roundrobin priority enabled, DMA
+                                                                                    channel priority changes with each
+                                                                                    transfer */
+/* DMA_DMAPRIO[BURSTSZ] Bits */
+#define DMA_DMAPRIO_BURSTSZ_OFS                  (16)                            /* !< BURSTSZ Offset */
+#define DMA_DMAPRIO_BURSTSZ_MASK                 ((uint32_t)0x00030000U)         /* !< Define the burst size of a block
+                                                                                    transfer, before the priority is
+                                                                                    re-evaluated */
+#define DMA_DMAPRIO_BURSTSZ_INFINITI             ((uint32_t)0x00000000U)         /* !< There is no burst size, the whole
+                                                                                    block transfer is completed on one
+                                                                                    transfer without interruption */
+#define DMA_DMAPRIO_BURSTSZ_BURST_8              ((uint32_t)0x00010000U)         /* !< The burst size is 8, after 8
+                                                                                    transfers the block transfer is
+                                                                                    interrupted and the priority is
+                                                                                    reevaluated */
+#define DMA_DMAPRIO_BURSTSZ_BUSRT_16             ((uint32_t)0x00020000U)         /* !< The burst size is 16, after 16
+                                                                                    transfers the block transfer is
+                                                                                    interrupted and the priority is
+                                                                                    reevaluated */
+#define DMA_DMAPRIO_BURSTSZ_BURST_32             ((uint32_t)0x00030000U)         /* !< The burst size is 32, after 32
+                                                                                    transfers the block transfer is
+                                                                                    interrupted and the priority is
+                                                                                    reevaluated */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_dma__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_flashctl.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_flashctl.h
@@ -1,0 +1,1269 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+   Redistributions of source code must retain the above copyright 
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the   
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_flashctl__include
+#define ti_devices_msp_peripherals_hw_flashctl__include
+
+/* Filename: hw_flashctl.h */
+/* Revised: 2023-05-04 09:46:28 */
+/* Revision: 59e844638cbc4054026b3e132f05a3e05d70f5a2 */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* FLASHCTL Registers
+******************************************************************************/
+#define FLASHCTL_GEN_OFS                         ((uint32_t)0x00000000U)
+
+
+/** @addtogroup FLASHCTL_GEN
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[1032];
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt Index Register */
+       uint32_t RESERVED1;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt Mask Register */
+       uint32_t RESERVED2;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw Interrupt Status Register */
+       uint32_t RESERVED3;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked Interrupt Status Register */
+       uint32_t RESERVED4;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt Set Register */
+       uint32_t RESERVED5;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt Clear Register */
+       uint32_t RESERVED6[37];
+  __I  uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED7[6];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Hardware Version Description Register */
+  __IO uint32_t CMDEXEC;                           /* !< (@ 0x00001100) Command Execute Register */
+  __IO uint32_t CMDTYPE;                           /* !< (@ 0x00001104) Command Type Register */
+  __IO uint32_t CMDCTL;                            /* !< (@ 0x00001108) Command Control Register */
+       uint32_t RESERVED8[5];
+  __IO uint32_t CMDADDR;                           /* !< (@ 0x00001120) Command Address Register */
+  __IO uint32_t CMDBYTEN;                          /* !< (@ 0x00001124) Command Program Byte Enable Register */
+       uint32_t RESERVED9;
+  __IO uint32_t CMDDATAINDEX;                      /* !< (@ 0x0000112C) Command Data Index Register */
+  __IO uint32_t CMDDATA0;                          /* !< (@ 0x00001130) Command Data Register 0 */
+  __IO uint32_t CMDDATA1;                          /* !< (@ 0x00001134) Command Data Register 1 */
+  __IO uint32_t CMDDATA2;                          /* !< (@ 0x00001138) Command Data Register 2 */
+  __IO uint32_t CMDDATA3;                          /* !< (@ 0x0000113C) Command Data Register Bits 127:96 */
+  __IO uint32_t CMDDATA4;                          /* !< (@ 0x00001140) Command Data Register 4 */
+  __IO uint32_t CMDDATA5;                          /* !< (@ 0x00001144) Command Data Register 5 */
+  __IO uint32_t CMDDATA6;                          /* !< (@ 0x00001148) Command Data Register 6 */
+  __IO uint32_t CMDDATA7;                          /* !< (@ 0x0000114C) Command Data Register 7 */
+  __IO uint32_t CMDDATA8;                          /* !< (@ 0x00001150) Command Data Register 8 */
+  __IO uint32_t CMDDATA9;                          /* !< (@ 0x00001154) Command Data Register 9 */
+  __IO uint32_t CMDDATA10;                         /* !< (@ 0x00001158) Command Data Register 10 */
+  __IO uint32_t CMDDATA11;                         /* !< (@ 0x0000115C) Command Data Register 11 */
+  __IO uint32_t CMDDATA12;                         /* !< (@ 0x00001160) Command Data Register 12 */
+  __IO uint32_t CMDDATA13;                         /* !< (@ 0x00001164) Command Data Register 13 */
+  __IO uint32_t CMDDATA14;                         /* !< (@ 0x00001168) Command Data Register 14 */
+  __IO uint32_t CMDDATA15;                         /* !< (@ 0x0000116C) Command Data Register 15 */
+  __IO uint32_t CMDDATA16;                         /* !< (@ 0x00001170) Command Data Register 16 */
+  __IO uint32_t CMDDATA17;                         /* !< (@ 0x00001174) Command Data Register 17 */
+  __IO uint32_t CMDDATA18;                         /* !< (@ 0x00001178) Command Data Register 18 */
+  __IO uint32_t CMDDATA19;                         /* !< (@ 0x0000117C) Command Data Register 19 */
+  __IO uint32_t CMDDATA20;                         /* !< (@ 0x00001180) Command Data Register 20 */
+  __IO uint32_t CMDDATA21;                         /* !< (@ 0x00001184) Command Data Register 21 */
+  __IO uint32_t CMDDATA22;                         /* !< (@ 0x00001188) Command Data Register 22 */
+  __IO uint32_t CMDDATA23;                         /* !< (@ 0x0000118C) Command Data Register 23 */
+  __IO uint32_t CMDDATA24;                         /* !< (@ 0x00001190) Command Data Register 24 */
+  __IO uint32_t CMDDATA25;                         /* !< (@ 0x00001194) Command Data Register 25 */
+  __IO uint32_t CMDDATA26;                         /* !< (@ 0x00001198) Command Data Register 26 */
+  __IO uint32_t CMDDATA27;                         /* !< (@ 0x0000119C) Command Data Register 27 */
+  __IO uint32_t CMDDATA28;                         /* !< (@ 0x000011A0) Command Data Register 28 */
+  __IO uint32_t CMDDATA29;                         /* !< (@ 0x000011A4) Command Data Register 29 */
+  __IO uint32_t CMDDATA30;                         /* !< (@ 0x000011A8) Command Data Register 30 */
+  __IO uint32_t CMDDATA31;                         /* !< (@ 0x000011AC) Command Data Register 31 */
+  __IO uint32_t CMDDATAECC0;                       /* !< (@ 0x000011B0) Command Data Register ECC 0 */
+  __IO uint32_t CMDDATAECC1;                       /* !< (@ 0x000011B4) Command Data Register ECC 1 */
+  __IO uint32_t CMDDATAECC2;                       /* !< (@ 0x000011B8) Command Data Register ECC 2 */
+  __IO uint32_t CMDDATAECC3;                       /* !< (@ 0x000011BC) Command Data Register ECC 3 */
+  __IO uint32_t CMDDATAECC4;                       /* !< (@ 0x000011C0) Command Data Register ECC 4 */
+  __IO uint32_t CMDDATAECC5;                       /* !< (@ 0x000011C4) Command Data Register ECC 5 */
+  __IO uint32_t CMDDATAECC6;                       /* !< (@ 0x000011C8) Command Data Register ECC 6 */
+  __IO uint32_t CMDDATAECC7;                       /* !< (@ 0x000011CC) Command Data Register ECC 7 */
+  __IO uint32_t CMDWEPROTA;                        /* !< (@ 0x000011D0) Command Write Erase Protect A Register */
+  __IO uint32_t CMDWEPROTB;                        /* !< (@ 0x000011D4) Command Write Erase Protect B Register */
+  __IO uint32_t CMDWEPROTC;                        /* !< (@ 0x000011D8) Command Write Erase Protect C Register */
+       uint32_t RESERVED10[13];
+  __IO uint32_t CMDWEPROTNM;                       /* !< (@ 0x00001210) Command Write Erase Protect Non-Main Register */
+  __IO uint32_t CMDWEPROTTR;                       /* !< (@ 0x00001214) Command Write Erase Protect Trim Register */
+  __IO uint32_t CMDWEPROTEN;                       /* !< (@ 0x00001218) Command Write Erase Protect Engr Register */
+       uint32_t RESERVED11[101];
+  __IO uint32_t CFGCMD;                            /* !< (@ 0x000013B0) Command Configuration Register */
+  __IO uint32_t CFGPCNT;                           /* !< (@ 0x000013B4) Pulse Counter Configuration Register */
+       uint32_t RESERVED12[6];
+  __I  uint32_t STATCMD;                           /* !< (@ 0x000013D0) Command Status Register */
+  __I  uint32_t STATADDR;                          /* !< (@ 0x000013D4) Address Status Register */
+  __I  uint32_t STATPCNT;                          /* !< (@ 0x000013D8) Pulse Count Status Register */
+  __I  uint32_t STATMODE;                          /* !< (@ 0x000013DC) Mode Status Register */
+       uint32_t RESERVED13[4];
+  __I  uint32_t GBLINFO0;                          /* !< (@ 0x000013F0) Global Information Register 0 */
+  __I  uint32_t GBLINFO1;                          /* !< (@ 0x000013F4) Global Information Register 1 */
+  __I  uint32_t GBLINFO2;                          /* !< (@ 0x000013F8) Global Information Register 2 */
+       uint32_t RESERVED14;
+  __I  uint32_t BANK0INFO0;                        /* !< (@ 0x00001400) Bank Information Register 0 for Bank 0 */
+  __I  uint32_t BANK0INFO1;                        /* !< (@ 0x00001404) Bank Information Register 1 for Bank 0 */
+       uint32_t RESERVED15[2];
+  __I  uint32_t BANK1INFO0;                        /* !< (@ 0x00001410) Bank Information Register 0 for Bank 1 */
+  __I  uint32_t BANK1INFO1;                        /* !< (@ 0x00001414) Bank Information Register 1 for Bank 1 */
+       uint32_t RESERVED16[2];
+  __I  uint32_t BANK2INFO0;                        /* !< (@ 0x00001420) Bank Information Register 0 for Bank 2 */
+  __I  uint32_t BANK2INFO1;                        /* !< (@ 0x00001424) Bank Information Register 1 for Bank 2 */
+       uint32_t RESERVED17[2];
+  __I  uint32_t BANK3INFO0;                        /* !< (@ 0x00001430) Bank Information Register 0 for Bank 3 */
+  __I  uint32_t BANK3INFO1;                        /* !< (@ 0x00001434) Bank Information Register 1 for Bank 3 */
+       uint32_t RESERVED18[2];
+  __I  uint32_t BANK4INFO0;                        /* !< (@ 0x00001440) Bank Information Register 0 for Bank 4 */
+  __I  uint32_t BANK4INFO1;                        /* !< (@ 0x00001444) Bank Information Register 1 for Bank 4 */
+} FLASHCTL_GEN_Regs;
+
+/*@}*/ /* end of group FLASHCTL_GEN */
+
+/** @addtogroup FLASHCTL
+  @{
+*/
+
+typedef struct {
+  FLASHCTL_GEN_Regs  GEN;                               /* !< (@ 0x00000000) */
+} FLASHCTL_Regs;
+
+/*@}*/ /* end of group FLASHCTL */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* FLASHCTL Register Control Bits
+******************************************************************************/
+
+/* FLASHCTL_IIDX Bits */
+/* FLASHCTL_IIDX[STAT] Bits */
+#define FLASHCTL_IIDX_STAT_OFS                   (0)                             /* !< STAT Offset */
+#define FLASHCTL_IIDX_STAT_MASK                  ((uint32_t)0x00000001U)         /* !< Indicates which interrupt has
+                                                                                    fired. 0x0 means no event pending.
+                                                                                    The priority order is fixed. On each
+                                                                                    read, only one interrupt is
+                                                                                    indicated. On a read, the current
+                                                                                    interrupt (highest priority) is
+                                                                                    automatically cleared by the hardware
+                                                                                    and the corresponding interrupt flags
+                                                                                    in the RIS and MIS are cleared as
+                                                                                    well. After a read from the CPU (not
+                                                                                    from the debug interface), the
+                                                                                    register must be updated with the
+                                                                                    next highest priority interrupt. */
+#define FLASHCTL_IIDX_STAT_NO_INTR               ((uint32_t)0x00000000U)         /* !< No Interrupt Pending */
+#define FLASHCTL_IIDX_STAT_DONE                  ((uint32_t)0x00000001U)         /* !< DONE Interrupt Pending */
+
+/* FLASHCTL_IMASK Bits */
+/* FLASHCTL_IMASK[DONE] Bits */
+#define FLASHCTL_IMASK_DONE_OFS                  (0)                             /* !< DONE Offset */
+#define FLASHCTL_IMASK_DONE_MASK                 ((uint32_t)0x00000001U)         /* !< Interrupt mask for DONE: 0:
+                                                                                    Interrupt is disabled in MIS register
+                                                                                    1: Interrupt is enabled in MIS
+                                                                                    register */
+#define FLASHCTL_IMASK_DONE_DISABLED             ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define FLASHCTL_IMASK_DONE_ENABLED              ((uint32_t)0x00000001U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in [IPSTANDARD.MIS] will be set */
+
+/* FLASHCTL_RIS Bits */
+/* FLASHCTL_RIS[DONE] Bits */
+#define FLASHCTL_RIS_DONE_OFS                    (0)                             /* !< DONE Offset */
+#define FLASHCTL_RIS_DONE_MASK                   ((uint32_t)0x00000001U)         /* !< Flash wrapper operation completed.
+                                                                                    This interrupt bit is set by firmware
+                                                                                    or the corresponding bit in the ISET
+                                                                                    register. It is cleared by the
+                                                                                    corresponding bit in in the ICLR
+                                                                                    register or reading the IIDX register
+                                                                                    when this interrupt is the highest
+                                                                                    priority. */
+#define FLASHCTL_RIS_DONE_CLR                    ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define FLASHCTL_RIS_DONE_SET                    ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+
+/* FLASHCTL_MIS Bits */
+/* FLASHCTL_MIS[DONE] Bits */
+#define FLASHCTL_MIS_DONE_OFS                    (0)                             /* !< DONE Offset */
+#define FLASHCTL_MIS_DONE_MASK                   ((uint32_t)0x00000001U)         /* !< Flash wrapper operation completed.
+                                                                                    This masked interrupt bit reflects
+                                                                                    the bitwise AND of the corresponding
+                                                                                    RIS and IMASK bits. */
+#define FLASHCTL_MIS_DONE_CLR                    ((uint32_t)0x00000000U)         /* !< Masked interrupt did not occur */
+#define FLASHCTL_MIS_DONE_SET                    ((uint32_t)0x00000001U)         /* !< Masked interrupt occurred */
+
+/* FLASHCTL_ISET Bits */
+/* FLASHCTL_ISET[DONE] Bits */
+#define FLASHCTL_ISET_DONE_OFS                   (0)                             /* !< DONE Offset */
+#define FLASHCTL_ISET_DONE_MASK                  ((uint32_t)0x00000001U)         /* !< 0: No effect 1: Set the DONE
+                                                                                    interrupt in the RIS register */
+#define FLASHCTL_ISET_DONE_NO_EFFECT             ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define FLASHCTL_ISET_DONE_SET                   ((uint32_t)0x00000001U)         /* !< Set [IPSTANDARD.RIS] bit */
+
+/* FLASHCTL_ICLR Bits */
+/* FLASHCTL_ICLR[DONE] Bits */
+#define FLASHCTL_ICLR_DONE_OFS                   (0)                             /* !< DONE Offset */
+#define FLASHCTL_ICLR_DONE_MASK                  ((uint32_t)0x00000001U)         /* !< 0: No effect 1: Clear the DONE
+                                                                                    interrupt in the RIS register */
+#define FLASHCTL_ICLR_DONE_NO_EFFECT             ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define FLASHCTL_ICLR_DONE_CLR                   ((uint32_t)0x00000001U)         /* !< Clear [IPSTANDARD.RIS] bit */
+
+/* FLASHCTL_EVT_MODE Bits */
+/* FLASHCTL_EVT_MODE[INT0_CFG] Bits */
+#define FLASHCTL_EVT_MODE_INT0_CFG_OFS           (0)                             /* !< INT0_CFG Offset */
+#define FLASHCTL_EVT_MODE_INT0_CFG_MASK          ((uint32_t)0x00000003U)         /* !< Event line mode select for
+                                                                                    peripheral event */
+#define FLASHCTL_EVT_MODE_INT0_CFG_DISABLE       ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define FLASHCTL_EVT_MODE_INT0_CFG_SOFTWARE      ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define FLASHCTL_EVT_MODE_INT0_CFG_HARDWARE      ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. Hardware must clear
+                                                                                    the RIS. */
+
+/* FLASHCTL_DESC Bits */
+/* FLASHCTL_DESC[MINREV] Bits */
+#define FLASHCTL_DESC_MINREV_OFS                 (0)                             /* !< MINREV Offset */
+#define FLASHCTL_DESC_MINREV_MASK                ((uint32_t)0x0000000FU)         /* !< Minor Revision */
+#define FLASHCTL_DESC_MINREV_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define FLASHCTL_DESC_MINREV_MAXIMUM             ((uint32_t)0x0000000FU)         /* !< Highest possible value */
+/* FLASHCTL_DESC[MAJREV] Bits */
+#define FLASHCTL_DESC_MAJREV_OFS                 (4)                             /* !< MAJREV Offset */
+#define FLASHCTL_DESC_MAJREV_MASK                ((uint32_t)0x000000F0U)         /* !< Major Revision */
+#define FLASHCTL_DESC_MAJREV_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define FLASHCTL_DESC_MAJREV_MAXIMUM             ((uint32_t)0x000000F0U)         /* !< Highest possible value */
+/* FLASHCTL_DESC[INSTNUM] Bits */
+#define FLASHCTL_DESC_INSTNUM_OFS                (8)                             /* !< INSTNUM Offset */
+#define FLASHCTL_DESC_INSTNUM_MASK               ((uint32_t)0x00000F00U)         /* !< Instance number */
+#define FLASHCTL_DESC_INSTNUM_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define FLASHCTL_DESC_INSTNUM_MAXIMUM            ((uint32_t)0x00000F00U)         /* !< Highest possible value */
+/* FLASHCTL_DESC[FEATUREVER] Bits */
+#define FLASHCTL_DESC_FEATUREVER_OFS             (12)                            /* !< FEATUREVER Offset */
+#define FLASHCTL_DESC_FEATUREVER_MASK            ((uint32_t)0x0000F000U)         /* !< Feature set */
+#define FLASHCTL_DESC_FEATUREVER_MINIMUM         ((uint32_t)0x00000000U)         /* !< Minimum Value */
+#define FLASHCTL_DESC_FEATUREVER_MAXIMUM         ((uint32_t)0x0000F000U)         /* !< Maximum Value */
+/* FLASHCTL_DESC[MODULEID] Bits */
+#define FLASHCTL_DESC_MODULEID_OFS               (16)                            /* !< MODULEID Offset */
+#define FLASHCTL_DESC_MODULEID_MASK              ((uint32_t)0xFFFF0000U)         /* !< Module ID */
+#define FLASHCTL_DESC_MODULEID_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define FLASHCTL_DESC_MODULEID_MAXIMUM           ((uint32_t)0xFFFF0000U)         /* !< Highest possible value */
+
+/* FLASHCTL_CMDEXEC Bits */
+/* FLASHCTL_CMDEXEC[VAL] Bits */
+#define FLASHCTL_CMDEXEC_VAL_OFS                 (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDEXEC_VAL_MASK                ((uint32_t)0x00000001U)         /* !< Command Execute value Initiates
+                                                                                    execution of the command specified in
+                                                                                    the CMDTYPE register. */
+#define FLASHCTL_CMDEXEC_VAL_NOEXECUTE           ((uint32_t)0x00000000U)         /* !< Command will not execute or is not
+                                                                                    executing in flash wrapper */
+#define FLASHCTL_CMDEXEC_VAL_EXECUTE             ((uint32_t)0x00000001U)         /* !< Command will execute or is
+                                                                                    executing in flash wrapper */
+
+/* FLASHCTL_CMDTYPE Bits */
+/* FLASHCTL_CMDTYPE[COMMAND] Bits */
+#define FLASHCTL_CMDTYPE_COMMAND_OFS             (0)                             /* !< COMMAND Offset */
+#define FLASHCTL_CMDTYPE_COMMAND_MASK            ((uint32_t)0x00000007U)         /* !< Command type */
+#define FLASHCTL_CMDTYPE_COMMAND_NOOP            ((uint32_t)0x00000000U)         /* !< No Operation */
+#define FLASHCTL_CMDTYPE_COMMAND_PROGRAM         ((uint32_t)0x00000001U)         /* !< Program */
+#define FLASHCTL_CMDTYPE_COMMAND_ERASE           ((uint32_t)0x00000002U)         /* !< Erase */
+#define FLASHCTL_CMDTYPE_COMMAND_READVERIFY      ((uint32_t)0x00000003U)         /* !< ReadVerify - Perform a standalone
+                                                                                    ReadVerify operation. */
+#define FLASHCTL_CMDTYPE_COMMAND_MODECHANGE      ((uint32_t)0x00000004U)         /* !< Mode Change - Perform a mode change
+                                                                                    only, no other operation. */
+#define FLASHCTL_CMDTYPE_COMMAND_CLEARSTATUS     ((uint32_t)0x00000005U)         /* !< Clear Status - Clear status bits in
+                                                                                    FW_SMSTAT only. */
+#define FLASHCTL_CMDTYPE_COMMAND_BLANKVERIFY     ((uint32_t)0x00000006U)         /* !< Blank Verify - Check whether a
+                                                                                    flash word is in the erased state.
+                                                                                    This command may only be used with
+                                                                                    CMDTYPE.SIZE = ONEWORD */
+/* FLASHCTL_CMDTYPE[SIZE] Bits */
+#define FLASHCTL_CMDTYPE_SIZE_OFS                (4)                             /* !< SIZE Offset */
+#define FLASHCTL_CMDTYPE_SIZE_MASK               ((uint32_t)0x00000070U)         /* !< Command size */
+#define FLASHCTL_CMDTYPE_SIZE_ONEWORD            ((uint32_t)0x00000000U)         /* !< Operate on 1 flash word */
+#define FLASHCTL_CMDTYPE_SIZE_TWOWORD            ((uint32_t)0x00000010U)         /* !< Operate on 2 flash words */
+#define FLASHCTL_CMDTYPE_SIZE_FOURWORD           ((uint32_t)0x00000020U)         /* !< Operate on 4 flash words */
+#define FLASHCTL_CMDTYPE_SIZE_EIGHTWORD          ((uint32_t)0x00000030U)         /* !< Operate on 8 flash words */
+#define FLASHCTL_CMDTYPE_SIZE_SECTOR             ((uint32_t)0x00000040U)         /* !< Operate on a flash sector */
+#define FLASHCTL_CMDTYPE_SIZE_BANK               ((uint32_t)0x00000050U)         /* !< Operate on an entire flash bank */
+
+/* FLASHCTL_CMDCTL Bits */
+/* FLASHCTL_CMDCTL[MODESEL] Bits */
+#define FLASHCTL_CMDCTL_MODESEL_OFS              (0)                             /* !< MODESEL Offset */
+#define FLASHCTL_CMDCTL_MODESEL_MASK             ((uint32_t)0x0000000FU)         /* !< Mode This field is only used for
+                                                                                    the Mode Change command type.
+                                                                                    Otherwise, bank and pump modes are
+                                                                                    set automaticlly through the NW
+                                                                                    hardware. */
+#define FLASHCTL_CMDCTL_MODESEL_READ             ((uint32_t)0x00000000U)         /* !< Read Mode */
+#define FLASHCTL_CMDCTL_MODESEL_RDMARG0          ((uint32_t)0x00000002U)         /* !< Read Margin 0 Mode */
+#define FLASHCTL_CMDCTL_MODESEL_RDMARG1          ((uint32_t)0x00000004U)         /* !< Read Margin 1 Mode */
+#define FLASHCTL_CMDCTL_MODESEL_RDMARG0B         ((uint32_t)0x00000006U)         /* !< Read Margin 0B Mode */
+#define FLASHCTL_CMDCTL_MODESEL_RDMARG1B         ((uint32_t)0x00000007U)         /* !< Read Margin 1B Mode */
+#define FLASHCTL_CMDCTL_MODESEL_PGMVER           ((uint32_t)0x00000009U)         /* !< Program Verify Mode */
+#define FLASHCTL_CMDCTL_MODESEL_PGMSW            ((uint32_t)0x0000000AU)         /* !< Program Single Word */
+#define FLASHCTL_CMDCTL_MODESEL_ERASEVER         ((uint32_t)0x0000000BU)         /* !< Erase Verify Mode */
+#define FLASHCTL_CMDCTL_MODESEL_ERASESECT        ((uint32_t)0x0000000CU)         /* !< Erase Sector */
+#define FLASHCTL_CMDCTL_MODESEL_PGMMW            ((uint32_t)0x0000000EU)         /* !< Program Multiple Word */
+#define FLASHCTL_CMDCTL_MODESEL_ERASEBNK         ((uint32_t)0x0000000FU)         /* !< Erase Bank */
+/* FLASHCTL_CMDCTL[BANKSEL] Bits */
+#define FLASHCTL_CMDCTL_BANKSEL_OFS              (4)                             /* !< BANKSEL Offset */
+#define FLASHCTL_CMDCTL_BANKSEL_MASK             ((uint32_t)0x000001F0U)         /* !< Bank Select A specific Bank ID can
+                                                                                    be written to this field to indicate
+                                                                                    to which bank an  operation is to be
+                                                                                    applied if CMDCTL.ADDRXLATEOVR is
+                                                                                    set. */
+#define FLASHCTL_CMDCTL_BANKSEL_BANK0            ((uint32_t)0x00000010U)         /* !< Bank 0 */
+#define FLASHCTL_CMDCTL_BANKSEL_BANK1            ((uint32_t)0x00000020U)         /* !< Bank 1 */
+#define FLASHCTL_CMDCTL_BANKSEL_BANK2            ((uint32_t)0x00000040U)         /* !< Bank 2 */
+#define FLASHCTL_CMDCTL_BANKSEL_BANK3            ((uint32_t)0x00000080U)         /* !< Bank 3 */
+#define FLASHCTL_CMDCTL_BANKSEL_BANK4            ((uint32_t)0x00000100U)         /* !< Bank 4 */
+/* FLASHCTL_CMDCTL[REGIONSEL] Bits */
+#define FLASHCTL_CMDCTL_REGIONSEL_OFS            (9)                             /* !< REGIONSEL Offset */
+#define FLASHCTL_CMDCTL_REGIONSEL_MASK           ((uint32_t)0x00001E00U)         /* !< Bank Region A specific region ID
+                                                                                    can be written to this field to
+                                                                                    indicate to which region an
+                                                                                    operation is to be applied if
+                                                                                    CMDCTL.ADDRXLATEOVR is set. */
+#define FLASHCTL_CMDCTL_REGIONSEL_MAIN           ((uint32_t)0x00000200U)         /* !< Main Region */
+#define FLASHCTL_CMDCTL_REGIONSEL_NONMAIN        ((uint32_t)0x00000400U)         /* !< Non-Main Region */
+#define FLASHCTL_CMDCTL_REGIONSEL_TRIM           ((uint32_t)0x00000800U)         /* !< Trim Region */
+#define FLASHCTL_CMDCTL_REGIONSEL_ENGR           ((uint32_t)0x00001000U)         /* !< Engr Region */
+/* FLASHCTL_CMDCTL[ECCGENOVR] Bits */
+#define FLASHCTL_CMDCTL_ECCGENOVR_OFS            (17)                            /* !< ECCGENOVR Offset */
+#define FLASHCTL_CMDCTL_ECCGENOVR_MASK           ((uint32_t)0x00020000U)         /* !< Override hardware generation of ECC
+                                                                                    data for program.  Use data written
+                                                                                    to  CMDDATAECC*. */
+#define FLASHCTL_CMDCTL_ECCGENOVR_NOOVERRIDE     ((uint32_t)0x00000000U)         /* !< Do not override */
+#define FLASHCTL_CMDCTL_ECCGENOVR_OVERRIDE       ((uint32_t)0x00020000U)         /* !< Override */
+/* FLASHCTL_CMDCTL[ADDRXLATEOVR] Bits */
+#define FLASHCTL_CMDCTL_ADDRXLATEOVR_OFS         (16)                            /* !< ADDRXLATEOVR Offset */
+#define FLASHCTL_CMDCTL_ADDRXLATEOVR_MASK        ((uint32_t)0x00010000U)         /* !< Override hardware address
+                                                                                    translation of address in CMDADDR
+                                                                                    from a  system address to a bank
+                                                                                    address and bank ID.  Use data
+                                                                                    written to  CMDADDR directly as the
+                                                                                    bank address.  Use the value written
+                                                                                    to  CMDCTL.BANKSEL directly as the
+                                                                                    bank ID.  Use the value written to
+                                                                                    CMDCTL.REGIONSEL directly as the
+                                                                                    region ID. */
+#define FLASHCTL_CMDCTL_ADDRXLATEOVR_NOOVERRIDE  ((uint32_t)0x00000000U)         /* !< Do not override */
+#define FLASHCTL_CMDCTL_ADDRXLATEOVR_OVERRIDE    ((uint32_t)0x00010000U)         /* !< Override */
+/* FLASHCTL_CMDCTL[SSERASEDIS] Bits */
+#define FLASHCTL_CMDCTL_SSERASEDIS_OFS           (20)                            /* !< SSERASEDIS Offset */
+#define FLASHCTL_CMDCTL_SSERASEDIS_MASK          ((uint32_t)0x00100000U)         /* !< Disable Stair-Step Erase.  If set,
+                                                                                    the default VHV trim voltage setting
+                                                                                    will be used for all erase pulses. By
+                                                                                    default, this bit is reset, meaning
+                                                                                    that the VHV voltage will be stepped
+                                                                                    during successive erase pulses.  The
+                                                                                    step count, step voltage, begin and
+                                                                                    end voltages are all hard-wired. */
+#define FLASHCTL_CMDCTL_SSERASEDIS_ENABLE        ((uint32_t)0x00000000U)         /* !< Enable */
+#define FLASHCTL_CMDCTL_SSERASEDIS_DISABLE       ((uint32_t)0x00100000U)         /* !< Disable */
+/* FLASHCTL_CMDCTL[DATAVEREN] Bits */
+#define FLASHCTL_CMDCTL_DATAVEREN_OFS            (21)                            /* !< DATAVEREN Offset */
+#define FLASHCTL_CMDCTL_DATAVEREN_MASK           ((uint32_t)0x00200000U)         /* !< Enable invalid data verify.   This
+                                                                                    checks for 0->1 transitions in the
+                                                                                    memory when a program operation is
+                                                                                    initiated.  If such a transition is
+                                                                                    found, the program will fail with an
+                                                                                    error without executing the program. */
+#define FLASHCTL_CMDCTL_DATAVEREN_DISABLE        ((uint32_t)0x00000000U)         /* !< Disable */
+#define FLASHCTL_CMDCTL_DATAVEREN_ENABLE         ((uint32_t)0x00200000U)         /* !< Enable */
+
+/* FLASHCTL_CMDADDR Bits */
+/* FLASHCTL_CMDADDR[VAL] Bits */
+#define FLASHCTL_CMDADDR_VAL_OFS                 (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDADDR_VAL_MASK                ((uint32_t)0xFFFFFFFFU)         /* !< Address value */
+#define FLASHCTL_CMDADDR_VAL_MINIMUM             ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDADDR_VAL_MAXIMUM             ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDBYTEN Bits */
+/* FLASHCTL_CMDBYTEN[VAL] Bits */
+#define FLASHCTL_CMDBYTEN_VAL_OFS                (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDBYTEN_VAL_MASK               ((uint32_t)0x0003FFFFU)         /* !< Command Byte Enable value. A 1-bit
+                                                                                    per flash word byte value is placed
+                                                                                    in this register. */
+#define FLASHCTL_CMDBYTEN_VAL_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDBYTEN_VAL_MAXIMUM            ((uint32_t)0x0003FFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATAINDEX Bits */
+/* FLASHCTL_CMDDATAINDEX[VAL] Bits */
+#define FLASHCTL_CMDDATAINDEX_VAL_OFS            (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATAINDEX_VAL_MASK           ((uint32_t)0x00000007U)         /* !< Data register index */
+#define FLASHCTL_CMDDATAINDEX_VAL_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATAINDEX_VAL_MAXIMUM        ((uint32_t)0x00000007U)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA0 Bits */
+/* FLASHCTL_CMDDATA0[VAL] Bits */
+#define FLASHCTL_CMDDATA0_VAL_OFS                (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA0_VAL_MASK               ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA0_VAL_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA0_VAL_MAXIMUM            ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA1 Bits */
+/* FLASHCTL_CMDDATA1[VAL] Bits */
+#define FLASHCTL_CMDDATA1_VAL_OFS                (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA1_VAL_MASK               ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA1_VAL_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA1_VAL_MAXIMUM            ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA2 Bits */
+/* FLASHCTL_CMDDATA2[VAL] Bits */
+#define FLASHCTL_CMDDATA2_VAL_OFS                (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA2_VAL_MASK               ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA2_VAL_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA2_VAL_MAXIMUM            ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA3 Bits */
+/* FLASHCTL_CMDDATA3[VAL] Bits */
+#define FLASHCTL_CMDDATA3_VAL_OFS                (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA3_VAL_MASK               ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA3_VAL_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA3_VAL_MAXIMUM            ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA4 Bits */
+/* FLASHCTL_CMDDATA4[VAL] Bits */
+#define FLASHCTL_CMDDATA4_VAL_OFS                (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA4_VAL_MASK               ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. T */
+#define FLASHCTL_CMDDATA4_VAL_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA4_VAL_MAXIMUM            ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA5 Bits */
+/* FLASHCTL_CMDDATA5[VAL] Bits */
+#define FLASHCTL_CMDDATA5_VAL_OFS                (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA5_VAL_MASK               ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA5_VAL_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA5_VAL_MAXIMUM            ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA6 Bits */
+/* FLASHCTL_CMDDATA6[VAL] Bits */
+#define FLASHCTL_CMDDATA6_VAL_OFS                (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA6_VAL_MASK               ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA6_VAL_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA6_VAL_MAXIMUM            ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA7 Bits */
+/* FLASHCTL_CMDDATA7[VAL] Bits */
+#define FLASHCTL_CMDDATA7_VAL_OFS                (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA7_VAL_MASK               ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA7_VAL_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA7_VAL_MAXIMUM            ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA8 Bits */
+/* FLASHCTL_CMDDATA8[VAL] Bits */
+#define FLASHCTL_CMDDATA8_VAL_OFS                (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA8_VAL_MASK               ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA8_VAL_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA8_VAL_MAXIMUM            ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA9 Bits */
+/* FLASHCTL_CMDDATA9[VAL] Bits */
+#define FLASHCTL_CMDDATA9_VAL_OFS                (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA9_VAL_MASK               ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA9_VAL_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA9_VAL_MAXIMUM            ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA10 Bits */
+/* FLASHCTL_CMDDATA10[VAL] Bits */
+#define FLASHCTL_CMDDATA10_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA10_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA10_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA10_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA11 Bits */
+/* FLASHCTL_CMDDATA11[VAL] Bits */
+#define FLASHCTL_CMDDATA11_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA11_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA11_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA11_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA12 Bits */
+/* FLASHCTL_CMDDATA12[VAL] Bits */
+#define FLASHCTL_CMDDATA12_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA12_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA12_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA12_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA13 Bits */
+/* FLASHCTL_CMDDATA13[VAL] Bits */
+#define FLASHCTL_CMDDATA13_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA13_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA13_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA13_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA14 Bits */
+/* FLASHCTL_CMDDATA14[VAL] Bits */
+#define FLASHCTL_CMDDATA14_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA14_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA14_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA14_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA15 Bits */
+/* FLASHCTL_CMDDATA15[VAL] Bits */
+#define FLASHCTL_CMDDATA15_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA15_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA15_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA15_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA16 Bits */
+/* FLASHCTL_CMDDATA16[VAL] Bits */
+#define FLASHCTL_CMDDATA16_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA16_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA16_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA16_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA17 Bits */
+/* FLASHCTL_CMDDATA17[VAL] Bits */
+#define FLASHCTL_CMDDATA17_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA17_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA17_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA17_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA18 Bits */
+/* FLASHCTL_CMDDATA18[VAL] Bits */
+#define FLASHCTL_CMDDATA18_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA18_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA18_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA18_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA19 Bits */
+/* FLASHCTL_CMDDATA19[VAL] Bits */
+#define FLASHCTL_CMDDATA19_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA19_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA19_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA19_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA20 Bits */
+/* FLASHCTL_CMDDATA20[VAL] Bits */
+#define FLASHCTL_CMDDATA20_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA20_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA20_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA20_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA21 Bits */
+/* FLASHCTL_CMDDATA21[VAL] Bits */
+#define FLASHCTL_CMDDATA21_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA21_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA21_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA21_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA22 Bits */
+/* FLASHCTL_CMDDATA22[VAL] Bits */
+#define FLASHCTL_CMDDATA22_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA22_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA22_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA22_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA23 Bits */
+/* FLASHCTL_CMDDATA23[VAL] Bits */
+#define FLASHCTL_CMDDATA23_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA23_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA23_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA23_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA24 Bits */
+/* FLASHCTL_CMDDATA24[VAL] Bits */
+#define FLASHCTL_CMDDATA24_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA24_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA24_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA24_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA25 Bits */
+/* FLASHCTL_CMDDATA25[VAL] Bits */
+#define FLASHCTL_CMDDATA25_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA25_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA25_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA25_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA26 Bits */
+/* FLASHCTL_CMDDATA26[VAL] Bits */
+#define FLASHCTL_CMDDATA26_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA26_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA26_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA26_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA27 Bits */
+/* FLASHCTL_CMDDATA27[VAL] Bits */
+#define FLASHCTL_CMDDATA27_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA27_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA27_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA27_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA28 Bits */
+/* FLASHCTL_CMDDATA28[VAL] Bits */
+#define FLASHCTL_CMDDATA28_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA28_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA28_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA28_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA29 Bits */
+/* FLASHCTL_CMDDATA29[VAL] Bits */
+#define FLASHCTL_CMDDATA29_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA29_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA29_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA29_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA30 Bits */
+/* FLASHCTL_CMDDATA30[VAL] Bits */
+#define FLASHCTL_CMDDATA30_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA30_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA30_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA30_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATA31 Bits */
+/* FLASHCTL_CMDDATA31[VAL] Bits */
+#define FLASHCTL_CMDDATA31_VAL_OFS               (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDDATA31_VAL_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< A 32-bit data value is placed in
+                                                                                    this field. */
+#define FLASHCTL_CMDDATA31_VAL_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDDATA31_VAL_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDDATAECC0 Bits */
+/* FLASHCTL_CMDDATAECC0[VAL0] Bits */
+#define FLASHCTL_CMDDATAECC0_VAL0_OFS            (0)                             /* !< VAL0 Offset */
+#define FLASHCTL_CMDDATAECC0_VAL0_MASK           ((uint32_t)0x000000FFU)         /* !< ECC data for bits 63:0 of the data
+                                                                                    is placed here. */
+#define FLASHCTL_CMDDATAECC0_VAL0_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC0_VAL0_MAXIMUM        ((uint32_t)0x000000FFU)         /* !< Maximum value */
+/* FLASHCTL_CMDDATAECC0[VAL1] Bits */
+#define FLASHCTL_CMDDATAECC0_VAL1_OFS            (8)                             /* !< VAL1 Offset */
+#define FLASHCTL_CMDDATAECC0_VAL1_MASK           ((uint32_t)0x0000FF00U)         /* !< ECC data for bits 127:64 of the
+                                                                                    data is placed here. */
+#define FLASHCTL_CMDDATAECC0_VAL1_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC0_VAL1_MAXIMUM        ((uint32_t)0x0000FF00U)         /* !< Maximum value */
+
+/* FLASHCTL_CMDDATAECC1 Bits */
+/* FLASHCTL_CMDDATAECC1[VAL0] Bits */
+#define FLASHCTL_CMDDATAECC1_VAL0_OFS            (0)                             /* !< VAL0 Offset */
+#define FLASHCTL_CMDDATAECC1_VAL0_MASK           ((uint32_t)0x000000FFU)         /* !< ECC data for bits 63:0 of the data
+                                                                                    is placed here. */
+#define FLASHCTL_CMDDATAECC1_VAL0_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC1_VAL0_MAXIMUM        ((uint32_t)0x000000FFU)         /* !< Maximum value */
+/* FLASHCTL_CMDDATAECC1[VAL1] Bits */
+#define FLASHCTL_CMDDATAECC1_VAL1_OFS            (8)                             /* !< VAL1 Offset */
+#define FLASHCTL_CMDDATAECC1_VAL1_MASK           ((uint32_t)0x0000FF00U)         /* !< ECC data for bits 127:64 of the
+                                                                                    data is placed here. */
+#define FLASHCTL_CMDDATAECC1_VAL1_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC1_VAL1_MAXIMUM        ((uint32_t)0x0000FF00U)         /* !< Maximum value */
+
+/* FLASHCTL_CMDDATAECC2 Bits */
+/* FLASHCTL_CMDDATAECC2[VAL0] Bits */
+#define FLASHCTL_CMDDATAECC2_VAL0_OFS            (0)                             /* !< VAL0 Offset */
+#define FLASHCTL_CMDDATAECC2_VAL0_MASK           ((uint32_t)0x000000FFU)         /* !< ECC data for bits 63:0 of the data
+                                                                                    is placed here. */
+#define FLASHCTL_CMDDATAECC2_VAL0_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC2_VAL0_MAXIMUM        ((uint32_t)0x000000FFU)         /* !< Maximum value */
+/* FLASHCTL_CMDDATAECC2[VAL1] Bits */
+#define FLASHCTL_CMDDATAECC2_VAL1_OFS            (8)                             /* !< VAL1 Offset */
+#define FLASHCTL_CMDDATAECC2_VAL1_MASK           ((uint32_t)0x0000FF00U)         /* !< ECC data for bits 127:64 of the
+                                                                                    data is placed here. */
+#define FLASHCTL_CMDDATAECC2_VAL1_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC2_VAL1_MAXIMUM        ((uint32_t)0x0000FF00U)         /* !< Maximum value */
+
+/* FLASHCTL_CMDDATAECC3 Bits */
+/* FLASHCTL_CMDDATAECC3[VAL0] Bits */
+#define FLASHCTL_CMDDATAECC3_VAL0_OFS            (0)                             /* !< VAL0 Offset */
+#define FLASHCTL_CMDDATAECC3_VAL0_MASK           ((uint32_t)0x000000FFU)         /* !< ECC data for bits 63:0 of the data
+                                                                                    is placed here. */
+#define FLASHCTL_CMDDATAECC3_VAL0_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC3_VAL0_MAXIMUM        ((uint32_t)0x000000FFU)         /* !< Maximum value */
+/* FLASHCTL_CMDDATAECC3[VAL1] Bits */
+#define FLASHCTL_CMDDATAECC3_VAL1_OFS            (8)                             /* !< VAL1 Offset */
+#define FLASHCTL_CMDDATAECC3_VAL1_MASK           ((uint32_t)0x0000FF00U)         /* !< ECC data for bits 127:64 of the
+                                                                                    data is placed here. */
+#define FLASHCTL_CMDDATAECC3_VAL1_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC3_VAL1_MAXIMUM        ((uint32_t)0x0000FF00U)         /* !< Maximum value */
+
+/* FLASHCTL_CMDDATAECC4 Bits */
+/* FLASHCTL_CMDDATAECC4[VAL0] Bits */
+#define FLASHCTL_CMDDATAECC4_VAL0_OFS            (0)                             /* !< VAL0 Offset */
+#define FLASHCTL_CMDDATAECC4_VAL0_MASK           ((uint32_t)0x000000FFU)         /* !< ECC data for bits 63:0 of the data
+                                                                                    is placed here. */
+#define FLASHCTL_CMDDATAECC4_VAL0_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC4_VAL0_MAXIMUM        ((uint32_t)0x000000FFU)         /* !< Maximum value */
+/* FLASHCTL_CMDDATAECC4[VAL1] Bits */
+#define FLASHCTL_CMDDATAECC4_VAL1_OFS            (8)                             /* !< VAL1 Offset */
+#define FLASHCTL_CMDDATAECC4_VAL1_MASK           ((uint32_t)0x0000FF00U)         /* !< ECC data for bits 127:64 of the
+                                                                                    data is placed here. */
+#define FLASHCTL_CMDDATAECC4_VAL1_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC4_VAL1_MAXIMUM        ((uint32_t)0x0000FF00U)         /* !< Maximum value */
+
+/* FLASHCTL_CMDDATAECC5 Bits */
+/* FLASHCTL_CMDDATAECC5[VAL0] Bits */
+#define FLASHCTL_CMDDATAECC5_VAL0_OFS            (0)                             /* !< VAL0 Offset */
+#define FLASHCTL_CMDDATAECC5_VAL0_MASK           ((uint32_t)0x000000FFU)         /* !< ECC data for bits 63:0 of the data
+                                                                                    is placed here. */
+#define FLASHCTL_CMDDATAECC5_VAL0_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC5_VAL0_MAXIMUM        ((uint32_t)0x000000FFU)         /* !< Maximum value */
+/* FLASHCTL_CMDDATAECC5[VAL1] Bits */
+#define FLASHCTL_CMDDATAECC5_VAL1_OFS            (8)                             /* !< VAL1 Offset */
+#define FLASHCTL_CMDDATAECC5_VAL1_MASK           ((uint32_t)0x0000FF00U)         /* !< ECC data for bits 127:64 of the
+                                                                                    data is placed here. */
+#define FLASHCTL_CMDDATAECC5_VAL1_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC5_VAL1_MAXIMUM        ((uint32_t)0x0000FF00U)         /* !< Maximum value */
+
+/* FLASHCTL_CMDDATAECC6 Bits */
+/* FLASHCTL_CMDDATAECC6[VAL0] Bits */
+#define FLASHCTL_CMDDATAECC6_VAL0_OFS            (0)                             /* !< VAL0 Offset */
+#define FLASHCTL_CMDDATAECC6_VAL0_MASK           ((uint32_t)0x000000FFU)         /* !< ECC data for bits 63:0 of the data
+                                                                                    is placed here. */
+#define FLASHCTL_CMDDATAECC6_VAL0_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC6_VAL0_MAXIMUM        ((uint32_t)0x000000FFU)         /* !< Maximum value */
+/* FLASHCTL_CMDDATAECC6[VAL1] Bits */
+#define FLASHCTL_CMDDATAECC6_VAL1_OFS            (8)                             /* !< VAL1 Offset */
+#define FLASHCTL_CMDDATAECC6_VAL1_MASK           ((uint32_t)0x0000FF00U)         /* !< ECC data for bits 127:64 of the
+                                                                                    data is placed here. */
+#define FLASHCTL_CMDDATAECC6_VAL1_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC6_VAL1_MAXIMUM        ((uint32_t)0x0000FF00U)         /* !< Maximum value */
+
+/* FLASHCTL_CMDDATAECC7 Bits */
+/* FLASHCTL_CMDDATAECC7[VAL0] Bits */
+#define FLASHCTL_CMDDATAECC7_VAL0_OFS            (0)                             /* !< VAL0 Offset */
+#define FLASHCTL_CMDDATAECC7_VAL0_MASK           ((uint32_t)0x000000FFU)         /* !< ECC data for bits 63:0 of the data
+                                                                                    is placed here. */
+#define FLASHCTL_CMDDATAECC7_VAL0_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC7_VAL0_MAXIMUM        ((uint32_t)0x000000FFU)         /* !< Maximum value */
+/* FLASHCTL_CMDDATAECC7[VAL1] Bits */
+#define FLASHCTL_CMDDATAECC7_VAL1_OFS            (8)                             /* !< VAL1 Offset */
+#define FLASHCTL_CMDDATAECC7_VAL1_MASK           ((uint32_t)0x0000FF00U)         /* !< ECC data for bits 127:64 of the
+                                                                                    data is placed here. */
+#define FLASHCTL_CMDDATAECC7_VAL1_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CMDDATAECC7_VAL1_MAXIMUM        ((uint32_t)0x0000FF00U)         /* !< Maximum value */
+
+/* FLASHCTL_CMDWEPROTA Bits */
+/* FLASHCTL_CMDWEPROTA[VAL] Bits */
+#define FLASHCTL_CMDWEPROTA_VAL_OFS              (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDWEPROTA_VAL_MASK             ((uint32_t)0xFFFFFFFFU)         /* !< Each bit protects 1 sector.  bit
+                                                                                    [0]:	When 1, sector 0 of the flash
+                                                                                    memory will be protected from program
+                                                                                    and erase. bit [1]:	When 1, sector
+                                                                                    1 of the flash memory will be
+                                                                                    protected from program 		and erase.
+                                                                                    : 	: bit [31]:	When 1, sector 31 of
+                                                                                    the flash memory will be protected
+                                                                                    from program 		and erase. */
+#define FLASHCTL_CMDWEPROTA_VAL_MINIMUM          ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDWEPROTA_VAL_MAXIMUM          ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDWEPROTB Bits */
+/* FLASHCTL_CMDWEPROTB[VAL] Bits */
+#define FLASHCTL_CMDWEPROTB_VAL_OFS              (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDWEPROTB_VAL_MASK             ((uint32_t)0xFFFFFFFFU)         /* !< Each bit protects a group of 8
+                                                                                    sectors.  When a bit is 1, the
+                                                                                    associated 8 sectors in the flash
+                                                                                    will be protected from program and
+                                                                                    erase.  A maximum of 256 sectors can
+                                                                                    be protected with this register. */
+#define FLASHCTL_CMDWEPROTB_VAL_MINIMUM          ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDWEPROTB_VAL_MAXIMUM          ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDWEPROTC Bits */
+/* FLASHCTL_CMDWEPROTC[VAL] Bits */
+#define FLASHCTL_CMDWEPROTC_VAL_OFS              (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDWEPROTC_VAL_MASK             ((uint32_t)0xFFFFFFFFU)         /* !< Each bit protects a group of 8
+                                                                                    sectors.  When a bit is 1, the
+                                                                                    associated 8 sectors in the flash
+                                                                                    will be protected from program and
+                                                                                    erase.  Note that the sectors
+                                                                                    protected with this register start at
+                                                                                    sector 256 in the flash, where the
+                                                                                    sectors protected by the CMDWEPROTB
+                                                                                    register end. */
+#define FLASHCTL_CMDWEPROTC_VAL_MINIMUM          ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDWEPROTC_VAL_MAXIMUM          ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDWEPROTNM Bits */
+/* FLASHCTL_CMDWEPROTNM[VAL] Bits */
+#define FLASHCTL_CMDWEPROTNM_VAL_OFS             (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDWEPROTNM_VAL_MASK            ((uint32_t)0xFFFFFFFFU)         /* !< Each bit protects 1 sector.  bit
+                                                                                    [0]:	When 1, sector 0 of the non-main
+                                                                                    region will be protected from program
+                                                                                    and erase. bit [1]:	When 1, sector
+                                                                                    1 of the non-main region will be
+                                                                                    protected from program 		and erase.
+                                                                                    : 	: bit [31]:	When 1, sector 31 of
+                                                                                    the non-main will be protected from
+                                                                                    program 		and erase. */
+#define FLASHCTL_CMDWEPROTNM_VAL_MINIMUM         ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDWEPROTNM_VAL_MAXIMUM         ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDWEPROTTR Bits */
+/* FLASHCTL_CMDWEPROTTR[VAL] Bits */
+#define FLASHCTL_CMDWEPROTTR_VAL_OFS             (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDWEPROTTR_VAL_MASK            ((uint32_t)0xFFFFFFFFU)         /* !< Each bit protects 1 sector.  bit
+                                                                                    [0]:	When 1, sector 0 of the engr
+                                                                                    region will be protected from program
+                                                                                    and erase. bit [1]:	When 1, sector
+                                                                                    1 of the engr region will be
+                                                                                    protected from program 		and erase.
+                                                                                    : 	: bit [31]:	When 1, sector 31 of
+                                                                                    the engr region will be protected
+                                                                                    from program 		and erase. */
+#define FLASHCTL_CMDWEPROTTR_VAL_MINIMUM         ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDWEPROTTR_VAL_MAXIMUM         ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CMDWEPROTEN Bits */
+/* FLASHCTL_CMDWEPROTEN[VAL] Bits */
+#define FLASHCTL_CMDWEPROTEN_VAL_OFS             (0)                             /* !< VAL Offset */
+#define FLASHCTL_CMDWEPROTEN_VAL_MASK            ((uint32_t)0xFFFFFFFFU)         /* !< Each bit protects 1 sector.  bit
+                                                                                    [0]:	When 1, sector 0 of the engr
+                                                                                    region will be protected from program
+                                                                                    and erase. bit [1]:	When 1, sector
+                                                                                    1 of the engr region will be
+                                                                                    protected from program 		and erase.
+                                                                                    : 	: bit [31]:	When 1, sector 31 of
+                                                                                    the engr region will be protected
+                                                                                    from program 		and erase. */
+#define FLASHCTL_CMDWEPROTEN_VAL_MINIMUM         ((uint32_t)0x00000000U)         /* !< Minimum value of [VAL] */
+#define FLASHCTL_CMDWEPROTEN_VAL_MAXIMUM         ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value of [VAL] */
+
+/* FLASHCTL_CFGCMD Bits */
+/* FLASHCTL_CFGCMD[WAITSTATE] Bits */
+#define FLASHCTL_CFGCMD_WAITSTATE_OFS            (0)                             /* !< WAITSTATE Offset */
+#define FLASHCTL_CFGCMD_WAITSTATE_MASK           ((uint32_t)0x0000000FU)         /* !< Wait State setting for verify reads */
+#define FLASHCTL_CFGCMD_WAITSTATE_MINIMUM        ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CFGCMD_WAITSTATE_MAXIMUM        ((uint32_t)0x0000000FU)         /* !< Maximum value */
+
+/* FLASHCTL_CFGPCNT Bits */
+/* FLASHCTL_CFGPCNT[MAXPCNTOVR] Bits */
+#define FLASHCTL_CFGPCNT_MAXPCNTOVR_OFS          (0)                             /* !< MAXPCNTOVR Offset */
+#define FLASHCTL_CFGPCNT_MAXPCNTOVR_MASK         ((uint32_t)0x00000001U)         /* !< Override hard-wired maximum pulse
+                                                                                    count.  If MAXERSPCNTOVR is not set,
+                                                                                    then setting this value alone will
+                                                                                    override the max pulse count for both
+                                                                                    program and erase.  If MAXERSPCNTOVR
+                                                                                    is set, then this bit will only
+                                                                                    control the max pulse count setting
+                                                                                    for program. By default, this bit is
+                                                                                    0, and a hard-wired max pulse count
+                                                                                    is used. */
+#define FLASHCTL_CFGPCNT_MAXPCNTOVR_DEFAULT      ((uint32_t)0x00000000U)         /* !< Use hard-wired (default) value for
+                                                                                    maximum pulse count */
+#define FLASHCTL_CFGPCNT_MAXPCNTOVR_OVERRIDE     ((uint32_t)0x00000001U)         /* !< Use value from MAXPCNTVAL field as
+                                                                                    maximum puse count */
+/* FLASHCTL_CFGPCNT[MAXPCNTVAL] Bits */
+#define FLASHCTL_CFGPCNT_MAXPCNTVAL_OFS          (4)                             /* !< MAXPCNTVAL Offset */
+#define FLASHCTL_CFGPCNT_MAXPCNTVAL_MASK         ((uint32_t)0x00000FF0U)         /* !< Override maximum pulse counter with
+                                                                                    this value.   If MAXPCNTOVR = 0, then
+                                                                                    this field is ignored. If MAXPCNTOVR
+                                                                                    = 1 and MAXERSPCNTOVR = 0, then this
+                                                                                    value will be used  to override the
+                                                                                    max pulse count for both program and
+                                                                                    erase.  Full max value will be {4'h0,
+                                                                                    MAXPCNTVAL} . If MAXPCNTOVR = 1 and
+                                                                                    MAXERSPCNTOVR = 1, then this value
+                                                                                    will be used to override the max
+                                                                                    pulse count for program only.  Full
+                                                                                    max value will be {4'h0, MAXPCNTVAL}. */
+#define FLASHCTL_CFGPCNT_MAXPCNTVAL_MINIMUM      ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_CFGPCNT_MAXPCNTVAL_MAXIMUM      ((uint32_t)0x00000FF0U)         /* !< Maximum value */
+
+/* FLASHCTL_STATCMD Bits */
+/* FLASHCTL_STATCMD[CMDDONE] Bits */
+#define FLASHCTL_STATCMD_CMDDONE_OFS             (0)                             /* !< CMDDONE Offset */
+#define FLASHCTL_STATCMD_CMDDONE_MASK            ((uint32_t)0x00000001U)         /* !< Command Done */
+#define FLASHCTL_STATCMD_CMDDONE_STATNOTDONE     ((uint32_t)0x00000000U)         /* !< Not Done */
+#define FLASHCTL_STATCMD_CMDDONE_STATDONE        ((uint32_t)0x00000001U)         /* !< Done */
+/* FLASHCTL_STATCMD[CMDPASS] Bits */
+#define FLASHCTL_STATCMD_CMDPASS_OFS             (1)                             /* !< CMDPASS Offset */
+#define FLASHCTL_STATCMD_CMDPASS_MASK            ((uint32_t)0x00000002U)         /* !< Command Pass - valid when CMD_DONE
+                                                                                    field is 1 */
+#define FLASHCTL_STATCMD_CMDPASS_STATFAIL        ((uint32_t)0x00000000U)         /* !< Fail */
+#define FLASHCTL_STATCMD_CMDPASS_STATPASS        ((uint32_t)0x00000002U)         /* !< Pass */
+/* FLASHCTL_STATCMD[CMDINPROGRESS] Bits */
+#define FLASHCTL_STATCMD_CMDINPROGRESS_OFS       (2)                             /* !< CMDINPROGRESS Offset */
+#define FLASHCTL_STATCMD_CMDINPROGRESS_MASK      ((uint32_t)0x00000004U)         /* !< Command In Progress */
+#define FLASHCTL_STATCMD_CMDINPROGRESS_STATCOMPLETE ((uint32_t)0x00000000U)         /* !< Complete */
+#define FLASHCTL_STATCMD_CMDINPROGRESS_STATINPROGRESS ((uint32_t)0x00000004U)         /* !< In Progress */
+/* FLASHCTL_STATCMD[FAILWEPROT] Bits */
+#define FLASHCTL_STATCMD_FAILWEPROT_OFS          (4)                             /* !< FAILWEPROT Offset */
+#define FLASHCTL_STATCMD_FAILWEPROT_MASK         ((uint32_t)0x00000010U)         /* !< Command failed due to Write/Erase
+                                                                                    Protect Sector Violation */
+#define FLASHCTL_STATCMD_FAILWEPROT_STATNOFAIL   ((uint32_t)0x00000000U)         /* !< No Fail */
+#define FLASHCTL_STATCMD_FAILWEPROT_STATFAIL     ((uint32_t)0x00000010U)         /* !< Fail */
+/* FLASHCTL_STATCMD[FAILVERIFY] Bits */
+#define FLASHCTL_STATCMD_FAILVERIFY_OFS          (5)                             /* !< FAILVERIFY Offset */
+#define FLASHCTL_STATCMD_FAILVERIFY_MASK         ((uint32_t)0x00000020U)         /* !< Command failed due to verify error */
+#define FLASHCTL_STATCMD_FAILVERIFY_STATNOFAIL   ((uint32_t)0x00000000U)         /* !< No Fail */
+#define FLASHCTL_STATCMD_FAILVERIFY_STATFAIL     ((uint32_t)0x00000020U)         /* !< Fail */
+/* FLASHCTL_STATCMD[FAILMISC] Bits */
+#define FLASHCTL_STATCMD_FAILMISC_OFS            (12)                            /* !< FAILMISC Offset */
+#define FLASHCTL_STATCMD_FAILMISC_MASK           ((uint32_t)0x00001000U)         /* !< Command failed due to error other
+                                                                                    than write/erase protect violation or
+                                                                                    verify error.  This is an extra bit
+                                                                                    in case a new failure mechanism is
+                                                                                    added which requires a status bit. */
+#define FLASHCTL_STATCMD_FAILMISC_STATNOFAIL     ((uint32_t)0x00000000U)         /* !< No Fail */
+#define FLASHCTL_STATCMD_FAILMISC_STATFAIL       ((uint32_t)0x00001000U)         /* !< Fail */
+/* FLASHCTL_STATCMD[FAILILLADDR] Bits */
+#define FLASHCTL_STATCMD_FAILILLADDR_OFS         (6)                             /* !< FAILILLADDR Offset */
+#define FLASHCTL_STATCMD_FAILILLADDR_MASK        ((uint32_t)0x00000040U)         /* !< Command failed due to the use of an
+                                                                                    illegal address */
+#define FLASHCTL_STATCMD_FAILILLADDR_STATNOFAIL  ((uint32_t)0x00000000U)         /* !< No Fail */
+#define FLASHCTL_STATCMD_FAILILLADDR_STATFAIL    ((uint32_t)0x00000040U)         /* !< Fail */
+/* FLASHCTL_STATCMD[FAILMODE] Bits */
+#define FLASHCTL_STATCMD_FAILMODE_OFS            (7)                             /* !< FAILMODE Offset */
+#define FLASHCTL_STATCMD_FAILMODE_MASK           ((uint32_t)0x00000080U)         /* !< Command failed because a bank has
+                                                                                    been set to a mode other than READ.
+                                                                                    Program and Erase commands cannot be
+                                                                                    initiated unless all banks are in
+                                                                                    READ mode. */
+#define FLASHCTL_STATCMD_FAILMODE_STATNOFAIL     ((uint32_t)0x00000000U)         /* !< No Fail */
+#define FLASHCTL_STATCMD_FAILMODE_STATFAIL       ((uint32_t)0x00000080U)         /* !< Fail */
+/* FLASHCTL_STATCMD[FAILINVDATA] Bits */
+#define FLASHCTL_STATCMD_FAILINVDATA_OFS         (8)                             /* !< FAILINVDATA Offset */
+#define FLASHCTL_STATCMD_FAILINVDATA_MASK        ((uint32_t)0x00000100U)         /* !< Program command failed because an
+                                                                                    attempt was made to program a stored
+                                                                                    0 value to a 1. */
+#define FLASHCTL_STATCMD_FAILINVDATA_STATNOFAIL  ((uint32_t)0x00000000U)         /* !< No Fail */
+#define FLASHCTL_STATCMD_FAILINVDATA_STATFAIL    ((uint32_t)0x00000100U)         /* !< Fail */
+
+/* FLASHCTL_STATADDR Bits */
+/* FLASHCTL_STATADDR[BANKADDR] Bits */
+#define FLASHCTL_STATADDR_BANKADDR_OFS           (0)                             /* !< BANKADDR Offset */
+#define FLASHCTL_STATADDR_BANKADDR_MASK          ((uint32_t)0x0000FFFFU)         /* !< Current Bank Address A bank offset
+                                                                                    address is stored in this register. */
+#define FLASHCTL_STATADDR_BANKADDR_MINIMUM       ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_STATADDR_BANKADDR_MAXIMUM       ((uint32_t)0x0000FFFFU)         /* !< Maximum value */
+/* FLASHCTL_STATADDR[BANKID] Bits */
+#define FLASHCTL_STATADDR_BANKID_OFS             (21)                            /* !< BANKID Offset */
+#define FLASHCTL_STATADDR_BANKID_MASK            ((uint32_t)0x03E00000U)         /* !< Current Bank ID A bank indicator is
+                                                                                    stored in this register which
+                                                                                    represents the current bank on which
+                                                                                    the state  machine is operating.
+                                                                                    There is 1 bit per bank. */
+#define FLASHCTL_STATADDR_BANKID_BANK0           ((uint32_t)0x00200000U)         /* !< Bank 0 */
+#define FLASHCTL_STATADDR_BANKID_BANK1           ((uint32_t)0x00400000U)         /* !< Bank 1 */
+#define FLASHCTL_STATADDR_BANKID_BANK2           ((uint32_t)0x00800000U)         /* !< Bank 2 */
+#define FLASHCTL_STATADDR_BANKID_BANK3           ((uint32_t)0x01000000U)         /* !< Bank 3 */
+#define FLASHCTL_STATADDR_BANKID_BANK4           ((uint32_t)0x02000000U)         /* !< Bank 4 */
+/* FLASHCTL_STATADDR[REGIONID] Bits */
+#define FLASHCTL_STATADDR_REGIONID_OFS           (16)                            /* !< REGIONID Offset */
+#define FLASHCTL_STATADDR_REGIONID_MASK          ((uint32_t)0x001F0000U)         /* !< Current Region ID A region
+                                                                                    indicator is stored in this register
+                                                                                    which represents the current flash
+                                                                                    region on which the state  machine is
+                                                                                    operating. */
+#define FLASHCTL_STATADDR_REGIONID_MAIN          ((uint32_t)0x00010000U)         /* !< Main Region */
+#define FLASHCTL_STATADDR_REGIONID_NONMAIN       ((uint32_t)0x00020000U)         /* !< Non-Main Region */
+#define FLASHCTL_STATADDR_REGIONID_TRIM          ((uint32_t)0x00040000U)         /* !< Trim Region */
+#define FLASHCTL_STATADDR_REGIONID_ENGR          ((uint32_t)0x00080000U)         /* !< Engr Region */
+
+/* FLASHCTL_STATPCNT Bits */
+/* FLASHCTL_STATPCNT[PULSECNT] Bits */
+#define FLASHCTL_STATPCNT_PULSECNT_OFS           (0)                             /* !< PULSECNT Offset */
+#define FLASHCTL_STATPCNT_PULSECNT_MASK          ((uint32_t)0x00000FFFU)         /* !< Current Pulse Counter Value */
+#define FLASHCTL_STATPCNT_PULSECNT_MINIMUM       ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define FLASHCTL_STATPCNT_PULSECNT_MAXIMUM       ((uint32_t)0x00000FFFU)         /* !< Maximum value */
+
+/* FLASHCTL_STATMODE Bits */
+/* FLASHCTL_STATMODE[BANKNOTINRD] Bits */
+#define FLASHCTL_STATMODE_BANKNOTINRD_OFS        (0)                             /* !< BANKNOTINRD Offset */
+#define FLASHCTL_STATMODE_BANKNOTINRD_MASK       ((uint32_t)0x0000001FU)         /* !< Bank not in read mode. Indicates
+                                                                                    which banks are not in READ mode.
+                                                                                    There is 1 bit per bank. */
+#define FLASHCTL_STATMODE_BANKNOTINRD_BANK0      ((uint32_t)0x00000001U)         /* !< Bank 0 */
+#define FLASHCTL_STATMODE_BANKNOTINRD_BANK1      ((uint32_t)0x00000002U)         /* !< Bank 1 */
+#define FLASHCTL_STATMODE_BANKNOTINRD_BANK2      ((uint32_t)0x00000004U)         /* !< Bank 2 */
+#define FLASHCTL_STATMODE_BANKNOTINRD_BANK3      ((uint32_t)0x00000008U)         /* !< Bank 3 */
+#define FLASHCTL_STATMODE_BANKNOTINRD_BANK4      ((uint32_t)0x00000010U)         /* !< Bank 4 */
+/* FLASHCTL_STATMODE[BANKMODE] Bits */
+#define FLASHCTL_STATMODE_BANKMODE_OFS           (8)                             /* !< BANKMODE Offset */
+#define FLASHCTL_STATMODE_BANKMODE_MASK          ((uint32_t)0x00000F00U)         /* !< Indicates mode of bank(s) that are
+                                                                                    not in READ mode */
+#define FLASHCTL_STATMODE_BANKMODE_READ          ((uint32_t)0x00000000U)         /* !< Read Mode */
+#define FLASHCTL_STATMODE_BANKMODE_RDMARG0       ((uint32_t)0x00000200U)         /* !< Read Margin 0 Mode */
+#define FLASHCTL_STATMODE_BANKMODE_RDMARG1       ((uint32_t)0x00000400U)         /* !< Read Margin 1 Mode */
+#define FLASHCTL_STATMODE_BANKMODE_RDMARG0B      ((uint32_t)0x00000600U)         /* !< Read Margin 0B Mode */
+#define FLASHCTL_STATMODE_BANKMODE_RDMARG1B      ((uint32_t)0x00000700U)         /* !< Read Margin 1B Mode */
+#define FLASHCTL_STATMODE_BANKMODE_PGMVER        ((uint32_t)0x00000900U)         /* !< Program Verify Mode */
+#define FLASHCTL_STATMODE_BANKMODE_PGMSW         ((uint32_t)0x00000A00U)         /* !< Program Single Word */
+#define FLASHCTL_STATMODE_BANKMODE_ERASEVER      ((uint32_t)0x00000B00U)         /* !< Erase Verify Mode */
+#define FLASHCTL_STATMODE_BANKMODE_ERASESECT     ((uint32_t)0x00000C00U)         /* !< Erase Sector */
+#define FLASHCTL_STATMODE_BANKMODE_PGMMW         ((uint32_t)0x00000E00U)         /* !< Program Multiple Word */
+#define FLASHCTL_STATMODE_BANKMODE_ERASEBNK      ((uint32_t)0x00000F00U)         /* !< Erase Bank */
+/* FLASHCTL_STATMODE[BANK2TRDY] Bits */
+#define FLASHCTL_STATMODE_BANK2TRDY_OFS          (16)                            /* !< BANK2TRDY Offset */
+#define FLASHCTL_STATMODE_BANK2TRDY_MASK         ((uint32_t)0x00010000U)         /* !< Bank 2T Ready. Bank(s) are ready
+                                                                                    for 2T access.  This is accomplished
+                                                                                    when the pump has fully driven power
+                                                                                    rails to the bank(s). */
+#define FLASHCTL_STATMODE_BANK2TRDY_FALSE        ((uint32_t)0x00000000U)         /* !< Not ready */
+#define FLASHCTL_STATMODE_BANK2TRDY_TRUE         ((uint32_t)0x00010000U)         /* !< Ready */
+/* FLASHCTL_STATMODE[BANK1TRDY] Bits */
+#define FLASHCTL_STATMODE_BANK1TRDY_OFS          (17)                            /* !< BANK1TRDY Offset */
+#define FLASHCTL_STATMODE_BANK1TRDY_MASK         ((uint32_t)0x00020000U)         /* !< Bank 1T Ready. Bank(s) are ready
+                                                                                    for 1T access.  This is accomplished
+                                                                                    when the bank and pump have been
+                                                                                    trimmed. */
+#define FLASHCTL_STATMODE_BANK1TRDY_FALSE        ((uint32_t)0x00000000U)         /* !< Not ready */
+#define FLASHCTL_STATMODE_BANK1TRDY_TRUE         ((uint32_t)0x00020000U)         /* !< Ready */
+
+/* FLASHCTL_GBLINFO0 Bits */
+/* FLASHCTL_GBLINFO0[SECTORSIZE] Bits */
+#define FLASHCTL_GBLINFO0_SECTORSIZE_OFS         (0)                             /* !< SECTORSIZE Offset */
+#define FLASHCTL_GBLINFO0_SECTORSIZE_MASK        ((uint32_t)0x0000FFFFU)         /* !< Sector size in bytes */
+#define FLASHCTL_GBLINFO0_SECTORSIZE_ONEKB       ((uint32_t)0x00000400U)         /* !< Sector size is ONEKB */
+#define FLASHCTL_GBLINFO0_SECTORSIZE_TWOKB       ((uint32_t)0x00000800U)         /* !< Sector size is TWOKB */
+/* FLASHCTL_GBLINFO0[NUMBANKS] Bits */
+#define FLASHCTL_GBLINFO0_NUMBANKS_OFS           (16)                            /* !< NUMBANKS Offset */
+#define FLASHCTL_GBLINFO0_NUMBANKS_MASK          ((uint32_t)0x00070000U)         /* !< Number of banks instantiated
+                                                                                    Minimum:	1 Maximum:	5 */
+#define FLASHCTL_GBLINFO0_NUMBANKS_MINIMUM       ((uint32_t)0x00010000U)         /* !< Minimum value */
+#define FLASHCTL_GBLINFO0_NUMBANKS_MAXIMUM       ((uint32_t)0x00050000U)         /* !< Maximum value */
+
+/* FLASHCTL_GBLINFO1 Bits */
+/* FLASHCTL_GBLINFO1[DATAWIDTH] Bits */
+#define FLASHCTL_GBLINFO1_DATAWIDTH_OFS          (0)                             /* !< DATAWIDTH Offset */
+#define FLASHCTL_GBLINFO1_DATAWIDTH_MASK         ((uint32_t)0x000000FFU)         /* !< Data width in bits */
+#define FLASHCTL_GBLINFO1_DATAWIDTH_W64BIT       ((uint32_t)0x00000040U)         /* !< Data width is 64 bits */
+#define FLASHCTL_GBLINFO1_DATAWIDTH_W128BIT      ((uint32_t)0x00000080U)         /* !< Data width is 128 bits */
+/* FLASHCTL_GBLINFO1[ECCWIDTH] Bits */
+#define FLASHCTL_GBLINFO1_ECCWIDTH_OFS           (8)                             /* !< ECCWIDTH Offset */
+#define FLASHCTL_GBLINFO1_ECCWIDTH_MASK          ((uint32_t)0x00001F00U)         /* !< ECC data width in bits */
+#define FLASHCTL_GBLINFO1_ECCWIDTH_W0BIT         ((uint32_t)0x00000000U)         /* !< ECC data width is 0.  ECC not used. */
+#define FLASHCTL_GBLINFO1_ECCWIDTH_W8BIT         ((uint32_t)0x00000800U)         /* !< ECC data width is 8 bits */
+#define FLASHCTL_GBLINFO1_ECCWIDTH_W16BIT        ((uint32_t)0x00001000U)         /* !< ECC data width is 16 bits */
+/* FLASHCTL_GBLINFO1[REDWIDTH] Bits */
+#define FLASHCTL_GBLINFO1_REDWIDTH_OFS           (16)                            /* !< REDWIDTH Offset */
+#define FLASHCTL_GBLINFO1_REDWIDTH_MASK          ((uint32_t)0x00070000U)         /* !< Redundant data width in bits */
+#define FLASHCTL_GBLINFO1_REDWIDTH_W0BIT         ((uint32_t)0x00000000U)         /* !< Redundant data width is 0.
+                                                                                    Redundancy/Repair not present. */
+#define FLASHCTL_GBLINFO1_REDWIDTH_W2BIT         ((uint32_t)0x00020000U)         /* !< Redundant data width is 2 bits */
+#define FLASHCTL_GBLINFO1_REDWIDTH_W4BIT         ((uint32_t)0x00040000U)         /* !< Redundant data width is 4 bits */
+
+/* FLASHCTL_GBLINFO2 Bits */
+/* FLASHCTL_GBLINFO2[DATAREGISTERS] Bits */
+#define FLASHCTL_GBLINFO2_DATAREGISTERS_OFS      (0)                             /* !< DATAREGISTERS Offset */
+#define FLASHCTL_GBLINFO2_DATAREGISTERS_MASK     ((uint32_t)0x0000000FU)         /* !< Number of data registers present. */
+#define FLASHCTL_GBLINFO2_DATAREGISTERS_MINIMUM  ((uint32_t)0x00000001U)         /* !< Minimum value of [DATAREGISTERS] */
+#define FLASHCTL_GBLINFO2_DATAREGISTERS_MAXIMUM  ((uint32_t)0x00000008U)         /* !< Maximum value of [DATAREGISTERS] */
+
+/* FLASHCTL_BANK0INFO0 Bits */
+/* FLASHCTL_BANK0INFO0[MAINSIZE] Bits */
+#define FLASHCTL_BANK0INFO0_MAINSIZE_OFS         (0)                             /* !< MAINSIZE Offset */
+#define FLASHCTL_BANK0INFO0_MAINSIZE_MASK        ((uint32_t)0x00000FFFU)         /* !< Main region size in sectors
+                                                                                    Minimum:	0x8 (8) Maximum:	0x200 (512) */
+#define FLASHCTL_BANK0INFO0_MAINSIZE_MINSECTORS  ((uint32_t)0x00000008U)         /* !< Minimum value of [MAINSIZE] */
+#define FLASHCTL_BANK0INFO0_MAINSIZE_MAXSECTORS  ((uint32_t)0x00000200U)         /* !< Maximum value of [MAINSIZE] */
+
+/* FLASHCTL_BANK0INFO1 Bits */
+/* FLASHCTL_BANK0INFO1[NONMAINSIZE] Bits */
+#define FLASHCTL_BANK0INFO1_NONMAINSIZE_OFS      (0)                             /* !< NONMAINSIZE Offset */
+#define FLASHCTL_BANK0INFO1_NONMAINSIZE_MASK     ((uint32_t)0x000000FFU)         /* !< Non-main region size in sectors
+                                                                                    Minimum:	0x0 (0) Maximum:	0x10 (16) */
+#define FLASHCTL_BANK0INFO1_NONMAINSIZE_MINSECTORS ((uint32_t)0x00000000U)         /* !< Minimum value of [NONMAINSIZE] */
+#define FLASHCTL_BANK0INFO1_NONMAINSIZE_MAXSECTORS ((uint32_t)0x00000020U)         /* !< Maximum value of [NONMAINSIZE] */
+/* FLASHCTL_BANK0INFO1[TRIMSIZE] Bits */
+#define FLASHCTL_BANK0INFO1_TRIMSIZE_OFS         (8)                             /* !< TRIMSIZE Offset */
+#define FLASHCTL_BANK0INFO1_TRIMSIZE_MASK        ((uint32_t)0x0000FF00U)         /* !< Trim region size in sectors
+                                                                                    Minimum:	0x0 (0) Maximum:	0x10 (16) */
+#define FLASHCTL_BANK0INFO1_TRIMSIZE_MINSECTORS  ((uint32_t)0x00000000U)         /* !< Minimum value of [TRIMSIZE] */
+#define FLASHCTL_BANK0INFO1_TRIMSIZE_MAXSECTORS  ((uint32_t)0x00002000U)         /* !< Maximum value of [TRIMSIZE] */
+/* FLASHCTL_BANK0INFO1[ENGRSIZE] Bits */
+#define FLASHCTL_BANK0INFO1_ENGRSIZE_OFS         (16)                            /* !< ENGRSIZE Offset */
+#define FLASHCTL_BANK0INFO1_ENGRSIZE_MASK        ((uint32_t)0x00FF0000U)         /* !< Engr region size in sectors
+                                                                                    Minimum:	0x0 (0) Maximum:	0x10 (16) */
+#define FLASHCTL_BANK0INFO1_ENGRSIZE_MINSECTORS  ((uint32_t)0x00000000U)         /* !< Minimum value of [ENGRSIZE] */
+#define FLASHCTL_BANK0INFO1_ENGRSIZE_MAXSECTORS  ((uint32_t)0x00200000U)         /* !< Maximum value of [ENGRSIZE] */
+
+/* FLASHCTL_BANK1INFO0 Bits */
+/* FLASHCTL_BANK1INFO0[MAINSIZE] Bits */
+#define FLASHCTL_BANK1INFO0_MAINSIZE_OFS         (0)                             /* !< MAINSIZE Offset */
+#define FLASHCTL_BANK1INFO0_MAINSIZE_MASK        ((uint32_t)0x00000FFFU)         /* !< Main region size in sectors
+                                                                                    Minimum:	0x8 (8) Maximum:	0x200 (512) */
+#define FLASHCTL_BANK1INFO0_MAINSIZE_MINSECTORS  ((uint32_t)0x00000008U)         /* !< Minimum value of [MAINSIZE] */
+#define FLASHCTL_BANK1INFO0_MAINSIZE_MAXSECTORS  ((uint32_t)0x00000200U)         /* !< Maximum value of [MAINSIZE] */
+
+/* FLASHCTL_BANK1INFO1 Bits */
+/* FLASHCTL_BANK1INFO1[NONMAINSIZE] Bits */
+#define FLASHCTL_BANK1INFO1_NONMAINSIZE_OFS      (0)                             /* !< NONMAINSIZE Offset */
+#define FLASHCTL_BANK1INFO1_NONMAINSIZE_MASK     ((uint32_t)0x000000FFU)         /* !< Non-main region size in sectors */
+#define FLASHCTL_BANK1INFO1_NONMAINSIZE_MINSECTORS ((uint32_t)0x00000000U)         /* !< Minimum value of [NONMAINSIZE] */
+#define FLASHCTL_BANK1INFO1_NONMAINSIZE_MAXSECTORS ((uint32_t)0x00000020U)         /* !< Maximum value of [NONMAINSIZE] */
+/* FLASHCTL_BANK1INFO1[TRIMSIZE] Bits */
+#define FLASHCTL_BANK1INFO1_TRIMSIZE_OFS         (8)                             /* !< TRIMSIZE Offset */
+#define FLASHCTL_BANK1INFO1_TRIMSIZE_MASK        ((uint32_t)0x0000FF00U)         /* !< Trim region size in sectors */
+#define FLASHCTL_BANK1INFO1_TRIMSIZE_MINSECTORS  ((uint32_t)0x00000000U)         /* !< Minimum value of [TRIMSIZE] */
+#define FLASHCTL_BANK1INFO1_TRIMSIZE_MAXSECTORS  ((uint32_t)0x00002000U)         /* !< Maximum value of [TRIMSIZE] */
+/* FLASHCTL_BANK1INFO1[ENGRSIZE] Bits */
+#define FLASHCTL_BANK1INFO1_ENGRSIZE_OFS         (16)                            /* !< ENGRSIZE Offset */
+#define FLASHCTL_BANK1INFO1_ENGRSIZE_MASK        ((uint32_t)0x00FF0000U)         /* !< Engr region size in sectors
+                                                                                    Minimum:	0x0 (0) Maximum:	0x10 (16) */
+#define FLASHCTL_BANK1INFO1_ENGRSIZE_MINSECTORS  ((uint32_t)0x00000000U)         /* !< Minimum value of [ENGRSIZE] */
+#define FLASHCTL_BANK1INFO1_ENGRSIZE_MAXSECTORS  ((uint32_t)0x00200000U)         /* !< Maximum value of [ENGRSIZE] */
+
+/* FLASHCTL_BANK2INFO0 Bits */
+/* FLASHCTL_BANK2INFO0[MAINSIZE] Bits */
+#define FLASHCTL_BANK2INFO0_MAINSIZE_OFS         (0)                             /* !< MAINSIZE Offset */
+#define FLASHCTL_BANK2INFO0_MAINSIZE_MASK        ((uint32_t)0x00000FFFU)         /* !< Main region size in sectors
+                                                                                    Minimum:	0x8 (8) Maximum:	0x200 (512) */
+#define FLASHCTL_BANK2INFO0_MAINSIZE_MINSECTORS  ((uint32_t)0x00000008U)         /* !< Minimum value of [MAINSIZE] */
+#define FLASHCTL_BANK2INFO0_MAINSIZE_MAXSECTORS  ((uint32_t)0x00000200U)         /* !< Maximum value of [MAINSIZE] */
+
+/* FLASHCTL_BANK2INFO1 Bits */
+/* FLASHCTL_BANK2INFO1[NONMAINSIZE] Bits */
+#define FLASHCTL_BANK2INFO1_NONMAINSIZE_OFS      (0)                             /* !< NONMAINSIZE Offset */
+#define FLASHCTL_BANK2INFO1_NONMAINSIZE_MASK     ((uint32_t)0x000000FFU)         /* !< Non-main region size in sectors */
+#define FLASHCTL_BANK2INFO1_NONMAINSIZE_MINSECTORS ((uint32_t)0x00000000U)         /* !< Minimum value of [NONMAINSIZE] */
+#define FLASHCTL_BANK2INFO1_NONMAINSIZE_MAXSECTORS ((uint32_t)0x00000020U)         /* !< Maximum value of [NONMAINSIZE] */
+/* FLASHCTL_BANK2INFO1[TRIMSIZE] Bits */
+#define FLASHCTL_BANK2INFO1_TRIMSIZE_OFS         (8)                             /* !< TRIMSIZE Offset */
+#define FLASHCTL_BANK2INFO1_TRIMSIZE_MASK        ((uint32_t)0x0000FF00U)         /* !< Trim region size in sectors */
+#define FLASHCTL_BANK2INFO1_TRIMSIZE_MINSECTORS  ((uint32_t)0x00000000U)         /* !< Minimum value of [TRIMSIZE] */
+#define FLASHCTL_BANK2INFO1_TRIMSIZE_MAXSECTORS  ((uint32_t)0x00002000U)         /* !< Maximum value of [TRIMSIZE] */
+/* FLASHCTL_BANK2INFO1[ENGRSIZE] Bits */
+#define FLASHCTL_BANK2INFO1_ENGRSIZE_OFS         (16)                            /* !< ENGRSIZE Offset */
+#define FLASHCTL_BANK2INFO1_ENGRSIZE_MASK        ((uint32_t)0x00FF0000U)         /* !< Engr region size in sectors */
+#define FLASHCTL_BANK2INFO1_ENGRSIZE_MINSECTORS  ((uint32_t)0x00000000U)         /* !< Minimum value of [ENGRSIZE] */
+#define FLASHCTL_BANK2INFO1_ENGRSIZE_MAXSECTORS  ((uint32_t)0x00200000U)         /* !< Maximum value of [ENGRSIZE] */
+
+/* FLASHCTL_BANK3INFO0 Bits */
+/* FLASHCTL_BANK3INFO0[MAINSIZE] Bits */
+#define FLASHCTL_BANK3INFO0_MAINSIZE_OFS         (0)                             /* !< MAINSIZE Offset */
+#define FLASHCTL_BANK3INFO0_MAINSIZE_MASK        ((uint32_t)0x00000FFFU)         /* !< Main region size in sectors */
+#define FLASHCTL_BANK3INFO0_MAINSIZE_MINSECTORS  ((uint32_t)0x00000008U)         /* !< Minimum value of [MAINSIZE] */
+#define FLASHCTL_BANK3INFO0_MAINSIZE_MAXSECTORS  ((uint32_t)0x00000200U)         /* !< Maximum value of [MAINSIZE] */
+
+/* FLASHCTL_BANK3INFO1 Bits */
+/* FLASHCTL_BANK3INFO1[NONMAINSIZE] Bits */
+#define FLASHCTL_BANK3INFO1_NONMAINSIZE_OFS      (0)                             /* !< NONMAINSIZE Offset */
+#define FLASHCTL_BANK3INFO1_NONMAINSIZE_MASK     ((uint32_t)0x000000FFU)         /* !< Non-main region size in sectors */
+#define FLASHCTL_BANK3INFO1_NONMAINSIZE_MINSECTORS ((uint32_t)0x00000000U)         /* !< Minimum value of [NONMAINSIZE] */
+#define FLASHCTL_BANK3INFO1_NONMAINSIZE_MAXSECTORS ((uint32_t)0x00000020U)         /* !< Maximum value of [NONMAINSIZE] */
+/* FLASHCTL_BANK3INFO1[TRIMSIZE] Bits */
+#define FLASHCTL_BANK3INFO1_TRIMSIZE_OFS         (8)                             /* !< TRIMSIZE Offset */
+#define FLASHCTL_BANK3INFO1_TRIMSIZE_MASK        ((uint32_t)0x0000FF00U)         /* !< Trim region size in sectors */
+#define FLASHCTL_BANK3INFO1_TRIMSIZE_MINSECTORS  ((uint32_t)0x00000000U)         /* !< Minimum value of [TRIMSIZE] */
+#define FLASHCTL_BANK3INFO1_TRIMSIZE_MAXSECTORS  ((uint32_t)0x00002000U)         /* !< Maximum value of [TRIMSIZE] */
+/* FLASHCTL_BANK3INFO1[ENGRSIZE] Bits */
+#define FLASHCTL_BANK3INFO1_ENGRSIZE_OFS         (16)                            /* !< ENGRSIZE Offset */
+#define FLASHCTL_BANK3INFO1_ENGRSIZE_MASK        ((uint32_t)0x00FF0000U)         /* !< Engr region size in sectors */
+#define FLASHCTL_BANK3INFO1_ENGRSIZE_MINSECTORS  ((uint32_t)0x00000000U)         /* !< Minimum value of [ENGRSIZE] */
+#define FLASHCTL_BANK3INFO1_ENGRSIZE_MAXSECTORS  ((uint32_t)0x00200000U)         /* !< Maximum value of [ENGRSIZE] */
+
+/* FLASHCTL_BANK4INFO0 Bits */
+/* FLASHCTL_BANK4INFO0[MAINSIZE] Bits */
+#define FLASHCTL_BANK4INFO0_MAINSIZE_OFS         (0)                             /* !< MAINSIZE Offset */
+#define FLASHCTL_BANK4INFO0_MAINSIZE_MASK        ((uint32_t)0x00000FFFU)         /* !< Main region size in sectors */
+#define FLASHCTL_BANK4INFO0_MAINSIZE_MINSECTORS  ((uint32_t)0x00000008U)         /* !< Minimum value of [MAINSIZE] */
+#define FLASHCTL_BANK4INFO0_MAINSIZE_MAXSECTORS  ((uint32_t)0x00000200U)         /* !< Maximum value of [MAINSIZE] */
+
+/* FLASHCTL_BANK4INFO1 Bits */
+/* FLASHCTL_BANK4INFO1[NONMAINSIZE] Bits */
+#define FLASHCTL_BANK4INFO1_NONMAINSIZE_OFS      (0)                             /* !< NONMAINSIZE Offset */
+#define FLASHCTL_BANK4INFO1_NONMAINSIZE_MASK     ((uint32_t)0x000000FFU)         /* !< Non-main region size in sectors */
+#define FLASHCTL_BANK4INFO1_NONMAINSIZE_MINSECTORS ((uint32_t)0x00000000U)         /* !< Minimum value of [NONMAINSIZE] */
+#define FLASHCTL_BANK4INFO1_NONMAINSIZE_MAXSECTORS ((uint32_t)0x00000020U)         /* !< Maximum value of [NONMAINSIZE] */
+/* FLASHCTL_BANK4INFO1[TRIMSIZE] Bits */
+#define FLASHCTL_BANK4INFO1_TRIMSIZE_OFS         (8)                             /* !< TRIMSIZE Offset */
+#define FLASHCTL_BANK4INFO1_TRIMSIZE_MASK        ((uint32_t)0x0000FF00U)         /* !< Trim region size in sectors */
+#define FLASHCTL_BANK4INFO1_TRIMSIZE_MINSECTORS  ((uint32_t)0x00000000U)         /* !< Minimum value of [TRIMSIZE] */
+#define FLASHCTL_BANK4INFO1_TRIMSIZE_MAXSECTORS  ((uint32_t)0x00002000U)         /* !< Maximum value of [TRIMSIZE] */
+/* FLASHCTL_BANK4INFO1[ENGRSIZE] Bits */
+#define FLASHCTL_BANK4INFO1_ENGRSIZE_OFS         (16)                            /* !< ENGRSIZE Offset */
+#define FLASHCTL_BANK4INFO1_ENGRSIZE_MASK        ((uint32_t)0x00FF0000U)         /* !< Engr region size in sectors */
+#define FLASHCTL_BANK4INFO1_ENGRSIZE_MINSECTORS  ((uint32_t)0x00000000U)         /* !< Minimum value of [ENGRSIZE] */
+#define FLASHCTL_BANK4INFO1_ENGRSIZE_MAXSECTORS  ((uint32_t)0x00200000U)         /* !< Maximum value of [ENGRSIZE] */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_flashctl__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_gpio.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_gpio.h
@@ -1,0 +1,5313 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_gpio__include
+#define ti_devices_msp_peripherals_hw_gpio__include
+
+/* Filename: hw_gpio.h */
+/* Revised: 2023-05-10 21:28:12 */
+/* Revision: 63b77c412ca552f19fdd3e7971450ee8560270af */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* GPIO Registers
+******************************************************************************/
+#define GPIO_GEN_EVENT1_OFS                      ((uint32_t)0x00001080U)
+#define GPIO_GEN_EVENT0_OFS                      ((uint32_t)0x00001050U)
+#define GPIO_CPU_INT_OFS                         ((uint32_t)0x00001020U)
+#define GPIO_GPRCM_OFS                           ((uint32_t)0x00000800U)
+
+
+/** @addtogroup GPIO_GEN_EVENT1
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001080) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001088) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001090) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001098) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x000010A0) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x000010A8) Interrupt clear */
+} GPIO_GEN_EVENT1_Regs;
+
+/*@}*/ /* end of group GPIO_GEN_EVENT1 */
+
+/** @addtogroup GPIO_GEN_EVENT0
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001050) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001058) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001060) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001068) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001070) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001078) Interrupt clear */
+} GPIO_GEN_EVENT0_Regs;
+
+/*@}*/ /* end of group GPIO_GEN_EVENT0 */
+
+/** @addtogroup GPIO_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} GPIO_CPU_INT_Regs;
+
+/*@}*/ /* end of group GPIO_CPU_INT */
+
+/** @addtogroup GPIO_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} GPIO_GPRCM_Regs;
+
+/*@}*/ /* end of group GPIO_GPRCM */
+
+/** @addtogroup GPIO
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[256];
+  __IO uint32_t FSUB_0;                            /* !< (@ 0x00000400) Subsciber Port 0 */
+  __IO uint32_t FSUB_1;                            /* !< (@ 0x00000404) Subscriber Port 1 */
+       uint32_t RESERVED1[15];
+  __IO uint32_t FPUB_0;                            /* !< (@ 0x00000444) Publisher Port 0 */
+  __IO uint32_t FPUB_1;                            /* !< (@ 0x00000448) Publisher Port 1 */
+       uint32_t RESERVED2[237];
+  GPIO_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED3[510];
+  __IO uint32_t CLKOVR;                            /* !< (@ 0x00001010) Clock Override */
+       uint32_t RESERVED4;
+  __IO uint32_t PDBGCTL;                           /* !< (@ 0x00001018) Peripheral Debug Control */
+       uint32_t RESERVED5;
+  GPIO_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED6;
+  GPIO_GEN_EVENT0_Regs  GEN_EVENT0;                        /* !< (@ 0x00001050) */
+       uint32_t RESERVED7;
+  GPIO_GEN_EVENT1_Regs  GEN_EVENT1;                        /* !< (@ 0x00001080) */
+       uint32_t RESERVED8[13];
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED9[6];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Module Description */
+       uint32_t RESERVED10[64];
+  __O  uint32_t DOUT3_0;                           /* !< (@ 0x00001200) Data output 3 to 0 */
+  __O  uint32_t DOUT7_4;                           /* !< (@ 0x00001204) Data output 7 to 4 */
+  __O  uint32_t DOUT11_8;                          /* !< (@ 0x00001208) Data output 11 to 8 */
+  __O  uint32_t DOUT15_12;                         /* !< (@ 0x0000120C) Data output 15 to 12 */
+  __O  uint32_t DOUT19_16;                         /* !< (@ 0x00001210) Data output 19 to 16 */
+  __O  uint32_t DOUT23_20;                         /* !< (@ 0x00001214) Data output 23 to 20 */
+  __O  uint32_t DOUT27_24;                         /* !< (@ 0x00001218) Data output 27 to 24 */
+  __O  uint32_t DOUT31_28;                         /* !< (@ 0x0000121C) Data output 31 to 28 */
+       uint32_t RESERVED11[24];
+  __IO uint32_t DOUT31_0;                          /* !< (@ 0x00001280) Data output 31 to 0 */
+       uint32_t RESERVED12[3];
+  __O  uint32_t DOUTSET31_0;                       /* !< (@ 0x00001290) Data output set 31 to 0 */
+       uint32_t RESERVED13[3];
+  __O  uint32_t DOUTCLR31_0;                       /* !< (@ 0x000012A0) Data output clear 31 to 0 */
+       uint32_t RESERVED14[3];
+  __O  uint32_t DOUTTGL31_0;                       /* !< (@ 0x000012B0) Data output toggle 31 to 0 */
+       uint32_t RESERVED15[3];
+  __IO uint32_t DOE31_0;                           /* !< (@ 0x000012C0) Data output enable 31 to 0 */
+       uint32_t RESERVED16[3];
+  __O  uint32_t DOESET31_0;                        /* !< (@ 0x000012D0) Data output enable set 31 to 0 */
+       uint32_t RESERVED17[3];
+  __O  uint32_t DOECLR31_0;                        /* !< (@ 0x000012E0) Data output enable clear 31 to 0 */
+       uint32_t RESERVED18[7];
+  __I  uint32_t DIN3_0;                            /* !< (@ 0x00001300) Data input 3 to 0 */
+  __I  uint32_t DIN7_4;                            /* !< (@ 0x00001304) Data input 7 to 4 */
+  __I  uint32_t DIN11_8;                           /* !< (@ 0x00001308) Data input 11 to 8 */
+  __I  uint32_t DIN15_12;                          /* !< (@ 0x0000130C) Data input 15 to 12 */
+  __I  uint32_t DIN19_16;                          /* !< (@ 0x00001310) Data input 19 to 16 */
+  __I  uint32_t DIN23_20;                          /* !< (@ 0x00001314) Data input 23 to 20 */
+  __I  uint32_t DIN27_24;                          /* !< (@ 0x00001318) Data input 27 to 24 */
+  __I  uint32_t DIN31_28;                          /* !< (@ 0x0000131C) Data input 31 to 28 */
+       uint32_t RESERVED19[24];
+  __I  uint32_t DIN31_0;                           /* !< (@ 0x00001380) Data input 31 to 0 */
+       uint32_t RESERVED20[3];
+  __IO uint32_t POLARITY15_0;                      /* !< (@ 0x00001390) Polarity 15 to 0 */
+       uint32_t RESERVED21[3];
+  __IO uint32_t POLARITY31_16;                     /* !< (@ 0x000013A0) Polarity 31 to 16 */
+       uint32_t RESERVED22[23];
+  __IO uint32_t CTL;                               /* !< (@ 0x00001400) FAST WAKE GLOBAL EN */
+  __IO uint32_t FASTWAKE;                          /* !< (@ 0x00001404) FAST WAKE ENABLE */
+       uint32_t RESERVED23[62];
+  __IO uint32_t SUB0CFG;                           /* !< (@ 0x00001500) Subscriber 0 configuration */
+       uint32_t RESERVED24;
+  __IO uint32_t FILTEREN15_0;                      /* !< (@ 0x00001508) Filter Enable 15 to 0 */
+  __IO uint32_t FILTEREN31_16;                     /* !< (@ 0x0000150C) Filter Enable 31 to 16 */
+  __IO uint32_t DMAMASK;                           /* !< (@ 0x00001510) DMA Write MASK */
+       uint32_t RESERVED25[3];
+  __IO uint32_t SUB1CFG;                           /* !< (@ 0x00001520) Subscriber 1 configuration */
+} GPIO_Regs;
+
+/*@}*/ /* end of group GPIO */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* GPIO Register Control Bits
+******************************************************************************/
+
+/* GPIO_GEN_EVENT1_IIDX Bits */
+/* GPIO_GEN_EVENT1_IIDX[STAT] Bits */
+#define GPIO_GEN_EVENT1_IIDX_STAT_OFS            (0)                             /* !< STAT Offset */
+#define GPIO_GEN_EVENT1_IIDX_STAT_MASK           ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define GPIO_GEN_EVENT1_IIDX_STAT_NO_INTR        ((uint32_t)0x00000000U)         /* !< No bit is set means there is no
+                                                                                    pending interrupt request */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO16          ((uint32_t)0x00000001U)         /* !< DIO0 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO17          ((uint32_t)0x00000002U)         /* !< DIO1 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO18          ((uint32_t)0x00000003U)         /* !< DIO2 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO19          ((uint32_t)0x00000004U)         /* !< DIO3 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO20          ((uint32_t)0x00000005U)         /* !< DIO4 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO21          ((uint32_t)0x00000006U)         /* !< DIO5 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO22          ((uint32_t)0x00000007U)         /* !< DIO6 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO23          ((uint32_t)0x00000008U)         /* !< DIO7 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO24          ((uint32_t)0x00000009U)         /* !< DIO8 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO25          ((uint32_t)0x0000000AU)         /* !< DIO9 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO26          ((uint32_t)0x0000000BU)         /* !< DIO10 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO27          ((uint32_t)0x0000000CU)         /* !< DIO11 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO28          ((uint32_t)0x0000000DU)         /* !< DIO12 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO29          ((uint32_t)0x0000000EU)         /* !< DIO13 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO30          ((uint32_t)0x0000000FU)         /* !< DIO14 interrupt */
+#define GPIO_GEN_EVENT1_IIDX_STAT_DIO31          ((uint32_t)0x00000010U)         /* !< DIO15 interrupt */
+
+/* GPIO_GEN_EVENT1_IMASK Bits */
+/* GPIO_GEN_EVENT1_IMASK[DIO16] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO16_OFS          (16)                            /* !< DIO16 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO16_MASK         ((uint32_t)0x00010000U)         /* !< DIO16 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO16_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO16_SET          ((uint32_t)0x00010000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO17] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO17_OFS          (17)                            /* !< DIO17 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO17_MASK         ((uint32_t)0x00020000U)         /* !< DIO17 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO17_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO17_SET          ((uint32_t)0x00020000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO18] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO18_OFS          (18)                            /* !< DIO18 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO18_MASK         ((uint32_t)0x00040000U)         /* !< DIO18 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO18_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO18_SET          ((uint32_t)0x00040000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO19] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO19_OFS          (19)                            /* !< DIO19 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO19_MASK         ((uint32_t)0x00080000U)         /* !< DIO19 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO19_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO19_SET          ((uint32_t)0x00080000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO20] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO20_OFS          (20)                            /* !< DIO20 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO20_MASK         ((uint32_t)0x00100000U)         /* !< DIO20 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO20_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO20_SET          ((uint32_t)0x00100000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO21] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO21_OFS          (21)                            /* !< DIO21 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO21_MASK         ((uint32_t)0x00200000U)         /* !< DIO21 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO21_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO21_SET          ((uint32_t)0x00200000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO22] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO22_OFS          (22)                            /* !< DIO22 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO22_MASK         ((uint32_t)0x00400000U)         /* !< DIO22 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO22_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO22_SET          ((uint32_t)0x00400000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO23] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO23_OFS          (23)                            /* !< DIO23 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO23_MASK         ((uint32_t)0x00800000U)         /* !< DIO23 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO23_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO23_SET          ((uint32_t)0x00800000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO24] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO24_OFS          (24)                            /* !< DIO24 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO24_MASK         ((uint32_t)0x01000000U)         /* !< DIO24 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO24_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO24_SET          ((uint32_t)0x01000000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO25] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO25_OFS          (25)                            /* !< DIO25 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO25_MASK         ((uint32_t)0x02000000U)         /* !< DIO25 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO25_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO25_SET          ((uint32_t)0x02000000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO26] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO26_OFS          (26)                            /* !< DIO26 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO26_MASK         ((uint32_t)0x04000000U)         /* !< DIO26 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO26_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO26_SET          ((uint32_t)0x04000000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO27] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO27_OFS          (27)                            /* !< DIO27 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO27_MASK         ((uint32_t)0x08000000U)         /* !< DIO27 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO27_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO27_SET          ((uint32_t)0x08000000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO28] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO28_OFS          (28)                            /* !< DIO28 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO28_MASK         ((uint32_t)0x10000000U)         /* !< DIO28 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO28_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO28_SET          ((uint32_t)0x10000000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO29] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO29_OFS          (29)                            /* !< DIO29 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO29_MASK         ((uint32_t)0x20000000U)         /* !< DIO29 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO29_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO29_SET          ((uint32_t)0x20000000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO30] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO30_OFS          (30)                            /* !< DIO30 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO30_MASK         ((uint32_t)0x40000000U)         /* !< DIO30 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO30_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO30_SET          ((uint32_t)0x40000000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT1_IMASK[DIO31] Bits */
+#define GPIO_GEN_EVENT1_IMASK_DIO31_OFS          (31)                            /* !< DIO31 Offset */
+#define GPIO_GEN_EVENT1_IMASK_DIO31_MASK         ((uint32_t)0x80000000U)         /* !< DIO31 event mask */
+#define GPIO_GEN_EVENT1_IMASK_DIO31_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT1_IMASK_DIO31_SET          ((uint32_t)0x80000000U)         /* !< Event is unmasked */
+
+/* GPIO_GEN_EVENT1_RIS Bits */
+/* GPIO_GEN_EVENT1_RIS[DIO16] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO16_OFS            (16)                            /* !< DIO16 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO16_MASK           ((uint32_t)0x00010000U)         /* !< DIO16 event */
+#define GPIO_GEN_EVENT1_RIS_DIO16_CLR            ((uint32_t)0x00000000U)         /* !< DIO16 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO16_SET            ((uint32_t)0x00010000U)         /* !< DIO16 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO17] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO17_OFS            (17)                            /* !< DIO17 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO17_MASK           ((uint32_t)0x00020000U)         /* !< DIO17 event */
+#define GPIO_GEN_EVENT1_RIS_DIO17_CLR            ((uint32_t)0x00000000U)         /* !< DIO17 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO17_SET            ((uint32_t)0x00020000U)         /* !< DIO17 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO18] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO18_OFS            (18)                            /* !< DIO18 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO18_MASK           ((uint32_t)0x00040000U)         /* !< DIO18 event */
+#define GPIO_GEN_EVENT1_RIS_DIO18_CLR            ((uint32_t)0x00000000U)         /* !< DIO18 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO18_SET            ((uint32_t)0x00040000U)         /* !< DIO18 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO19] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO19_OFS            (19)                            /* !< DIO19 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO19_MASK           ((uint32_t)0x00080000U)         /* !< DIO19 event */
+#define GPIO_GEN_EVENT1_RIS_DIO19_CLR            ((uint32_t)0x00000000U)         /* !< DIO19 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO19_SET            ((uint32_t)0x00080000U)         /* !< DIO19 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO20] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO20_OFS            (20)                            /* !< DIO20 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO20_MASK           ((uint32_t)0x00100000U)         /* !< DIO20 event */
+#define GPIO_GEN_EVENT1_RIS_DIO20_CLR            ((uint32_t)0x00000000U)         /* !< DIO20 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO20_SET            ((uint32_t)0x00100000U)         /* !< DIO20 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO21] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO21_OFS            (21)                            /* !< DIO21 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO21_MASK           ((uint32_t)0x00200000U)         /* !< DIO21 event */
+#define GPIO_GEN_EVENT1_RIS_DIO21_CLR            ((uint32_t)0x00000000U)         /* !< DIO21 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO21_SET            ((uint32_t)0x00200000U)         /* !< DIO21 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO22] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO22_OFS            (22)                            /* !< DIO22 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO22_MASK           ((uint32_t)0x00400000U)         /* !< DIO22 event */
+#define GPIO_GEN_EVENT1_RIS_DIO22_CLR            ((uint32_t)0x00000000U)         /* !< DIO22 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO22_SET            ((uint32_t)0x00400000U)         /* !< DIO22 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO23] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO23_OFS            (23)                            /* !< DIO23 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO23_MASK           ((uint32_t)0x00800000U)         /* !< DIO23 event */
+#define GPIO_GEN_EVENT1_RIS_DIO23_CLR            ((uint32_t)0x00000000U)         /* !< DIO23 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO23_SET            ((uint32_t)0x00800000U)         /* !< DIO23 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO24] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO24_OFS            (24)                            /* !< DIO24 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO24_MASK           ((uint32_t)0x01000000U)         /* !< DIO24 event */
+#define GPIO_GEN_EVENT1_RIS_DIO24_CLR            ((uint32_t)0x00000000U)         /* !< DIO24 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO24_SET            ((uint32_t)0x01000000U)         /* !< DIO24 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO25] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO25_OFS            (25)                            /* !< DIO25 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO25_MASK           ((uint32_t)0x02000000U)         /* !< DIO25 event */
+#define GPIO_GEN_EVENT1_RIS_DIO25_CLR            ((uint32_t)0x00000000U)         /* !< DIO25 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO25_SET            ((uint32_t)0x02000000U)         /* !< DIO25 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO26] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO26_OFS            (26)                            /* !< DIO26 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO26_MASK           ((uint32_t)0x04000000U)         /* !< DIO26 event */
+#define GPIO_GEN_EVENT1_RIS_DIO26_CLR            ((uint32_t)0x00000000U)         /* !< DIO26 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO26_SET            ((uint32_t)0x04000000U)         /* !< DIO26 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO27] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO27_OFS            (27)                            /* !< DIO27 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO27_MASK           ((uint32_t)0x08000000U)         /* !< DIO27 event */
+#define GPIO_GEN_EVENT1_RIS_DIO27_CLR            ((uint32_t)0x00000000U)         /* !< DIO27 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO27_SET            ((uint32_t)0x08000000U)         /* !< DIO27 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO28] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO28_OFS            (28)                            /* !< DIO28 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO28_MASK           ((uint32_t)0x10000000U)         /* !< DIO28 event */
+#define GPIO_GEN_EVENT1_RIS_DIO28_CLR            ((uint32_t)0x00000000U)         /* !< DIO28 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO28_SET            ((uint32_t)0x10000000U)         /* !< DIO28 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO29] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO29_OFS            (29)                            /* !< DIO29 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO29_MASK           ((uint32_t)0x20000000U)         /* !< DIO29 event */
+#define GPIO_GEN_EVENT1_RIS_DIO29_CLR            ((uint32_t)0x00000000U)         /* !< DIO29 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO29_SET            ((uint32_t)0x20000000U)         /* !< DIO29 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO30] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO30_OFS            (30)                            /* !< DIO30 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO30_MASK           ((uint32_t)0x40000000U)         /* !< DIO30 event */
+#define GPIO_GEN_EVENT1_RIS_DIO30_CLR            ((uint32_t)0x00000000U)         /* !< DIO30 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO30_SET            ((uint32_t)0x40000000U)         /* !< DIO30 event occurred */
+/* GPIO_GEN_EVENT1_RIS[DIO31] Bits */
+#define GPIO_GEN_EVENT1_RIS_DIO31_OFS            (31)                            /* !< DIO31 Offset */
+#define GPIO_GEN_EVENT1_RIS_DIO31_MASK           ((uint32_t)0x80000000U)         /* !< DIO31 event */
+#define GPIO_GEN_EVENT1_RIS_DIO31_CLR            ((uint32_t)0x00000000U)         /* !< DIO31 event did not occur */
+#define GPIO_GEN_EVENT1_RIS_DIO31_SET            ((uint32_t)0x80000000U)         /* !< DIO31 event occurred */
+
+/* GPIO_GEN_EVENT1_MIS Bits */
+/* GPIO_GEN_EVENT1_MIS[DIO16] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO16_OFS            (16)                            /* !< DIO16 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO16_MASK           ((uint32_t)0x00010000U)         /* !< DIO16 event */
+#define GPIO_GEN_EVENT1_MIS_DIO16_CLR            ((uint32_t)0x00000000U)         /* !< DIO16 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO16_SET            ((uint32_t)0x00010000U)         /* !< DIO16 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO17] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO17_OFS            (17)                            /* !< DIO17 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO17_MASK           ((uint32_t)0x00020000U)         /* !< DIO17 event */
+#define GPIO_GEN_EVENT1_MIS_DIO17_CLR            ((uint32_t)0x00000000U)         /* !< DIO17 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO17_SET            ((uint32_t)0x00020000U)         /* !< DIO17 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO18] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO18_OFS            (18)                            /* !< DIO18 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO18_MASK           ((uint32_t)0x00040000U)         /* !< DIO18 event */
+#define GPIO_GEN_EVENT1_MIS_DIO18_CLR            ((uint32_t)0x00000000U)         /* !< DIO18 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO18_SET            ((uint32_t)0x00040000U)         /* !< DIO18 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO19] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO19_OFS            (19)                            /* !< DIO19 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO19_MASK           ((uint32_t)0x00080000U)         /* !< DIO19 event */
+#define GPIO_GEN_EVENT1_MIS_DIO19_CLR            ((uint32_t)0x00000000U)         /* !< DIO19 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO19_SET            ((uint32_t)0x00080000U)         /* !< DIO19 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO20] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO20_OFS            (20)                            /* !< DIO20 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO20_MASK           ((uint32_t)0x00100000U)         /* !< DIO20 event */
+#define GPIO_GEN_EVENT1_MIS_DIO20_CLR            ((uint32_t)0x00000000U)         /* !< DIO20 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO20_SET            ((uint32_t)0x00100000U)         /* !< DIO20 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO21] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO21_OFS            (21)                            /* !< DIO21 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO21_MASK           ((uint32_t)0x00200000U)         /* !< DIO21 event */
+#define GPIO_GEN_EVENT1_MIS_DIO21_CLR            ((uint32_t)0x00000000U)         /* !< DIO21 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO21_SET            ((uint32_t)0x00200000U)         /* !< DIO21 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO22] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO22_OFS            (22)                            /* !< DIO22 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO22_MASK           ((uint32_t)0x00400000U)         /* !< DIO22 event */
+#define GPIO_GEN_EVENT1_MIS_DIO22_CLR            ((uint32_t)0x00000000U)         /* !< DIO22 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO22_SET            ((uint32_t)0x00400000U)         /* !< DIO22 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO23] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO23_OFS            (23)                            /* !< DIO23 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO23_MASK           ((uint32_t)0x00800000U)         /* !< DIO23 event */
+#define GPIO_GEN_EVENT1_MIS_DIO23_CLR            ((uint32_t)0x00000000U)         /* !< DIO23 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO23_SET            ((uint32_t)0x00800000U)         /* !< DIO23 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO24] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO24_OFS            (24)                            /* !< DIO24 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO24_MASK           ((uint32_t)0x01000000U)         /* !< DIO24 event */
+#define GPIO_GEN_EVENT1_MIS_DIO24_CLR            ((uint32_t)0x00000000U)         /* !< DIO24 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO24_SET            ((uint32_t)0x01000000U)         /* !< DIO24 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO25] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO25_OFS            (25)                            /* !< DIO25 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO25_MASK           ((uint32_t)0x02000000U)         /* !< DIO25 event */
+#define GPIO_GEN_EVENT1_MIS_DIO25_CLR            ((uint32_t)0x00000000U)         /* !< DIO25 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO25_SET            ((uint32_t)0x02000000U)         /* !< DIO25 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO26] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO26_OFS            (26)                            /* !< DIO26 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO26_MASK           ((uint32_t)0x04000000U)         /* !< DIO26 event */
+#define GPIO_GEN_EVENT1_MIS_DIO26_CLR            ((uint32_t)0x00000000U)         /* !< DIO26 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO26_SET            ((uint32_t)0x04000000U)         /* !< DIO26 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO27] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO27_OFS            (27)                            /* !< DIO27 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO27_MASK           ((uint32_t)0x08000000U)         /* !< DIO27 event */
+#define GPIO_GEN_EVENT1_MIS_DIO27_CLR            ((uint32_t)0x00000000U)         /* !< DIO27 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO27_SET            ((uint32_t)0x08000000U)         /* !< DIO27 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO28] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO28_OFS            (28)                            /* !< DIO28 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO28_MASK           ((uint32_t)0x10000000U)         /* !< DIO28 event */
+#define GPIO_GEN_EVENT1_MIS_DIO28_CLR            ((uint32_t)0x00000000U)         /* !< DIO28 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO28_SET            ((uint32_t)0x10000000U)         /* !< DIO28 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO29] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO29_OFS            (29)                            /* !< DIO29 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO29_MASK           ((uint32_t)0x20000000U)         /* !< DIO29 event */
+#define GPIO_GEN_EVENT1_MIS_DIO29_CLR            ((uint32_t)0x00000000U)         /* !< DIO29 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO29_SET            ((uint32_t)0x20000000U)         /* !< DIO29 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO30] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO30_OFS            (30)                            /* !< DIO30 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO30_MASK           ((uint32_t)0x40000000U)         /* !< DIO30 event */
+#define GPIO_GEN_EVENT1_MIS_DIO30_CLR            ((uint32_t)0x00000000U)         /* !< DIO30 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO30_SET            ((uint32_t)0x40000000U)         /* !< DIO30 event occurred */
+/* GPIO_GEN_EVENT1_MIS[DIO31] Bits */
+#define GPIO_GEN_EVENT1_MIS_DIO31_OFS            (31)                            /* !< DIO31 Offset */
+#define GPIO_GEN_EVENT1_MIS_DIO31_MASK           ((uint32_t)0x80000000U)         /* !< DIO31 event */
+#define GPIO_GEN_EVENT1_MIS_DIO31_CLR            ((uint32_t)0x00000000U)         /* !< DIO31 event did not occur */
+#define GPIO_GEN_EVENT1_MIS_DIO31_SET            ((uint32_t)0x80000000U)         /* !< DIO31 event occurred */
+
+/* GPIO_GEN_EVENT1_ISET Bits */
+/* GPIO_GEN_EVENT1_ISET[DIO16] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO16_OFS           (16)                            /* !< DIO16 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO16_MASK          ((uint32_t)0x00010000U)         /* !< DIO16 event */
+#define GPIO_GEN_EVENT1_ISET_DIO16_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO16_SET           ((uint32_t)0x00010000U)         /* !< Sets DIO16 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO17] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO17_OFS           (17)                            /* !< DIO17 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO17_MASK          ((uint32_t)0x00020000U)         /* !< DIO17 event */
+#define GPIO_GEN_EVENT1_ISET_DIO17_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO17_SET           ((uint32_t)0x00020000U)         /* !< Sets DIO17 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO18] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO18_OFS           (18)                            /* !< DIO18 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO18_MASK          ((uint32_t)0x00040000U)         /* !< DIO18 event */
+#define GPIO_GEN_EVENT1_ISET_DIO18_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO18_SET           ((uint32_t)0x00040000U)         /* !< Sets DIO18 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO19] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO19_OFS           (19)                            /* !< DIO19 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO19_MASK          ((uint32_t)0x00080000U)         /* !< DIO19 event */
+#define GPIO_GEN_EVENT1_ISET_DIO19_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO19_SET           ((uint32_t)0x00080000U)         /* !< Sets DIO19 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO20] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO20_OFS           (20)                            /* !< DIO20 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO20_MASK          ((uint32_t)0x00100000U)         /* !< DIO20 event */
+#define GPIO_GEN_EVENT1_ISET_DIO20_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO20_SET           ((uint32_t)0x00100000U)         /* !< Sets DIO20 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO21] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO21_OFS           (21)                            /* !< DIO21 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO21_MASK          ((uint32_t)0x00200000U)         /* !< DIO21 event */
+#define GPIO_GEN_EVENT1_ISET_DIO21_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO21_SET           ((uint32_t)0x00200000U)         /* !< Sets DIO21 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO22] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO22_OFS           (22)                            /* !< DIO22 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO22_MASK          ((uint32_t)0x00400000U)         /* !< DIO22 event */
+#define GPIO_GEN_EVENT1_ISET_DIO22_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO22_SET           ((uint32_t)0x00400000U)         /* !< Sets DIO22 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO23] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO23_OFS           (23)                            /* !< DIO23 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO23_MASK          ((uint32_t)0x00800000U)         /* !< DIO23 event */
+#define GPIO_GEN_EVENT1_ISET_DIO23_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO23_SET           ((uint32_t)0x00800000U)         /* !< Sets DIO23 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO24] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO24_OFS           (24)                            /* !< DIO24 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO24_MASK          ((uint32_t)0x01000000U)         /* !< DIO24 event */
+#define GPIO_GEN_EVENT1_ISET_DIO24_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO24_SET           ((uint32_t)0x01000000U)         /* !< Sets DIO24 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO25] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO25_OFS           (25)                            /* !< DIO25 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO25_MASK          ((uint32_t)0x02000000U)         /* !< DIO25 event */
+#define GPIO_GEN_EVENT1_ISET_DIO25_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO25_SET           ((uint32_t)0x02000000U)         /* !< Sets DIO25 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO26] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO26_OFS           (26)                            /* !< DIO26 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO26_MASK          ((uint32_t)0x04000000U)         /* !< DIO26 event */
+#define GPIO_GEN_EVENT1_ISET_DIO26_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO26_SET           ((uint32_t)0x04000000U)         /* !< Sets DIO26 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO27] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO27_OFS           (27)                            /* !< DIO27 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO27_MASK          ((uint32_t)0x08000000U)         /* !< DIO27 event */
+#define GPIO_GEN_EVENT1_ISET_DIO27_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO27_SET           ((uint32_t)0x08000000U)         /* !< Sets DIO27 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO28] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO28_OFS           (28)                            /* !< DIO28 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO28_MASK          ((uint32_t)0x10000000U)         /* !< DIO28 event */
+#define GPIO_GEN_EVENT1_ISET_DIO28_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO28_SET           ((uint32_t)0x10000000U)         /* !< Sets DIO28 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO29] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO29_OFS           (29)                            /* !< DIO29 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO29_MASK          ((uint32_t)0x20000000U)         /* !< DIO29 event */
+#define GPIO_GEN_EVENT1_ISET_DIO29_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO29_SET           ((uint32_t)0x20000000U)         /* !< Sets DIO29 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO30] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO30_OFS           (30)                            /* !< DIO30 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO30_MASK          ((uint32_t)0x40000000U)         /* !< DIO30 event */
+#define GPIO_GEN_EVENT1_ISET_DIO30_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO30_SET           ((uint32_t)0x40000000U)         /* !< Sets DIO30 in RIS register */
+/* GPIO_GEN_EVENT1_ISET[DIO31] Bits */
+#define GPIO_GEN_EVENT1_ISET_DIO31_OFS           (31)                            /* !< DIO31 Offset */
+#define GPIO_GEN_EVENT1_ISET_DIO31_MASK          ((uint32_t)0x80000000U)         /* !< DIO31 event */
+#define GPIO_GEN_EVENT1_ISET_DIO31_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ISET_DIO31_SET           ((uint32_t)0x80000000U)         /* !< Sets DIO31 in RIS register */
+
+/* GPIO_GEN_EVENT1_ICLR Bits */
+/* GPIO_GEN_EVENT1_ICLR[DIO16] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO16_OFS           (16)                            /* !< DIO16 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO16_MASK          ((uint32_t)0x00010000U)         /* !< DIO16 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO16_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO16_CLR           ((uint32_t)0x00010000U)         /* !< Clears DIO16 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO17] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO17_OFS           (17)                            /* !< DIO17 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO17_MASK          ((uint32_t)0x00020000U)         /* !< DIO17 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO17_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO17_CLR           ((uint32_t)0x00020000U)         /* !< Clears DIO17 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO18] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO18_OFS           (18)                            /* !< DIO18 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO18_MASK          ((uint32_t)0x00040000U)         /* !< DIO18 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO18_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO18_CLR           ((uint32_t)0x00040000U)         /* !< Clears DIO18 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO19] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO19_OFS           (19)                            /* !< DIO19 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO19_MASK          ((uint32_t)0x00080000U)         /* !< DIO19 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO19_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO19_CLR           ((uint32_t)0x00080000U)         /* !< Clears DIO19 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO20] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO20_OFS           (20)                            /* !< DIO20 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO20_MASK          ((uint32_t)0x00100000U)         /* !< DIO20 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO20_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO20_CLR           ((uint32_t)0x00100000U)         /* !< Clears DIO20 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO21] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO21_OFS           (21)                            /* !< DIO21 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO21_MASK          ((uint32_t)0x00200000U)         /* !< DIO21 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO21_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO21_CLR           ((uint32_t)0x00200000U)         /* !< Clears DIO21 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO22] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO22_OFS           (22)                            /* !< DIO22 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO22_MASK          ((uint32_t)0x00400000U)         /* !< DIO22 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO22_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO22_CLR           ((uint32_t)0x00400000U)         /* !< Clears DIO22 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO23] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO23_OFS           (23)                            /* !< DIO23 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO23_MASK          ((uint32_t)0x00800000U)         /* !< DIO23 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO23_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO23_CLR           ((uint32_t)0x00800000U)         /* !< Clears DIO23 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO24] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO24_OFS           (24)                            /* !< DIO24 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO24_MASK          ((uint32_t)0x01000000U)         /* !< DIO24 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO24_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO24_CLR           ((uint32_t)0x01000000U)         /* !< Clears DIO24 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO25] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO25_OFS           (25)                            /* !< DIO25 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO25_MASK          ((uint32_t)0x02000000U)         /* !< DIO25 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO25_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO25_CLR           ((uint32_t)0x02000000U)         /* !< Clears DIO25 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO26] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO26_OFS           (26)                            /* !< DIO26 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO26_MASK          ((uint32_t)0x04000000U)         /* !< DIO26 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO26_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO26_CLR           ((uint32_t)0x04000000U)         /* !< Clears DIO26 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO27] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO27_OFS           (27)                            /* !< DIO27 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO27_MASK          ((uint32_t)0x08000000U)         /* !< DIO27 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO27_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO27_CLR           ((uint32_t)0x08000000U)         /* !< Clears DIO27 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO28] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO28_OFS           (28)                            /* !< DIO28 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO28_MASK          ((uint32_t)0x10000000U)         /* !< DIO28 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO28_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO28_CLR           ((uint32_t)0x10000000U)         /* !< Clears DIO28 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO29] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO29_OFS           (29)                            /* !< DIO29 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO29_MASK          ((uint32_t)0x20000000U)         /* !< DIO29 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO29_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO29_CLR           ((uint32_t)0x20000000U)         /* !< Clears DIO29 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO30] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO30_OFS           (30)                            /* !< DIO30 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO30_MASK          ((uint32_t)0x40000000U)         /* !< DIO30 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO30_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO30_CLR           ((uint32_t)0x40000000U)         /* !< Clears DIO30 in RIS register */
+/* GPIO_GEN_EVENT1_ICLR[DIO31] Bits */
+#define GPIO_GEN_EVENT1_ICLR_DIO31_OFS           (31)                            /* !< DIO31 Offset */
+#define GPIO_GEN_EVENT1_ICLR_DIO31_MASK          ((uint32_t)0x80000000U)         /* !< DIO31 event */
+#define GPIO_GEN_EVENT1_ICLR_DIO31_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT1_ICLR_DIO31_CLR           ((uint32_t)0x80000000U)         /* !< Clears DIO31 in RIS register */
+
+/* GPIO_GEN_EVENT0_IIDX Bits */
+/* GPIO_GEN_EVENT0_IIDX[STAT] Bits */
+#define GPIO_GEN_EVENT0_IIDX_STAT_OFS            (0)                             /* !< STAT Offset */
+#define GPIO_GEN_EVENT0_IIDX_STAT_MASK           ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define GPIO_GEN_EVENT0_IIDX_STAT_NO_INTR        ((uint32_t)0x00000000U)         /* !< No bit is set means there is no
+                                                                                    pending interrupt request */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO0           ((uint32_t)0x00000001U)         /* !< DIO0 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO1           ((uint32_t)0x00000002U)         /* !< DIO1 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO2           ((uint32_t)0x00000003U)         /* !< DIO2 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO3           ((uint32_t)0x00000004U)         /* !< DIO3 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO4           ((uint32_t)0x00000005U)         /* !< DIO4 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO5           ((uint32_t)0x00000006U)         /* !< DIO5 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO6           ((uint32_t)0x00000007U)         /* !< DIO6 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO7           ((uint32_t)0x00000008U)         /* !< DIO7 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO8           ((uint32_t)0x00000009U)         /* !< DIO8 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO9           ((uint32_t)0x0000000AU)         /* !< DIO9 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO10          ((uint32_t)0x0000000BU)         /* !< DIO10 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO11          ((uint32_t)0x0000000CU)         /* !< DIO11 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO12          ((uint32_t)0x0000000DU)         /* !< DIO12 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO13          ((uint32_t)0x0000000EU)         /* !< DIO13 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO14          ((uint32_t)0x0000000FU)         /* !< DIO14 interrupt */
+#define GPIO_GEN_EVENT0_IIDX_STAT_DIO15          ((uint32_t)0x00000010U)         /* !< DIO15 interrupt */
+
+/* GPIO_GEN_EVENT0_IMASK Bits */
+/* GPIO_GEN_EVENT0_IMASK[DIO0] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO0_OFS           (0)                             /* !< DIO0 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO0_MASK          ((uint32_t)0x00000001U)         /* !< DIO0 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO0_CLR           ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO0_SET           ((uint32_t)0x00000001U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO1] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO1_OFS           (1)                             /* !< DIO1 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO1_MASK          ((uint32_t)0x00000002U)         /* !< DIO1 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO1_CLR           ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO1_SET           ((uint32_t)0x00000002U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO2] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO2_OFS           (2)                             /* !< DIO2 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO2_MASK          ((uint32_t)0x00000004U)         /* !< DIO2 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO2_CLR           ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO2_SET           ((uint32_t)0x00000004U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO3] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO3_OFS           (3)                             /* !< DIO3 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO3_MASK          ((uint32_t)0x00000008U)         /* !< DIO3 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO3_CLR           ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO3_SET           ((uint32_t)0x00000008U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO4] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO4_OFS           (4)                             /* !< DIO4 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO4_MASK          ((uint32_t)0x00000010U)         /* !< DIO4 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO4_CLR           ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO4_SET           ((uint32_t)0x00000010U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO5] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO5_OFS           (5)                             /* !< DIO5 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO5_MASK          ((uint32_t)0x00000020U)         /* !< DIO5 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO5_CLR           ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO5_SET           ((uint32_t)0x00000020U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO6] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO6_OFS           (6)                             /* !< DIO6 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO6_MASK          ((uint32_t)0x00000040U)         /* !< DIO6 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO6_CLR           ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO6_SET           ((uint32_t)0x00000040U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO7] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO7_OFS           (7)                             /* !< DIO7 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO7_MASK          ((uint32_t)0x00000080U)         /* !< DIO7 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO7_CLR           ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO7_SET           ((uint32_t)0x00000080U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO8] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO8_OFS           (8)                             /* !< DIO8 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO8_MASK          ((uint32_t)0x00000100U)         /* !< DIO8 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO8_CLR           ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO8_SET           ((uint32_t)0x00000100U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO9] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO9_OFS           (9)                             /* !< DIO9 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO9_MASK          ((uint32_t)0x00000200U)         /* !< DIO9 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO9_CLR           ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO9_SET           ((uint32_t)0x00000200U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO10] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO10_OFS          (10)                            /* !< DIO10 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO10_MASK         ((uint32_t)0x00000400U)         /* !< DIO10 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO10_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO10_SET          ((uint32_t)0x00000400U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO11] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO11_OFS          (11)                            /* !< DIO11 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO11_MASK         ((uint32_t)0x00000800U)         /* !< DIO11 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO11_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO11_SET          ((uint32_t)0x00000800U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO12] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO12_OFS          (12)                            /* !< DIO12 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO12_MASK         ((uint32_t)0x00001000U)         /* !< DIO12 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO12_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO12_SET          ((uint32_t)0x00001000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO13] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO13_OFS          (13)                            /* !< DIO13 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO13_MASK         ((uint32_t)0x00002000U)         /* !< DIO13 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO13_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO13_SET          ((uint32_t)0x00002000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO14] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO14_OFS          (14)                            /* !< DIO14 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO14_MASK         ((uint32_t)0x00004000U)         /* !< DIO14 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO14_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO14_SET          ((uint32_t)0x00004000U)         /* !< Event is unmasked */
+/* GPIO_GEN_EVENT0_IMASK[DIO15] Bits */
+#define GPIO_GEN_EVENT0_IMASK_DIO15_OFS          (15)                            /* !< DIO15 Offset */
+#define GPIO_GEN_EVENT0_IMASK_DIO15_MASK         ((uint32_t)0x00008000U)         /* !< DIO15 event mask */
+#define GPIO_GEN_EVENT0_IMASK_DIO15_CLR          ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_GEN_EVENT0_IMASK_DIO15_SET          ((uint32_t)0x00008000U)         /* !< Event is unmasked */
+
+/* GPIO_GEN_EVENT0_RIS Bits */
+/* GPIO_GEN_EVENT0_RIS[DIO0] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO0_OFS             (0)                             /* !< DIO0 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO0_MASK            ((uint32_t)0x00000001U)         /* !< DIO0 event */
+#define GPIO_GEN_EVENT0_RIS_DIO0_CLR             ((uint32_t)0x00000000U)         /* !< DIO0 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO0_SET             ((uint32_t)0x00000001U)         /* !< DIO0 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO1] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO1_OFS             (1)                             /* !< DIO1 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO1_MASK            ((uint32_t)0x00000002U)         /* !< DIO1 event */
+#define GPIO_GEN_EVENT0_RIS_DIO1_CLR             ((uint32_t)0x00000000U)         /* !< DIO1 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO1_SET             ((uint32_t)0x00000002U)         /* !< DIO1 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO2] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO2_OFS             (2)                             /* !< DIO2 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO2_MASK            ((uint32_t)0x00000004U)         /* !< DIO2 event */
+#define GPIO_GEN_EVENT0_RIS_DIO2_CLR             ((uint32_t)0x00000000U)         /* !< DIO2 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO2_SET             ((uint32_t)0x00000004U)         /* !< DIO2 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO3] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO3_OFS             (3)                             /* !< DIO3 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO3_MASK            ((uint32_t)0x00000008U)         /* !< DIO3 event */
+#define GPIO_GEN_EVENT0_RIS_DIO3_CLR             ((uint32_t)0x00000000U)         /* !< DIO3 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO3_SET             ((uint32_t)0x00000008U)         /* !< DIO3 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO4] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO4_OFS             (4)                             /* !< DIO4 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO4_MASK            ((uint32_t)0x00000010U)         /* !< DIO4 event */
+#define GPIO_GEN_EVENT0_RIS_DIO4_CLR             ((uint32_t)0x00000000U)         /* !< DIO4 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO4_SET             ((uint32_t)0x00000010U)         /* !< DIO4 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO5] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO5_OFS             (5)                             /* !< DIO5 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO5_MASK            ((uint32_t)0x00000020U)         /* !< DIO5 event */
+#define GPIO_GEN_EVENT0_RIS_DIO5_CLR             ((uint32_t)0x00000000U)         /* !< DIO5 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO5_SET             ((uint32_t)0x00000020U)         /* !< DIO5 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO6] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO6_OFS             (6)                             /* !< DIO6 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO6_MASK            ((uint32_t)0x00000040U)         /* !< DIO6 event */
+#define GPIO_GEN_EVENT0_RIS_DIO6_CLR             ((uint32_t)0x00000000U)         /* !< DIO6 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO6_SET             ((uint32_t)0x00000040U)         /* !< DIO6 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO7] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO7_OFS             (7)                             /* !< DIO7 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO7_MASK            ((uint32_t)0x00000080U)         /* !< DIO7 event */
+#define GPIO_GEN_EVENT0_RIS_DIO7_CLR             ((uint32_t)0x00000000U)         /* !< DIO7 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO7_SET             ((uint32_t)0x00000080U)         /* !< DIO7 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO8] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO8_OFS             (8)                             /* !< DIO8 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO8_MASK            ((uint32_t)0x00000100U)         /* !< DIO8 event */
+#define GPIO_GEN_EVENT0_RIS_DIO8_CLR             ((uint32_t)0x00000000U)         /* !< DIO8 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO8_SET             ((uint32_t)0x00000100U)         /* !< DIO8 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO9] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO9_OFS             (9)                             /* !< DIO9 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO9_MASK            ((uint32_t)0x00000200U)         /* !< DIO9 event */
+#define GPIO_GEN_EVENT0_RIS_DIO9_CLR             ((uint32_t)0x00000000U)         /* !< DIO9 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO9_SET             ((uint32_t)0x00000200U)         /* !< DIO9 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO10] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO10_OFS            (10)                            /* !< DIO10 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO10_MASK           ((uint32_t)0x00000400U)         /* !< DIO10 event */
+#define GPIO_GEN_EVENT0_RIS_DIO10_CLR            ((uint32_t)0x00000000U)         /* !< DIO10 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO10_SET            ((uint32_t)0x00000400U)         /* !< DIO10 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO11] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO11_OFS            (11)                            /* !< DIO11 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO11_MASK           ((uint32_t)0x00000800U)         /* !< DIO11 event */
+#define GPIO_GEN_EVENT0_RIS_DIO11_CLR            ((uint32_t)0x00000000U)         /* !< DIO11 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO11_SET            ((uint32_t)0x00000800U)         /* !< DIO11 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO12] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO12_OFS            (12)                            /* !< DIO12 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO12_MASK           ((uint32_t)0x00001000U)         /* !< DIO12 event */
+#define GPIO_GEN_EVENT0_RIS_DIO12_CLR            ((uint32_t)0x00000000U)         /* !< DIO12 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO12_SET            ((uint32_t)0x00001000U)         /* !< DIO12 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO13] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO13_OFS            (13)                            /* !< DIO13 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO13_MASK           ((uint32_t)0x00002000U)         /* !< DIO13 event */
+#define GPIO_GEN_EVENT0_RIS_DIO13_CLR            ((uint32_t)0x00000000U)         /* !< DIO13 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO13_SET            ((uint32_t)0x00002000U)         /* !< DIO13 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO14] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO14_OFS            (14)                            /* !< DIO14 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO14_MASK           ((uint32_t)0x00004000U)         /* !< DIO14 event */
+#define GPIO_GEN_EVENT0_RIS_DIO14_CLR            ((uint32_t)0x00000000U)         /* !< DIO14 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO14_SET            ((uint32_t)0x00004000U)         /* !< DIO14 event occurred */
+/* GPIO_GEN_EVENT0_RIS[DIO15] Bits */
+#define GPIO_GEN_EVENT0_RIS_DIO15_OFS            (15)                            /* !< DIO15 Offset */
+#define GPIO_GEN_EVENT0_RIS_DIO15_MASK           ((uint32_t)0x00008000U)         /* !< DIO15 event */
+#define GPIO_GEN_EVENT0_RIS_DIO15_CLR            ((uint32_t)0x00000000U)         /* !< DIO15 event did not occur */
+#define GPIO_GEN_EVENT0_RIS_DIO15_SET            ((uint32_t)0x00008000U)         /* !< DIO15 event occurred */
+
+/* GPIO_GEN_EVENT0_MIS Bits */
+/* GPIO_GEN_EVENT0_MIS[DIO0] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO0_OFS             (0)                             /* !< DIO0 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO0_MASK            ((uint32_t)0x00000001U)         /* !< DIO0 event */
+#define GPIO_GEN_EVENT0_MIS_DIO0_CLR             ((uint32_t)0x00000000U)         /* !< DIO0 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO0_SET             ((uint32_t)0x00000001U)         /* !< DIO0 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO1] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO1_OFS             (1)                             /* !< DIO1 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO1_MASK            ((uint32_t)0x00000002U)         /* !< DIO1 event */
+#define GPIO_GEN_EVENT0_MIS_DIO1_CLR             ((uint32_t)0x00000000U)         /* !< DIO1 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO1_SET             ((uint32_t)0x00000002U)         /* !< DIO1 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO2] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO2_OFS             (2)                             /* !< DIO2 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO2_MASK            ((uint32_t)0x00000004U)         /* !< DIO2 event */
+#define GPIO_GEN_EVENT0_MIS_DIO2_CLR             ((uint32_t)0x00000000U)         /* !< DIO2 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO2_SET             ((uint32_t)0x00000004U)         /* !< DIO2 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO3] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO3_OFS             (3)                             /* !< DIO3 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO3_MASK            ((uint32_t)0x00000008U)         /* !< DIO3 event */
+#define GPIO_GEN_EVENT0_MIS_DIO3_CLR             ((uint32_t)0x00000000U)         /* !< DIO3 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO3_SET             ((uint32_t)0x00000008U)         /* !< DIO3 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO4] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO4_OFS             (4)                             /* !< DIO4 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO4_MASK            ((uint32_t)0x00000010U)         /* !< DIO4 event */
+#define GPIO_GEN_EVENT0_MIS_DIO4_CLR             ((uint32_t)0x00000000U)         /* !< DIO4 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO4_SET             ((uint32_t)0x00000010U)         /* !< DIO4 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO5] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO5_OFS             (5)                             /* !< DIO5 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO5_MASK            ((uint32_t)0x00000020U)         /* !< DIO5 event */
+#define GPIO_GEN_EVENT0_MIS_DIO5_CLR             ((uint32_t)0x00000000U)         /* !< DIO5 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO5_SET             ((uint32_t)0x00000020U)         /* !< DIO5 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO6] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO6_OFS             (6)                             /* !< DIO6 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO6_MASK            ((uint32_t)0x00000040U)         /* !< DIO6 event */
+#define GPIO_GEN_EVENT0_MIS_DIO6_CLR             ((uint32_t)0x00000000U)         /* !< DIO6 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO6_SET             ((uint32_t)0x00000040U)         /* !< DIO6 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO7] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO7_OFS             (7)                             /* !< DIO7 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO7_MASK            ((uint32_t)0x00000080U)         /* !< DIO7 event */
+#define GPIO_GEN_EVENT0_MIS_DIO7_CLR             ((uint32_t)0x00000000U)         /* !< DIO7 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO7_SET             ((uint32_t)0x00000080U)         /* !< DIO7 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO8] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO8_OFS             (8)                             /* !< DIO8 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO8_MASK            ((uint32_t)0x00000100U)         /* !< DIO8 event */
+#define GPIO_GEN_EVENT0_MIS_DIO8_CLR             ((uint32_t)0x00000000U)         /* !< DIO8 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO8_SET             ((uint32_t)0x00000100U)         /* !< DIO8 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO9] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO9_OFS             (9)                             /* !< DIO9 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO9_MASK            ((uint32_t)0x00000200U)         /* !< DIO9 event */
+#define GPIO_GEN_EVENT0_MIS_DIO9_CLR             ((uint32_t)0x00000000U)         /* !< DIO9 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO9_SET             ((uint32_t)0x00000200U)         /* !< DIO9 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO10] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO10_OFS            (10)                            /* !< DIO10 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO10_MASK           ((uint32_t)0x00000400U)         /* !< DIO10 event */
+#define GPIO_GEN_EVENT0_MIS_DIO10_CLR            ((uint32_t)0x00000000U)         /* !< DIO10 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO10_SET            ((uint32_t)0x00000400U)         /* !< DIO10 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO11] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO11_OFS            (11)                            /* !< DIO11 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO11_MASK           ((uint32_t)0x00000800U)         /* !< DIO11 event */
+#define GPIO_GEN_EVENT0_MIS_DIO11_CLR            ((uint32_t)0x00000000U)         /* !< DIO11 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO11_SET            ((uint32_t)0x00000800U)         /* !< DIO11 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO12] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO12_OFS            (12)                            /* !< DIO12 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO12_MASK           ((uint32_t)0x00001000U)         /* !< DIO12 event */
+#define GPIO_GEN_EVENT0_MIS_DIO12_CLR            ((uint32_t)0x00000000U)         /* !< DIO12 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO12_SET            ((uint32_t)0x00001000U)         /* !< DIO12 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO13] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO13_OFS            (13)                            /* !< DIO13 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO13_MASK           ((uint32_t)0x00002000U)         /* !< DIO13 event */
+#define GPIO_GEN_EVENT0_MIS_DIO13_CLR            ((uint32_t)0x00000000U)         /* !< DIO13 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO13_SET            ((uint32_t)0x00002000U)         /* !< DIO13 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO14] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO14_OFS            (14)                            /* !< DIO14 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO14_MASK           ((uint32_t)0x00004000U)         /* !< DIO14 event */
+#define GPIO_GEN_EVENT0_MIS_DIO14_CLR            ((uint32_t)0x00000000U)         /* !< DIO14 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO14_SET            ((uint32_t)0x00004000U)         /* !< DIO14 event occurred */
+/* GPIO_GEN_EVENT0_MIS[DIO15] Bits */
+#define GPIO_GEN_EVENT0_MIS_DIO15_OFS            (15)                            /* !< DIO15 Offset */
+#define GPIO_GEN_EVENT0_MIS_DIO15_MASK           ((uint32_t)0x00008000U)         /* !< DIO15 event */
+#define GPIO_GEN_EVENT0_MIS_DIO15_CLR            ((uint32_t)0x00000000U)         /* !< DIO15 event did not occur */
+#define GPIO_GEN_EVENT0_MIS_DIO15_SET            ((uint32_t)0x00008000U)         /* !< DIO15 event occurred */
+
+/* GPIO_GEN_EVENT0_ISET Bits */
+/* GPIO_GEN_EVENT0_ISET[DIO0] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO0_OFS            (0)                             /* !< DIO0 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO0_MASK           ((uint32_t)0x00000001U)         /* !< DIO0 event */
+#define GPIO_GEN_EVENT0_ISET_DIO0_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO0_SET            ((uint32_t)0x00000001U)         /* !< Sets DIO0 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO1] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO1_OFS            (1)                             /* !< DIO1 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO1_MASK           ((uint32_t)0x00000002U)         /* !< DIO1 event */
+#define GPIO_GEN_EVENT0_ISET_DIO1_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO1_SET            ((uint32_t)0x00000002U)         /* !< Sets DIO1 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO2] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO2_OFS            (2)                             /* !< DIO2 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO2_MASK           ((uint32_t)0x00000004U)         /* !< DIO2 event */
+#define GPIO_GEN_EVENT0_ISET_DIO2_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO2_SET            ((uint32_t)0x00000004U)         /* !< Sets DIO2 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO3] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO3_OFS            (3)                             /* !< DIO3 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO3_MASK           ((uint32_t)0x00000008U)         /* !< DIO3 event */
+#define GPIO_GEN_EVENT0_ISET_DIO3_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO3_SET            ((uint32_t)0x00000008U)         /* !< Sets DIO3 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO4] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO4_OFS            (4)                             /* !< DIO4 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO4_MASK           ((uint32_t)0x00000010U)         /* !< DIO4 event */
+#define GPIO_GEN_EVENT0_ISET_DIO4_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO4_SET            ((uint32_t)0x00000010U)         /* !< Sets DIO4 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO5] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO5_OFS            (5)                             /* !< DIO5 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO5_MASK           ((uint32_t)0x00000020U)         /* !< DIO5 event */
+#define GPIO_GEN_EVENT0_ISET_DIO5_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO5_SET            ((uint32_t)0x00000020U)         /* !< Sets DIO5 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO6] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO6_OFS            (6)                             /* !< DIO6 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO6_MASK           ((uint32_t)0x00000040U)         /* !< DIO6 event */
+#define GPIO_GEN_EVENT0_ISET_DIO6_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO6_SET            ((uint32_t)0x00000040U)         /* !< Sets DIO6 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO7] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO7_OFS            (7)                             /* !< DIO7 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO7_MASK           ((uint32_t)0x00000080U)         /* !< DIO7 event */
+#define GPIO_GEN_EVENT0_ISET_DIO7_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO7_SET            ((uint32_t)0x00000080U)         /* !< Sets DIO7 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO8] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO8_OFS            (8)                             /* !< DIO8 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO8_MASK           ((uint32_t)0x00000100U)         /* !< DIO8 event */
+#define GPIO_GEN_EVENT0_ISET_DIO8_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO8_SET            ((uint32_t)0x00000100U)         /* !< Sets DIO8 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO9] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO9_OFS            (9)                             /* !< DIO9 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO9_MASK           ((uint32_t)0x00000200U)         /* !< DIO9 event */
+#define GPIO_GEN_EVENT0_ISET_DIO9_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO9_SET            ((uint32_t)0x00000200U)         /* !< Sets DIO9 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO10] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO10_OFS           (10)                            /* !< DIO10 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO10_MASK          ((uint32_t)0x00000400U)         /* !< DIO10 event */
+#define GPIO_GEN_EVENT0_ISET_DIO10_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO10_SET           ((uint32_t)0x00000400U)         /* !< Sets DIO10 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO11] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO11_OFS           (11)                            /* !< DIO11 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO11_MASK          ((uint32_t)0x00000800U)         /* !< DIO11 event */
+#define GPIO_GEN_EVENT0_ISET_DIO11_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO11_SET           ((uint32_t)0x00000800U)         /* !< Sets DIO11 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO12] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO12_OFS           (12)                            /* !< DIO12 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO12_MASK          ((uint32_t)0x00001000U)         /* !< DIO12 event */
+#define GPIO_GEN_EVENT0_ISET_DIO12_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO12_SET           ((uint32_t)0x00001000U)         /* !< Sets DIO12 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO13] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO13_OFS           (13)                            /* !< DIO13 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO13_MASK          ((uint32_t)0x00002000U)         /* !< DIO13 event */
+#define GPIO_GEN_EVENT0_ISET_DIO13_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO13_SET           ((uint32_t)0x00002000U)         /* !< Sets DIO13 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO14] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO14_OFS           (14)                            /* !< DIO14 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO14_MASK          ((uint32_t)0x00004000U)         /* !< DIO14 event */
+#define GPIO_GEN_EVENT0_ISET_DIO14_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO14_SET           ((uint32_t)0x00004000U)         /* !< Sets DIO14 in RIS register */
+/* GPIO_GEN_EVENT0_ISET[DIO15] Bits */
+#define GPIO_GEN_EVENT0_ISET_DIO15_OFS           (15)                            /* !< DIO15 Offset */
+#define GPIO_GEN_EVENT0_ISET_DIO15_MASK          ((uint32_t)0x00008000U)         /* !< DIO15 event */
+#define GPIO_GEN_EVENT0_ISET_DIO15_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ISET_DIO15_SET           ((uint32_t)0x00008000U)         /* !< Sets DIO15 in RIS register */
+
+/* GPIO_GEN_EVENT0_ICLR Bits */
+/* GPIO_GEN_EVENT0_ICLR[DIO0] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO0_OFS            (0)                             /* !< DIO0 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO0_MASK           ((uint32_t)0x00000001U)         /* !< DIO0 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO0_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO0_CLR            ((uint32_t)0x00000001U)         /* !< Clears DIO0 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO1] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO1_OFS            (1)                             /* !< DIO1 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO1_MASK           ((uint32_t)0x00000002U)         /* !< DIO1 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO1_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO1_CLR            ((uint32_t)0x00000002U)         /* !< Clears DIO1 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO2] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO2_OFS            (2)                             /* !< DIO2 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO2_MASK           ((uint32_t)0x00000004U)         /* !< DIO2 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO2_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO2_CLR            ((uint32_t)0x00000004U)         /* !< Clears DIO2 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO3] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO3_OFS            (3)                             /* !< DIO3 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO3_MASK           ((uint32_t)0x00000008U)         /* !< DIO3 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO3_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO3_CLR            ((uint32_t)0x00000008U)         /* !< Clears DIO3 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO4] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO4_OFS            (4)                             /* !< DIO4 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO4_MASK           ((uint32_t)0x00000010U)         /* !< DIO4 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO4_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO4_CLR            ((uint32_t)0x00000010U)         /* !< Clears DIO4 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO5] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO5_OFS            (5)                             /* !< DIO5 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO5_MASK           ((uint32_t)0x00000020U)         /* !< DIO5 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO5_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO5_CLR            ((uint32_t)0x00000020U)         /* !< Clears DIO5 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO6] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO6_OFS            (6)                             /* !< DIO6 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO6_MASK           ((uint32_t)0x00000040U)         /* !< DIO6 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO6_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO6_CLR            ((uint32_t)0x00000040U)         /* !< Clears DIO6 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO7] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO7_OFS            (7)                             /* !< DIO7 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO7_MASK           ((uint32_t)0x00000080U)         /* !< DIO7 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO7_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO7_CLR            ((uint32_t)0x00000080U)         /* !< Clears DIO7 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO8] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO8_OFS            (8)                             /* !< DIO8 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO8_MASK           ((uint32_t)0x00000100U)         /* !< DIO8 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO8_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO8_CLR            ((uint32_t)0x00000100U)         /* !< Clears DIO8 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO9] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO9_OFS            (9)                             /* !< DIO9 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO9_MASK           ((uint32_t)0x00000200U)         /* !< DIO9 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO9_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO9_CLR            ((uint32_t)0x00000200U)         /* !< Clears DIO9 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO10] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO10_OFS           (10)                            /* !< DIO10 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO10_MASK          ((uint32_t)0x00000400U)         /* !< DIO10 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO10_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO10_CLR           ((uint32_t)0x00000400U)         /* !< Clears DIO10 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO11] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO11_OFS           (11)                            /* !< DIO11 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO11_MASK          ((uint32_t)0x00000800U)         /* !< DIO11 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO11_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO11_CLR           ((uint32_t)0x00000800U)         /* !< Clears DIO11 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO12] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO12_OFS           (12)                            /* !< DIO12 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO12_MASK          ((uint32_t)0x00001000U)         /* !< DIO12 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO12_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO12_CLR           ((uint32_t)0x00001000U)         /* !< Clears DIO12 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO13] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO13_OFS           (13)                            /* !< DIO13 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO13_MASK          ((uint32_t)0x00002000U)         /* !< DIO13 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO13_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO13_CLR           ((uint32_t)0x00002000U)         /* !< Clears DIO13 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO14] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO14_OFS           (14)                            /* !< DIO14 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO14_MASK          ((uint32_t)0x00004000U)         /* !< DIO14 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO14_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO14_CLR           ((uint32_t)0x00004000U)         /* !< Clears DIO14 in RIS register */
+/* GPIO_GEN_EVENT0_ICLR[DIO15] Bits */
+#define GPIO_GEN_EVENT0_ICLR_DIO15_OFS           (15)                            /* !< DIO15 Offset */
+#define GPIO_GEN_EVENT0_ICLR_DIO15_MASK          ((uint32_t)0x00008000U)         /* !< DIO15 event */
+#define GPIO_GEN_EVENT0_ICLR_DIO15_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_GEN_EVENT0_ICLR_DIO15_CLR           ((uint32_t)0x00008000U)         /* !< Clears DIO15 in RIS register */
+
+/* GPIO_CPU_INT_IIDX Bits */
+/* GPIO_CPU_INT_IIDX[STAT] Bits */
+#define GPIO_CPU_INT_IIDX_STAT_OFS               (0)                             /* !< STAT Offset */
+#define GPIO_CPU_INT_IIDX_STAT_MASK              ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define GPIO_CPU_INT_IIDX_STAT_NO_INTR           ((uint32_t)0x00000000U)         /* !< No bit is set means there is no
+                                                                                    pending interrupt request */
+#define GPIO_CPU_INT_IIDX_STAT_DIO0              ((uint32_t)0x00000001U)         /* !< DIO0 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO1              ((uint32_t)0x00000002U)         /* !< DIO1 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO2              ((uint32_t)0x00000003U)         /* !< DIO2 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO3              ((uint32_t)0x00000004U)         /* !< DIO3 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO4              ((uint32_t)0x00000005U)         /* !< DIO4 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO5              ((uint32_t)0x00000006U)         /* !< DIO5 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO6              ((uint32_t)0x00000007U)         /* !< DIO6 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO7              ((uint32_t)0x00000008U)         /* !< DIO7 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO8              ((uint32_t)0x00000009U)         /* !< DIO8 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO9              ((uint32_t)0x0000000AU)         /* !< DIO9 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO10             ((uint32_t)0x0000000BU)         /* !< DIO10 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO11             ((uint32_t)0x0000000CU)         /* !< DIO11 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO12             ((uint32_t)0x0000000DU)         /* !< DIO12 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO13             ((uint32_t)0x0000000EU)         /* !< DIO13 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO14             ((uint32_t)0x0000000FU)         /* !< DIO14 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO15             ((uint32_t)0x00000010U)         /* !< DIO15 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO16             ((uint32_t)0x00000011U)         /* !< DIO16 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO17             ((uint32_t)0x00000012U)         /* !< DIO17 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO18             ((uint32_t)0x00000013U)         /* !< DIO18 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO19             ((uint32_t)0x00000014U)         /* !< DIO19 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO20             ((uint32_t)0x00000015U)         /* !< DIO20 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO21             ((uint32_t)0x00000016U)         /* !< DIO21 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO22             ((uint32_t)0x00000017U)         /* !< DIO22 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO23             ((uint32_t)0x00000018U)         /* !< DIO23 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO24             ((uint32_t)0x00000019U)         /* !< DIO24 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO25             ((uint32_t)0x0000001AU)         /* !< DIO25 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO26             ((uint32_t)0x0000001BU)         /* !< DIO26 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO27             ((uint32_t)0x0000001CU)         /* !< DIO27 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO28             ((uint32_t)0x0000001DU)         /* !< DIO28 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO29             ((uint32_t)0x0000001EU)         /* !< DIO29 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO30             ((uint32_t)0x0000001FU)         /* !< DIO30 interrupt */
+#define GPIO_CPU_INT_IIDX_STAT_DIO31             ((uint32_t)0x00000020U)         /* !< DIO31 interrupt */
+
+/* GPIO_CPU_INT_IMASK Bits */
+/* GPIO_CPU_INT_IMASK[DIO0] Bits */
+#define GPIO_CPU_INT_IMASK_DIO0_OFS              (0)                             /* !< DIO0 Offset */
+#define GPIO_CPU_INT_IMASK_DIO0_MASK             ((uint32_t)0x00000001U)         /* !< DIO0 event mask */
+#define GPIO_CPU_INT_IMASK_DIO0_CLR              ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO0_SET              ((uint32_t)0x00000001U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO1] Bits */
+#define GPIO_CPU_INT_IMASK_DIO1_OFS              (1)                             /* !< DIO1 Offset */
+#define GPIO_CPU_INT_IMASK_DIO1_MASK             ((uint32_t)0x00000002U)         /* !< DIO1 event mask */
+#define GPIO_CPU_INT_IMASK_DIO1_CLR              ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO1_SET              ((uint32_t)0x00000002U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO2] Bits */
+#define GPIO_CPU_INT_IMASK_DIO2_OFS              (2)                             /* !< DIO2 Offset */
+#define GPIO_CPU_INT_IMASK_DIO2_MASK             ((uint32_t)0x00000004U)         /* !< DIO2 event mask */
+#define GPIO_CPU_INT_IMASK_DIO2_CLR              ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO2_SET              ((uint32_t)0x00000004U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO3] Bits */
+#define GPIO_CPU_INT_IMASK_DIO3_OFS              (3)                             /* !< DIO3 Offset */
+#define GPIO_CPU_INT_IMASK_DIO3_MASK             ((uint32_t)0x00000008U)         /* !< DIO3 event mask */
+#define GPIO_CPU_INT_IMASK_DIO3_CLR              ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO3_SET              ((uint32_t)0x00000008U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO4] Bits */
+#define GPIO_CPU_INT_IMASK_DIO4_OFS              (4)                             /* !< DIO4 Offset */
+#define GPIO_CPU_INT_IMASK_DIO4_MASK             ((uint32_t)0x00000010U)         /* !< DIO4 event mask */
+#define GPIO_CPU_INT_IMASK_DIO4_CLR              ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO4_SET              ((uint32_t)0x00000010U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO5] Bits */
+#define GPIO_CPU_INT_IMASK_DIO5_OFS              (5)                             /* !< DIO5 Offset */
+#define GPIO_CPU_INT_IMASK_DIO5_MASK             ((uint32_t)0x00000020U)         /* !< DIO5 event mask */
+#define GPIO_CPU_INT_IMASK_DIO5_CLR              ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO5_SET              ((uint32_t)0x00000020U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO6] Bits */
+#define GPIO_CPU_INT_IMASK_DIO6_OFS              (6)                             /* !< DIO6 Offset */
+#define GPIO_CPU_INT_IMASK_DIO6_MASK             ((uint32_t)0x00000040U)         /* !< DIO6 event mask */
+#define GPIO_CPU_INT_IMASK_DIO6_CLR              ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO6_SET              ((uint32_t)0x00000040U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO7] Bits */
+#define GPIO_CPU_INT_IMASK_DIO7_OFS              (7)                             /* !< DIO7 Offset */
+#define GPIO_CPU_INT_IMASK_DIO7_MASK             ((uint32_t)0x00000080U)         /* !< DIO7 event mask */
+#define GPIO_CPU_INT_IMASK_DIO7_CLR              ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO7_SET              ((uint32_t)0x00000080U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO8] Bits */
+#define GPIO_CPU_INT_IMASK_DIO8_OFS              (8)                             /* !< DIO8 Offset */
+#define GPIO_CPU_INT_IMASK_DIO8_MASK             ((uint32_t)0x00000100U)         /* !< DIO8 event mask */
+#define GPIO_CPU_INT_IMASK_DIO8_CLR              ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO8_SET              ((uint32_t)0x00000100U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO9] Bits */
+#define GPIO_CPU_INT_IMASK_DIO9_OFS              (9)                             /* !< DIO9 Offset */
+#define GPIO_CPU_INT_IMASK_DIO9_MASK             ((uint32_t)0x00000200U)         /* !< DIO9 event mask */
+#define GPIO_CPU_INT_IMASK_DIO9_CLR              ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO9_SET              ((uint32_t)0x00000200U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO10] Bits */
+#define GPIO_CPU_INT_IMASK_DIO10_OFS             (10)                            /* !< DIO10 Offset */
+#define GPIO_CPU_INT_IMASK_DIO10_MASK            ((uint32_t)0x00000400U)         /* !< DIO10 event mask */
+#define GPIO_CPU_INT_IMASK_DIO10_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO10_SET             ((uint32_t)0x00000400U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO11] Bits */
+#define GPIO_CPU_INT_IMASK_DIO11_OFS             (11)                            /* !< DIO11 Offset */
+#define GPIO_CPU_INT_IMASK_DIO11_MASK            ((uint32_t)0x00000800U)         /* !< DIO11 event mask */
+#define GPIO_CPU_INT_IMASK_DIO11_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO11_SET             ((uint32_t)0x00000800U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO12] Bits */
+#define GPIO_CPU_INT_IMASK_DIO12_OFS             (12)                            /* !< DIO12 Offset */
+#define GPIO_CPU_INT_IMASK_DIO12_MASK            ((uint32_t)0x00001000U)         /* !< DIO12 event mask */
+#define GPIO_CPU_INT_IMASK_DIO12_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO12_SET             ((uint32_t)0x00001000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO13] Bits */
+#define GPIO_CPU_INT_IMASK_DIO13_OFS             (13)                            /* !< DIO13 Offset */
+#define GPIO_CPU_INT_IMASK_DIO13_MASK            ((uint32_t)0x00002000U)         /* !< DIO13 event mask */
+#define GPIO_CPU_INT_IMASK_DIO13_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO13_SET             ((uint32_t)0x00002000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO14] Bits */
+#define GPIO_CPU_INT_IMASK_DIO14_OFS             (14)                            /* !< DIO14 Offset */
+#define GPIO_CPU_INT_IMASK_DIO14_MASK            ((uint32_t)0x00004000U)         /* !< DIO14 event mask */
+#define GPIO_CPU_INT_IMASK_DIO14_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO14_SET             ((uint32_t)0x00004000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO15] Bits */
+#define GPIO_CPU_INT_IMASK_DIO15_OFS             (15)                            /* !< DIO15 Offset */
+#define GPIO_CPU_INT_IMASK_DIO15_MASK            ((uint32_t)0x00008000U)         /* !< DIO15 event mask */
+#define GPIO_CPU_INT_IMASK_DIO15_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO15_SET             ((uint32_t)0x00008000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO16] Bits */
+#define GPIO_CPU_INT_IMASK_DIO16_OFS             (16)                            /* !< DIO16 Offset */
+#define GPIO_CPU_INT_IMASK_DIO16_MASK            ((uint32_t)0x00010000U)         /* !< DIO16 event mask */
+#define GPIO_CPU_INT_IMASK_DIO16_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO16_SET             ((uint32_t)0x00010000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO17] Bits */
+#define GPIO_CPU_INT_IMASK_DIO17_OFS             (17)                            /* !< DIO17 Offset */
+#define GPIO_CPU_INT_IMASK_DIO17_MASK            ((uint32_t)0x00020000U)         /* !< DIO17 event mask */
+#define GPIO_CPU_INT_IMASK_DIO17_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO17_SET             ((uint32_t)0x00020000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO18] Bits */
+#define GPIO_CPU_INT_IMASK_DIO18_OFS             (18)                            /* !< DIO18 Offset */
+#define GPIO_CPU_INT_IMASK_DIO18_MASK            ((uint32_t)0x00040000U)         /* !< DIO18 event mask */
+#define GPIO_CPU_INT_IMASK_DIO18_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO18_SET             ((uint32_t)0x00040000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO19] Bits */
+#define GPIO_CPU_INT_IMASK_DIO19_OFS             (19)                            /* !< DIO19 Offset */
+#define GPIO_CPU_INT_IMASK_DIO19_MASK            ((uint32_t)0x00080000U)         /* !< DIO19 event mask */
+#define GPIO_CPU_INT_IMASK_DIO19_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO19_SET             ((uint32_t)0x00080000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO20] Bits */
+#define GPIO_CPU_INT_IMASK_DIO20_OFS             (20)                            /* !< DIO20 Offset */
+#define GPIO_CPU_INT_IMASK_DIO20_MASK            ((uint32_t)0x00100000U)         /* !< DIO20 event mask */
+#define GPIO_CPU_INT_IMASK_DIO20_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO20_SET             ((uint32_t)0x00100000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO21] Bits */
+#define GPIO_CPU_INT_IMASK_DIO21_OFS             (21)                            /* !< DIO21 Offset */
+#define GPIO_CPU_INT_IMASK_DIO21_MASK            ((uint32_t)0x00200000U)         /* !< DIO21 event mask */
+#define GPIO_CPU_INT_IMASK_DIO21_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO21_SET             ((uint32_t)0x00200000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO22] Bits */
+#define GPIO_CPU_INT_IMASK_DIO22_OFS             (22)                            /* !< DIO22 Offset */
+#define GPIO_CPU_INT_IMASK_DIO22_MASK            ((uint32_t)0x00400000U)         /* !< DIO22 event mask */
+#define GPIO_CPU_INT_IMASK_DIO22_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO22_SET             ((uint32_t)0x00400000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO23] Bits */
+#define GPIO_CPU_INT_IMASK_DIO23_OFS             (23)                            /* !< DIO23 Offset */
+#define GPIO_CPU_INT_IMASK_DIO23_MASK            ((uint32_t)0x00800000U)         /* !< DIO23 event mask */
+#define GPIO_CPU_INT_IMASK_DIO23_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO23_SET             ((uint32_t)0x00800000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO24] Bits */
+#define GPIO_CPU_INT_IMASK_DIO24_OFS             (24)                            /* !< DIO24 Offset */
+#define GPIO_CPU_INT_IMASK_DIO24_MASK            ((uint32_t)0x01000000U)         /* !< DIO24 event mask */
+#define GPIO_CPU_INT_IMASK_DIO24_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO24_SET             ((uint32_t)0x01000000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO25] Bits */
+#define GPIO_CPU_INT_IMASK_DIO25_OFS             (25)                            /* !< DIO25 Offset */
+#define GPIO_CPU_INT_IMASK_DIO25_MASK            ((uint32_t)0x02000000U)         /* !< DIO25 event mask */
+#define GPIO_CPU_INT_IMASK_DIO25_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO25_SET             ((uint32_t)0x02000000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO26] Bits */
+#define GPIO_CPU_INT_IMASK_DIO26_OFS             (26)                            /* !< DIO26 Offset */
+#define GPIO_CPU_INT_IMASK_DIO26_MASK            ((uint32_t)0x04000000U)         /* !< DIO26 event mask */
+#define GPIO_CPU_INT_IMASK_DIO26_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO26_SET             ((uint32_t)0x04000000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO27] Bits */
+#define GPIO_CPU_INT_IMASK_DIO27_OFS             (27)                            /* !< DIO27 Offset */
+#define GPIO_CPU_INT_IMASK_DIO27_MASK            ((uint32_t)0x08000000U)         /* !< DIO27 event mask */
+#define GPIO_CPU_INT_IMASK_DIO27_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO27_SET             ((uint32_t)0x08000000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO28] Bits */
+#define GPIO_CPU_INT_IMASK_DIO28_OFS             (28)                            /* !< DIO28 Offset */
+#define GPIO_CPU_INT_IMASK_DIO28_MASK            ((uint32_t)0x10000000U)         /* !< DIO28 event mask */
+#define GPIO_CPU_INT_IMASK_DIO28_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO28_SET             ((uint32_t)0x10000000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO29] Bits */
+#define GPIO_CPU_INT_IMASK_DIO29_OFS             (29)                            /* !< DIO29 Offset */
+#define GPIO_CPU_INT_IMASK_DIO29_MASK            ((uint32_t)0x20000000U)         /* !< DIO29 event mask */
+#define GPIO_CPU_INT_IMASK_DIO29_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO29_SET             ((uint32_t)0x20000000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO30] Bits */
+#define GPIO_CPU_INT_IMASK_DIO30_OFS             (30)                            /* !< DIO30 Offset */
+#define GPIO_CPU_INT_IMASK_DIO30_MASK            ((uint32_t)0x40000000U)         /* !< DIO30 event mask */
+#define GPIO_CPU_INT_IMASK_DIO30_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO30_SET             ((uint32_t)0x40000000U)         /* !< Event is unmasked */
+/* GPIO_CPU_INT_IMASK[DIO31] Bits */
+#define GPIO_CPU_INT_IMASK_DIO31_OFS             (31)                            /* !< DIO31 Offset */
+#define GPIO_CPU_INT_IMASK_DIO31_MASK            ((uint32_t)0x80000000U)         /* !< DIO31 event mask */
+#define GPIO_CPU_INT_IMASK_DIO31_CLR             ((uint32_t)0x00000000U)         /* !< Event is masked */
+#define GPIO_CPU_INT_IMASK_DIO31_SET             ((uint32_t)0x80000000U)         /* !< Event is unmasked */
+
+/* GPIO_CPU_INT_RIS Bits */
+/* GPIO_CPU_INT_RIS[DIO0] Bits */
+#define GPIO_CPU_INT_RIS_DIO0_OFS                (0)                             /* !< DIO0 Offset */
+#define GPIO_CPU_INT_RIS_DIO0_MASK               ((uint32_t)0x00000001U)         /* !< DIO0 event */
+#define GPIO_CPU_INT_RIS_DIO0_CLR                ((uint32_t)0x00000000U)         /* !< DIO0 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO0_SET                ((uint32_t)0x00000001U)         /* !< DIO0 event occurred */
+/* GPIO_CPU_INT_RIS[DIO1] Bits */
+#define GPIO_CPU_INT_RIS_DIO1_OFS                (1)                             /* !< DIO1 Offset */
+#define GPIO_CPU_INT_RIS_DIO1_MASK               ((uint32_t)0x00000002U)         /* !< DIO1 event */
+#define GPIO_CPU_INT_RIS_DIO1_CLR                ((uint32_t)0x00000000U)         /* !< DIO1 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO1_SET                ((uint32_t)0x00000002U)         /* !< DIO1 event occurred */
+/* GPIO_CPU_INT_RIS[DIO2] Bits */
+#define GPIO_CPU_INT_RIS_DIO2_OFS                (2)                             /* !< DIO2 Offset */
+#define GPIO_CPU_INT_RIS_DIO2_MASK               ((uint32_t)0x00000004U)         /* !< DIO2 event */
+#define GPIO_CPU_INT_RIS_DIO2_CLR                ((uint32_t)0x00000000U)         /* !< DIO2 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO2_SET                ((uint32_t)0x00000004U)         /* !< DIO2 event occurred */
+/* GPIO_CPU_INT_RIS[DIO3] Bits */
+#define GPIO_CPU_INT_RIS_DIO3_OFS                (3)                             /* !< DIO3 Offset */
+#define GPIO_CPU_INT_RIS_DIO3_MASK               ((uint32_t)0x00000008U)         /* !< DIO3 event */
+#define GPIO_CPU_INT_RIS_DIO3_CLR                ((uint32_t)0x00000000U)         /* !< DIO3 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO3_SET                ((uint32_t)0x00000008U)         /* !< DIO3 event occurred */
+/* GPIO_CPU_INT_RIS[DIO4] Bits */
+#define GPIO_CPU_INT_RIS_DIO4_OFS                (4)                             /* !< DIO4 Offset */
+#define GPIO_CPU_INT_RIS_DIO4_MASK               ((uint32_t)0x00000010U)         /* !< DIO4 event */
+#define GPIO_CPU_INT_RIS_DIO4_CLR                ((uint32_t)0x00000000U)         /* !< DIO4 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO4_SET                ((uint32_t)0x00000010U)         /* !< DIO4 event occurred */
+/* GPIO_CPU_INT_RIS[DIO5] Bits */
+#define GPIO_CPU_INT_RIS_DIO5_OFS                (5)                             /* !< DIO5 Offset */
+#define GPIO_CPU_INT_RIS_DIO5_MASK               ((uint32_t)0x00000020U)         /* !< DIO5 event */
+#define GPIO_CPU_INT_RIS_DIO5_CLR                ((uint32_t)0x00000000U)         /* !< DIO5 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO5_SET                ((uint32_t)0x00000020U)         /* !< DIO5 event occurred */
+/* GPIO_CPU_INT_RIS[DIO6] Bits */
+#define GPIO_CPU_INT_RIS_DIO6_OFS                (6)                             /* !< DIO6 Offset */
+#define GPIO_CPU_INT_RIS_DIO6_MASK               ((uint32_t)0x00000040U)         /* !< DIO6 event */
+#define GPIO_CPU_INT_RIS_DIO6_CLR                ((uint32_t)0x00000000U)         /* !< DIO6 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO6_SET                ((uint32_t)0x00000040U)         /* !< DIO6 event occurred */
+/* GPIO_CPU_INT_RIS[DIO7] Bits */
+#define GPIO_CPU_INT_RIS_DIO7_OFS                (7)                             /* !< DIO7 Offset */
+#define GPIO_CPU_INT_RIS_DIO7_MASK               ((uint32_t)0x00000080U)         /* !< DIO7 event */
+#define GPIO_CPU_INT_RIS_DIO7_CLR                ((uint32_t)0x00000000U)         /* !< DIO7 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO7_SET                ((uint32_t)0x00000080U)         /* !< DIO7 event occurred */
+/* GPIO_CPU_INT_RIS[DIO8] Bits */
+#define GPIO_CPU_INT_RIS_DIO8_OFS                (8)                             /* !< DIO8 Offset */
+#define GPIO_CPU_INT_RIS_DIO8_MASK               ((uint32_t)0x00000100U)         /* !< DIO8 event */
+#define GPIO_CPU_INT_RIS_DIO8_CLR                ((uint32_t)0x00000000U)         /* !< DIO8 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO8_SET                ((uint32_t)0x00000100U)         /* !< DIO8 event occurred */
+/* GPIO_CPU_INT_RIS[DIO9] Bits */
+#define GPIO_CPU_INT_RIS_DIO9_OFS                (9)                             /* !< DIO9 Offset */
+#define GPIO_CPU_INT_RIS_DIO9_MASK               ((uint32_t)0x00000200U)         /* !< DIO9 event */
+#define GPIO_CPU_INT_RIS_DIO9_CLR                ((uint32_t)0x00000000U)         /* !< DIO9 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO9_SET                ((uint32_t)0x00000200U)         /* !< DIO9 event occurred */
+/* GPIO_CPU_INT_RIS[DIO10] Bits */
+#define GPIO_CPU_INT_RIS_DIO10_OFS               (10)                            /* !< DIO10 Offset */
+#define GPIO_CPU_INT_RIS_DIO10_MASK              ((uint32_t)0x00000400U)         /* !< DIO10 event */
+#define GPIO_CPU_INT_RIS_DIO10_CLR               ((uint32_t)0x00000000U)         /* !< DIO10 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO10_SET               ((uint32_t)0x00000400U)         /* !< DIO10 event occurred */
+/* GPIO_CPU_INT_RIS[DIO11] Bits */
+#define GPIO_CPU_INT_RIS_DIO11_OFS               (11)                            /* !< DIO11 Offset */
+#define GPIO_CPU_INT_RIS_DIO11_MASK              ((uint32_t)0x00000800U)         /* !< DIO11 event */
+#define GPIO_CPU_INT_RIS_DIO11_CLR               ((uint32_t)0x00000000U)         /* !< DIO11 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO11_SET               ((uint32_t)0x00000800U)         /* !< DIO11 event occurred */
+/* GPIO_CPU_INT_RIS[DIO12] Bits */
+#define GPIO_CPU_INT_RIS_DIO12_OFS               (12)                            /* !< DIO12 Offset */
+#define GPIO_CPU_INT_RIS_DIO12_MASK              ((uint32_t)0x00001000U)         /* !< DIO12 event */
+#define GPIO_CPU_INT_RIS_DIO12_CLR               ((uint32_t)0x00000000U)         /* !< DIO12 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO12_SET               ((uint32_t)0x00001000U)         /* !< DIO12 event occurred */
+/* GPIO_CPU_INT_RIS[DIO13] Bits */
+#define GPIO_CPU_INT_RIS_DIO13_OFS               (13)                            /* !< DIO13 Offset */
+#define GPIO_CPU_INT_RIS_DIO13_MASK              ((uint32_t)0x00002000U)         /* !< DIO13 event */
+#define GPIO_CPU_INT_RIS_DIO13_CLR               ((uint32_t)0x00000000U)         /* !< DIO13 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO13_SET               ((uint32_t)0x00002000U)         /* !< DIO13 event occurred */
+/* GPIO_CPU_INT_RIS[DIO14] Bits */
+#define GPIO_CPU_INT_RIS_DIO14_OFS               (14)                            /* !< DIO14 Offset */
+#define GPIO_CPU_INT_RIS_DIO14_MASK              ((uint32_t)0x00004000U)         /* !< DIO14 event */
+#define GPIO_CPU_INT_RIS_DIO14_CLR               ((uint32_t)0x00000000U)         /* !< DIO14 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO14_SET               ((uint32_t)0x00004000U)         /* !< DIO14 event occurred */
+/* GPIO_CPU_INT_RIS[DIO15] Bits */
+#define GPIO_CPU_INT_RIS_DIO15_OFS               (15)                            /* !< DIO15 Offset */
+#define GPIO_CPU_INT_RIS_DIO15_MASK              ((uint32_t)0x00008000U)         /* !< DIO15 event */
+#define GPIO_CPU_INT_RIS_DIO15_CLR               ((uint32_t)0x00000000U)         /* !< DIO15 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO15_SET               ((uint32_t)0x00008000U)         /* !< DIO15 event occurred */
+/* GPIO_CPU_INT_RIS[DIO16] Bits */
+#define GPIO_CPU_INT_RIS_DIO16_OFS               (16)                            /* !< DIO16 Offset */
+#define GPIO_CPU_INT_RIS_DIO16_MASK              ((uint32_t)0x00010000U)         /* !< DIO16 event */
+#define GPIO_CPU_INT_RIS_DIO16_CLR               ((uint32_t)0x00000000U)         /* !< DIO16 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO16_SET               ((uint32_t)0x00010000U)         /* !< DIO16 event occurred */
+/* GPIO_CPU_INT_RIS[DIO17] Bits */
+#define GPIO_CPU_INT_RIS_DIO17_OFS               (17)                            /* !< DIO17 Offset */
+#define GPIO_CPU_INT_RIS_DIO17_MASK              ((uint32_t)0x00020000U)         /* !< DIO17 event */
+#define GPIO_CPU_INT_RIS_DIO17_CLR               ((uint32_t)0x00000000U)         /* !< DIO17 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO17_SET               ((uint32_t)0x00020000U)         /* !< DIO17 event occurred */
+/* GPIO_CPU_INT_RIS[DIO18] Bits */
+#define GPIO_CPU_INT_RIS_DIO18_OFS               (18)                            /* !< DIO18 Offset */
+#define GPIO_CPU_INT_RIS_DIO18_MASK              ((uint32_t)0x00040000U)         /* !< DIO18 event */
+#define GPIO_CPU_INT_RIS_DIO18_CLR               ((uint32_t)0x00000000U)         /* !< DIO18 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO18_SET               ((uint32_t)0x00040000U)         /* !< DIO18 event occurred */
+/* GPIO_CPU_INT_RIS[DIO19] Bits */
+#define GPIO_CPU_INT_RIS_DIO19_OFS               (19)                            /* !< DIO19 Offset */
+#define GPIO_CPU_INT_RIS_DIO19_MASK              ((uint32_t)0x00080000U)         /* !< DIO19 event */
+#define GPIO_CPU_INT_RIS_DIO19_CLR               ((uint32_t)0x00000000U)         /* !< DIO19 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO19_SET               ((uint32_t)0x00080000U)         /* !< DIO19 event occurred */
+/* GPIO_CPU_INT_RIS[DIO20] Bits */
+#define GPIO_CPU_INT_RIS_DIO20_OFS               (20)                            /* !< DIO20 Offset */
+#define GPIO_CPU_INT_RIS_DIO20_MASK              ((uint32_t)0x00100000U)         /* !< DIO20 event */
+#define GPIO_CPU_INT_RIS_DIO20_CLR               ((uint32_t)0x00000000U)         /* !< DIO20 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO20_SET               ((uint32_t)0x00100000U)         /* !< DIO20 event occurred */
+/* GPIO_CPU_INT_RIS[DIO21] Bits */
+#define GPIO_CPU_INT_RIS_DIO21_OFS               (21)                            /* !< DIO21 Offset */
+#define GPIO_CPU_INT_RIS_DIO21_MASK              ((uint32_t)0x00200000U)         /* !< DIO21 event */
+#define GPIO_CPU_INT_RIS_DIO21_CLR               ((uint32_t)0x00000000U)         /* !< DIO21 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO21_SET               ((uint32_t)0x00200000U)         /* !< DIO21 event occurred */
+/* GPIO_CPU_INT_RIS[DIO22] Bits */
+#define GPIO_CPU_INT_RIS_DIO22_OFS               (22)                            /* !< DIO22 Offset */
+#define GPIO_CPU_INT_RIS_DIO22_MASK              ((uint32_t)0x00400000U)         /* !< DIO22 event */
+#define GPIO_CPU_INT_RIS_DIO22_CLR               ((uint32_t)0x00000000U)         /* !< DIO22 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO22_SET               ((uint32_t)0x00400000U)         /* !< DIO22 event occurred */
+/* GPIO_CPU_INT_RIS[DIO23] Bits */
+#define GPIO_CPU_INT_RIS_DIO23_OFS               (23)                            /* !< DIO23 Offset */
+#define GPIO_CPU_INT_RIS_DIO23_MASK              ((uint32_t)0x00800000U)         /* !< DIO23 event */
+#define GPIO_CPU_INT_RIS_DIO23_CLR               ((uint32_t)0x00000000U)         /* !< DIO23 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO23_SET               ((uint32_t)0x00800000U)         /* !< DIO23 event occurred */
+/* GPIO_CPU_INT_RIS[DIO24] Bits */
+#define GPIO_CPU_INT_RIS_DIO24_OFS               (24)                            /* !< DIO24 Offset */
+#define GPIO_CPU_INT_RIS_DIO24_MASK              ((uint32_t)0x01000000U)         /* !< DIO24 event */
+#define GPIO_CPU_INT_RIS_DIO24_CLR               ((uint32_t)0x00000000U)         /* !< DIO24 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO24_SET               ((uint32_t)0x01000000U)         /* !< DIO24 event occurred */
+/* GPIO_CPU_INT_RIS[DIO25] Bits */
+#define GPIO_CPU_INT_RIS_DIO25_OFS               (25)                            /* !< DIO25 Offset */
+#define GPIO_CPU_INT_RIS_DIO25_MASK              ((uint32_t)0x02000000U)         /* !< DIO25 event */
+#define GPIO_CPU_INT_RIS_DIO25_CLR               ((uint32_t)0x00000000U)         /* !< DIO25 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO25_SET               ((uint32_t)0x02000000U)         /* !< DIO25 event occurred */
+/* GPIO_CPU_INT_RIS[DIO26] Bits */
+#define GPIO_CPU_INT_RIS_DIO26_OFS               (26)                            /* !< DIO26 Offset */
+#define GPIO_CPU_INT_RIS_DIO26_MASK              ((uint32_t)0x04000000U)         /* !< DIO26 event */
+#define GPIO_CPU_INT_RIS_DIO26_CLR               ((uint32_t)0x00000000U)         /* !< DIO26 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO26_SET               ((uint32_t)0x04000000U)         /* !< DIO26 event occurred */
+/* GPIO_CPU_INT_RIS[DIO27] Bits */
+#define GPIO_CPU_INT_RIS_DIO27_OFS               (27)                            /* !< DIO27 Offset */
+#define GPIO_CPU_INT_RIS_DIO27_MASK              ((uint32_t)0x08000000U)         /* !< DIO27 event */
+#define GPIO_CPU_INT_RIS_DIO27_CLR               ((uint32_t)0x00000000U)         /* !< DIO27 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO27_SET               ((uint32_t)0x08000000U)         /* !< DIO27 event occurred */
+/* GPIO_CPU_INT_RIS[DIO28] Bits */
+#define GPIO_CPU_INT_RIS_DIO28_OFS               (28)                            /* !< DIO28 Offset */
+#define GPIO_CPU_INT_RIS_DIO28_MASK              ((uint32_t)0x10000000U)         /* !< DIO28 event */
+#define GPIO_CPU_INT_RIS_DIO28_CLR               ((uint32_t)0x00000000U)         /* !< DIO28 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO28_SET               ((uint32_t)0x10000000U)         /* !< DIO28 event occurred */
+/* GPIO_CPU_INT_RIS[DIO29] Bits */
+#define GPIO_CPU_INT_RIS_DIO29_OFS               (29)                            /* !< DIO29 Offset */
+#define GPIO_CPU_INT_RIS_DIO29_MASK              ((uint32_t)0x20000000U)         /* !< DIO29 event */
+#define GPIO_CPU_INT_RIS_DIO29_CLR               ((uint32_t)0x00000000U)         /* !< DIO29 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO29_SET               ((uint32_t)0x20000000U)         /* !< DIO29 event occurred */
+/* GPIO_CPU_INT_RIS[DIO30] Bits */
+#define GPIO_CPU_INT_RIS_DIO30_OFS               (30)                            /* !< DIO30 Offset */
+#define GPIO_CPU_INT_RIS_DIO30_MASK              ((uint32_t)0x40000000U)         /* !< DIO30 event */
+#define GPIO_CPU_INT_RIS_DIO30_CLR               ((uint32_t)0x00000000U)         /* !< DIO30 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO30_SET               ((uint32_t)0x40000000U)         /* !< DIO30 event occurred */
+/* GPIO_CPU_INT_RIS[DIO31] Bits */
+#define GPIO_CPU_INT_RIS_DIO31_OFS               (31)                            /* !< DIO31 Offset */
+#define GPIO_CPU_INT_RIS_DIO31_MASK              ((uint32_t)0x80000000U)         /* !< DIO31 event */
+#define GPIO_CPU_INT_RIS_DIO31_CLR               ((uint32_t)0x00000000U)         /* !< DIO31 event did not occur */
+#define GPIO_CPU_INT_RIS_DIO31_SET               ((uint32_t)0x80000000U)         /* !< DIO31 event occurred */
+
+/* GPIO_CPU_INT_MIS Bits */
+/* GPIO_CPU_INT_MIS[DIO0] Bits */
+#define GPIO_CPU_INT_MIS_DIO0_OFS                (0)                             /* !< DIO0 Offset */
+#define GPIO_CPU_INT_MIS_DIO0_MASK               ((uint32_t)0x00000001U)         /* !< DIO0 event */
+#define GPIO_CPU_INT_MIS_DIO0_CLR                ((uint32_t)0x00000000U)         /* !< DIO0 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO0_SET                ((uint32_t)0x00000001U)         /* !< DIO0 event occurred */
+/* GPIO_CPU_INT_MIS[DIO1] Bits */
+#define GPIO_CPU_INT_MIS_DIO1_OFS                (1)                             /* !< DIO1 Offset */
+#define GPIO_CPU_INT_MIS_DIO1_MASK               ((uint32_t)0x00000002U)         /* !< DIO1 event */
+#define GPIO_CPU_INT_MIS_DIO1_CLR                ((uint32_t)0x00000000U)         /* !< DIO1 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO1_SET                ((uint32_t)0x00000002U)         /* !< DIO1 event occurred */
+/* GPIO_CPU_INT_MIS[DIO2] Bits */
+#define GPIO_CPU_INT_MIS_DIO2_OFS                (2)                             /* !< DIO2 Offset */
+#define GPIO_CPU_INT_MIS_DIO2_MASK               ((uint32_t)0x00000004U)         /* !< DIO2 event */
+#define GPIO_CPU_INT_MIS_DIO2_CLR                ((uint32_t)0x00000000U)         /* !< DIO2 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO2_SET                ((uint32_t)0x00000004U)         /* !< DIO2 event occurred */
+/* GPIO_CPU_INT_MIS[DIO3] Bits */
+#define GPIO_CPU_INT_MIS_DIO3_OFS                (3)                             /* !< DIO3 Offset */
+#define GPIO_CPU_INT_MIS_DIO3_MASK               ((uint32_t)0x00000008U)         /* !< DIO3 event */
+#define GPIO_CPU_INT_MIS_DIO3_CLR                ((uint32_t)0x00000000U)         /* !< DIO3 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO3_SET                ((uint32_t)0x00000008U)         /* !< DIO3 event occurred */
+/* GPIO_CPU_INT_MIS[DIO4] Bits */
+#define GPIO_CPU_INT_MIS_DIO4_OFS                (4)                             /* !< DIO4 Offset */
+#define GPIO_CPU_INT_MIS_DIO4_MASK               ((uint32_t)0x00000010U)         /* !< DIO4 event */
+#define GPIO_CPU_INT_MIS_DIO4_CLR                ((uint32_t)0x00000000U)         /* !< DIO4 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO4_SET                ((uint32_t)0x00000010U)         /* !< DIO4 event occurred */
+/* GPIO_CPU_INT_MIS[DIO5] Bits */
+#define GPIO_CPU_INT_MIS_DIO5_OFS                (5)                             /* !< DIO5 Offset */
+#define GPIO_CPU_INT_MIS_DIO5_MASK               ((uint32_t)0x00000020U)         /* !< DIO5 event */
+#define GPIO_CPU_INT_MIS_DIO5_CLR                ((uint32_t)0x00000000U)         /* !< DIO5 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO5_SET                ((uint32_t)0x00000020U)         /* !< DIO5 event occurred */
+/* GPIO_CPU_INT_MIS[DIO6] Bits */
+#define GPIO_CPU_INT_MIS_DIO6_OFS                (6)                             /* !< DIO6 Offset */
+#define GPIO_CPU_INT_MIS_DIO6_MASK               ((uint32_t)0x00000040U)         /* !< DIO6 event */
+#define GPIO_CPU_INT_MIS_DIO6_CLR                ((uint32_t)0x00000000U)         /* !< DIO6 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO6_SET                ((uint32_t)0x00000040U)         /* !< DIO6 event occurred */
+/* GPIO_CPU_INT_MIS[DIO7] Bits */
+#define GPIO_CPU_INT_MIS_DIO7_OFS                (7)                             /* !< DIO7 Offset */
+#define GPIO_CPU_INT_MIS_DIO7_MASK               ((uint32_t)0x00000080U)         /* !< DIO7 event */
+#define GPIO_CPU_INT_MIS_DIO7_CLR                ((uint32_t)0x00000000U)         /* !< DIO7 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO7_SET                ((uint32_t)0x00000080U)         /* !< DIO7 event occurred */
+/* GPIO_CPU_INT_MIS[DIO8] Bits */
+#define GPIO_CPU_INT_MIS_DIO8_OFS                (8)                             /* !< DIO8 Offset */
+#define GPIO_CPU_INT_MIS_DIO8_MASK               ((uint32_t)0x00000100U)         /* !< DIO8 event */
+#define GPIO_CPU_INT_MIS_DIO8_CLR                ((uint32_t)0x00000000U)         /* !< DIO8 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO8_SET                ((uint32_t)0x00000100U)         /* !< DIO8 event occurred */
+/* GPIO_CPU_INT_MIS[DIO9] Bits */
+#define GPIO_CPU_INT_MIS_DIO9_OFS                (9)                             /* !< DIO9 Offset */
+#define GPIO_CPU_INT_MIS_DIO9_MASK               ((uint32_t)0x00000200U)         /* !< DIO9 event */
+#define GPIO_CPU_INT_MIS_DIO9_CLR                ((uint32_t)0x00000000U)         /* !< DIO9 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO9_SET                ((uint32_t)0x00000200U)         /* !< DIO9 event occurred */
+/* GPIO_CPU_INT_MIS[DIO10] Bits */
+#define GPIO_CPU_INT_MIS_DIO10_OFS               (10)                            /* !< DIO10 Offset */
+#define GPIO_CPU_INT_MIS_DIO10_MASK              ((uint32_t)0x00000400U)         /* !< DIO10 event */
+#define GPIO_CPU_INT_MIS_DIO10_CLR               ((uint32_t)0x00000000U)         /* !< DIO10 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO10_SET               ((uint32_t)0x00000400U)         /* !< DIO10 event occurred */
+/* GPIO_CPU_INT_MIS[DIO11] Bits */
+#define GPIO_CPU_INT_MIS_DIO11_OFS               (11)                            /* !< DIO11 Offset */
+#define GPIO_CPU_INT_MIS_DIO11_MASK              ((uint32_t)0x00000800U)         /* !< DIO11 event */
+#define GPIO_CPU_INT_MIS_DIO11_CLR               ((uint32_t)0x00000000U)         /* !< DIO11 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO11_SET               ((uint32_t)0x00000800U)         /* !< DIO11 event occurred */
+/* GPIO_CPU_INT_MIS[DIO12] Bits */
+#define GPIO_CPU_INT_MIS_DIO12_OFS               (12)                            /* !< DIO12 Offset */
+#define GPIO_CPU_INT_MIS_DIO12_MASK              ((uint32_t)0x00001000U)         /* !< DIO12 event */
+#define GPIO_CPU_INT_MIS_DIO12_CLR               ((uint32_t)0x00000000U)         /* !< DIO12 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO12_SET               ((uint32_t)0x00001000U)         /* !< DIO12 event occurred */
+/* GPIO_CPU_INT_MIS[DIO13] Bits */
+#define GPIO_CPU_INT_MIS_DIO13_OFS               (13)                            /* !< DIO13 Offset */
+#define GPIO_CPU_INT_MIS_DIO13_MASK              ((uint32_t)0x00002000U)         /* !< DIO13 event */
+#define GPIO_CPU_INT_MIS_DIO13_CLR               ((uint32_t)0x00000000U)         /* !< DIO13 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO13_SET               ((uint32_t)0x00002000U)         /* !< DIO13 event occurred */
+/* GPIO_CPU_INT_MIS[DIO14] Bits */
+#define GPIO_CPU_INT_MIS_DIO14_OFS               (14)                            /* !< DIO14 Offset */
+#define GPIO_CPU_INT_MIS_DIO14_MASK              ((uint32_t)0x00004000U)         /* !< DIO14 event */
+#define GPIO_CPU_INT_MIS_DIO14_CLR               ((uint32_t)0x00000000U)         /* !< DIO14 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO14_SET               ((uint32_t)0x00004000U)         /* !< DIO14 event occurred */
+/* GPIO_CPU_INT_MIS[DIO15] Bits */
+#define GPIO_CPU_INT_MIS_DIO15_OFS               (15)                            /* !< DIO15 Offset */
+#define GPIO_CPU_INT_MIS_DIO15_MASK              ((uint32_t)0x00008000U)         /* !< DIO15 event */
+#define GPIO_CPU_INT_MIS_DIO15_CLR               ((uint32_t)0x00000000U)         /* !< DIO15 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO15_SET               ((uint32_t)0x00008000U)         /* !< DIO15 event occurred */
+/* GPIO_CPU_INT_MIS[DIO16] Bits */
+#define GPIO_CPU_INT_MIS_DIO16_OFS               (16)                            /* !< DIO16 Offset */
+#define GPIO_CPU_INT_MIS_DIO16_MASK              ((uint32_t)0x00010000U)         /* !< DIO16 event */
+#define GPIO_CPU_INT_MIS_DIO16_CLR               ((uint32_t)0x00000000U)         /* !< DIO16 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO16_SET               ((uint32_t)0x00010000U)         /* !< DIO16 event occurred */
+/* GPIO_CPU_INT_MIS[DIO17] Bits */
+#define GPIO_CPU_INT_MIS_DIO17_OFS               (17)                            /* !< DIO17 Offset */
+#define GPIO_CPU_INT_MIS_DIO17_MASK              ((uint32_t)0x00020000U)         /* !< DIO17 event */
+#define GPIO_CPU_INT_MIS_DIO17_CLR               ((uint32_t)0x00000000U)         /* !< DIO17 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO17_SET               ((uint32_t)0x00020000U)         /* !< DIO17 event occurred */
+/* GPIO_CPU_INT_MIS[DIO18] Bits */
+#define GPIO_CPU_INT_MIS_DIO18_OFS               (18)                            /* !< DIO18 Offset */
+#define GPIO_CPU_INT_MIS_DIO18_MASK              ((uint32_t)0x00040000U)         /* !< DIO18 event */
+#define GPIO_CPU_INT_MIS_DIO18_CLR               ((uint32_t)0x00000000U)         /* !< DIO18 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO18_SET               ((uint32_t)0x00040000U)         /* !< DIO18 event occurred */
+/* GPIO_CPU_INT_MIS[DIO19] Bits */
+#define GPIO_CPU_INT_MIS_DIO19_OFS               (19)                            /* !< DIO19 Offset */
+#define GPIO_CPU_INT_MIS_DIO19_MASK              ((uint32_t)0x00080000U)         /* !< DIO19 event */
+#define GPIO_CPU_INT_MIS_DIO19_CLR               ((uint32_t)0x00000000U)         /* !< DIO19 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO19_SET               ((uint32_t)0x00080000U)         /* !< DIO19 event occurred */
+/* GPIO_CPU_INT_MIS[DIO20] Bits */
+#define GPIO_CPU_INT_MIS_DIO20_OFS               (20)                            /* !< DIO20 Offset */
+#define GPIO_CPU_INT_MIS_DIO20_MASK              ((uint32_t)0x00100000U)         /* !< DIO20 event */
+#define GPIO_CPU_INT_MIS_DIO20_CLR               ((uint32_t)0x00000000U)         /* !< DIO20 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO20_SET               ((uint32_t)0x00100000U)         /* !< DIO20 event occurred */
+/* GPIO_CPU_INT_MIS[DIO21] Bits */
+#define GPIO_CPU_INT_MIS_DIO21_OFS               (21)                            /* !< DIO21 Offset */
+#define GPIO_CPU_INT_MIS_DIO21_MASK              ((uint32_t)0x00200000U)         /* !< DIO21 event */
+#define GPIO_CPU_INT_MIS_DIO21_CLR               ((uint32_t)0x00000000U)         /* !< DIO21 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO21_SET               ((uint32_t)0x00200000U)         /* !< DIO21 event occurred */
+/* GPIO_CPU_INT_MIS[DIO22] Bits */
+#define GPIO_CPU_INT_MIS_DIO22_OFS               (22)                            /* !< DIO22 Offset */
+#define GPIO_CPU_INT_MIS_DIO22_MASK              ((uint32_t)0x00400000U)         /* !< DIO22 event */
+#define GPIO_CPU_INT_MIS_DIO22_CLR               ((uint32_t)0x00000000U)         /* !< DIO22 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO22_SET               ((uint32_t)0x00400000U)         /* !< DIO22 event occurred */
+/* GPIO_CPU_INT_MIS[DIO23] Bits */
+#define GPIO_CPU_INT_MIS_DIO23_OFS               (23)                            /* !< DIO23 Offset */
+#define GPIO_CPU_INT_MIS_DIO23_MASK              ((uint32_t)0x00800000U)         /* !< DIO23 event */
+#define GPIO_CPU_INT_MIS_DIO23_CLR               ((uint32_t)0x00000000U)         /* !< DIO23 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO23_SET               ((uint32_t)0x00800000U)         /* !< DIO23 event occurred */
+/* GPIO_CPU_INT_MIS[DIO24] Bits */
+#define GPIO_CPU_INT_MIS_DIO24_OFS               (24)                            /* !< DIO24 Offset */
+#define GPIO_CPU_INT_MIS_DIO24_MASK              ((uint32_t)0x01000000U)         /* !< DIO24 event */
+#define GPIO_CPU_INT_MIS_DIO24_CLR               ((uint32_t)0x00000000U)         /* !< DIO24 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO24_SET               ((uint32_t)0x01000000U)         /* !< DIO24 event occurred */
+/* GPIO_CPU_INT_MIS[DIO25] Bits */
+#define GPIO_CPU_INT_MIS_DIO25_OFS               (25)                            /* !< DIO25 Offset */
+#define GPIO_CPU_INT_MIS_DIO25_MASK              ((uint32_t)0x02000000U)         /* !< DIO25 event */
+#define GPIO_CPU_INT_MIS_DIO25_CLR               ((uint32_t)0x00000000U)         /* !< DIO25 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO25_SET               ((uint32_t)0x02000000U)         /* !< DIO25 event occurred */
+/* GPIO_CPU_INT_MIS[DIO26] Bits */
+#define GPIO_CPU_INT_MIS_DIO26_OFS               (26)                            /* !< DIO26 Offset */
+#define GPIO_CPU_INT_MIS_DIO26_MASK              ((uint32_t)0x04000000U)         /* !< DIO26 event */
+#define GPIO_CPU_INT_MIS_DIO26_CLR               ((uint32_t)0x00000000U)         /* !< DIO26 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO26_SET               ((uint32_t)0x04000000U)         /* !< DIO26 event occurred */
+/* GPIO_CPU_INT_MIS[DIO27] Bits */
+#define GPIO_CPU_INT_MIS_DIO27_OFS               (27)                            /* !< DIO27 Offset */
+#define GPIO_CPU_INT_MIS_DIO27_MASK              ((uint32_t)0x08000000U)         /* !< DIO27 event */
+#define GPIO_CPU_INT_MIS_DIO27_CLR               ((uint32_t)0x00000000U)         /* !< DIO27 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO27_SET               ((uint32_t)0x08000000U)         /* !< DIO27 event occurred */
+/* GPIO_CPU_INT_MIS[DIO28] Bits */
+#define GPIO_CPU_INT_MIS_DIO28_OFS               (28)                            /* !< DIO28 Offset */
+#define GPIO_CPU_INT_MIS_DIO28_MASK              ((uint32_t)0x10000000U)         /* !< DIO28 event */
+#define GPIO_CPU_INT_MIS_DIO28_CLR               ((uint32_t)0x00000000U)         /* !< DIO28 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO28_SET               ((uint32_t)0x10000000U)         /* !< DIO28 event occurred */
+/* GPIO_CPU_INT_MIS[DIO29] Bits */
+#define GPIO_CPU_INT_MIS_DIO29_OFS               (29)                            /* !< DIO29 Offset */
+#define GPIO_CPU_INT_MIS_DIO29_MASK              ((uint32_t)0x20000000U)         /* !< DIO29 event */
+#define GPIO_CPU_INT_MIS_DIO29_CLR               ((uint32_t)0x00000000U)         /* !< DIO29 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO29_SET               ((uint32_t)0x20000000U)         /* !< DIO29 event occurred */
+/* GPIO_CPU_INT_MIS[DIO30] Bits */
+#define GPIO_CPU_INT_MIS_DIO30_OFS               (30)                            /* !< DIO30 Offset */
+#define GPIO_CPU_INT_MIS_DIO30_MASK              ((uint32_t)0x40000000U)         /* !< DIO30 event */
+#define GPIO_CPU_INT_MIS_DIO30_CLR               ((uint32_t)0x00000000U)         /* !< DIO30 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO30_SET               ((uint32_t)0x40000000U)         /* !< DIO30 event occurred */
+/* GPIO_CPU_INT_MIS[DIO31] Bits */
+#define GPIO_CPU_INT_MIS_DIO31_OFS               (31)                            /* !< DIO31 Offset */
+#define GPIO_CPU_INT_MIS_DIO31_MASK              ((uint32_t)0x80000000U)         /* !< DIO31 event */
+#define GPIO_CPU_INT_MIS_DIO31_CLR               ((uint32_t)0x00000000U)         /* !< DIO31 event did not occur */
+#define GPIO_CPU_INT_MIS_DIO31_SET               ((uint32_t)0x80000000U)         /* !< DIO31 event occurred */
+
+/* GPIO_CPU_INT_ISET Bits */
+/* GPIO_CPU_INT_ISET[DIO0] Bits */
+#define GPIO_CPU_INT_ISET_DIO0_OFS               (0)                             /* !< DIO0 Offset */
+#define GPIO_CPU_INT_ISET_DIO0_MASK              ((uint32_t)0x00000001U)         /* !< DIO0 event */
+#define GPIO_CPU_INT_ISET_DIO0_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO0_SET               ((uint32_t)0x00000001U)         /* !< Sets DIO0 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO1] Bits */
+#define GPIO_CPU_INT_ISET_DIO1_OFS               (1)                             /* !< DIO1 Offset */
+#define GPIO_CPU_INT_ISET_DIO1_MASK              ((uint32_t)0x00000002U)         /* !< DIO1 event */
+#define GPIO_CPU_INT_ISET_DIO1_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO1_SET               ((uint32_t)0x00000002U)         /* !< Sets DIO1 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO2] Bits */
+#define GPIO_CPU_INT_ISET_DIO2_OFS               (2)                             /* !< DIO2 Offset */
+#define GPIO_CPU_INT_ISET_DIO2_MASK              ((uint32_t)0x00000004U)         /* !< DIO2 event */
+#define GPIO_CPU_INT_ISET_DIO2_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO2_SET               ((uint32_t)0x00000004U)         /* !< Sets DIO2 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO3] Bits */
+#define GPIO_CPU_INT_ISET_DIO3_OFS               (3)                             /* !< DIO3 Offset */
+#define GPIO_CPU_INT_ISET_DIO3_MASK              ((uint32_t)0x00000008U)         /* !< DIO3 event */
+#define GPIO_CPU_INT_ISET_DIO3_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO3_SET               ((uint32_t)0x00000008U)         /* !< Sets DIO3 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO4] Bits */
+#define GPIO_CPU_INT_ISET_DIO4_OFS               (4)                             /* !< DIO4 Offset */
+#define GPIO_CPU_INT_ISET_DIO4_MASK              ((uint32_t)0x00000010U)         /* !< DIO4 event */
+#define GPIO_CPU_INT_ISET_DIO4_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO4_SET               ((uint32_t)0x00000010U)         /* !< Sets DIO4 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO5] Bits */
+#define GPIO_CPU_INT_ISET_DIO5_OFS               (5)                             /* !< DIO5 Offset */
+#define GPIO_CPU_INT_ISET_DIO5_MASK              ((uint32_t)0x00000020U)         /* !< DIO5 event */
+#define GPIO_CPU_INT_ISET_DIO5_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO5_SET               ((uint32_t)0x00000020U)         /* !< Sets DIO5 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO6] Bits */
+#define GPIO_CPU_INT_ISET_DIO6_OFS               (6)                             /* !< DIO6 Offset */
+#define GPIO_CPU_INT_ISET_DIO6_MASK              ((uint32_t)0x00000040U)         /* !< DIO6 event */
+#define GPIO_CPU_INT_ISET_DIO6_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO6_SET               ((uint32_t)0x00000040U)         /* !< Sets DIO6 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO7] Bits */
+#define GPIO_CPU_INT_ISET_DIO7_OFS               (7)                             /* !< DIO7 Offset */
+#define GPIO_CPU_INT_ISET_DIO7_MASK              ((uint32_t)0x00000080U)         /* !< DIO7 event */
+#define GPIO_CPU_INT_ISET_DIO7_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO7_SET               ((uint32_t)0x00000080U)         /* !< Sets DIO7 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO8] Bits */
+#define GPIO_CPU_INT_ISET_DIO8_OFS               (8)                             /* !< DIO8 Offset */
+#define GPIO_CPU_INT_ISET_DIO8_MASK              ((uint32_t)0x00000100U)         /* !< DIO8 event */
+#define GPIO_CPU_INT_ISET_DIO8_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO8_SET               ((uint32_t)0x00000100U)         /* !< Sets DIO8 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO9] Bits */
+#define GPIO_CPU_INT_ISET_DIO9_OFS               (9)                             /* !< DIO9 Offset */
+#define GPIO_CPU_INT_ISET_DIO9_MASK              ((uint32_t)0x00000200U)         /* !< DIO9 event */
+#define GPIO_CPU_INT_ISET_DIO9_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO9_SET               ((uint32_t)0x00000200U)         /* !< Sets DIO9 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO10] Bits */
+#define GPIO_CPU_INT_ISET_DIO10_OFS              (10)                            /* !< DIO10 Offset */
+#define GPIO_CPU_INT_ISET_DIO10_MASK             ((uint32_t)0x00000400U)         /* !< DIO10 event */
+#define GPIO_CPU_INT_ISET_DIO10_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO10_SET              ((uint32_t)0x00000400U)         /* !< Sets DIO10 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO11] Bits */
+#define GPIO_CPU_INT_ISET_DIO11_OFS              (11)                            /* !< DIO11 Offset */
+#define GPIO_CPU_INT_ISET_DIO11_MASK             ((uint32_t)0x00000800U)         /* !< DIO11 event */
+#define GPIO_CPU_INT_ISET_DIO11_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO11_SET              ((uint32_t)0x00000800U)         /* !< Sets DIO11 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO12] Bits */
+#define GPIO_CPU_INT_ISET_DIO12_OFS              (12)                            /* !< DIO12 Offset */
+#define GPIO_CPU_INT_ISET_DIO12_MASK             ((uint32_t)0x00001000U)         /* !< DIO12 event */
+#define GPIO_CPU_INT_ISET_DIO12_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO12_SET              ((uint32_t)0x00001000U)         /* !< Sets DIO12 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO13] Bits */
+#define GPIO_CPU_INT_ISET_DIO13_OFS              (13)                            /* !< DIO13 Offset */
+#define GPIO_CPU_INT_ISET_DIO13_MASK             ((uint32_t)0x00002000U)         /* !< DIO13 event */
+#define GPIO_CPU_INT_ISET_DIO13_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO13_SET              ((uint32_t)0x00002000U)         /* !< Sets DIO13 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO14] Bits */
+#define GPIO_CPU_INT_ISET_DIO14_OFS              (14)                            /* !< DIO14 Offset */
+#define GPIO_CPU_INT_ISET_DIO14_MASK             ((uint32_t)0x00004000U)         /* !< DIO14 event */
+#define GPIO_CPU_INT_ISET_DIO14_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO14_SET              ((uint32_t)0x00004000U)         /* !< Sets DIO14 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO15] Bits */
+#define GPIO_CPU_INT_ISET_DIO15_OFS              (15)                            /* !< DIO15 Offset */
+#define GPIO_CPU_INT_ISET_DIO15_MASK             ((uint32_t)0x00008000U)         /* !< DIO15 event */
+#define GPIO_CPU_INT_ISET_DIO15_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO15_SET              ((uint32_t)0x00008000U)         /* !< Sets DIO15 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO16] Bits */
+#define GPIO_CPU_INT_ISET_DIO16_OFS              (16)                            /* !< DIO16 Offset */
+#define GPIO_CPU_INT_ISET_DIO16_MASK             ((uint32_t)0x00010000U)         /* !< DIO16 event */
+#define GPIO_CPU_INT_ISET_DIO16_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO16_SET              ((uint32_t)0x00010000U)         /* !< Sets DIO16 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO17] Bits */
+#define GPIO_CPU_INT_ISET_DIO17_OFS              (17)                            /* !< DIO17 Offset */
+#define GPIO_CPU_INT_ISET_DIO17_MASK             ((uint32_t)0x00020000U)         /* !< DIO17 event */
+#define GPIO_CPU_INT_ISET_DIO17_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO17_SET              ((uint32_t)0x00020000U)         /* !< Sets DIO17 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO18] Bits */
+#define GPIO_CPU_INT_ISET_DIO18_OFS              (18)                            /* !< DIO18 Offset */
+#define GPIO_CPU_INT_ISET_DIO18_MASK             ((uint32_t)0x00040000U)         /* !< DIO18 event */
+#define GPIO_CPU_INT_ISET_DIO18_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO18_SET              ((uint32_t)0x00040000U)         /* !< Sets DIO18 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO19] Bits */
+#define GPIO_CPU_INT_ISET_DIO19_OFS              (19)                            /* !< DIO19 Offset */
+#define GPIO_CPU_INT_ISET_DIO19_MASK             ((uint32_t)0x00080000U)         /* !< DIO19 event */
+#define GPIO_CPU_INT_ISET_DIO19_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO19_SET              ((uint32_t)0x00080000U)         /* !< Sets DIO19 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO20] Bits */
+#define GPIO_CPU_INT_ISET_DIO20_OFS              (20)                            /* !< DIO20 Offset */
+#define GPIO_CPU_INT_ISET_DIO20_MASK             ((uint32_t)0x00100000U)         /* !< DIO20 event */
+#define GPIO_CPU_INT_ISET_DIO20_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO20_SET              ((uint32_t)0x00100000U)         /* !< Sets DIO20 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO21] Bits */
+#define GPIO_CPU_INT_ISET_DIO21_OFS              (21)                            /* !< DIO21 Offset */
+#define GPIO_CPU_INT_ISET_DIO21_MASK             ((uint32_t)0x00200000U)         /* !< DIO21 event */
+#define GPIO_CPU_INT_ISET_DIO21_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO21_SET              ((uint32_t)0x00200000U)         /* !< Sets DIO21 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO22] Bits */
+#define GPIO_CPU_INT_ISET_DIO22_OFS              (22)                            /* !< DIO22 Offset */
+#define GPIO_CPU_INT_ISET_DIO22_MASK             ((uint32_t)0x00400000U)         /* !< DIO22 event */
+#define GPIO_CPU_INT_ISET_DIO22_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO22_SET              ((uint32_t)0x00400000U)         /* !< Sets DIO22 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO23] Bits */
+#define GPIO_CPU_INT_ISET_DIO23_OFS              (23)                            /* !< DIO23 Offset */
+#define GPIO_CPU_INT_ISET_DIO23_MASK             ((uint32_t)0x00800000U)         /* !< DIO23 event */
+#define GPIO_CPU_INT_ISET_DIO23_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO23_SET              ((uint32_t)0x00800000U)         /* !< Sets DIO23 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO24] Bits */
+#define GPIO_CPU_INT_ISET_DIO24_OFS              (24)                            /* !< DIO24 Offset */
+#define GPIO_CPU_INT_ISET_DIO24_MASK             ((uint32_t)0x01000000U)         /* !< DIO24 event */
+#define GPIO_CPU_INT_ISET_DIO24_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO24_SET              ((uint32_t)0x01000000U)         /* !< Sets DIO24 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO25] Bits */
+#define GPIO_CPU_INT_ISET_DIO25_OFS              (25)                            /* !< DIO25 Offset */
+#define GPIO_CPU_INT_ISET_DIO25_MASK             ((uint32_t)0x02000000U)         /* !< DIO25 event */
+#define GPIO_CPU_INT_ISET_DIO25_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO25_SET              ((uint32_t)0x02000000U)         /* !< Sets DIO25 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO26] Bits */
+#define GPIO_CPU_INT_ISET_DIO26_OFS              (26)                            /* !< DIO26 Offset */
+#define GPIO_CPU_INT_ISET_DIO26_MASK             ((uint32_t)0x04000000U)         /* !< DIO26 event */
+#define GPIO_CPU_INT_ISET_DIO26_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO26_SET              ((uint32_t)0x04000000U)         /* !< Sets DIO26 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO27] Bits */
+#define GPIO_CPU_INT_ISET_DIO27_OFS              (27)                            /* !< DIO27 Offset */
+#define GPIO_CPU_INT_ISET_DIO27_MASK             ((uint32_t)0x08000000U)         /* !< DIO27 event */
+#define GPIO_CPU_INT_ISET_DIO27_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO27_SET              ((uint32_t)0x08000000U)         /* !< Sets DIO27 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO28] Bits */
+#define GPIO_CPU_INT_ISET_DIO28_OFS              (28)                            /* !< DIO28 Offset */
+#define GPIO_CPU_INT_ISET_DIO28_MASK             ((uint32_t)0x10000000U)         /* !< DIO28 event */
+#define GPIO_CPU_INT_ISET_DIO28_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO28_SET              ((uint32_t)0x10000000U)         /* !< Sets DIO28 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO29] Bits */
+#define GPIO_CPU_INT_ISET_DIO29_OFS              (29)                            /* !< DIO29 Offset */
+#define GPIO_CPU_INT_ISET_DIO29_MASK             ((uint32_t)0x20000000U)         /* !< DIO29 event */
+#define GPIO_CPU_INT_ISET_DIO29_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO29_SET              ((uint32_t)0x20000000U)         /* !< Sets DIO29 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO30] Bits */
+#define GPIO_CPU_INT_ISET_DIO30_OFS              (30)                            /* !< DIO30 Offset */
+#define GPIO_CPU_INT_ISET_DIO30_MASK             ((uint32_t)0x40000000U)         /* !< DIO30 event */
+#define GPIO_CPU_INT_ISET_DIO30_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO30_SET              ((uint32_t)0x40000000U)         /* !< Sets DIO30 in RIS register */
+/* GPIO_CPU_INT_ISET[DIO31] Bits */
+#define GPIO_CPU_INT_ISET_DIO31_OFS              (31)                            /* !< DIO31 Offset */
+#define GPIO_CPU_INT_ISET_DIO31_MASK             ((uint32_t)0x80000000U)         /* !< DIO31 event */
+#define GPIO_CPU_INT_ISET_DIO31_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ISET_DIO31_SET              ((uint32_t)0x80000000U)         /* !< Sets DIO31 in RIS register */
+
+/* GPIO_CPU_INT_ICLR Bits */
+/* GPIO_CPU_INT_ICLR[DIO0] Bits */
+#define GPIO_CPU_INT_ICLR_DIO0_OFS               (0)                             /* !< DIO0 Offset */
+#define GPIO_CPU_INT_ICLR_DIO0_MASK              ((uint32_t)0x00000001U)         /* !< DIO0 event */
+#define GPIO_CPU_INT_ICLR_DIO0_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO0_CLR               ((uint32_t)0x00000001U)         /* !< Clears DIO0 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO1] Bits */
+#define GPIO_CPU_INT_ICLR_DIO1_OFS               (1)                             /* !< DIO1 Offset */
+#define GPIO_CPU_INT_ICLR_DIO1_MASK              ((uint32_t)0x00000002U)         /* !< DIO1 event */
+#define GPIO_CPU_INT_ICLR_DIO1_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO1_CLR               ((uint32_t)0x00000002U)         /* !< Clears DIO1 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO2] Bits */
+#define GPIO_CPU_INT_ICLR_DIO2_OFS               (2)                             /* !< DIO2 Offset */
+#define GPIO_CPU_INT_ICLR_DIO2_MASK              ((uint32_t)0x00000004U)         /* !< DIO2 event */
+#define GPIO_CPU_INT_ICLR_DIO2_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO2_CLR               ((uint32_t)0x00000004U)         /* !< Clears DIO2 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO3] Bits */
+#define GPIO_CPU_INT_ICLR_DIO3_OFS               (3)                             /* !< DIO3 Offset */
+#define GPIO_CPU_INT_ICLR_DIO3_MASK              ((uint32_t)0x00000008U)         /* !< DIO3 event */
+#define GPIO_CPU_INT_ICLR_DIO3_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO3_CLR               ((uint32_t)0x00000008U)         /* !< Clears DIO3 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO4] Bits */
+#define GPIO_CPU_INT_ICLR_DIO4_OFS               (4)                             /* !< DIO4 Offset */
+#define GPIO_CPU_INT_ICLR_DIO4_MASK              ((uint32_t)0x00000010U)         /* !< DIO4 event */
+#define GPIO_CPU_INT_ICLR_DIO4_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO4_CLR               ((uint32_t)0x00000010U)         /* !< Clears DIO4 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO5] Bits */
+#define GPIO_CPU_INT_ICLR_DIO5_OFS               (5)                             /* !< DIO5 Offset */
+#define GPIO_CPU_INT_ICLR_DIO5_MASK              ((uint32_t)0x00000020U)         /* !< DIO5 event */
+#define GPIO_CPU_INT_ICLR_DIO5_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO5_CLR               ((uint32_t)0x00000020U)         /* !< Clears DIO5 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO6] Bits */
+#define GPIO_CPU_INT_ICLR_DIO6_OFS               (6)                             /* !< DIO6 Offset */
+#define GPIO_CPU_INT_ICLR_DIO6_MASK              ((uint32_t)0x00000040U)         /* !< DIO6 event */
+#define GPIO_CPU_INT_ICLR_DIO6_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO6_CLR               ((uint32_t)0x00000040U)         /* !< Clears DIO6 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO7] Bits */
+#define GPIO_CPU_INT_ICLR_DIO7_OFS               (7)                             /* !< DIO7 Offset */
+#define GPIO_CPU_INT_ICLR_DIO7_MASK              ((uint32_t)0x00000080U)         /* !< DIO7 event */
+#define GPIO_CPU_INT_ICLR_DIO7_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO7_CLR               ((uint32_t)0x00000080U)         /* !< Clears DIO7 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO8] Bits */
+#define GPIO_CPU_INT_ICLR_DIO8_OFS               (8)                             /* !< DIO8 Offset */
+#define GPIO_CPU_INT_ICLR_DIO8_MASK              ((uint32_t)0x00000100U)         /* !< DIO8 event */
+#define GPIO_CPU_INT_ICLR_DIO8_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO8_CLR               ((uint32_t)0x00000100U)         /* !< Clears DIO8 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO9] Bits */
+#define GPIO_CPU_INT_ICLR_DIO9_OFS               (9)                             /* !< DIO9 Offset */
+#define GPIO_CPU_INT_ICLR_DIO9_MASK              ((uint32_t)0x00000200U)         /* !< DIO9 event */
+#define GPIO_CPU_INT_ICLR_DIO9_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO9_CLR               ((uint32_t)0x00000200U)         /* !< Clears DIO9 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO10] Bits */
+#define GPIO_CPU_INT_ICLR_DIO10_OFS              (10)                            /* !< DIO10 Offset */
+#define GPIO_CPU_INT_ICLR_DIO10_MASK             ((uint32_t)0x00000400U)         /* !< DIO10 event */
+#define GPIO_CPU_INT_ICLR_DIO10_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO10_CLR              ((uint32_t)0x00000400U)         /* !< Clears DIO10 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO11] Bits */
+#define GPIO_CPU_INT_ICLR_DIO11_OFS              (11)                            /* !< DIO11 Offset */
+#define GPIO_CPU_INT_ICLR_DIO11_MASK             ((uint32_t)0x00000800U)         /* !< DIO11 event */
+#define GPIO_CPU_INT_ICLR_DIO11_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO11_CLR              ((uint32_t)0x00000800U)         /* !< Clears DIO11 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO12] Bits */
+#define GPIO_CPU_INT_ICLR_DIO12_OFS              (12)                            /* !< DIO12 Offset */
+#define GPIO_CPU_INT_ICLR_DIO12_MASK             ((uint32_t)0x00001000U)         /* !< DIO12 event */
+#define GPIO_CPU_INT_ICLR_DIO12_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO12_CLR              ((uint32_t)0x00001000U)         /* !< Clears DIO12 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO13] Bits */
+#define GPIO_CPU_INT_ICLR_DIO13_OFS              (13)                            /* !< DIO13 Offset */
+#define GPIO_CPU_INT_ICLR_DIO13_MASK             ((uint32_t)0x00002000U)         /* !< DIO13 event */
+#define GPIO_CPU_INT_ICLR_DIO13_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO13_CLR              ((uint32_t)0x00002000U)         /* !< Clears DIO13 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO14] Bits */
+#define GPIO_CPU_INT_ICLR_DIO14_OFS              (14)                            /* !< DIO14 Offset */
+#define GPIO_CPU_INT_ICLR_DIO14_MASK             ((uint32_t)0x00004000U)         /* !< DIO14 event */
+#define GPIO_CPU_INT_ICLR_DIO14_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO14_CLR              ((uint32_t)0x00004000U)         /* !< Clears DIO14 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO15] Bits */
+#define GPIO_CPU_INT_ICLR_DIO15_OFS              (15)                            /* !< DIO15 Offset */
+#define GPIO_CPU_INT_ICLR_DIO15_MASK             ((uint32_t)0x00008000U)         /* !< DIO15 event */
+#define GPIO_CPU_INT_ICLR_DIO15_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO15_CLR              ((uint32_t)0x00008000U)         /* !< Clears DIO15 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO16] Bits */
+#define GPIO_CPU_INT_ICLR_DIO16_OFS              (16)                            /* !< DIO16 Offset */
+#define GPIO_CPU_INT_ICLR_DIO16_MASK             ((uint32_t)0x00010000U)         /* !< DIO16 event */
+#define GPIO_CPU_INT_ICLR_DIO16_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO16_CLR              ((uint32_t)0x00010000U)         /* !< Clears DIO16 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO17] Bits */
+#define GPIO_CPU_INT_ICLR_DIO17_OFS              (17)                            /* !< DIO17 Offset */
+#define GPIO_CPU_INT_ICLR_DIO17_MASK             ((uint32_t)0x00020000U)         /* !< DIO17 event */
+#define GPIO_CPU_INT_ICLR_DIO17_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO17_CLR              ((uint32_t)0x00020000U)         /* !< Clears DIO17 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO18] Bits */
+#define GPIO_CPU_INT_ICLR_DIO18_OFS              (18)                            /* !< DIO18 Offset */
+#define GPIO_CPU_INT_ICLR_DIO18_MASK             ((uint32_t)0x00040000U)         /* !< DIO18 event */
+#define GPIO_CPU_INT_ICLR_DIO18_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO18_CLR              ((uint32_t)0x00040000U)         /* !< Clears DIO18 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO19] Bits */
+#define GPIO_CPU_INT_ICLR_DIO19_OFS              (19)                            /* !< DIO19 Offset */
+#define GPIO_CPU_INT_ICLR_DIO19_MASK             ((uint32_t)0x00080000U)         /* !< DIO19 event */
+#define GPIO_CPU_INT_ICLR_DIO19_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO19_CLR              ((uint32_t)0x00080000U)         /* !< Clears DIO19 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO20] Bits */
+#define GPIO_CPU_INT_ICLR_DIO20_OFS              (20)                            /* !< DIO20 Offset */
+#define GPIO_CPU_INT_ICLR_DIO20_MASK             ((uint32_t)0x00100000U)         /* !< DIO20 event */
+#define GPIO_CPU_INT_ICLR_DIO20_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO20_CLR              ((uint32_t)0x00100000U)         /* !< Clears DIO20 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO21] Bits */
+#define GPIO_CPU_INT_ICLR_DIO21_OFS              (21)                            /* !< DIO21 Offset */
+#define GPIO_CPU_INT_ICLR_DIO21_MASK             ((uint32_t)0x00200000U)         /* !< DIO21 event */
+#define GPIO_CPU_INT_ICLR_DIO21_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO21_CLR              ((uint32_t)0x00200000U)         /* !< Clears DIO21 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO22] Bits */
+#define GPIO_CPU_INT_ICLR_DIO22_OFS              (22)                            /* !< DIO22 Offset */
+#define GPIO_CPU_INT_ICLR_DIO22_MASK             ((uint32_t)0x00400000U)         /* !< DIO22 event */
+#define GPIO_CPU_INT_ICLR_DIO22_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO22_CLR              ((uint32_t)0x00400000U)         /* !< Clears DIO22 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO23] Bits */
+#define GPIO_CPU_INT_ICLR_DIO23_OFS              (23)                            /* !< DIO23 Offset */
+#define GPIO_CPU_INT_ICLR_DIO23_MASK             ((uint32_t)0x00800000U)         /* !< DIO23 event */
+#define GPIO_CPU_INT_ICLR_DIO23_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO23_CLR              ((uint32_t)0x00800000U)         /* !< Clears DIO23 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO24] Bits */
+#define GPIO_CPU_INT_ICLR_DIO24_OFS              (24)                            /* !< DIO24 Offset */
+#define GPIO_CPU_INT_ICLR_DIO24_MASK             ((uint32_t)0x01000000U)         /* !< DIO24 event */
+#define GPIO_CPU_INT_ICLR_DIO24_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO24_CLR              ((uint32_t)0x01000000U)         /* !< Clears DIO24 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO25] Bits */
+#define GPIO_CPU_INT_ICLR_DIO25_OFS              (25)                            /* !< DIO25 Offset */
+#define GPIO_CPU_INT_ICLR_DIO25_MASK             ((uint32_t)0x02000000U)         /* !< DIO25 event */
+#define GPIO_CPU_INT_ICLR_DIO25_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO25_CLR              ((uint32_t)0x02000000U)         /* !< Clears DIO25 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO26] Bits */
+#define GPIO_CPU_INT_ICLR_DIO26_OFS              (26)                            /* !< DIO26 Offset */
+#define GPIO_CPU_INT_ICLR_DIO26_MASK             ((uint32_t)0x04000000U)         /* !< DIO26 event */
+#define GPIO_CPU_INT_ICLR_DIO26_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO26_CLR              ((uint32_t)0x04000000U)         /* !< Clears DIO26 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO27] Bits */
+#define GPIO_CPU_INT_ICLR_DIO27_OFS              (27)                            /* !< DIO27 Offset */
+#define GPIO_CPU_INT_ICLR_DIO27_MASK             ((uint32_t)0x08000000U)         /* !< DIO27 event */
+#define GPIO_CPU_INT_ICLR_DIO27_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO27_CLR              ((uint32_t)0x08000000U)         /* !< Clears DIO27 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO28] Bits */
+#define GPIO_CPU_INT_ICLR_DIO28_OFS              (28)                            /* !< DIO28 Offset */
+#define GPIO_CPU_INT_ICLR_DIO28_MASK             ((uint32_t)0x10000000U)         /* !< DIO28 event */
+#define GPIO_CPU_INT_ICLR_DIO28_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO28_CLR              ((uint32_t)0x10000000U)         /* !< Clears DIO28 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO29] Bits */
+#define GPIO_CPU_INT_ICLR_DIO29_OFS              (29)                            /* !< DIO29 Offset */
+#define GPIO_CPU_INT_ICLR_DIO29_MASK             ((uint32_t)0x20000000U)         /* !< DIO29 event */
+#define GPIO_CPU_INT_ICLR_DIO29_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO29_CLR              ((uint32_t)0x20000000U)         /* !< Clears DIO29 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO30] Bits */
+#define GPIO_CPU_INT_ICLR_DIO30_OFS              (30)                            /* !< DIO30 Offset */
+#define GPIO_CPU_INT_ICLR_DIO30_MASK             ((uint32_t)0x40000000U)         /* !< DIO30 event */
+#define GPIO_CPU_INT_ICLR_DIO30_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO30_CLR              ((uint32_t)0x40000000U)         /* !< Clears DIO30 in RIS register */
+/* GPIO_CPU_INT_ICLR[DIO31] Bits */
+#define GPIO_CPU_INT_ICLR_DIO31_OFS              (31)                            /* !< DIO31 Offset */
+#define GPIO_CPU_INT_ICLR_DIO31_MASK             ((uint32_t)0x80000000U)         /* !< DIO31 event */
+#define GPIO_CPU_INT_ICLR_DIO31_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_CPU_INT_ICLR_DIO31_CLR              ((uint32_t)0x80000000U)         /* !< Clears DIO31 in RIS register */
+
+/* GPIO_PWREN Bits */
+/* GPIO_PWREN[ENABLE] Bits */
+#define GPIO_PWREN_ENABLE_OFS                    (0)                             /* !< ENABLE Offset */
+#define GPIO_PWREN_ENABLE_MASK                   ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define GPIO_PWREN_ENABLE_DISABLE                ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define GPIO_PWREN_ENABLE_ENABLE                 ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* GPIO_PWREN[KEY] Bits */
+#define GPIO_PWREN_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define GPIO_PWREN_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define GPIO_PWREN_KEY_UNLOCK_W                  ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* GPIO_RSTCTL Bits */
+/* GPIO_RSTCTL[RESETSTKYCLR] Bits */
+#define GPIO_RSTCTL_RESETSTKYCLR_OFS             (1)                             /* !< RESETSTKYCLR Offset */
+#define GPIO_RSTCTL_RESETSTKYCLR_MASK            ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define GPIO_RSTCTL_RESETSTKYCLR_NOP             ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define GPIO_RSTCTL_RESETSTKYCLR_CLR             ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* GPIO_RSTCTL[RESETASSERT] Bits */
+#define GPIO_RSTCTL_RESETASSERT_OFS              (0)                             /* !< RESETASSERT Offset */
+#define GPIO_RSTCTL_RESETASSERT_MASK             ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define GPIO_RSTCTL_RESETASSERT_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define GPIO_RSTCTL_RESETASSERT_ASSERT           ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* GPIO_RSTCTL[KEY] Bits */
+#define GPIO_RSTCTL_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define GPIO_RSTCTL_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define GPIO_RSTCTL_KEY_UNLOCK_W                 ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* GPIO_STAT Bits */
+/* GPIO_STAT[RESETSTKY] Bits */
+#define GPIO_STAT_RESETSTKY_OFS                  (16)                            /* !< RESETSTKY Offset */
+#define GPIO_STAT_RESETSTKY_MASK                 ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define GPIO_STAT_RESETSTKY_NORES                ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define GPIO_STAT_RESETSTKY_RESET                ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* GPIO_FSUB_0 Bits */
+/* GPIO_FSUB_0[CHANID] Bits */
+#define GPIO_FSUB_0_CHANID_OFS                   (0)                             /* !< CHANID Offset */
+#define GPIO_FSUB_0_CHANID_MASK                  ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define GPIO_FSUB_0_CHANID_MNIMUM                ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define GPIO_FSUB_0_CHANID_UNCONNECTED           ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define GPIO_FSUB_0_CHANID_MAXIMUM               ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* GPIO_FSUB_1 Bits */
+/* GPIO_FSUB_1[CHANID] Bits */
+#define GPIO_FSUB_1_CHANID_OFS                   (0)                             /* !< CHANID Offset */
+#define GPIO_FSUB_1_CHANID_MASK                  ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define GPIO_FSUB_1_CHANID_MNIMUM                ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define GPIO_FSUB_1_CHANID_UNCONNECTED           ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define GPIO_FSUB_1_CHANID_MAXIMUM               ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* GPIO_FPUB_0 Bits */
+/* GPIO_FPUB_0[CHANID] Bits */
+#define GPIO_FPUB_0_CHANID_OFS                   (0)                             /* !< CHANID Offset */
+#define GPIO_FPUB_0_CHANID_MASK                  ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define GPIO_FPUB_0_CHANID_MNIMUM                ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define GPIO_FPUB_0_CHANID_UNCONNECTED           ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define GPIO_FPUB_0_CHANID_MAXIMUM               ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* GPIO_FPUB_1 Bits */
+/* GPIO_FPUB_1[CHANID] Bits */
+#define GPIO_FPUB_1_CHANID_OFS                   (0)                             /* !< CHANID Offset */
+#define GPIO_FPUB_1_CHANID_MASK                  ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define GPIO_FPUB_1_CHANID_MNIMUM                ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define GPIO_FPUB_1_CHANID_UNCONNECTED           ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define GPIO_FPUB_1_CHANID_MAXIMUM               ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* GPIO_CLKOVR Bits */
+/* GPIO_CLKOVR[OVERRIDE] Bits */
+#define GPIO_CLKOVR_OVERRIDE_OFS                 (0)                             /* !< OVERRIDE Offset */
+#define GPIO_CLKOVR_OVERRIDE_MASK                ((uint32_t)0x00000001U)         /* !< Unlocks the functionality of
+                                                                                    [RUN_STOP] to override the automatic
+                                                                                    peripheral clock request */
+#define GPIO_CLKOVR_OVERRIDE_DISABLED            ((uint32_t)0x00000000U)         /* !< Override disabled */
+#define GPIO_CLKOVR_OVERRIDE_ENABLED             ((uint32_t)0x00000001U)         /* !< Override enabled */
+/* GPIO_CLKOVR[RUN_STOP] Bits */
+#define GPIO_CLKOVR_RUN_STOP_OFS                 (1)                             /* !< RUN_STOP Offset */
+#define GPIO_CLKOVR_RUN_STOP_MASK                ((uint32_t)0x00000002U)         /* !< If [OVERRIDE] is enabled, this
+                                                                                    register is used to manually control
+                                                                                    the peripheral's clock request to the
+                                                                                    system */
+#define GPIO_CLKOVR_RUN_STOP_RUN                 ((uint32_t)0x00000000U)         /* !< Run/ungate functional clock */
+#define GPIO_CLKOVR_RUN_STOP_STOP                ((uint32_t)0x00000002U)         /* !< Stop/gate functional clock */
+
+/* GPIO_PDBGCTL Bits */
+/* GPIO_PDBGCTL[FREE] Bits */
+#define GPIO_PDBGCTL_FREE_OFS                    (0)                             /* !< FREE Offset */
+#define GPIO_PDBGCTL_FREE_MASK                   ((uint32_t)0x00000001U)         /* !< Free run control */
+#define GPIO_PDBGCTL_FREE_STOP                   ((uint32_t)0x00000000U)         /* !< The peripheral freezes
+                                                                                    functionality while the Core Halted
+                                                                                    input is asserted and resumes when it
+                                                                                    is deasserted. */
+#define GPIO_PDBGCTL_FREE_RUN                    ((uint32_t)0x00000001U)         /* !< The peripheral ignores the state of
+                                                                                    the Core Halted input */
+
+/* GPIO_EVT_MODE Bits */
+/* GPIO_EVT_MODE[INT0_CFG] Bits */
+#define GPIO_EVT_MODE_INT0_CFG_OFS               (0)                             /* !< INT0_CFG Offset */
+#define GPIO_EVT_MODE_INT0_CFG_MASK              ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to [IPSTANDARD.CPU_INT] */
+#define GPIO_EVT_MODE_INT0_CFG_DISABLE           ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define GPIO_EVT_MODE_INT0_CFG_SOFTWARE          ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define GPIO_EVT_MODE_INT0_CFG_HARDWARE          ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* GPIO_EVT_MODE[EVT1_CFG] Bits */
+#define GPIO_EVT_MODE_EVT1_CFG_OFS               (2)                             /* !< EVT1_CFG Offset */
+#define GPIO_EVT_MODE_EVT1_CFG_MASK              ((uint32_t)0x0000000CU)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.GEN_EVENT0] */
+#define GPIO_EVT_MODE_EVT1_CFG_DISABLE           ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define GPIO_EVT_MODE_EVT1_CFG_SOFTWARE          ((uint32_t)0x00000004U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define GPIO_EVT_MODE_EVT1_CFG_HARDWARE          ((uint32_t)0x00000008U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* GPIO_EVT_MODE[EVT2_CFG] Bits */
+#define GPIO_EVT_MODE_EVT2_CFG_OFS               (4)                             /* !< EVT2_CFG Offset */
+#define GPIO_EVT_MODE_EVT2_CFG_MASK              ((uint32_t)0x00000030U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.GEN_EVENT1] */
+#define GPIO_EVT_MODE_EVT2_CFG_DISABLE           ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define GPIO_EVT_MODE_EVT2_CFG_SOFTWARE          ((uint32_t)0x00000010U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define GPIO_EVT_MODE_EVT2_CFG_HARDWARE          ((uint32_t)0x00000020U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* GPIO_DESC Bits */
+/* GPIO_DESC[MINREV] Bits */
+#define GPIO_DESC_MINREV_OFS                     (0)                             /* !< MINREV Offset */
+#define GPIO_DESC_MINREV_MASK                    ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+#define GPIO_DESC_MINREV_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define GPIO_DESC_MINREV_MAXIMUM                 ((uint32_t)0x0000000FU)         /* !< Highest possible value */
+/* GPIO_DESC[MAJREV] Bits */
+#define GPIO_DESC_MAJREV_OFS                     (4)                             /* !< MAJREV Offset */
+#define GPIO_DESC_MAJREV_MASK                    ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+#define GPIO_DESC_MAJREV_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define GPIO_DESC_MAJREV_MAXIMUM                 ((uint32_t)0x000000F0U)         /* !< Highest possible value */
+/* GPIO_DESC[FEATUREVER] Bits */
+#define GPIO_DESC_FEATUREVER_OFS                 (12)                            /* !< FEATUREVER Offset */
+#define GPIO_DESC_FEATUREVER_MASK                ((uint32_t)0x0000F000U)         /* !< Feature Set for the module
+                                                                                    *instance* */
+#define GPIO_DESC_FEATUREVER_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define GPIO_DESC_FEATUREVER_MAXIMUM             ((uint32_t)0x0000F000U)         /* !< Highest possible value */
+/* GPIO_DESC[MODULEID] Bits */
+#define GPIO_DESC_MODULEID_OFS                   (16)                            /* !< MODULEID Offset */
+#define GPIO_DESC_MODULEID_MASK                  ((uint32_t)0xFFFF0000U)         /* !< Module identification contains a
+                                                                                    unique peripheral identification
+                                                                                    number. The assignments are
+                                                                                    maintained in a central database for
+                                                                                    all of the platform modules to ensure
+                                                                                    uniqueness. */
+#define GPIO_DESC_MODULEID_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define GPIO_DESC_MODULEID_MAXIMUM               ((uint32_t)0xFFFF0000U)         /* !< Highest possible value */
+
+/* GPIO_DOUT3_0 Bits */
+/* GPIO_DOUT3_0[DIO0] Bits */
+#define GPIO_DOUT3_0_DIO0_OFS                    (0)                             /* !< DIO0 Offset */
+#define GPIO_DOUT3_0_DIO0_MASK                   ((uint32_t)0x00000001U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO0 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT3_0_DIO0_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT3_0_DIO0_ONE                    ((uint32_t)0x00000001U)         /* !< Output is set to 1 */
+/* GPIO_DOUT3_0[DIO1] Bits */
+#define GPIO_DOUT3_0_DIO1_OFS                    (8)                             /* !< DIO1 Offset */
+#define GPIO_DOUT3_0_DIO1_MASK                   ((uint32_t)0x00000100U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO1 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT3_0_DIO1_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT3_0_DIO1_ONE                    ((uint32_t)0x00000100U)         /* !< Output is set to 1 */
+/* GPIO_DOUT3_0[DIO2] Bits */
+#define GPIO_DOUT3_0_DIO2_OFS                    (16)                            /* !< DIO2 Offset */
+#define GPIO_DOUT3_0_DIO2_MASK                   ((uint32_t)0x00010000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO2 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT3_0_DIO2_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT3_0_DIO2_ONE                    ((uint32_t)0x00010000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT3_0[DIO3] Bits */
+#define GPIO_DOUT3_0_DIO3_OFS                    (24)                            /* !< DIO3 Offset */
+#define GPIO_DOUT3_0_DIO3_MASK                   ((uint32_t)0x01000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO3 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT3_0_DIO3_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT3_0_DIO3_ONE                    ((uint32_t)0x01000000U)         /* !< Output is set to 1 */
+
+/* GPIO_DOUT7_4 Bits */
+/* GPIO_DOUT7_4[DIO4] Bits */
+#define GPIO_DOUT7_4_DIO4_OFS                    (0)                             /* !< DIO4 Offset */
+#define GPIO_DOUT7_4_DIO4_MASK                   ((uint32_t)0x00000001U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO4 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT7_4_DIO4_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT7_4_DIO4_ONE                    ((uint32_t)0x00000001U)         /* !< Output is set to 1 */
+/* GPIO_DOUT7_4[DIO5] Bits */
+#define GPIO_DOUT7_4_DIO5_OFS                    (8)                             /* !< DIO5 Offset */
+#define GPIO_DOUT7_4_DIO5_MASK                   ((uint32_t)0x00000100U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO5 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT7_4_DIO5_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT7_4_DIO5_ONE                    ((uint32_t)0x00000100U)         /* !< Output is set to 1 */
+/* GPIO_DOUT7_4[DIO6] Bits */
+#define GPIO_DOUT7_4_DIO6_OFS                    (16)                            /* !< DIO6 Offset */
+#define GPIO_DOUT7_4_DIO6_MASK                   ((uint32_t)0x00010000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO6 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT7_4_DIO6_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT7_4_DIO6_ONE                    ((uint32_t)0x00010000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT7_4[DIO7] Bits */
+#define GPIO_DOUT7_4_DIO7_OFS                    (24)                            /* !< DIO7 Offset */
+#define GPIO_DOUT7_4_DIO7_MASK                   ((uint32_t)0x01000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO7 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT7_4_DIO7_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT7_4_DIO7_ONE                    ((uint32_t)0x01000000U)         /* !< Output is set to 1 */
+
+/* GPIO_DOUT11_8 Bits */
+/* GPIO_DOUT11_8[DIO8] Bits */
+#define GPIO_DOUT11_8_DIO8_OFS                   (0)                             /* !< DIO8 Offset */
+#define GPIO_DOUT11_8_DIO8_MASK                  ((uint32_t)0x00000001U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO8 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT11_8_DIO8_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT11_8_DIO8_ONE                   ((uint32_t)0x00000001U)         /* !< Output is set to 1 */
+/* GPIO_DOUT11_8[DIO9] Bits */
+#define GPIO_DOUT11_8_DIO9_OFS                   (8)                             /* !< DIO9 Offset */
+#define GPIO_DOUT11_8_DIO9_MASK                  ((uint32_t)0x00000100U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO9 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT11_8_DIO9_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT11_8_DIO9_ONE                   ((uint32_t)0x00000100U)         /* !< Output is set to 1 */
+/* GPIO_DOUT11_8[DIO10] Bits */
+#define GPIO_DOUT11_8_DIO10_OFS                  (16)                            /* !< DIO10 Offset */
+#define GPIO_DOUT11_8_DIO10_MASK                 ((uint32_t)0x00010000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO10 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT11_8_DIO10_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT11_8_DIO10_ONE                  ((uint32_t)0x00010000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT11_8[DIO11] Bits */
+#define GPIO_DOUT11_8_DIO11_OFS                  (24)                            /* !< DIO11 Offset */
+#define GPIO_DOUT11_8_DIO11_MASK                 ((uint32_t)0x01000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO11 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT11_8_DIO11_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT11_8_DIO11_ONE                  ((uint32_t)0x01000000U)         /* !< Output is set to 1 */
+
+/* GPIO_DOUT15_12 Bits */
+/* GPIO_DOUT15_12[DIO12] Bits */
+#define GPIO_DOUT15_12_DIO12_OFS                 (0)                             /* !< DIO12 Offset */
+#define GPIO_DOUT15_12_DIO12_MASK                ((uint32_t)0x00000001U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO12 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT15_12_DIO12_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT15_12_DIO12_ONE                 ((uint32_t)0x00000001U)         /* !< Output is set to 1 */
+/* GPIO_DOUT15_12[DIO13] Bits */
+#define GPIO_DOUT15_12_DIO13_OFS                 (8)                             /* !< DIO13 Offset */
+#define GPIO_DOUT15_12_DIO13_MASK                ((uint32_t)0x00000100U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO13 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT15_12_DIO13_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT15_12_DIO13_ONE                 ((uint32_t)0x00000100U)         /* !< Output is set to 1 */
+/* GPIO_DOUT15_12[DIO14] Bits */
+#define GPIO_DOUT15_12_DIO14_OFS                 (16)                            /* !< DIO14 Offset */
+#define GPIO_DOUT15_12_DIO14_MASK                ((uint32_t)0x00010000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO14 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT15_12_DIO14_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT15_12_DIO14_ONE                 ((uint32_t)0x00010000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT15_12[DIO15] Bits */
+#define GPIO_DOUT15_12_DIO15_OFS                 (24)                            /* !< DIO15 Offset */
+#define GPIO_DOUT15_12_DIO15_MASK                ((uint32_t)0x01000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO15 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT15_12_DIO15_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT15_12_DIO15_ONE                 ((uint32_t)0x01000000U)         /* !< Output is set to 1 */
+
+/* GPIO_DOUT19_16 Bits */
+/* GPIO_DOUT19_16[DIO16] Bits */
+#define GPIO_DOUT19_16_DIO16_OFS                 (0)                             /* !< DIO16 Offset */
+#define GPIO_DOUT19_16_DIO16_MASK                ((uint32_t)0x00000001U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO16 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT19_16_DIO16_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT19_16_DIO16_ONE                 ((uint32_t)0x00000001U)         /* !< Output is set to 1 */
+/* GPIO_DOUT19_16[DIO17] Bits */
+#define GPIO_DOUT19_16_DIO17_OFS                 (8)                             /* !< DIO17 Offset */
+#define GPIO_DOUT19_16_DIO17_MASK                ((uint32_t)0x00000100U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO17 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT19_16_DIO17_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT19_16_DIO17_ONE                 ((uint32_t)0x00000100U)         /* !< Output is set to 1 */
+/* GPIO_DOUT19_16[DIO18] Bits */
+#define GPIO_DOUT19_16_DIO18_OFS                 (16)                            /* !< DIO18 Offset */
+#define GPIO_DOUT19_16_DIO18_MASK                ((uint32_t)0x00010000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO18 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT19_16_DIO18_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT19_16_DIO18_ONE                 ((uint32_t)0x00010000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT19_16[DIO19] Bits */
+#define GPIO_DOUT19_16_DIO19_OFS                 (24)                            /* !< DIO19 Offset */
+#define GPIO_DOUT19_16_DIO19_MASK                ((uint32_t)0x01000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO19 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT19_16_DIO19_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT19_16_DIO19_ONE                 ((uint32_t)0x01000000U)         /* !< Output is set to 1 */
+
+/* GPIO_DOUT23_20 Bits */
+/* GPIO_DOUT23_20[DIO20] Bits */
+#define GPIO_DOUT23_20_DIO20_OFS                 (0)                             /* !< DIO20 Offset */
+#define GPIO_DOUT23_20_DIO20_MASK                ((uint32_t)0x00000001U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO20 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT23_20_DIO20_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT23_20_DIO20_ONE                 ((uint32_t)0x00000001U)         /* !< Output is set to 1 */
+/* GPIO_DOUT23_20[DIO21] Bits */
+#define GPIO_DOUT23_20_DIO21_OFS                 (8)                             /* !< DIO21 Offset */
+#define GPIO_DOUT23_20_DIO21_MASK                ((uint32_t)0x00000100U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO21 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT23_20_DIO21_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT23_20_DIO21_ONE                 ((uint32_t)0x00000100U)         /* !< Output is set to 1 */
+/* GPIO_DOUT23_20[DIO22] Bits */
+#define GPIO_DOUT23_20_DIO22_OFS                 (16)                            /* !< DIO22 Offset */
+#define GPIO_DOUT23_20_DIO22_MASK                ((uint32_t)0x00010000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO22 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT23_20_DIO22_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT23_20_DIO22_ONE                 ((uint32_t)0x00010000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT23_20[DIO23] Bits */
+#define GPIO_DOUT23_20_DIO23_OFS                 (24)                            /* !< DIO23 Offset */
+#define GPIO_DOUT23_20_DIO23_MASK                ((uint32_t)0x01000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO23 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT23_20_DIO23_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT23_20_DIO23_ONE                 ((uint32_t)0x01000000U)         /* !< Output is set to 1 */
+
+/* GPIO_DOUT27_24 Bits */
+/* GPIO_DOUT27_24[DIO24] Bits */
+#define GPIO_DOUT27_24_DIO24_OFS                 (0)                             /* !< DIO24 Offset */
+#define GPIO_DOUT27_24_DIO24_MASK                ((uint32_t)0x00000001U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO24 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT27_24_DIO24_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT27_24_DIO24_ONE                 ((uint32_t)0x00000001U)         /* !< Output is set to 1 */
+/* GPIO_DOUT27_24[DIO25] Bits */
+#define GPIO_DOUT27_24_DIO25_OFS                 (8)                             /* !< DIO25 Offset */
+#define GPIO_DOUT27_24_DIO25_MASK                ((uint32_t)0x00000100U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO25 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT27_24_DIO25_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT27_24_DIO25_ONE                 ((uint32_t)0x00000100U)         /* !< Output is set to 1 */
+/* GPIO_DOUT27_24[DIO26] Bits */
+#define GPIO_DOUT27_24_DIO26_OFS                 (16)                            /* !< DIO26 Offset */
+#define GPIO_DOUT27_24_DIO26_MASK                ((uint32_t)0x00010000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO26 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT27_24_DIO26_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT27_24_DIO26_ONE                 ((uint32_t)0x00010000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT27_24[DIO27] Bits */
+#define GPIO_DOUT27_24_DIO27_OFS                 (24)                            /* !< DIO27 Offset */
+#define GPIO_DOUT27_24_DIO27_MASK                ((uint32_t)0x01000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO27 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT27_24_DIO27_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT27_24_DIO27_ONE                 ((uint32_t)0x01000000U)         /* !< Output is set to 1 */
+
+/* GPIO_DOUT31_28 Bits */
+/* GPIO_DOUT31_28[DIO28] Bits */
+#define GPIO_DOUT31_28_DIO28_OFS                 (0)                             /* !< DIO28 Offset */
+#define GPIO_DOUT31_28_DIO28_MASK                ((uint32_t)0x00000001U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO28 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_28_DIO28_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_28_DIO28_ONE                 ((uint32_t)0x00000001U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_28[DIO29] Bits */
+#define GPIO_DOUT31_28_DIO29_OFS                 (8)                             /* !< DIO29 Offset */
+#define GPIO_DOUT31_28_DIO29_MASK                ((uint32_t)0x00000100U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO29 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_28_DIO29_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_28_DIO29_ONE                 ((uint32_t)0x00000100U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_28[DIO30] Bits */
+#define GPIO_DOUT31_28_DIO30_OFS                 (16)                            /* !< DIO30 Offset */
+#define GPIO_DOUT31_28_DIO30_MASK                ((uint32_t)0x00010000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO30 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_28_DIO30_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_28_DIO30_ONE                 ((uint32_t)0x00010000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_28[DIO31] Bits */
+#define GPIO_DOUT31_28_DIO31_OFS                 (24)                            /* !< DIO31 Offset */
+#define GPIO_DOUT31_28_DIO31_MASK                ((uint32_t)0x01000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO31 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_28_DIO31_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_28_DIO31_ONE                 ((uint32_t)0x01000000U)         /* !< Output is set to 1 */
+
+/* GPIO_DOUT31_0 Bits */
+/* GPIO_DOUT31_0[DIO0] Bits */
+#define GPIO_DOUT31_0_DIO0_OFS                   (0)                             /* !< DIO0 Offset */
+#define GPIO_DOUT31_0_DIO0_MASK                  ((uint32_t)0x00000001U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO0 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO0_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO0_ONE                   ((uint32_t)0x00000001U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO1] Bits */
+#define GPIO_DOUT31_0_DIO1_OFS                   (1)                             /* !< DIO1 Offset */
+#define GPIO_DOUT31_0_DIO1_MASK                  ((uint32_t)0x00000002U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO1 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO1_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO1_ONE                   ((uint32_t)0x00000002U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO2] Bits */
+#define GPIO_DOUT31_0_DIO2_OFS                   (2)                             /* !< DIO2 Offset */
+#define GPIO_DOUT31_0_DIO2_MASK                  ((uint32_t)0x00000004U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO2 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO2_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO2_ONE                   ((uint32_t)0x00000004U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO3] Bits */
+#define GPIO_DOUT31_0_DIO3_OFS                   (3)                             /* !< DIO3 Offset */
+#define GPIO_DOUT31_0_DIO3_MASK                  ((uint32_t)0x00000008U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO3 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO3_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO3_ONE                   ((uint32_t)0x00000008U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO4] Bits */
+#define GPIO_DOUT31_0_DIO4_OFS                   (4)                             /* !< DIO4 Offset */
+#define GPIO_DOUT31_0_DIO4_MASK                  ((uint32_t)0x00000010U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO4 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO4_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO4_ONE                   ((uint32_t)0x00000010U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO5] Bits */
+#define GPIO_DOUT31_0_DIO5_OFS                   (5)                             /* !< DIO5 Offset */
+#define GPIO_DOUT31_0_DIO5_MASK                  ((uint32_t)0x00000020U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO5 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO5_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO5_ONE                   ((uint32_t)0x00000020U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO6] Bits */
+#define GPIO_DOUT31_0_DIO6_OFS                   (6)                             /* !< DIO6 Offset */
+#define GPIO_DOUT31_0_DIO6_MASK                  ((uint32_t)0x00000040U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO6 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO6_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO6_ONE                   ((uint32_t)0x00000040U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO7] Bits */
+#define GPIO_DOUT31_0_DIO7_OFS                   (7)                             /* !< DIO7 Offset */
+#define GPIO_DOUT31_0_DIO7_MASK                  ((uint32_t)0x00000080U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO7 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO7_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO7_ONE                   ((uint32_t)0x00000080U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO8] Bits */
+#define GPIO_DOUT31_0_DIO8_OFS                   (8)                             /* !< DIO8 Offset */
+#define GPIO_DOUT31_0_DIO8_MASK                  ((uint32_t)0x00000100U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO8 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO8_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO8_ONE                   ((uint32_t)0x00000100U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO9] Bits */
+#define GPIO_DOUT31_0_DIO9_OFS                   (9)                             /* !< DIO9 Offset */
+#define GPIO_DOUT31_0_DIO9_MASK                  ((uint32_t)0x00000200U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO9 when the output is
+                                                                                    enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO9_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO9_ONE                   ((uint32_t)0x00000200U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO10] Bits */
+#define GPIO_DOUT31_0_DIO10_OFS                  (10)                            /* !< DIO10 Offset */
+#define GPIO_DOUT31_0_DIO10_MASK                 ((uint32_t)0x00000400U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO10 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO10_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO10_ONE                  ((uint32_t)0x00000400U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO11] Bits */
+#define GPIO_DOUT31_0_DIO11_OFS                  (11)                            /* !< DIO11 Offset */
+#define GPIO_DOUT31_0_DIO11_MASK                 ((uint32_t)0x00000800U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO11 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO11_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO11_ONE                  ((uint32_t)0x00000800U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO12] Bits */
+#define GPIO_DOUT31_0_DIO12_OFS                  (12)                            /* !< DIO12 Offset */
+#define GPIO_DOUT31_0_DIO12_MASK                 ((uint32_t)0x00001000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO12 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO12_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO12_ONE                  ((uint32_t)0x00001000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO13] Bits */
+#define GPIO_DOUT31_0_DIO13_OFS                  (13)                            /* !< DIO13 Offset */
+#define GPIO_DOUT31_0_DIO13_MASK                 ((uint32_t)0x00002000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO13 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO13_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO13_ONE                  ((uint32_t)0x00002000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO14] Bits */
+#define GPIO_DOUT31_0_DIO14_OFS                  (14)                            /* !< DIO14 Offset */
+#define GPIO_DOUT31_0_DIO14_MASK                 ((uint32_t)0x00004000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO14 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO14_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO14_ONE                  ((uint32_t)0x00004000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO15] Bits */
+#define GPIO_DOUT31_0_DIO15_OFS                  (15)                            /* !< DIO15 Offset */
+#define GPIO_DOUT31_0_DIO15_MASK                 ((uint32_t)0x00008000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO15 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO15_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO15_ONE                  ((uint32_t)0x00008000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO16] Bits */
+#define GPIO_DOUT31_0_DIO16_OFS                  (16)                            /* !< DIO16 Offset */
+#define GPIO_DOUT31_0_DIO16_MASK                 ((uint32_t)0x00010000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO16 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO16_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO16_ONE                  ((uint32_t)0x00010000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO17] Bits */
+#define GPIO_DOUT31_0_DIO17_OFS                  (17)                            /* !< DIO17 Offset */
+#define GPIO_DOUT31_0_DIO17_MASK                 ((uint32_t)0x00020000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO17 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO17_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO17_ONE                  ((uint32_t)0x00020000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO18] Bits */
+#define GPIO_DOUT31_0_DIO18_OFS                  (18)                            /* !< DIO18 Offset */
+#define GPIO_DOUT31_0_DIO18_MASK                 ((uint32_t)0x00040000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO18 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO18_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO18_ONE                  ((uint32_t)0x00040000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO19] Bits */
+#define GPIO_DOUT31_0_DIO19_OFS                  (19)                            /* !< DIO19 Offset */
+#define GPIO_DOUT31_0_DIO19_MASK                 ((uint32_t)0x00080000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO19 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO19_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO19_ONE                  ((uint32_t)0x00080000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO20] Bits */
+#define GPIO_DOUT31_0_DIO20_OFS                  (20)                            /* !< DIO20 Offset */
+#define GPIO_DOUT31_0_DIO20_MASK                 ((uint32_t)0x00100000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO20 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO20_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO20_ONE                  ((uint32_t)0x00100000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO21] Bits */
+#define GPIO_DOUT31_0_DIO21_OFS                  (21)                            /* !< DIO21 Offset */
+#define GPIO_DOUT31_0_DIO21_MASK                 ((uint32_t)0x00200000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO21 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO21_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO21_ONE                  ((uint32_t)0x00200000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO22] Bits */
+#define GPIO_DOUT31_0_DIO22_OFS                  (22)                            /* !< DIO22 Offset */
+#define GPIO_DOUT31_0_DIO22_MASK                 ((uint32_t)0x00400000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO22 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO22_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO22_ONE                  ((uint32_t)0x00400000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO23] Bits */
+#define GPIO_DOUT31_0_DIO23_OFS                  (23)                            /* !< DIO23 Offset */
+#define GPIO_DOUT31_0_DIO23_MASK                 ((uint32_t)0x00800000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO23 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO23_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO23_ONE                  ((uint32_t)0x00800000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO24] Bits */
+#define GPIO_DOUT31_0_DIO24_OFS                  (24)                            /* !< DIO24 Offset */
+#define GPIO_DOUT31_0_DIO24_MASK                 ((uint32_t)0x01000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO24 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO24_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO24_ONE                  ((uint32_t)0x01000000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO25] Bits */
+#define GPIO_DOUT31_0_DIO25_OFS                  (25)                            /* !< DIO25 Offset */
+#define GPIO_DOUT31_0_DIO25_MASK                 ((uint32_t)0x02000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO25 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO25_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO25_ONE                  ((uint32_t)0x02000000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO26] Bits */
+#define GPIO_DOUT31_0_DIO26_OFS                  (26)                            /* !< DIO26 Offset */
+#define GPIO_DOUT31_0_DIO26_MASK                 ((uint32_t)0x04000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO26 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO26_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO26_ONE                  ((uint32_t)0x04000000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO27] Bits */
+#define GPIO_DOUT31_0_DIO27_OFS                  (27)                            /* !< DIO27 Offset */
+#define GPIO_DOUT31_0_DIO27_MASK                 ((uint32_t)0x08000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO27 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO27_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO27_ONE                  ((uint32_t)0x08000000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO28] Bits */
+#define GPIO_DOUT31_0_DIO28_OFS                  (28)                            /* !< DIO28 Offset */
+#define GPIO_DOUT31_0_DIO28_MASK                 ((uint32_t)0x10000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO28 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO28_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO28_ONE                  ((uint32_t)0x10000000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO29] Bits */
+#define GPIO_DOUT31_0_DIO29_OFS                  (29)                            /* !< DIO29 Offset */
+#define GPIO_DOUT31_0_DIO29_MASK                 ((uint32_t)0x20000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO29 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO29_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO29_ONE                  ((uint32_t)0x20000000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO30] Bits */
+#define GPIO_DOUT31_0_DIO30_OFS                  (30)                            /* !< DIO30 Offset */
+#define GPIO_DOUT31_0_DIO30_MASK                 ((uint32_t)0x40000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO30 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO30_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO30_ONE                  ((uint32_t)0x40000000U)         /* !< Output is set to 1 */
+/* GPIO_DOUT31_0[DIO31] Bits */
+#define GPIO_DOUT31_0_DIO31_OFS                  (31)                            /* !< DIO31 Offset */
+#define GPIO_DOUT31_0_DIO31_MASK                 ((uint32_t)0x80000000U)         /* !< This bit sets the value of the pin
+                                                                                    configured as DIO31 when the output
+                                                                                    is enabled through DOE31_0 register. */
+#define GPIO_DOUT31_0_DIO31_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define GPIO_DOUT31_0_DIO31_ONE                  ((uint32_t)0x80000000U)         /* !< Output is set to 1 */
+
+/* GPIO_DOUTSET31_0 Bits */
+/* GPIO_DOUTSET31_0[DIO0] Bits */
+#define GPIO_DOUTSET31_0_DIO0_OFS                (0)                             /* !< DIO0 Offset */
+#define GPIO_DOUTSET31_0_DIO0_MASK               ((uint32_t)0x00000001U)         /* !< Writing 1 to this bit sets the DIO0
+                                                                                    bit in the DOUT31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO0_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO0_SET                ((uint32_t)0x00000001U)         /* !< Sets DIO0 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO1] Bits */
+#define GPIO_DOUTSET31_0_DIO1_OFS                (1)                             /* !< DIO1 Offset */
+#define GPIO_DOUTSET31_0_DIO1_MASK               ((uint32_t)0x00000002U)         /* !< Writing 1 to this bit sets the DIO1
+                                                                                    bit in the DOUT31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO1_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO1_SET                ((uint32_t)0x00000002U)         /* !< Sets DIO1 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO2] Bits */
+#define GPIO_DOUTSET31_0_DIO2_OFS                (2)                             /* !< DIO2 Offset */
+#define GPIO_DOUTSET31_0_DIO2_MASK               ((uint32_t)0x00000004U)         /* !< Writing 1 to this bit sets the DIO2
+                                                                                    bit in the DOUT31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO2_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO2_SET                ((uint32_t)0x00000004U)         /* !< Sets DIO2 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO3] Bits */
+#define GPIO_DOUTSET31_0_DIO3_OFS                (3)                             /* !< DIO3 Offset */
+#define GPIO_DOUTSET31_0_DIO3_MASK               ((uint32_t)0x00000008U)         /* !< Writing 1 to this bit sets the DIO3
+                                                                                    bit in the DOUT31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO3_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO3_SET                ((uint32_t)0x00000008U)         /* !< Sets DIO3 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO4] Bits */
+#define GPIO_DOUTSET31_0_DIO4_OFS                (4)                             /* !< DIO4 Offset */
+#define GPIO_DOUTSET31_0_DIO4_MASK               ((uint32_t)0x00000010U)         /* !< Writing 1 to this bit sets the DIO4
+                                                                                    bit in the DOUT31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO4_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO4_SET                ((uint32_t)0x00000010U)         /* !< Sets DIO4 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO5] Bits */
+#define GPIO_DOUTSET31_0_DIO5_OFS                (5)                             /* !< DIO5 Offset */
+#define GPIO_DOUTSET31_0_DIO5_MASK               ((uint32_t)0x00000020U)         /* !< Writing 1 to this bit sets the DIO5
+                                                                                    bit in the DOUT31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO5_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO5_SET                ((uint32_t)0x00000020U)         /* !< Sets DIO5 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO6] Bits */
+#define GPIO_DOUTSET31_0_DIO6_OFS                (6)                             /* !< DIO6 Offset */
+#define GPIO_DOUTSET31_0_DIO6_MASK               ((uint32_t)0x00000040U)         /* !< Writing 1 to this bit sets the DIO6
+                                                                                    bit in the DOUT31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO6_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO6_SET                ((uint32_t)0x00000040U)         /* !< Sets DIO6 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO7] Bits */
+#define GPIO_DOUTSET31_0_DIO7_OFS                (7)                             /* !< DIO7 Offset */
+#define GPIO_DOUTSET31_0_DIO7_MASK               ((uint32_t)0x00000080U)         /* !< Writing 1 to this bit sets the DIO7
+                                                                                    bit in the DOUT31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO7_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO7_SET                ((uint32_t)0x00000080U)         /* !< Sets DIO7 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO8] Bits */
+#define GPIO_DOUTSET31_0_DIO8_OFS                (8)                             /* !< DIO8 Offset */
+#define GPIO_DOUTSET31_0_DIO8_MASK               ((uint32_t)0x00000100U)         /* !< Writing 1 to this bit sets the DIO8
+                                                                                    bit in the DOUT31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO8_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO8_SET                ((uint32_t)0x00000100U)         /* !< Sets DIO8 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO9] Bits */
+#define GPIO_DOUTSET31_0_DIO9_OFS                (9)                             /* !< DIO9 Offset */
+#define GPIO_DOUTSET31_0_DIO9_MASK               ((uint32_t)0x00000200U)         /* !< Writing 1 to this bit sets the DIO9
+                                                                                    bit in the DOUT31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO9_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO9_SET                ((uint32_t)0x00000200U)         /* !< Sets DIO9 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO10] Bits */
+#define GPIO_DOUTSET31_0_DIO10_OFS               (10)                            /* !< DIO10 Offset */
+#define GPIO_DOUTSET31_0_DIO10_MASK              ((uint32_t)0x00000400U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO10 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO10_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO10_SET               ((uint32_t)0x00000400U)         /* !< Sets DIO10 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO11] Bits */
+#define GPIO_DOUTSET31_0_DIO11_OFS               (11)                            /* !< DIO11 Offset */
+#define GPIO_DOUTSET31_0_DIO11_MASK              ((uint32_t)0x00000800U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO11 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO11_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO11_SET               ((uint32_t)0x00000800U)         /* !< Sets DIO11 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO12] Bits */
+#define GPIO_DOUTSET31_0_DIO12_OFS               (12)                            /* !< DIO12 Offset */
+#define GPIO_DOUTSET31_0_DIO12_MASK              ((uint32_t)0x00001000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO12 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO12_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO12_SET               ((uint32_t)0x00001000U)         /* !< Sets DIO12 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO13] Bits */
+#define GPIO_DOUTSET31_0_DIO13_OFS               (13)                            /* !< DIO13 Offset */
+#define GPIO_DOUTSET31_0_DIO13_MASK              ((uint32_t)0x00002000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO13 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO13_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO13_SET               ((uint32_t)0x00002000U)         /* !< Sets DIO13 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO14] Bits */
+#define GPIO_DOUTSET31_0_DIO14_OFS               (14)                            /* !< DIO14 Offset */
+#define GPIO_DOUTSET31_0_DIO14_MASK              ((uint32_t)0x00004000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO14 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO14_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO14_SET               ((uint32_t)0x00004000U)         /* !< Sets DIO14 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO15] Bits */
+#define GPIO_DOUTSET31_0_DIO15_OFS               (15)                            /* !< DIO15 Offset */
+#define GPIO_DOUTSET31_0_DIO15_MASK              ((uint32_t)0x00008000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO15 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO15_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO15_SET               ((uint32_t)0x00008000U)         /* !< Sets DIO15 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO16] Bits */
+#define GPIO_DOUTSET31_0_DIO16_OFS               (16)                            /* !< DIO16 Offset */
+#define GPIO_DOUTSET31_0_DIO16_MASK              ((uint32_t)0x00010000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO16 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO16_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO16_SET               ((uint32_t)0x00010000U)         /* !< Sets DIO16 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO17] Bits */
+#define GPIO_DOUTSET31_0_DIO17_OFS               (17)                            /* !< DIO17 Offset */
+#define GPIO_DOUTSET31_0_DIO17_MASK              ((uint32_t)0x00020000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO17 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO17_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO17_SET               ((uint32_t)0x00020000U)         /* !< Sets DIO17 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO18] Bits */
+#define GPIO_DOUTSET31_0_DIO18_OFS               (18)                            /* !< DIO18 Offset */
+#define GPIO_DOUTSET31_0_DIO18_MASK              ((uint32_t)0x00040000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO18 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO18_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO18_SET               ((uint32_t)0x00040000U)         /* !< Sets DIO18 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO19] Bits */
+#define GPIO_DOUTSET31_0_DIO19_OFS               (19)                            /* !< DIO19 Offset */
+#define GPIO_DOUTSET31_0_DIO19_MASK              ((uint32_t)0x00080000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO19 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO19_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO19_SET               ((uint32_t)0x00080000U)         /* !< Sets DIO19 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO20] Bits */
+#define GPIO_DOUTSET31_0_DIO20_OFS               (20)                            /* !< DIO20 Offset */
+#define GPIO_DOUTSET31_0_DIO20_MASK              ((uint32_t)0x00100000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO20 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO20_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO20_SET               ((uint32_t)0x00100000U)         /* !< Sets DIO20 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO21] Bits */
+#define GPIO_DOUTSET31_0_DIO21_OFS               (21)                            /* !< DIO21 Offset */
+#define GPIO_DOUTSET31_0_DIO21_MASK              ((uint32_t)0x00200000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO21 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO21_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO21_SET               ((uint32_t)0x00200000U)         /* !< Sets DIO21 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO22] Bits */
+#define GPIO_DOUTSET31_0_DIO22_OFS               (22)                            /* !< DIO22 Offset */
+#define GPIO_DOUTSET31_0_DIO22_MASK              ((uint32_t)0x00400000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO22 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO22_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO22_SET               ((uint32_t)0x00400000U)         /* !< Sets DIO22 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO23] Bits */
+#define GPIO_DOUTSET31_0_DIO23_OFS               (23)                            /* !< DIO23 Offset */
+#define GPIO_DOUTSET31_0_DIO23_MASK              ((uint32_t)0x00800000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO23 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO23_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO23_SET               ((uint32_t)0x00800000U)         /* !< Sets DIO23 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO24] Bits */
+#define GPIO_DOUTSET31_0_DIO24_OFS               (24)                            /* !< DIO24 Offset */
+#define GPIO_DOUTSET31_0_DIO24_MASK              ((uint32_t)0x01000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO24 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO24_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO24_SET               ((uint32_t)0x01000000U)         /* !< Sets DIO24 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO25] Bits */
+#define GPIO_DOUTSET31_0_DIO25_OFS               (25)                            /* !< DIO25 Offset */
+#define GPIO_DOUTSET31_0_DIO25_MASK              ((uint32_t)0x02000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO25 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO25_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO25_SET               ((uint32_t)0x02000000U)         /* !< Sets DIO25 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO26] Bits */
+#define GPIO_DOUTSET31_0_DIO26_OFS               (26)                            /* !< DIO26 Offset */
+#define GPIO_DOUTSET31_0_DIO26_MASK              ((uint32_t)0x04000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO26 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO26_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO26_SET               ((uint32_t)0x04000000U)         /* !< Sets DIO26 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO27] Bits */
+#define GPIO_DOUTSET31_0_DIO27_OFS               (27)                            /* !< DIO27 Offset */
+#define GPIO_DOUTSET31_0_DIO27_MASK              ((uint32_t)0x08000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO27 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO27_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO27_SET               ((uint32_t)0x08000000U)         /* !< Sets DIO27 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO28] Bits */
+#define GPIO_DOUTSET31_0_DIO28_OFS               (28)                            /* !< DIO28 Offset */
+#define GPIO_DOUTSET31_0_DIO28_MASK              ((uint32_t)0x10000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO28 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO28_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO28_SET               ((uint32_t)0x10000000U)         /* !< Sets DIO28 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO29] Bits */
+#define GPIO_DOUTSET31_0_DIO29_OFS               (29)                            /* !< DIO29 Offset */
+#define GPIO_DOUTSET31_0_DIO29_MASK              ((uint32_t)0x20000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO29 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO29_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO29_SET               ((uint32_t)0x20000000U)         /* !< Sets DIO29 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO30] Bits */
+#define GPIO_DOUTSET31_0_DIO30_OFS               (30)                            /* !< DIO30 Offset */
+#define GPIO_DOUTSET31_0_DIO30_MASK              ((uint32_t)0x40000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO30 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO30_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO30_SET               ((uint32_t)0x40000000U)         /* !< Sets DIO30 in DOUT31_0 */
+/* GPIO_DOUTSET31_0[DIO31] Bits */
+#define GPIO_DOUTSET31_0_DIO31_OFS               (31)                            /* !< DIO31 Offset */
+#define GPIO_DOUTSET31_0_DIO31_MASK              ((uint32_t)0x80000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO31 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTSET31_0_DIO31_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTSET31_0_DIO31_SET               ((uint32_t)0x80000000U)         /* !< Sets DIO31 in DOUT31_0 */
+
+/* GPIO_DOUTCLR31_0 Bits */
+/* GPIO_DOUTCLR31_0[DIO0] Bits */
+#define GPIO_DOUTCLR31_0_DIO0_OFS                (0)                             /* !< DIO0 Offset */
+#define GPIO_DOUTCLR31_0_DIO0_MASK               ((uint32_t)0x00000001U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO0 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO0_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO0_CLR                ((uint32_t)0x00000001U)         /* !< Clears DIO0 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO1] Bits */
+#define GPIO_DOUTCLR31_0_DIO1_OFS                (1)                             /* !< DIO1 Offset */
+#define GPIO_DOUTCLR31_0_DIO1_MASK               ((uint32_t)0x00000002U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO1 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO1_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO1_CLR                ((uint32_t)0x00000002U)         /* !< Clears DIO1 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO2] Bits */
+#define GPIO_DOUTCLR31_0_DIO2_OFS                (2)                             /* !< DIO2 Offset */
+#define GPIO_DOUTCLR31_0_DIO2_MASK               ((uint32_t)0x00000004U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO2 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO2_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO2_CLR                ((uint32_t)0x00000004U)         /* !< Clears DIO2 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO3] Bits */
+#define GPIO_DOUTCLR31_0_DIO3_OFS                (3)                             /* !< DIO3 Offset */
+#define GPIO_DOUTCLR31_0_DIO3_MASK               ((uint32_t)0x00000008U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO3 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO3_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO3_CLR                ((uint32_t)0x00000008U)         /* !< Clears DIO3 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO4] Bits */
+#define GPIO_DOUTCLR31_0_DIO4_OFS                (4)                             /* !< DIO4 Offset */
+#define GPIO_DOUTCLR31_0_DIO4_MASK               ((uint32_t)0x00000010U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO4 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO4_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO4_CLR                ((uint32_t)0x00000010U)         /* !< Clears DIO4 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO5] Bits */
+#define GPIO_DOUTCLR31_0_DIO5_OFS                (5)                             /* !< DIO5 Offset */
+#define GPIO_DOUTCLR31_0_DIO5_MASK               ((uint32_t)0x00000020U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO5 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO5_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO5_CLR                ((uint32_t)0x00000020U)         /* !< Clears DIO5 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO6] Bits */
+#define GPIO_DOUTCLR31_0_DIO6_OFS                (6)                             /* !< DIO6 Offset */
+#define GPIO_DOUTCLR31_0_DIO6_MASK               ((uint32_t)0x00000040U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO6 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO6_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO6_CLR                ((uint32_t)0x00000040U)         /* !< Clears DIO6 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO7] Bits */
+#define GPIO_DOUTCLR31_0_DIO7_OFS                (7)                             /* !< DIO7 Offset */
+#define GPIO_DOUTCLR31_0_DIO7_MASK               ((uint32_t)0x00000080U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO7 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO7_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO7_CLR                ((uint32_t)0x00000080U)         /* !< Clears DIO7 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO8] Bits */
+#define GPIO_DOUTCLR31_0_DIO8_OFS                (8)                             /* !< DIO8 Offset */
+#define GPIO_DOUTCLR31_0_DIO8_MASK               ((uint32_t)0x00000100U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO8 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO8_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO8_CLR                ((uint32_t)0x00000100U)         /* !< Clears DIO8 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO9] Bits */
+#define GPIO_DOUTCLR31_0_DIO9_OFS                (9)                             /* !< DIO9 Offset */
+#define GPIO_DOUTCLR31_0_DIO9_MASK               ((uint32_t)0x00000200U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO9 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO9_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO9_CLR                ((uint32_t)0x00000200U)         /* !< Clears DIO9 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO10] Bits */
+#define GPIO_DOUTCLR31_0_DIO10_OFS               (10)                            /* !< DIO10 Offset */
+#define GPIO_DOUTCLR31_0_DIO10_MASK              ((uint32_t)0x00000400U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO10 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO10_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO10_CLR               ((uint32_t)0x00000400U)         /* !< Clears DIO10 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO11] Bits */
+#define GPIO_DOUTCLR31_0_DIO11_OFS               (11)                            /* !< DIO11 Offset */
+#define GPIO_DOUTCLR31_0_DIO11_MASK              ((uint32_t)0x00000800U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO11 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO11_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO11_CLR               ((uint32_t)0x00000800U)         /* !< Clears DIO11 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO12] Bits */
+#define GPIO_DOUTCLR31_0_DIO12_OFS               (12)                            /* !< DIO12 Offset */
+#define GPIO_DOUTCLR31_0_DIO12_MASK              ((uint32_t)0x00001000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO12 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO12_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO12_CLR               ((uint32_t)0x00001000U)         /* !< Clears DIO12 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO13] Bits */
+#define GPIO_DOUTCLR31_0_DIO13_OFS               (13)                            /* !< DIO13 Offset */
+#define GPIO_DOUTCLR31_0_DIO13_MASK              ((uint32_t)0x00002000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO13 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO13_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO13_CLR               ((uint32_t)0x00002000U)         /* !< Clears DIO13 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO14] Bits */
+#define GPIO_DOUTCLR31_0_DIO14_OFS               (14)                            /* !< DIO14 Offset */
+#define GPIO_DOUTCLR31_0_DIO14_MASK              ((uint32_t)0x00004000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO14 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO14_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO14_CLR               ((uint32_t)0x00004000U)         /* !< Clears DIO14 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO15] Bits */
+#define GPIO_DOUTCLR31_0_DIO15_OFS               (15)                            /* !< DIO15 Offset */
+#define GPIO_DOUTCLR31_0_DIO15_MASK              ((uint32_t)0x00008000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO15 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO15_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO15_CLR               ((uint32_t)0x00008000U)         /* !< Clears DIO15 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO16] Bits */
+#define GPIO_DOUTCLR31_0_DIO16_OFS               (16)                            /* !< DIO16 Offset */
+#define GPIO_DOUTCLR31_0_DIO16_MASK              ((uint32_t)0x00010000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO16 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO16_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO16_CLR               ((uint32_t)0x00010000U)         /* !< Clears DIO16 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO17] Bits */
+#define GPIO_DOUTCLR31_0_DIO17_OFS               (17)                            /* !< DIO17 Offset */
+#define GPIO_DOUTCLR31_0_DIO17_MASK              ((uint32_t)0x00020000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO17 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO17_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO17_CLR               ((uint32_t)0x00020000U)         /* !< Clears DIO17 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO18] Bits */
+#define GPIO_DOUTCLR31_0_DIO18_OFS               (18)                            /* !< DIO18 Offset */
+#define GPIO_DOUTCLR31_0_DIO18_MASK              ((uint32_t)0x00040000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO18 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO18_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO18_CLR               ((uint32_t)0x00040000U)         /* !< Clears DIO18 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO19] Bits */
+#define GPIO_DOUTCLR31_0_DIO19_OFS               (19)                            /* !< DIO19 Offset */
+#define GPIO_DOUTCLR31_0_DIO19_MASK              ((uint32_t)0x00080000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO19 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO19_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO19_CLR               ((uint32_t)0x00080000U)         /* !< Clears DIO19 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO20] Bits */
+#define GPIO_DOUTCLR31_0_DIO20_OFS               (20)                            /* !< DIO20 Offset */
+#define GPIO_DOUTCLR31_0_DIO20_MASK              ((uint32_t)0x00100000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO20 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO20_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO20_CLR               ((uint32_t)0x00100000U)         /* !< Clears DIO20 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO21] Bits */
+#define GPIO_DOUTCLR31_0_DIO21_OFS               (21)                            /* !< DIO21 Offset */
+#define GPIO_DOUTCLR31_0_DIO21_MASK              ((uint32_t)0x00200000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO21 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO21_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO21_CLR               ((uint32_t)0x00200000U)         /* !< Clears DIO21 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO22] Bits */
+#define GPIO_DOUTCLR31_0_DIO22_OFS               (22)                            /* !< DIO22 Offset */
+#define GPIO_DOUTCLR31_0_DIO22_MASK              ((uint32_t)0x00400000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO22 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO22_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO22_CLR               ((uint32_t)0x00400000U)         /* !< Clears DIO22 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO23] Bits */
+#define GPIO_DOUTCLR31_0_DIO23_OFS               (23)                            /* !< DIO23 Offset */
+#define GPIO_DOUTCLR31_0_DIO23_MASK              ((uint32_t)0x00800000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO23 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO23_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO23_CLR               ((uint32_t)0x00800000U)         /* !< Clears DIO23 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO24] Bits */
+#define GPIO_DOUTCLR31_0_DIO24_OFS               (24)                            /* !< DIO24 Offset */
+#define GPIO_DOUTCLR31_0_DIO24_MASK              ((uint32_t)0x01000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO24 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO24_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO24_CLR               ((uint32_t)0x01000000U)         /* !< Clears DIO24 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO25] Bits */
+#define GPIO_DOUTCLR31_0_DIO25_OFS               (25)                            /* !< DIO25 Offset */
+#define GPIO_DOUTCLR31_0_DIO25_MASK              ((uint32_t)0x02000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO25 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO25_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO25_CLR               ((uint32_t)0x02000000U)         /* !< Clears DIO25 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO26] Bits */
+#define GPIO_DOUTCLR31_0_DIO26_OFS               (26)                            /* !< DIO26 Offset */
+#define GPIO_DOUTCLR31_0_DIO26_MASK              ((uint32_t)0x04000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO26 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO26_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO26_CLR               ((uint32_t)0x04000000U)         /* !< Clears DIO26 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO27] Bits */
+#define GPIO_DOUTCLR31_0_DIO27_OFS               (27)                            /* !< DIO27 Offset */
+#define GPIO_DOUTCLR31_0_DIO27_MASK              ((uint32_t)0x08000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO27 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO27_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO27_CLR               ((uint32_t)0x08000000U)         /* !< Clears DIO27 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO28] Bits */
+#define GPIO_DOUTCLR31_0_DIO28_OFS               (28)                            /* !< DIO28 Offset */
+#define GPIO_DOUTCLR31_0_DIO28_MASK              ((uint32_t)0x10000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO28 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO28_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO28_CLR               ((uint32_t)0x10000000U)         /* !< Clears DIO28 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO29] Bits */
+#define GPIO_DOUTCLR31_0_DIO29_OFS               (29)                            /* !< DIO29 Offset */
+#define GPIO_DOUTCLR31_0_DIO29_MASK              ((uint32_t)0x20000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO29 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO29_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO29_CLR               ((uint32_t)0x20000000U)         /* !< Clears DIO29 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO30] Bits */
+#define GPIO_DOUTCLR31_0_DIO30_OFS               (30)                            /* !< DIO30 Offset */
+#define GPIO_DOUTCLR31_0_DIO30_MASK              ((uint32_t)0x40000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO30 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO30_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO30_CLR               ((uint32_t)0x40000000U)         /* !< Clears DIO30 in DOUT31_0 */
+/* GPIO_DOUTCLR31_0[DIO31] Bits */
+#define GPIO_DOUTCLR31_0_DIO31_OFS               (31)                            /* !< DIO31 Offset */
+#define GPIO_DOUTCLR31_0_DIO31_MASK              ((uint32_t)0x80000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO31 bit in the DOUT31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOUTCLR31_0_DIO31_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTCLR31_0_DIO31_CLR               ((uint32_t)0x80000000U)         /* !< Clears DIO31 in DOUT31_0 */
+
+/* GPIO_DOUTTGL31_0 Bits */
+/* GPIO_DOUTTGL31_0[DIO0] Bits */
+#define GPIO_DOUTTGL31_0_DIO0_OFS                (0)                             /* !< DIO0 Offset */
+#define GPIO_DOUTTGL31_0_DIO0_MASK               ((uint32_t)0x00000001U)         /* !< This bit is used to toggle DIO0
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO0_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO0_TOGGLE             ((uint32_t)0x00000001U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO1] Bits */
+#define GPIO_DOUTTGL31_0_DIO1_OFS                (1)                             /* !< DIO1 Offset */
+#define GPIO_DOUTTGL31_0_DIO1_MASK               ((uint32_t)0x00000002U)         /* !< This bit is used to toggle DIO1
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO1_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO1_TOGGLE             ((uint32_t)0x00000002U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO2] Bits */
+#define GPIO_DOUTTGL31_0_DIO2_OFS                (2)                             /* !< DIO2 Offset */
+#define GPIO_DOUTTGL31_0_DIO2_MASK               ((uint32_t)0x00000004U)         /* !< This bit is used to toggle DIO2
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO2_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO2_TOGGLE             ((uint32_t)0x00000004U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO3] Bits */
+#define GPIO_DOUTTGL31_0_DIO3_OFS                (3)                             /* !< DIO3 Offset */
+#define GPIO_DOUTTGL31_0_DIO3_MASK               ((uint32_t)0x00000008U)         /* !< This bit is used to toggle DIO3
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO3_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO3_TOGGLE             ((uint32_t)0x00000008U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO4] Bits */
+#define GPIO_DOUTTGL31_0_DIO4_OFS                (4)                             /* !< DIO4 Offset */
+#define GPIO_DOUTTGL31_0_DIO4_MASK               ((uint32_t)0x00000010U)         /* !< This bit is used to toggle DIO4
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO4_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO4_TOGGLE             ((uint32_t)0x00000010U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO5] Bits */
+#define GPIO_DOUTTGL31_0_DIO5_OFS                (5)                             /* !< DIO5 Offset */
+#define GPIO_DOUTTGL31_0_DIO5_MASK               ((uint32_t)0x00000020U)         /* !< This bit is used to toggle DIO5
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO5_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO5_TOGGLE             ((uint32_t)0x00000020U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO6] Bits */
+#define GPIO_DOUTTGL31_0_DIO6_OFS                (6)                             /* !< DIO6 Offset */
+#define GPIO_DOUTTGL31_0_DIO6_MASK               ((uint32_t)0x00000040U)         /* !< This bit is used to toggle DIO6
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO6_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO6_TOGGLE             ((uint32_t)0x00000040U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO7] Bits */
+#define GPIO_DOUTTGL31_0_DIO7_OFS                (7)                             /* !< DIO7 Offset */
+#define GPIO_DOUTTGL31_0_DIO7_MASK               ((uint32_t)0x00000080U)         /* !< This bit is used to toggle DIO7
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO7_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO7_TOGGLE             ((uint32_t)0x00000080U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO8] Bits */
+#define GPIO_DOUTTGL31_0_DIO8_OFS                (8)                             /* !< DIO8 Offset */
+#define GPIO_DOUTTGL31_0_DIO8_MASK               ((uint32_t)0x00000100U)         /* !< This bit is used to toggle DIO8
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO8_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO8_TOGGLE             ((uint32_t)0x00000100U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO9] Bits */
+#define GPIO_DOUTTGL31_0_DIO9_OFS                (9)                             /* !< DIO9 Offset */
+#define GPIO_DOUTTGL31_0_DIO9_MASK               ((uint32_t)0x00000200U)         /* !< This bit is used to toggle DIO9
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO9_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO9_TOGGLE             ((uint32_t)0x00000200U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO10] Bits */
+#define GPIO_DOUTTGL31_0_DIO10_OFS               (10)                            /* !< DIO10 Offset */
+#define GPIO_DOUTTGL31_0_DIO10_MASK              ((uint32_t)0x00000400U)         /* !< This bit is used to toggle DIO10
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO10_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO10_TOGGLE            ((uint32_t)0x00000400U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO11] Bits */
+#define GPIO_DOUTTGL31_0_DIO11_OFS               (11)                            /* !< DIO11 Offset */
+#define GPIO_DOUTTGL31_0_DIO11_MASK              ((uint32_t)0x00000800U)         /* !< This bit is used to toggle DIO11
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO11_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO11_TOGGLE            ((uint32_t)0x00000800U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO12] Bits */
+#define GPIO_DOUTTGL31_0_DIO12_OFS               (12)                            /* !< DIO12 Offset */
+#define GPIO_DOUTTGL31_0_DIO12_MASK              ((uint32_t)0x00001000U)         /* !< This bit is used to toggle DIO12
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO12_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO12_TOGGLE            ((uint32_t)0x00001000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO13] Bits */
+#define GPIO_DOUTTGL31_0_DIO13_OFS               (13)                            /* !< DIO13 Offset */
+#define GPIO_DOUTTGL31_0_DIO13_MASK              ((uint32_t)0x00002000U)         /* !< This bit is used to toggle DIO13
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO13_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO13_TOGGLE            ((uint32_t)0x00002000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO14] Bits */
+#define GPIO_DOUTTGL31_0_DIO14_OFS               (14)                            /* !< DIO14 Offset */
+#define GPIO_DOUTTGL31_0_DIO14_MASK              ((uint32_t)0x00004000U)         /* !< This bit is used to toggle DIO14
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO14_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO14_TOGGLE            ((uint32_t)0x00004000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO15] Bits */
+#define GPIO_DOUTTGL31_0_DIO15_OFS               (15)                            /* !< DIO15 Offset */
+#define GPIO_DOUTTGL31_0_DIO15_MASK              ((uint32_t)0x00008000U)         /* !< This bit is used to toggle DIO15
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO15_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO15_TOGGLE            ((uint32_t)0x00008000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO16] Bits */
+#define GPIO_DOUTTGL31_0_DIO16_OFS               (16)                            /* !< DIO16 Offset */
+#define GPIO_DOUTTGL31_0_DIO16_MASK              ((uint32_t)0x00010000U)         /* !< This bit is used to toggle DIO16
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO16_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO16_TOGGLE            ((uint32_t)0x00010000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO17] Bits */
+#define GPIO_DOUTTGL31_0_DIO17_OFS               (17)                            /* !< DIO17 Offset */
+#define GPIO_DOUTTGL31_0_DIO17_MASK              ((uint32_t)0x00020000U)         /* !< This bit is used to toggle DIO17
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO17_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO17_TOGGLE            ((uint32_t)0x00020000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO18] Bits */
+#define GPIO_DOUTTGL31_0_DIO18_OFS               (18)                            /* !< DIO18 Offset */
+#define GPIO_DOUTTGL31_0_DIO18_MASK              ((uint32_t)0x00040000U)         /* !< This bit is used to toggle DIO18
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO18_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO18_TOGGLE            ((uint32_t)0x00040000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO19] Bits */
+#define GPIO_DOUTTGL31_0_DIO19_OFS               (19)                            /* !< DIO19 Offset */
+#define GPIO_DOUTTGL31_0_DIO19_MASK              ((uint32_t)0x00080000U)         /* !< This bit is used to toggle DIO19
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO19_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO19_TOGGLE            ((uint32_t)0x00080000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO20] Bits */
+#define GPIO_DOUTTGL31_0_DIO20_OFS               (20)                            /* !< DIO20 Offset */
+#define GPIO_DOUTTGL31_0_DIO20_MASK              ((uint32_t)0x00100000U)         /* !< This bit is used to toggle DIO20
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO20_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO20_TOGGLE            ((uint32_t)0x00100000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO21] Bits */
+#define GPIO_DOUTTGL31_0_DIO21_OFS               (21)                            /* !< DIO21 Offset */
+#define GPIO_DOUTTGL31_0_DIO21_MASK              ((uint32_t)0x00200000U)         /* !< This bit is used to toggle DIO21
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO21_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO21_TOGGLE            ((uint32_t)0x00200000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO22] Bits */
+#define GPIO_DOUTTGL31_0_DIO22_OFS               (22)                            /* !< DIO22 Offset */
+#define GPIO_DOUTTGL31_0_DIO22_MASK              ((uint32_t)0x00400000U)         /* !< This bit is used to toggle DIO22
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO22_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO22_TOGGLE            ((uint32_t)0x00400000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO23] Bits */
+#define GPIO_DOUTTGL31_0_DIO23_OFS               (23)                            /* !< DIO23 Offset */
+#define GPIO_DOUTTGL31_0_DIO23_MASK              ((uint32_t)0x00800000U)         /* !< This bit is used to toggle DIO23
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO23_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO23_TOGGLE            ((uint32_t)0x00800000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO24] Bits */
+#define GPIO_DOUTTGL31_0_DIO24_OFS               (24)                            /* !< DIO24 Offset */
+#define GPIO_DOUTTGL31_0_DIO24_MASK              ((uint32_t)0x01000000U)         /* !< This bit is used to toggle DIO24
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO24_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO24_TOGGLE            ((uint32_t)0x01000000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO25] Bits */
+#define GPIO_DOUTTGL31_0_DIO25_OFS               (25)                            /* !< DIO25 Offset */
+#define GPIO_DOUTTGL31_0_DIO25_MASK              ((uint32_t)0x02000000U)         /* !< This bit is used to toggle DIO25
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO25_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO25_TOGGLE            ((uint32_t)0x02000000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO26] Bits */
+#define GPIO_DOUTTGL31_0_DIO26_OFS               (26)                            /* !< DIO26 Offset */
+#define GPIO_DOUTTGL31_0_DIO26_MASK              ((uint32_t)0x04000000U)         /* !< This bit is used to toggle DIO26
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO26_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO26_TOGGLE            ((uint32_t)0x04000000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO27] Bits */
+#define GPIO_DOUTTGL31_0_DIO27_OFS               (27)                            /* !< DIO27 Offset */
+#define GPIO_DOUTTGL31_0_DIO27_MASK              ((uint32_t)0x08000000U)         /* !< This bit is used to toggle DIO27
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO27_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO27_TOGGLE            ((uint32_t)0x08000000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO28] Bits */
+#define GPIO_DOUTTGL31_0_DIO28_OFS               (28)                            /* !< DIO28 Offset */
+#define GPIO_DOUTTGL31_0_DIO28_MASK              ((uint32_t)0x10000000U)         /* !< This bit is used to toggle DIO28
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO28_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO28_TOGGLE            ((uint32_t)0x10000000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO29] Bits */
+#define GPIO_DOUTTGL31_0_DIO29_OFS               (29)                            /* !< DIO29 Offset */
+#define GPIO_DOUTTGL31_0_DIO29_MASK              ((uint32_t)0x20000000U)         /* !< This bit is used to toggle DIO29
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO29_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO29_TOGGLE            ((uint32_t)0x20000000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO30] Bits */
+#define GPIO_DOUTTGL31_0_DIO30_OFS               (30)                            /* !< DIO30 Offset */
+#define GPIO_DOUTTGL31_0_DIO30_MASK              ((uint32_t)0x40000000U)         /* !< This bit is used to toggle DIO30
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO30_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO30_TOGGLE            ((uint32_t)0x40000000U)         /* !< Toggle output */
+/* GPIO_DOUTTGL31_0[DIO31] Bits */
+#define GPIO_DOUTTGL31_0_DIO31_OFS               (31)                            /* !< DIO31 Offset */
+#define GPIO_DOUTTGL31_0_DIO31_MASK              ((uint32_t)0x80000000U)         /* !< This bit is used to toggle DIO31
+                                                                                    output. */
+#define GPIO_DOUTTGL31_0_DIO31_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOUTTGL31_0_DIO31_TOGGLE            ((uint32_t)0x80000000U)         /* !< Toggle output */
+
+/* GPIO_DOE31_0 Bits */
+/* GPIO_DOE31_0[DIO0] Bits */
+#define GPIO_DOE31_0_DIO0_OFS                    (0)                             /* !< DIO0 Offset */
+#define GPIO_DOE31_0_DIO0_MASK                   ((uint32_t)0x00000001U)         /* !< Enables data output for DIO0. */
+#define GPIO_DOE31_0_DIO0_DISABLE                ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO0_ENABLE                 ((uint32_t)0x00000001U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO1] Bits */
+#define GPIO_DOE31_0_DIO1_OFS                    (1)                             /* !< DIO1 Offset */
+#define GPIO_DOE31_0_DIO1_MASK                   ((uint32_t)0x00000002U)         /* !< Enables data output for DIO1. */
+#define GPIO_DOE31_0_DIO1_DISABLE                ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO1_ENABLE                 ((uint32_t)0x00000002U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO2] Bits */
+#define GPIO_DOE31_0_DIO2_OFS                    (2)                             /* !< DIO2 Offset */
+#define GPIO_DOE31_0_DIO2_MASK                   ((uint32_t)0x00000004U)         /* !< Enables data output for DIO2. */
+#define GPIO_DOE31_0_DIO2_DISABLE                ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO2_ENABLE                 ((uint32_t)0x00000004U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO3] Bits */
+#define GPIO_DOE31_0_DIO3_OFS                    (3)                             /* !< DIO3 Offset */
+#define GPIO_DOE31_0_DIO3_MASK                   ((uint32_t)0x00000008U)         /* !< Enables data output for DIO3. */
+#define GPIO_DOE31_0_DIO3_DISABLE                ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO3_ENABLE                 ((uint32_t)0x00000008U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO4] Bits */
+#define GPIO_DOE31_0_DIO4_OFS                    (4)                             /* !< DIO4 Offset */
+#define GPIO_DOE31_0_DIO4_MASK                   ((uint32_t)0x00000010U)         /* !< Enables data output for DIO4. */
+#define GPIO_DOE31_0_DIO4_DISABLE                ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO4_ENABLE                 ((uint32_t)0x00000010U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO5] Bits */
+#define GPIO_DOE31_0_DIO5_OFS                    (5)                             /* !< DIO5 Offset */
+#define GPIO_DOE31_0_DIO5_MASK                   ((uint32_t)0x00000020U)         /* !< Enables data output for DIO5. */
+#define GPIO_DOE31_0_DIO5_DISABLE                ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO5_ENABLE                 ((uint32_t)0x00000020U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO6] Bits */
+#define GPIO_DOE31_0_DIO6_OFS                    (6)                             /* !< DIO6 Offset */
+#define GPIO_DOE31_0_DIO6_MASK                   ((uint32_t)0x00000040U)         /* !< Enables data output for DIO6. */
+#define GPIO_DOE31_0_DIO6_DISABLE                ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO6_ENABLE                 ((uint32_t)0x00000040U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO7] Bits */
+#define GPIO_DOE31_0_DIO7_OFS                    (7)                             /* !< DIO7 Offset */
+#define GPIO_DOE31_0_DIO7_MASK                   ((uint32_t)0x00000080U)         /* !< Enables data output for DIO7. */
+#define GPIO_DOE31_0_DIO7_DISABLE                ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO7_ENABLE                 ((uint32_t)0x00000080U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO8] Bits */
+#define GPIO_DOE31_0_DIO8_OFS                    (8)                             /* !< DIO8 Offset */
+#define GPIO_DOE31_0_DIO8_MASK                   ((uint32_t)0x00000100U)         /* !< Enables data output for DIO8. */
+#define GPIO_DOE31_0_DIO8_DISABLE                ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO8_ENABLE                 ((uint32_t)0x00000100U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO9] Bits */
+#define GPIO_DOE31_0_DIO9_OFS                    (9)                             /* !< DIO9 Offset */
+#define GPIO_DOE31_0_DIO9_MASK                   ((uint32_t)0x00000200U)         /* !< Enables data output for DIO9. */
+#define GPIO_DOE31_0_DIO9_DISABLE                ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO9_ENABLE                 ((uint32_t)0x00000200U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO10] Bits */
+#define GPIO_DOE31_0_DIO10_OFS                   (10)                            /* !< DIO10 Offset */
+#define GPIO_DOE31_0_DIO10_MASK                  ((uint32_t)0x00000400U)         /* !< Enables data output for DIO10. */
+#define GPIO_DOE31_0_DIO10_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO10_ENABLE                ((uint32_t)0x00000400U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO11] Bits */
+#define GPIO_DOE31_0_DIO11_OFS                   (11)                            /* !< DIO11 Offset */
+#define GPIO_DOE31_0_DIO11_MASK                  ((uint32_t)0x00000800U)         /* !< Enables data output for DIO11. */
+#define GPIO_DOE31_0_DIO11_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO11_ENABLE                ((uint32_t)0x00000800U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO12] Bits */
+#define GPIO_DOE31_0_DIO12_OFS                   (12)                            /* !< DIO12 Offset */
+#define GPIO_DOE31_0_DIO12_MASK                  ((uint32_t)0x00001000U)         /* !< Enables data output for DIO12. */
+#define GPIO_DOE31_0_DIO12_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO12_ENABLE                ((uint32_t)0x00001000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO13] Bits */
+#define GPIO_DOE31_0_DIO13_OFS                   (13)                            /* !< DIO13 Offset */
+#define GPIO_DOE31_0_DIO13_MASK                  ((uint32_t)0x00002000U)         /* !< Enables data output for DIO13. */
+#define GPIO_DOE31_0_DIO13_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO13_ENABLE                ((uint32_t)0x00002000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO14] Bits */
+#define GPIO_DOE31_0_DIO14_OFS                   (14)                            /* !< DIO14 Offset */
+#define GPIO_DOE31_0_DIO14_MASK                  ((uint32_t)0x00004000U)         /* !< Enables data output for DIO14. */
+#define GPIO_DOE31_0_DIO14_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO14_ENABLE                ((uint32_t)0x00004000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO15] Bits */
+#define GPIO_DOE31_0_DIO15_OFS                   (15)                            /* !< DIO15 Offset */
+#define GPIO_DOE31_0_DIO15_MASK                  ((uint32_t)0x00008000U)         /* !< Enables data output for DIO15. */
+#define GPIO_DOE31_0_DIO15_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO15_ENABLE                ((uint32_t)0x00008000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO16] Bits */
+#define GPIO_DOE31_0_DIO16_OFS                   (16)                            /* !< DIO16 Offset */
+#define GPIO_DOE31_0_DIO16_MASK                  ((uint32_t)0x00010000U)         /* !< Enables data output for DIO16. */
+#define GPIO_DOE31_0_DIO16_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO16_ENABLE                ((uint32_t)0x00010000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO17] Bits */
+#define GPIO_DOE31_0_DIO17_OFS                   (17)                            /* !< DIO17 Offset */
+#define GPIO_DOE31_0_DIO17_MASK                  ((uint32_t)0x00020000U)         /* !< Enables data output for DIO17. */
+#define GPIO_DOE31_0_DIO17_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO17_ENABLE                ((uint32_t)0x00020000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO18] Bits */
+#define GPIO_DOE31_0_DIO18_OFS                   (18)                            /* !< DIO18 Offset */
+#define GPIO_DOE31_0_DIO18_MASK                  ((uint32_t)0x00040000U)         /* !< Enables data output for DIO18. */
+#define GPIO_DOE31_0_DIO18_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO18_ENABLE                ((uint32_t)0x00040000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO19] Bits */
+#define GPIO_DOE31_0_DIO19_OFS                   (19)                            /* !< DIO19 Offset */
+#define GPIO_DOE31_0_DIO19_MASK                  ((uint32_t)0x00080000U)         /* !< Enables data output for DIO19. */
+#define GPIO_DOE31_0_DIO19_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO19_ENABLE                ((uint32_t)0x00080000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO20] Bits */
+#define GPIO_DOE31_0_DIO20_OFS                   (20)                            /* !< DIO20 Offset */
+#define GPIO_DOE31_0_DIO20_MASK                  ((uint32_t)0x00100000U)         /* !< Enables data output for DIO20. */
+#define GPIO_DOE31_0_DIO20_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO20_ENABLE                ((uint32_t)0x00100000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO21] Bits */
+#define GPIO_DOE31_0_DIO21_OFS                   (21)                            /* !< DIO21 Offset */
+#define GPIO_DOE31_0_DIO21_MASK                  ((uint32_t)0x00200000U)         /* !< Enables data output for DIO21. */
+#define GPIO_DOE31_0_DIO21_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO21_ENABLE                ((uint32_t)0x00200000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO22] Bits */
+#define GPIO_DOE31_0_DIO22_OFS                   (22)                            /* !< DIO22 Offset */
+#define GPIO_DOE31_0_DIO22_MASK                  ((uint32_t)0x00400000U)         /* !< Enables data output for DIO22. */
+#define GPIO_DOE31_0_DIO22_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO22_ENABLE                ((uint32_t)0x00400000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO23] Bits */
+#define GPIO_DOE31_0_DIO23_OFS                   (23)                            /* !< DIO23 Offset */
+#define GPIO_DOE31_0_DIO23_MASK                  ((uint32_t)0x00800000U)         /* !< Enables data output for DIO23. */
+#define GPIO_DOE31_0_DIO23_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO23_ENABLE                ((uint32_t)0x00800000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO24] Bits */
+#define GPIO_DOE31_0_DIO24_OFS                   (24)                            /* !< DIO24 Offset */
+#define GPIO_DOE31_0_DIO24_MASK                  ((uint32_t)0x01000000U)         /* !< Enables data output for DIO24. */
+#define GPIO_DOE31_0_DIO24_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO24_ENABLE                ((uint32_t)0x01000000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO25] Bits */
+#define GPIO_DOE31_0_DIO25_OFS                   (25)                            /* !< DIO25 Offset */
+#define GPIO_DOE31_0_DIO25_MASK                  ((uint32_t)0x02000000U)         /* !< Enables data output for DIO25. */
+#define GPIO_DOE31_0_DIO25_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO25_ENABLE                ((uint32_t)0x02000000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO26] Bits */
+#define GPIO_DOE31_0_DIO26_OFS                   (26)                            /* !< DIO26 Offset */
+#define GPIO_DOE31_0_DIO26_MASK                  ((uint32_t)0x04000000U)         /* !< Enables data output for DIO26. */
+#define GPIO_DOE31_0_DIO26_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO26_ENABLE                ((uint32_t)0x04000000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO27] Bits */
+#define GPIO_DOE31_0_DIO27_OFS                   (27)                            /* !< DIO27 Offset */
+#define GPIO_DOE31_0_DIO27_MASK                  ((uint32_t)0x08000000U)         /* !< Enables data output for DIO27. */
+#define GPIO_DOE31_0_DIO27_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO27_ENABLE                ((uint32_t)0x08000000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO28] Bits */
+#define GPIO_DOE31_0_DIO28_OFS                   (28)                            /* !< DIO28 Offset */
+#define GPIO_DOE31_0_DIO28_MASK                  ((uint32_t)0x10000000U)         /* !< Enables data output for DIO28. */
+#define GPIO_DOE31_0_DIO28_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO28_ENABLE                ((uint32_t)0x10000000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO29] Bits */
+#define GPIO_DOE31_0_DIO29_OFS                   (29)                            /* !< DIO29 Offset */
+#define GPIO_DOE31_0_DIO29_MASK                  ((uint32_t)0x20000000U)         /* !< Enables data output for DIO29. */
+#define GPIO_DOE31_0_DIO29_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO29_ENABLE                ((uint32_t)0x20000000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO30] Bits */
+#define GPIO_DOE31_0_DIO30_OFS                   (30)                            /* !< DIO30 Offset */
+#define GPIO_DOE31_0_DIO30_MASK                  ((uint32_t)0x40000000U)         /* !< Enables data output for DIO30. */
+#define GPIO_DOE31_0_DIO30_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO30_ENABLE                ((uint32_t)0x40000000U)         /* !< Output enabled */
+/* GPIO_DOE31_0[DIO31] Bits */
+#define GPIO_DOE31_0_DIO31_OFS                   (31)                            /* !< DIO31 Offset */
+#define GPIO_DOE31_0_DIO31_MASK                  ((uint32_t)0x80000000U)         /* !< Enables data output for DIO31. */
+#define GPIO_DOE31_0_DIO31_DISABLE               ((uint32_t)0x00000000U)         /* !< Output disabled */
+#define GPIO_DOE31_0_DIO31_ENABLE                ((uint32_t)0x80000000U)         /* !< Output enabled */
+
+/* GPIO_DOESET31_0 Bits */
+/* GPIO_DOESET31_0[DIO0] Bits */
+#define GPIO_DOESET31_0_DIO0_OFS                 (0)                             /* !< DIO0 Offset */
+#define GPIO_DOESET31_0_DIO0_MASK                ((uint32_t)0x00000001U)         /* !< Writing 1 to this bit sets the DIO0
+                                                                                    bit in the DOE31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOESET31_0_DIO0_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO0_SET                 ((uint32_t)0x00000001U)         /* !< Sets DIO0 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO1] Bits */
+#define GPIO_DOESET31_0_DIO1_OFS                 (1)                             /* !< DIO1 Offset */
+#define GPIO_DOESET31_0_DIO1_MASK                ((uint32_t)0x00000002U)         /* !< Writing 1 to this bit sets the DIO1
+                                                                                    bit in the DOE31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOESET31_0_DIO1_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO1_SET                 ((uint32_t)0x00000002U)         /* !< Sets DIO1 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO2] Bits */
+#define GPIO_DOESET31_0_DIO2_OFS                 (2)                             /* !< DIO2 Offset */
+#define GPIO_DOESET31_0_DIO2_MASK                ((uint32_t)0x00000004U)         /* !< Writing 1 to this bit sets the DIO2
+                                                                                    bit in the DOE31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOESET31_0_DIO2_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO2_SET                 ((uint32_t)0x00000004U)         /* !< Sets DIO2 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO3] Bits */
+#define GPIO_DOESET31_0_DIO3_OFS                 (3)                             /* !< DIO3 Offset */
+#define GPIO_DOESET31_0_DIO3_MASK                ((uint32_t)0x00000008U)         /* !< Writing 1 to this bit sets the DIO3
+                                                                                    bit in the DOE31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOESET31_0_DIO3_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO3_SET                 ((uint32_t)0x00000008U)         /* !< Sets DIO3 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO4] Bits */
+#define GPIO_DOESET31_0_DIO4_OFS                 (4)                             /* !< DIO4 Offset */
+#define GPIO_DOESET31_0_DIO4_MASK                ((uint32_t)0x00000010U)         /* !< Writing 1 to this bit sets the DIO4
+                                                                                    bit in the DOE31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOESET31_0_DIO4_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO4_SET                 ((uint32_t)0x00000010U)         /* !< Sets DIO4 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO5] Bits */
+#define GPIO_DOESET31_0_DIO5_OFS                 (5)                             /* !< DIO5 Offset */
+#define GPIO_DOESET31_0_DIO5_MASK                ((uint32_t)0x00000020U)         /* !< Writing 1 to this bit sets the DIO5
+                                                                                    bit in the DOE31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOESET31_0_DIO5_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO5_SET                 ((uint32_t)0x00000020U)         /* !< Sets DIO5 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO6] Bits */
+#define GPIO_DOESET31_0_DIO6_OFS                 (6)                             /* !< DIO6 Offset */
+#define GPIO_DOESET31_0_DIO6_MASK                ((uint32_t)0x00000040U)         /* !< Writing 1 to this bit sets the DIO6
+                                                                                    bit in the DOE31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOESET31_0_DIO6_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO6_SET                 ((uint32_t)0x00000040U)         /* !< Sets DIO6 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO7] Bits */
+#define GPIO_DOESET31_0_DIO7_OFS                 (7)                             /* !< DIO7 Offset */
+#define GPIO_DOESET31_0_DIO7_MASK                ((uint32_t)0x00000080U)         /* !< Writing 1 to this bit sets the DIO7
+                                                                                    bit in the DOE31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOESET31_0_DIO7_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO7_SET                 ((uint32_t)0x00000080U)         /* !< Sets DIO7 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO8] Bits */
+#define GPIO_DOESET31_0_DIO8_OFS                 (8)                             /* !< DIO8 Offset */
+#define GPIO_DOESET31_0_DIO8_MASK                ((uint32_t)0x00000100U)         /* !< Writing 1 to this bit sets the DIO8
+                                                                                    bit in the DOE31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOESET31_0_DIO8_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO8_SET                 ((uint32_t)0x00000100U)         /* !< Sets DIO8 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO9] Bits */
+#define GPIO_DOESET31_0_DIO9_OFS                 (9)                             /* !< DIO9 Offset */
+#define GPIO_DOESET31_0_DIO9_MASK                ((uint32_t)0x00000200U)         /* !< Writing 1 to this bit sets the DIO9
+                                                                                    bit in the DOE31_0 register. Writing
+                                                                                    0 has no effect. */
+#define GPIO_DOESET31_0_DIO9_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO9_SET                 ((uint32_t)0x00000200U)         /* !< Sets DIO9 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO10] Bits */
+#define GPIO_DOESET31_0_DIO10_OFS                (10)                            /* !< DIO10 Offset */
+#define GPIO_DOESET31_0_DIO10_MASK               ((uint32_t)0x00000400U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO10 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO10_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO10_SET                ((uint32_t)0x00000400U)         /* !< Sets DIO10 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO11] Bits */
+#define GPIO_DOESET31_0_DIO11_OFS                (11)                            /* !< DIO11 Offset */
+#define GPIO_DOESET31_0_DIO11_MASK               ((uint32_t)0x00000800U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO11 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO11_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO11_SET                ((uint32_t)0x00000800U)         /* !< Sets DIO11 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO12] Bits */
+#define GPIO_DOESET31_0_DIO12_OFS                (12)                            /* !< DIO12 Offset */
+#define GPIO_DOESET31_0_DIO12_MASK               ((uint32_t)0x00001000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO12 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO12_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO12_SET                ((uint32_t)0x00001000U)         /* !< Sets DIO12 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO13] Bits */
+#define GPIO_DOESET31_0_DIO13_OFS                (13)                            /* !< DIO13 Offset */
+#define GPIO_DOESET31_0_DIO13_MASK               ((uint32_t)0x00002000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO13 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO13_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO13_SET                ((uint32_t)0x00002000U)         /* !< Sets DIO13 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO14] Bits */
+#define GPIO_DOESET31_0_DIO14_OFS                (14)                            /* !< DIO14 Offset */
+#define GPIO_DOESET31_0_DIO14_MASK               ((uint32_t)0x00004000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO14 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO14_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO14_SET                ((uint32_t)0x00004000U)         /* !< Sets DIO14 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO15] Bits */
+#define GPIO_DOESET31_0_DIO15_OFS                (15)                            /* !< DIO15 Offset */
+#define GPIO_DOESET31_0_DIO15_MASK               ((uint32_t)0x00008000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO15 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO15_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO15_SET                ((uint32_t)0x00008000U)         /* !< Sets DIO15 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO16] Bits */
+#define GPIO_DOESET31_0_DIO16_OFS                (16)                            /* !< DIO16 Offset */
+#define GPIO_DOESET31_0_DIO16_MASK               ((uint32_t)0x00010000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO16 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO16_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO16_SET                ((uint32_t)0x00010000U)         /* !< Sets DIO16 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO17] Bits */
+#define GPIO_DOESET31_0_DIO17_OFS                (17)                            /* !< DIO17 Offset */
+#define GPIO_DOESET31_0_DIO17_MASK               ((uint32_t)0x00020000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO17 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO17_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO17_SET                ((uint32_t)0x00020000U)         /* !< Sets DIO17 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO18] Bits */
+#define GPIO_DOESET31_0_DIO18_OFS                (18)                            /* !< DIO18 Offset */
+#define GPIO_DOESET31_0_DIO18_MASK               ((uint32_t)0x00040000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO18 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO18_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO18_SET                ((uint32_t)0x00040000U)         /* !< Sets DIO18 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO19] Bits */
+#define GPIO_DOESET31_0_DIO19_OFS                (19)                            /* !< DIO19 Offset */
+#define GPIO_DOESET31_0_DIO19_MASK               ((uint32_t)0x00080000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO19 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO19_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO19_SET                ((uint32_t)0x00080000U)         /* !< Sets DIO19 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO20] Bits */
+#define GPIO_DOESET31_0_DIO20_OFS                (20)                            /* !< DIO20 Offset */
+#define GPIO_DOESET31_0_DIO20_MASK               ((uint32_t)0x00100000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO20 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO20_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO20_SET                ((uint32_t)0x00100000U)         /* !< Sets DIO20 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO21] Bits */
+#define GPIO_DOESET31_0_DIO21_OFS                (21)                            /* !< DIO21 Offset */
+#define GPIO_DOESET31_0_DIO21_MASK               ((uint32_t)0x00200000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO21 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO21_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO21_SET                ((uint32_t)0x00200000U)         /* !< Sets DIO21 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO22] Bits */
+#define GPIO_DOESET31_0_DIO22_OFS                (22)                            /* !< DIO22 Offset */
+#define GPIO_DOESET31_0_DIO22_MASK               ((uint32_t)0x00400000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO22 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO22_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO22_SET                ((uint32_t)0x00400000U)         /* !< Sets DIO22 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO23] Bits */
+#define GPIO_DOESET31_0_DIO23_OFS                (23)                            /* !< DIO23 Offset */
+#define GPIO_DOESET31_0_DIO23_MASK               ((uint32_t)0x00800000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO23 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO23_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO23_SET                ((uint32_t)0x00800000U)         /* !< Sets DIO23 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO24] Bits */
+#define GPIO_DOESET31_0_DIO24_OFS                (24)                            /* !< DIO24 Offset */
+#define GPIO_DOESET31_0_DIO24_MASK               ((uint32_t)0x01000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO24 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO24_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO24_SET                ((uint32_t)0x01000000U)         /* !< Sets DIO24 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO25] Bits */
+#define GPIO_DOESET31_0_DIO25_OFS                (25)                            /* !< DIO25 Offset */
+#define GPIO_DOESET31_0_DIO25_MASK               ((uint32_t)0x02000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO25 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO25_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO25_SET                ((uint32_t)0x02000000U)         /* !< Sets DIO25 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO26] Bits */
+#define GPIO_DOESET31_0_DIO26_OFS                (26)                            /* !< DIO26 Offset */
+#define GPIO_DOESET31_0_DIO26_MASK               ((uint32_t)0x04000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO26 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO26_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO26_SET                ((uint32_t)0x04000000U)         /* !< Sets DIO26 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO27] Bits */
+#define GPIO_DOESET31_0_DIO27_OFS                (27)                            /* !< DIO27 Offset */
+#define GPIO_DOESET31_0_DIO27_MASK               ((uint32_t)0x08000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO27 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO27_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO27_SET                ((uint32_t)0x08000000U)         /* !< Sets DIO27 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO28] Bits */
+#define GPIO_DOESET31_0_DIO28_OFS                (28)                            /* !< DIO28 Offset */
+#define GPIO_DOESET31_0_DIO28_MASK               ((uint32_t)0x10000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO28 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO28_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO28_SET                ((uint32_t)0x10000000U)         /* !< Sets DIO28 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO29] Bits */
+#define GPIO_DOESET31_0_DIO29_OFS                (29)                            /* !< DIO29 Offset */
+#define GPIO_DOESET31_0_DIO29_MASK               ((uint32_t)0x20000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO29 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO29_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO29_SET                ((uint32_t)0x20000000U)         /* !< Sets DIO29 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO30] Bits */
+#define GPIO_DOESET31_0_DIO30_OFS                (30)                            /* !< DIO30 Offset */
+#define GPIO_DOESET31_0_DIO30_MASK               ((uint32_t)0x40000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO30 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO30_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO30_SET                ((uint32_t)0x40000000U)         /* !< Sets DIO30 in DOE31_0 */
+/* GPIO_DOESET31_0[DIO31] Bits */
+#define GPIO_DOESET31_0_DIO31_OFS                (31)                            /* !< DIO31 Offset */
+#define GPIO_DOESET31_0_DIO31_MASK               ((uint32_t)0x80000000U)         /* !< Writing 1 to this bit sets the
+                                                                                    DIO31 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOESET31_0_DIO31_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOESET31_0_DIO31_SET                ((uint32_t)0x80000000U)         /* !< Sets DIO31 in DOE31_0 */
+
+/* GPIO_DOECLR31_0 Bits */
+/* GPIO_DOECLR31_0[DIO0] Bits */
+#define GPIO_DOECLR31_0_DIO0_OFS                 (0)                             /* !< DIO0 Offset */
+#define GPIO_DOECLR31_0_DIO0_MASK                ((uint32_t)0x00000001U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO0 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO0_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO0_CLR                 ((uint32_t)0x00000001U)         /* !< Clears DIO0 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO1] Bits */
+#define GPIO_DOECLR31_0_DIO1_OFS                 (1)                             /* !< DIO1 Offset */
+#define GPIO_DOECLR31_0_DIO1_MASK                ((uint32_t)0x00000002U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO1 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO1_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO1_CLR                 ((uint32_t)0x00000002U)         /* !< Clears DIO1 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO2] Bits */
+#define GPIO_DOECLR31_0_DIO2_OFS                 (2)                             /* !< DIO2 Offset */
+#define GPIO_DOECLR31_0_DIO2_MASK                ((uint32_t)0x00000004U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO2 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO2_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO2_CLR                 ((uint32_t)0x00000004U)         /* !< Clears DIO2 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO3] Bits */
+#define GPIO_DOECLR31_0_DIO3_OFS                 (3)                             /* !< DIO3 Offset */
+#define GPIO_DOECLR31_0_DIO3_MASK                ((uint32_t)0x00000008U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO3 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO3_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO3_CLR                 ((uint32_t)0x00000008U)         /* !< Clears DIO3 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO4] Bits */
+#define GPIO_DOECLR31_0_DIO4_OFS                 (4)                             /* !< DIO4 Offset */
+#define GPIO_DOECLR31_0_DIO4_MASK                ((uint32_t)0x00000010U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO4 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO4_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO4_CLR                 ((uint32_t)0x00000010U)         /* !< Clears DIO4 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO5] Bits */
+#define GPIO_DOECLR31_0_DIO5_OFS                 (5)                             /* !< DIO5 Offset */
+#define GPIO_DOECLR31_0_DIO5_MASK                ((uint32_t)0x00000020U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO5 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO5_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO5_CLR                 ((uint32_t)0x00000020U)         /* !< Clears DIO5 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO6] Bits */
+#define GPIO_DOECLR31_0_DIO6_OFS                 (6)                             /* !< DIO6 Offset */
+#define GPIO_DOECLR31_0_DIO6_MASK                ((uint32_t)0x00000040U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO6 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO6_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO6_CLR                 ((uint32_t)0x00000040U)         /* !< Clears DIO6 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO7] Bits */
+#define GPIO_DOECLR31_0_DIO7_OFS                 (7)                             /* !< DIO7 Offset */
+#define GPIO_DOECLR31_0_DIO7_MASK                ((uint32_t)0x00000080U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO7 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO7_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO7_CLR                 ((uint32_t)0x00000080U)         /* !< Clears DIO7 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO8] Bits */
+#define GPIO_DOECLR31_0_DIO8_OFS                 (8)                             /* !< DIO8 Offset */
+#define GPIO_DOECLR31_0_DIO8_MASK                ((uint32_t)0x00000100U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO8 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO8_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO8_CLR                 ((uint32_t)0x00000100U)         /* !< Clears DIO8 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO9] Bits */
+#define GPIO_DOECLR31_0_DIO9_OFS                 (9)                             /* !< DIO9 Offset */
+#define GPIO_DOECLR31_0_DIO9_MASK                ((uint32_t)0x00000200U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO9 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO9_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO9_CLR                 ((uint32_t)0x00000200U)         /* !< Clears DIO9 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO10] Bits */
+#define GPIO_DOECLR31_0_DIO10_OFS                (10)                            /* !< DIO10 Offset */
+#define GPIO_DOECLR31_0_DIO10_MASK               ((uint32_t)0x00000400U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO10 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO10_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO10_CLR                ((uint32_t)0x00000400U)         /* !< Clears DIO10 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO11] Bits */
+#define GPIO_DOECLR31_0_DIO11_OFS                (11)                            /* !< DIO11 Offset */
+#define GPIO_DOECLR31_0_DIO11_MASK               ((uint32_t)0x00000800U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO11 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO11_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO11_CLR                ((uint32_t)0x00000800U)         /* !< Clears DIO11 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO12] Bits */
+#define GPIO_DOECLR31_0_DIO12_OFS                (12)                            /* !< DIO12 Offset */
+#define GPIO_DOECLR31_0_DIO12_MASK               ((uint32_t)0x00001000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO12 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO12_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO12_CLR                ((uint32_t)0x00001000U)         /* !< Clears DIO12 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO13] Bits */
+#define GPIO_DOECLR31_0_DIO13_OFS                (13)                            /* !< DIO13 Offset */
+#define GPIO_DOECLR31_0_DIO13_MASK               ((uint32_t)0x00002000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO13 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO13_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO13_CLR                ((uint32_t)0x00002000U)         /* !< Clears DIO13 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO14] Bits */
+#define GPIO_DOECLR31_0_DIO14_OFS                (14)                            /* !< DIO14 Offset */
+#define GPIO_DOECLR31_0_DIO14_MASK               ((uint32_t)0x00004000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO14 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO14_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO14_CLR                ((uint32_t)0x00004000U)         /* !< Clears DIO14 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO15] Bits */
+#define GPIO_DOECLR31_0_DIO15_OFS                (15)                            /* !< DIO15 Offset */
+#define GPIO_DOECLR31_0_DIO15_MASK               ((uint32_t)0x00008000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO15 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO15_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO15_CLR                ((uint32_t)0x00008000U)         /* !< Clears DIO15 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO16] Bits */
+#define GPIO_DOECLR31_0_DIO16_OFS                (16)                            /* !< DIO16 Offset */
+#define GPIO_DOECLR31_0_DIO16_MASK               ((uint32_t)0x00010000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO16 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO16_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO16_CLR                ((uint32_t)0x00010000U)         /* !< Clears DIO16 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO17] Bits */
+#define GPIO_DOECLR31_0_DIO17_OFS                (17)                            /* !< DIO17 Offset */
+#define GPIO_DOECLR31_0_DIO17_MASK               ((uint32_t)0x00020000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO17 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO17_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO17_CLR                ((uint32_t)0x00020000U)         /* !< Clears DIO17 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO18] Bits */
+#define GPIO_DOECLR31_0_DIO18_OFS                (18)                            /* !< DIO18 Offset */
+#define GPIO_DOECLR31_0_DIO18_MASK               ((uint32_t)0x00040000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO18 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO18_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO18_CLR                ((uint32_t)0x00040000U)         /* !< Clears DIO18 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO19] Bits */
+#define GPIO_DOECLR31_0_DIO19_OFS                (19)                            /* !< DIO19 Offset */
+#define GPIO_DOECLR31_0_DIO19_MASK               ((uint32_t)0x00080000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO19 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO19_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO19_CLR                ((uint32_t)0x00080000U)         /* !< Clears DIO19 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO20] Bits */
+#define GPIO_DOECLR31_0_DIO20_OFS                (20)                            /* !< DIO20 Offset */
+#define GPIO_DOECLR31_0_DIO20_MASK               ((uint32_t)0x00100000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO20 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO20_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO20_CLR                ((uint32_t)0x00100000U)         /* !< Clears DIO20 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO21] Bits */
+#define GPIO_DOECLR31_0_DIO21_OFS                (21)                            /* !< DIO21 Offset */
+#define GPIO_DOECLR31_0_DIO21_MASK               ((uint32_t)0x00200000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO21 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO21_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO21_CLR                ((uint32_t)0x00200000U)         /* !< Clears DIO21 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO22] Bits */
+#define GPIO_DOECLR31_0_DIO22_OFS                (22)                            /* !< DIO22 Offset */
+#define GPIO_DOECLR31_0_DIO22_MASK               ((uint32_t)0x00400000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO22 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO22_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO22_CLR                ((uint32_t)0x00400000U)         /* !< Clears DIO22 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO23] Bits */
+#define GPIO_DOECLR31_0_DIO23_OFS                (23)                            /* !< DIO23 Offset */
+#define GPIO_DOECLR31_0_DIO23_MASK               ((uint32_t)0x00800000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO23 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO23_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO23_CLR                ((uint32_t)0x00800000U)         /* !< Clears DIO23 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO24] Bits */
+#define GPIO_DOECLR31_0_DIO24_OFS                (24)                            /* !< DIO24 Offset */
+#define GPIO_DOECLR31_0_DIO24_MASK               ((uint32_t)0x01000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO24 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO24_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO24_CLR                ((uint32_t)0x01000000U)         /* !< Clears DIO24 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO25] Bits */
+#define GPIO_DOECLR31_0_DIO25_OFS                (25)                            /* !< DIO25 Offset */
+#define GPIO_DOECLR31_0_DIO25_MASK               ((uint32_t)0x02000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO25 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO25_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO25_CLR                ((uint32_t)0x02000000U)         /* !< Clears DIO25 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO26] Bits */
+#define GPIO_DOECLR31_0_DIO26_OFS                (26)                            /* !< DIO26 Offset */
+#define GPIO_DOECLR31_0_DIO26_MASK               ((uint32_t)0x04000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO26 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO26_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO26_CLR                ((uint32_t)0x04000000U)         /* !< Clears DIO26 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO27] Bits */
+#define GPIO_DOECLR31_0_DIO27_OFS                (27)                            /* !< DIO27 Offset */
+#define GPIO_DOECLR31_0_DIO27_MASK               ((uint32_t)0x08000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO27 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO27_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO27_CLR                ((uint32_t)0x08000000U)         /* !< Clears DIO27 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO28] Bits */
+#define GPIO_DOECLR31_0_DIO28_OFS                (28)                            /* !< DIO28 Offset */
+#define GPIO_DOECLR31_0_DIO28_MASK               ((uint32_t)0x10000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO28 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO28_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO28_CLR                ((uint32_t)0x10000000U)         /* !< Clears DIO28 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO29] Bits */
+#define GPIO_DOECLR31_0_DIO29_OFS                (29)                            /* !< DIO29 Offset */
+#define GPIO_DOECLR31_0_DIO29_MASK               ((uint32_t)0x20000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO29 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO29_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO29_CLR                ((uint32_t)0x20000000U)         /* !< Clears DIO29 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO30] Bits */
+#define GPIO_DOECLR31_0_DIO30_OFS                (30)                            /* !< DIO30 Offset */
+#define GPIO_DOECLR31_0_DIO30_MASK               ((uint32_t)0x40000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO30 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO30_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO30_CLR                ((uint32_t)0x40000000U)         /* !< Clears DIO30 in DOE31_0 */
+/* GPIO_DOECLR31_0[DIO31] Bits */
+#define GPIO_DOECLR31_0_DIO31_OFS                (31)                            /* !< DIO31 Offset */
+#define GPIO_DOECLR31_0_DIO31_MASK               ((uint32_t)0x80000000U)         /* !< Writing 1 to this bit clears the
+                                                                                    DIO31 bit in the DOE31_0 register.
+                                                                                    Writing 0 has no effect. */
+#define GPIO_DOECLR31_0_DIO31_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< No effect */
+#define GPIO_DOECLR31_0_DIO31_CLR                ((uint32_t)0x80000000U)         /* !< Clears DIO31 in DOE31_0 */
+
+/* GPIO_DIN3_0 Bits */
+/* GPIO_DIN3_0[DIO0] Bits */
+#define GPIO_DIN3_0_DIO0_OFS                     (0)                             /* !< DIO0 Offset */
+#define GPIO_DIN3_0_DIO0_MASK                    ((uint32_t)0x00000001U)         /* !< This bit reads the data input value
+                                                                                    of DIO0. */
+#define GPIO_DIN3_0_DIO0_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN3_0_DIO0_ONE                     ((uint32_t)0x00000001U)         /* !< Input value is 1 */
+/* GPIO_DIN3_0[DIO1] Bits */
+#define GPIO_DIN3_0_DIO1_OFS                     (8)                             /* !< DIO1 Offset */
+#define GPIO_DIN3_0_DIO1_MASK                    ((uint32_t)0x00000100U)         /* !< This bit reads the data input value
+                                                                                    of DIO1. */
+#define GPIO_DIN3_0_DIO1_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN3_0_DIO1_ONE                     ((uint32_t)0x00000100U)         /* !< Input value is 1 */
+/* GPIO_DIN3_0[DIO2] Bits */
+#define GPIO_DIN3_0_DIO2_OFS                     (16)                            /* !< DIO2 Offset */
+#define GPIO_DIN3_0_DIO2_MASK                    ((uint32_t)0x00010000U)         /* !< This bit reads the data input value
+                                                                                    of DIO2. */
+#define GPIO_DIN3_0_DIO2_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN3_0_DIO2_ONE                     ((uint32_t)0x00010000U)         /* !< Input value is 1 */
+/* GPIO_DIN3_0[DIO3] Bits */
+#define GPIO_DIN3_0_DIO3_OFS                     (24)                            /* !< DIO3 Offset */
+#define GPIO_DIN3_0_DIO3_MASK                    ((uint32_t)0x01000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO3. */
+#define GPIO_DIN3_0_DIO3_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN3_0_DIO3_ONE                     ((uint32_t)0x01000000U)         /* !< Input value is 1 */
+
+/* GPIO_DIN7_4 Bits */
+/* GPIO_DIN7_4[DIO4] Bits */
+#define GPIO_DIN7_4_DIO4_OFS                     (0)                             /* !< DIO4 Offset */
+#define GPIO_DIN7_4_DIO4_MASK                    ((uint32_t)0x00000001U)         /* !< This bit reads the data input value
+                                                                                    of DIO4. */
+#define GPIO_DIN7_4_DIO4_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN7_4_DIO4_ONE                     ((uint32_t)0x00000001U)         /* !< Input value is 1 */
+/* GPIO_DIN7_4[DIO5] Bits */
+#define GPIO_DIN7_4_DIO5_OFS                     (8)                             /* !< DIO5 Offset */
+#define GPIO_DIN7_4_DIO5_MASK                    ((uint32_t)0x00000100U)         /* !< This bit reads the data input value
+                                                                                    of DIO5. */
+#define GPIO_DIN7_4_DIO5_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN7_4_DIO5_ONE                     ((uint32_t)0x00000100U)         /* !< Input value is 1 */
+/* GPIO_DIN7_4[DIO6] Bits */
+#define GPIO_DIN7_4_DIO6_OFS                     (16)                            /* !< DIO6 Offset */
+#define GPIO_DIN7_4_DIO6_MASK                    ((uint32_t)0x00010000U)         /* !< This bit reads the data input value
+                                                                                    of DIO6. */
+#define GPIO_DIN7_4_DIO6_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN7_4_DIO6_ONE                     ((uint32_t)0x00010000U)         /* !< Input value is 1 */
+/* GPIO_DIN7_4[DIO7] Bits */
+#define GPIO_DIN7_4_DIO7_OFS                     (24)                            /* !< DIO7 Offset */
+#define GPIO_DIN7_4_DIO7_MASK                    ((uint32_t)0x01000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO7. */
+#define GPIO_DIN7_4_DIO7_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN7_4_DIO7_ONE                     ((uint32_t)0x01000000U)         /* !< Input value is 1 */
+
+/* GPIO_DIN11_8 Bits */
+/* GPIO_DIN11_8[DIO8] Bits */
+#define GPIO_DIN11_8_DIO8_OFS                    (0)                             /* !< DIO8 Offset */
+#define GPIO_DIN11_8_DIO8_MASK                   ((uint32_t)0x00000001U)         /* !< This bit reads the data input value
+                                                                                    of DIO8. */
+#define GPIO_DIN11_8_DIO8_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN11_8_DIO8_ONE                    ((uint32_t)0x00000001U)         /* !< Input value is 1 */
+/* GPIO_DIN11_8[DIO9] Bits */
+#define GPIO_DIN11_8_DIO9_OFS                    (8)                             /* !< DIO9 Offset */
+#define GPIO_DIN11_8_DIO9_MASK                   ((uint32_t)0x00000100U)         /* !< This bit reads the data input value
+                                                                                    of DIO9. */
+#define GPIO_DIN11_8_DIO9_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN11_8_DIO9_ONE                    ((uint32_t)0x00000100U)         /* !< Input value is 1 */
+/* GPIO_DIN11_8[DIO10] Bits */
+#define GPIO_DIN11_8_DIO10_OFS                   (16)                            /* !< DIO10 Offset */
+#define GPIO_DIN11_8_DIO10_MASK                  ((uint32_t)0x00010000U)         /* !< This bit reads the data input value
+                                                                                    of DIO10. */
+#define GPIO_DIN11_8_DIO10_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN11_8_DIO10_ONE                   ((uint32_t)0x00010000U)         /* !< Input value is 1 */
+/* GPIO_DIN11_8[DIO11] Bits */
+#define GPIO_DIN11_8_DIO11_OFS                   (24)                            /* !< DIO11 Offset */
+#define GPIO_DIN11_8_DIO11_MASK                  ((uint32_t)0x01000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO11. */
+#define GPIO_DIN11_8_DIO11_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN11_8_DIO11_ONE                   ((uint32_t)0x01000000U)         /* !< Input value is 1 */
+
+/* GPIO_DIN15_12 Bits */
+/* GPIO_DIN15_12[DIO12] Bits */
+#define GPIO_DIN15_12_DIO12_OFS                  (0)                             /* !< DIO12 Offset */
+#define GPIO_DIN15_12_DIO12_MASK                 ((uint32_t)0x00000001U)         /* !< This bit reads the data input value
+                                                                                    of DIO12. */
+#define GPIO_DIN15_12_DIO12_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN15_12_DIO12_ONE                  ((uint32_t)0x00000001U)         /* !< Input value is 1 */
+/* GPIO_DIN15_12[DIO13] Bits */
+#define GPIO_DIN15_12_DIO13_OFS                  (8)                             /* !< DIO13 Offset */
+#define GPIO_DIN15_12_DIO13_MASK                 ((uint32_t)0x00000100U)         /* !< This bit reads the data input value
+                                                                                    of DIO13. */
+#define GPIO_DIN15_12_DIO13_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN15_12_DIO13_ONE                  ((uint32_t)0x00000100U)         /* !< Input value is 1 */
+/* GPIO_DIN15_12[DIO14] Bits */
+#define GPIO_DIN15_12_DIO14_OFS                  (16)                            /* !< DIO14 Offset */
+#define GPIO_DIN15_12_DIO14_MASK                 ((uint32_t)0x00010000U)         /* !< This bit reads the data input value
+                                                                                    of DIO14. */
+#define GPIO_DIN15_12_DIO14_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN15_12_DIO14_ONE                  ((uint32_t)0x00010000U)         /* !< Input value is 1 */
+/* GPIO_DIN15_12[DIO15] Bits */
+#define GPIO_DIN15_12_DIO15_OFS                  (24)                            /* !< DIO15 Offset */
+#define GPIO_DIN15_12_DIO15_MASK                 ((uint32_t)0x01000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO15. */
+#define GPIO_DIN15_12_DIO15_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN15_12_DIO15_ONE                  ((uint32_t)0x01000000U)         /* !< Input value is 1 */
+
+/* GPIO_DIN19_16 Bits */
+/* GPIO_DIN19_16[DIO16] Bits */
+#define GPIO_DIN19_16_DIO16_OFS                  (0)                             /* !< DIO16 Offset */
+#define GPIO_DIN19_16_DIO16_MASK                 ((uint32_t)0x00000001U)         /* !< This bit reads the data input value
+                                                                                    of DIO16. */
+#define GPIO_DIN19_16_DIO16_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN19_16_DIO16_ONE                  ((uint32_t)0x00000001U)         /* !< Input value is 1 */
+/* GPIO_DIN19_16[DIO17] Bits */
+#define GPIO_DIN19_16_DIO17_OFS                  (8)                             /* !< DIO17 Offset */
+#define GPIO_DIN19_16_DIO17_MASK                 ((uint32_t)0x00000100U)         /* !< This bit reads the data input value
+                                                                                    of DIO17. */
+#define GPIO_DIN19_16_DIO17_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN19_16_DIO17_ONE                  ((uint32_t)0x00000100U)         /* !< Input value is 1 */
+/* GPIO_DIN19_16[DIO18] Bits */
+#define GPIO_DIN19_16_DIO18_OFS                  (16)                            /* !< DIO18 Offset */
+#define GPIO_DIN19_16_DIO18_MASK                 ((uint32_t)0x00010000U)         /* !< This bit reads the data input value
+                                                                                    of DIO18. */
+#define GPIO_DIN19_16_DIO18_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN19_16_DIO18_ONE                  ((uint32_t)0x00010000U)         /* !< Input value is 1 */
+/* GPIO_DIN19_16[DIO19] Bits */
+#define GPIO_DIN19_16_DIO19_OFS                  (24)                            /* !< DIO19 Offset */
+#define GPIO_DIN19_16_DIO19_MASK                 ((uint32_t)0x01000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO19. */
+#define GPIO_DIN19_16_DIO19_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN19_16_DIO19_ONE                  ((uint32_t)0x01000000U)         /* !< Input value is 1 */
+
+/* GPIO_DIN23_20 Bits */
+/* GPIO_DIN23_20[DIO20] Bits */
+#define GPIO_DIN23_20_DIO20_OFS                  (0)                             /* !< DIO20 Offset */
+#define GPIO_DIN23_20_DIO20_MASK                 ((uint32_t)0x00000001U)         /* !< This bit reads the data input value
+                                                                                    of DIO20. */
+#define GPIO_DIN23_20_DIO20_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN23_20_DIO20_ONE                  ((uint32_t)0x00000001U)         /* !< Input value is 1 */
+/* GPIO_DIN23_20[DIO21] Bits */
+#define GPIO_DIN23_20_DIO21_OFS                  (8)                             /* !< DIO21 Offset */
+#define GPIO_DIN23_20_DIO21_MASK                 ((uint32_t)0x00000100U)         /* !< This bit reads the data input value
+                                                                                    of DIO21. */
+#define GPIO_DIN23_20_DIO21_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN23_20_DIO21_ONE                  ((uint32_t)0x00000100U)         /* !< Input value is 1 */
+/* GPIO_DIN23_20[DIO22] Bits */
+#define GPIO_DIN23_20_DIO22_OFS                  (16)                            /* !< DIO22 Offset */
+#define GPIO_DIN23_20_DIO22_MASK                 ((uint32_t)0x00010000U)         /* !< This bit reads the data input value
+                                                                                    of DIO22. */
+#define GPIO_DIN23_20_DIO22_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN23_20_DIO22_ONE                  ((uint32_t)0x00010000U)         /* !< Input value is 1 */
+/* GPIO_DIN23_20[DIO23] Bits */
+#define GPIO_DIN23_20_DIO23_OFS                  (24)                            /* !< DIO23 Offset */
+#define GPIO_DIN23_20_DIO23_MASK                 ((uint32_t)0x01000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO23. */
+#define GPIO_DIN23_20_DIO23_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN23_20_DIO23_ONE                  ((uint32_t)0x01000000U)         /* !< Input value is 1 */
+
+/* GPIO_DIN27_24 Bits */
+/* GPIO_DIN27_24[DIO24] Bits */
+#define GPIO_DIN27_24_DIO24_OFS                  (0)                             /* !< DIO24 Offset */
+#define GPIO_DIN27_24_DIO24_MASK                 ((uint32_t)0x00000001U)         /* !< This bit reads the data input value
+                                                                                    of DIO24. */
+#define GPIO_DIN27_24_DIO24_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN27_24_DIO24_ONE                  ((uint32_t)0x00000001U)         /* !< Input value is 1 */
+/* GPIO_DIN27_24[DIO25] Bits */
+#define GPIO_DIN27_24_DIO25_OFS                  (8)                             /* !< DIO25 Offset */
+#define GPIO_DIN27_24_DIO25_MASK                 ((uint32_t)0x00000100U)         /* !< This bit reads the data input value
+                                                                                    of DIO25. */
+#define GPIO_DIN27_24_DIO25_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN27_24_DIO25_ONE                  ((uint32_t)0x00000100U)         /* !< Input value is 1 */
+/* GPIO_DIN27_24[DIO26] Bits */
+#define GPIO_DIN27_24_DIO26_OFS                  (16)                            /* !< DIO26 Offset */
+#define GPIO_DIN27_24_DIO26_MASK                 ((uint32_t)0x00010000U)         /* !< This bit reads the data input value
+                                                                                    of DIO26. */
+#define GPIO_DIN27_24_DIO26_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN27_24_DIO26_ONE                  ((uint32_t)0x00010000U)         /* !< Input value is 1 */
+/* GPIO_DIN27_24[DIO27] Bits */
+#define GPIO_DIN27_24_DIO27_OFS                  (24)                            /* !< DIO27 Offset */
+#define GPIO_DIN27_24_DIO27_MASK                 ((uint32_t)0x01000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO27. */
+#define GPIO_DIN27_24_DIO27_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN27_24_DIO27_ONE                  ((uint32_t)0x01000000U)         /* !< Input value is 1 */
+
+/* GPIO_DIN31_28 Bits */
+/* GPIO_DIN31_28[DIO28] Bits */
+#define GPIO_DIN31_28_DIO28_OFS                  (0)                             /* !< DIO28 Offset */
+#define GPIO_DIN31_28_DIO28_MASK                 ((uint32_t)0x00000001U)         /* !< This bit reads the data input value
+                                                                                    of DIO28. */
+#define GPIO_DIN31_28_DIO28_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_28_DIO28_ONE                  ((uint32_t)0x00000001U)         /* !< Input value is 1 */
+/* GPIO_DIN31_28[DIO29] Bits */
+#define GPIO_DIN31_28_DIO29_OFS                  (8)                             /* !< DIO29 Offset */
+#define GPIO_DIN31_28_DIO29_MASK                 ((uint32_t)0x00000100U)         /* !< This bit reads the data input value
+                                                                                    of DIO29. */
+#define GPIO_DIN31_28_DIO29_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_28_DIO29_ONE                  ((uint32_t)0x00000100U)         /* !< Input value is 1 */
+/* GPIO_DIN31_28[DIO30] Bits */
+#define GPIO_DIN31_28_DIO30_OFS                  (16)                            /* !< DIO30 Offset */
+#define GPIO_DIN31_28_DIO30_MASK                 ((uint32_t)0x00010000U)         /* !< This bit reads the data input value
+                                                                                    of DIO30. */
+#define GPIO_DIN31_28_DIO30_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_28_DIO30_ONE                  ((uint32_t)0x00010000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_28[DIO31] Bits */
+#define GPIO_DIN31_28_DIO31_OFS                  (24)                            /* !< DIO31 Offset */
+#define GPIO_DIN31_28_DIO31_MASK                 ((uint32_t)0x01000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO31. */
+#define GPIO_DIN31_28_DIO31_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_28_DIO31_ONE                  ((uint32_t)0x01000000U)         /* !< Input value is 1 */
+
+/* GPIO_DIN31_0 Bits */
+/* GPIO_DIN31_0[DIO0] Bits */
+#define GPIO_DIN31_0_DIO0_OFS                    (0)                             /* !< DIO0 Offset */
+#define GPIO_DIN31_0_DIO0_MASK                   ((uint32_t)0x00000001U)         /* !< This bit reads the data input value
+                                                                                    of DIO0. */
+#define GPIO_DIN31_0_DIO0_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO0_ONE                    ((uint32_t)0x00000001U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO1] Bits */
+#define GPIO_DIN31_0_DIO1_OFS                    (1)                             /* !< DIO1 Offset */
+#define GPIO_DIN31_0_DIO1_MASK                   ((uint32_t)0x00000002U)         /* !< This bit reads the data input value
+                                                                                    of DIO1. */
+#define GPIO_DIN31_0_DIO1_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO1_ONE                    ((uint32_t)0x00000002U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO2] Bits */
+#define GPIO_DIN31_0_DIO2_OFS                    (2)                             /* !< DIO2 Offset */
+#define GPIO_DIN31_0_DIO2_MASK                   ((uint32_t)0x00000004U)         /* !< This bit reads the data input value
+                                                                                    of DIO2. */
+#define GPIO_DIN31_0_DIO2_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO2_ONE                    ((uint32_t)0x00000004U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO3] Bits */
+#define GPIO_DIN31_0_DIO3_OFS                    (3)                             /* !< DIO3 Offset */
+#define GPIO_DIN31_0_DIO3_MASK                   ((uint32_t)0x00000008U)         /* !< This bit reads the data input value
+                                                                                    of DIO3. */
+#define GPIO_DIN31_0_DIO3_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO3_ONE                    ((uint32_t)0x00000008U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO4] Bits */
+#define GPIO_DIN31_0_DIO4_OFS                    (4)                             /* !< DIO4 Offset */
+#define GPIO_DIN31_0_DIO4_MASK                   ((uint32_t)0x00000010U)         /* !< This bit reads the data input value
+                                                                                    of DIO4. */
+#define GPIO_DIN31_0_DIO4_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO4_ONE                    ((uint32_t)0x00000010U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO5] Bits */
+#define GPIO_DIN31_0_DIO5_OFS                    (5)                             /* !< DIO5 Offset */
+#define GPIO_DIN31_0_DIO5_MASK                   ((uint32_t)0x00000020U)         /* !< This bit reads the data input value
+                                                                                    of DIO5. */
+#define GPIO_DIN31_0_DIO5_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO5_ONE                    ((uint32_t)0x00000020U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO6] Bits */
+#define GPIO_DIN31_0_DIO6_OFS                    (6)                             /* !< DIO6 Offset */
+#define GPIO_DIN31_0_DIO6_MASK                   ((uint32_t)0x00000040U)         /* !< This bit reads the data input value
+                                                                                    of DIO6. */
+#define GPIO_DIN31_0_DIO6_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO6_ONE                    ((uint32_t)0x00000040U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO7] Bits */
+#define GPIO_DIN31_0_DIO7_OFS                    (7)                             /* !< DIO7 Offset */
+#define GPIO_DIN31_0_DIO7_MASK                   ((uint32_t)0x00000080U)         /* !< This bit reads the data input value
+                                                                                    of DIO7. */
+#define GPIO_DIN31_0_DIO7_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO7_ONE                    ((uint32_t)0x00000080U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO8] Bits */
+#define GPIO_DIN31_0_DIO8_OFS                    (8)                             /* !< DIO8 Offset */
+#define GPIO_DIN31_0_DIO8_MASK                   ((uint32_t)0x00000100U)         /* !< This bit reads the data input value
+                                                                                    of DIO8. */
+#define GPIO_DIN31_0_DIO8_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO8_ONE                    ((uint32_t)0x00000100U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO9] Bits */
+#define GPIO_DIN31_0_DIO9_OFS                    (9)                             /* !< DIO9 Offset */
+#define GPIO_DIN31_0_DIO9_MASK                   ((uint32_t)0x00000200U)         /* !< This bit reads the data input value
+                                                                                    of DIO9. */
+#define GPIO_DIN31_0_DIO9_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO9_ONE                    ((uint32_t)0x00000200U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO10] Bits */
+#define GPIO_DIN31_0_DIO10_OFS                   (10)                            /* !< DIO10 Offset */
+#define GPIO_DIN31_0_DIO10_MASK                  ((uint32_t)0x00000400U)         /* !< This bit reads the data input value
+                                                                                    of DIO10. */
+#define GPIO_DIN31_0_DIO10_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO10_ONE                   ((uint32_t)0x00000400U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO11] Bits */
+#define GPIO_DIN31_0_DIO11_OFS                   (11)                            /* !< DIO11 Offset */
+#define GPIO_DIN31_0_DIO11_MASK                  ((uint32_t)0x00000800U)         /* !< This bit reads the data input value
+                                                                                    of DIO11. */
+#define GPIO_DIN31_0_DIO11_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO11_ONE                   ((uint32_t)0x00000800U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO12] Bits */
+#define GPIO_DIN31_0_DIO12_OFS                   (12)                            /* !< DIO12 Offset */
+#define GPIO_DIN31_0_DIO12_MASK                  ((uint32_t)0x00001000U)         /* !< This bit reads the data input value
+                                                                                    of DIO12. */
+#define GPIO_DIN31_0_DIO12_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO12_ONE                   ((uint32_t)0x00001000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO13] Bits */
+#define GPIO_DIN31_0_DIO13_OFS                   (13)                            /* !< DIO13 Offset */
+#define GPIO_DIN31_0_DIO13_MASK                  ((uint32_t)0x00002000U)         /* !< This bit reads the data input value
+                                                                                    of DIO13. */
+#define GPIO_DIN31_0_DIO13_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO13_ONE                   ((uint32_t)0x00002000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO14] Bits */
+#define GPIO_DIN31_0_DIO14_OFS                   (14)                            /* !< DIO14 Offset */
+#define GPIO_DIN31_0_DIO14_MASK                  ((uint32_t)0x00004000U)         /* !< This bit reads the data input value
+                                                                                    of DIO14. */
+#define GPIO_DIN31_0_DIO14_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO14_ONE                   ((uint32_t)0x00004000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO15] Bits */
+#define GPIO_DIN31_0_DIO15_OFS                   (15)                            /* !< DIO15 Offset */
+#define GPIO_DIN31_0_DIO15_MASK                  ((uint32_t)0x00008000U)         /* !< This bit reads the data input value
+                                                                                    of DIO15. */
+#define GPIO_DIN31_0_DIO15_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO15_ONE                   ((uint32_t)0x00008000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO16] Bits */
+#define GPIO_DIN31_0_DIO16_OFS                   (16)                            /* !< DIO16 Offset */
+#define GPIO_DIN31_0_DIO16_MASK                  ((uint32_t)0x00010000U)         /* !< This bit reads the data input value
+                                                                                    of DIO16. */
+#define GPIO_DIN31_0_DIO16_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO16_ONE                   ((uint32_t)0x00010000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO17] Bits */
+#define GPIO_DIN31_0_DIO17_OFS                   (17)                            /* !< DIO17 Offset */
+#define GPIO_DIN31_0_DIO17_MASK                  ((uint32_t)0x00020000U)         /* !< This bit reads the data input value
+                                                                                    of DIO17. */
+#define GPIO_DIN31_0_DIO17_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO17_ONE                   ((uint32_t)0x00020000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO18] Bits */
+#define GPIO_DIN31_0_DIO18_OFS                   (18)                            /* !< DIO18 Offset */
+#define GPIO_DIN31_0_DIO18_MASK                  ((uint32_t)0x00040000U)         /* !< This bit reads the data input value
+                                                                                    of DIO18. */
+#define GPIO_DIN31_0_DIO18_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO18_ONE                   ((uint32_t)0x00040000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO19] Bits */
+#define GPIO_DIN31_0_DIO19_OFS                   (19)                            /* !< DIO19 Offset */
+#define GPIO_DIN31_0_DIO19_MASK                  ((uint32_t)0x00080000U)         /* !< This bit reads the data input value
+                                                                                    of DIO19. */
+#define GPIO_DIN31_0_DIO19_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO19_ONE                   ((uint32_t)0x00080000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO20] Bits */
+#define GPIO_DIN31_0_DIO20_OFS                   (20)                            /* !< DIO20 Offset */
+#define GPIO_DIN31_0_DIO20_MASK                  ((uint32_t)0x00100000U)         /* !< This bit reads the data input value
+                                                                                    of DIO20. */
+#define GPIO_DIN31_0_DIO20_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO20_ONE                   ((uint32_t)0x00100000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO21] Bits */
+#define GPIO_DIN31_0_DIO21_OFS                   (21)                            /* !< DIO21 Offset */
+#define GPIO_DIN31_0_DIO21_MASK                  ((uint32_t)0x00200000U)         /* !< This bit reads the data input value
+                                                                                    of DIO21. */
+#define GPIO_DIN31_0_DIO21_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO21_ONE                   ((uint32_t)0x00200000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO22] Bits */
+#define GPIO_DIN31_0_DIO22_OFS                   (22)                            /* !< DIO22 Offset */
+#define GPIO_DIN31_0_DIO22_MASK                  ((uint32_t)0x00400000U)         /* !< This bit reads the data input value
+                                                                                    of DIO22. */
+#define GPIO_DIN31_0_DIO22_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO22_ONE                   ((uint32_t)0x00400000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO23] Bits */
+#define GPIO_DIN31_0_DIO23_OFS                   (23)                            /* !< DIO23 Offset */
+#define GPIO_DIN31_0_DIO23_MASK                  ((uint32_t)0x00800000U)         /* !< This bit reads the data input value
+                                                                                    of DIO23. */
+#define GPIO_DIN31_0_DIO23_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO23_ONE                   ((uint32_t)0x00800000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO24] Bits */
+#define GPIO_DIN31_0_DIO24_OFS                   (24)                            /* !< DIO24 Offset */
+#define GPIO_DIN31_0_DIO24_MASK                  ((uint32_t)0x01000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO24. */
+#define GPIO_DIN31_0_DIO24_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO24_ONE                   ((uint32_t)0x01000000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO25] Bits */
+#define GPIO_DIN31_0_DIO25_OFS                   (25)                            /* !< DIO25 Offset */
+#define GPIO_DIN31_0_DIO25_MASK                  ((uint32_t)0x02000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO25. */
+#define GPIO_DIN31_0_DIO25_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO25_ONE                   ((uint32_t)0x02000000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO26] Bits */
+#define GPIO_DIN31_0_DIO26_OFS                   (26)                            /* !< DIO26 Offset */
+#define GPIO_DIN31_0_DIO26_MASK                  ((uint32_t)0x04000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO26. */
+#define GPIO_DIN31_0_DIO26_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO26_ONE                   ((uint32_t)0x04000000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO27] Bits */
+#define GPIO_DIN31_0_DIO27_OFS                   (27)                            /* !< DIO27 Offset */
+#define GPIO_DIN31_0_DIO27_MASK                  ((uint32_t)0x08000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO27. */
+#define GPIO_DIN31_0_DIO27_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO27_ONE                   ((uint32_t)0x08000000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO28] Bits */
+#define GPIO_DIN31_0_DIO28_OFS                   (28)                            /* !< DIO28 Offset */
+#define GPIO_DIN31_0_DIO28_MASK                  ((uint32_t)0x10000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO28. */
+#define GPIO_DIN31_0_DIO28_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO28_ONE                   ((uint32_t)0x10000000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO29] Bits */
+#define GPIO_DIN31_0_DIO29_OFS                   (29)                            /* !< DIO29 Offset */
+#define GPIO_DIN31_0_DIO29_MASK                  ((uint32_t)0x20000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO29. */
+#define GPIO_DIN31_0_DIO29_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO29_ONE                   ((uint32_t)0x20000000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO30] Bits */
+#define GPIO_DIN31_0_DIO30_OFS                   (30)                            /* !< DIO30 Offset */
+#define GPIO_DIN31_0_DIO30_MASK                  ((uint32_t)0x40000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO30. */
+#define GPIO_DIN31_0_DIO30_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO30_ONE                   ((uint32_t)0x40000000U)         /* !< Input value is 1 */
+/* GPIO_DIN31_0[DIO31] Bits */
+#define GPIO_DIN31_0_DIO31_OFS                   (31)                            /* !< DIO31 Offset */
+#define GPIO_DIN31_0_DIO31_MASK                  ((uint32_t)0x80000000U)         /* !< This bit reads the data input value
+                                                                                    of DIO31. */
+#define GPIO_DIN31_0_DIO31_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define GPIO_DIN31_0_DIO31_ONE                   ((uint32_t)0x80000000U)         /* !< Input value is 1 */
+
+/* GPIO_POLARITY15_0 Bits */
+/* GPIO_POLARITY15_0[DIO0] Bits */
+#define GPIO_POLARITY15_0_DIO0_OFS               (0)                             /* !< DIO0 Offset */
+#define GPIO_POLARITY15_0_DIO0_MASK              ((uint32_t)0x00000003U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO0. */
+#define GPIO_POLARITY15_0_DIO0_DISABLE           ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO0_RISE              ((uint32_t)0x00000001U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO0_FALL              ((uint32_t)0x00000002U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO0_RISE_FALL         ((uint32_t)0x00000003U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO1] Bits */
+#define GPIO_POLARITY15_0_DIO1_OFS               (2)                             /* !< DIO1 Offset */
+#define GPIO_POLARITY15_0_DIO1_MASK              ((uint32_t)0x0000000CU)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO1. */
+#define GPIO_POLARITY15_0_DIO1_DISABLE           ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO1_RISE              ((uint32_t)0x00000004U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO1_FALL              ((uint32_t)0x00000008U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO1_RISE_FALL         ((uint32_t)0x0000000CU)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO2] Bits */
+#define GPIO_POLARITY15_0_DIO2_OFS               (4)                             /* !< DIO2 Offset */
+#define GPIO_POLARITY15_0_DIO2_MASK              ((uint32_t)0x00000030U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO2. */
+#define GPIO_POLARITY15_0_DIO2_DISABLE           ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO2_RISE              ((uint32_t)0x00000010U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO2_FALL              ((uint32_t)0x00000020U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO2_RISE_FALL         ((uint32_t)0x00000030U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO3] Bits */
+#define GPIO_POLARITY15_0_DIO3_OFS               (6)                             /* !< DIO3 Offset */
+#define GPIO_POLARITY15_0_DIO3_MASK              ((uint32_t)0x000000C0U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO3. */
+#define GPIO_POLARITY15_0_DIO3_DISABLE           ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO3_RISE              ((uint32_t)0x00000040U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO3_FALL              ((uint32_t)0x00000080U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO3_RISE_FALL         ((uint32_t)0x000000C0U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO4] Bits */
+#define GPIO_POLARITY15_0_DIO4_OFS               (8)                             /* !< DIO4 Offset */
+#define GPIO_POLARITY15_0_DIO4_MASK              ((uint32_t)0x00000300U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO4. */
+#define GPIO_POLARITY15_0_DIO4_DISABLE           ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO4_RISE              ((uint32_t)0x00000100U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO4_FALL              ((uint32_t)0x00000200U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO4_RISE_FALL         ((uint32_t)0x00000300U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO5] Bits */
+#define GPIO_POLARITY15_0_DIO5_OFS               (10)                            /* !< DIO5 Offset */
+#define GPIO_POLARITY15_0_DIO5_MASK              ((uint32_t)0x00000C00U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO5. */
+#define GPIO_POLARITY15_0_DIO5_DISABLE           ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO5_RISE              ((uint32_t)0x00000400U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO5_FALL              ((uint32_t)0x00000800U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO5_RISE_FALL         ((uint32_t)0x00000C00U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO6] Bits */
+#define GPIO_POLARITY15_0_DIO6_OFS               (12)                            /* !< DIO6 Offset */
+#define GPIO_POLARITY15_0_DIO6_MASK              ((uint32_t)0x00003000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO6. */
+#define GPIO_POLARITY15_0_DIO6_DISABLE           ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO6_RISE              ((uint32_t)0x00001000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO6_FALL              ((uint32_t)0x00002000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO6_RISE_FALL         ((uint32_t)0x00003000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO7] Bits */
+#define GPIO_POLARITY15_0_DIO7_OFS               (14)                            /* !< DIO7 Offset */
+#define GPIO_POLARITY15_0_DIO7_MASK              ((uint32_t)0x0000C000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO7. */
+#define GPIO_POLARITY15_0_DIO7_DISABLE           ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO7_RISE              ((uint32_t)0x00004000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO7_FALL              ((uint32_t)0x00008000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO7_RISE_FALL         ((uint32_t)0x0000C000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO8] Bits */
+#define GPIO_POLARITY15_0_DIO8_OFS               (16)                            /* !< DIO8 Offset */
+#define GPIO_POLARITY15_0_DIO8_MASK              ((uint32_t)0x00030000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO8. */
+#define GPIO_POLARITY15_0_DIO8_DISABLE           ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO8_RISE              ((uint32_t)0x00010000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO8_FALL              ((uint32_t)0x00020000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO8_RISE_FALL         ((uint32_t)0x00030000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO9] Bits */
+#define GPIO_POLARITY15_0_DIO9_OFS               (18)                            /* !< DIO9 Offset */
+#define GPIO_POLARITY15_0_DIO9_MASK              ((uint32_t)0x000C0000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO9. */
+#define GPIO_POLARITY15_0_DIO9_DISABLE           ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO9_RISE              ((uint32_t)0x00040000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO9_FALL              ((uint32_t)0x00080000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO9_RISE_FALL         ((uint32_t)0x000C0000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO10] Bits */
+#define GPIO_POLARITY15_0_DIO10_OFS              (20)                            /* !< DIO10 Offset */
+#define GPIO_POLARITY15_0_DIO10_MASK             ((uint32_t)0x00300000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO10. */
+#define GPIO_POLARITY15_0_DIO10_DISABLE          ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO10_RISE             ((uint32_t)0x00100000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO10_FALL             ((uint32_t)0x00200000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO10_RISE_FALL        ((uint32_t)0x00300000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO11] Bits */
+#define GPIO_POLARITY15_0_DIO11_OFS              (22)                            /* !< DIO11 Offset */
+#define GPIO_POLARITY15_0_DIO11_MASK             ((uint32_t)0x00C00000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO11. */
+#define GPIO_POLARITY15_0_DIO11_DISABLE          ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO11_RISE             ((uint32_t)0x00400000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO11_FALL             ((uint32_t)0x00800000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO11_RISE_FALL        ((uint32_t)0x00C00000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO12] Bits */
+#define GPIO_POLARITY15_0_DIO12_OFS              (24)                            /* !< DIO12 Offset */
+#define GPIO_POLARITY15_0_DIO12_MASK             ((uint32_t)0x03000000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO12. */
+#define GPIO_POLARITY15_0_DIO12_DISABLE          ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO12_RISE             ((uint32_t)0x01000000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO12_FALL             ((uint32_t)0x02000000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO12_RISE_FALL        ((uint32_t)0x03000000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO13] Bits */
+#define GPIO_POLARITY15_0_DIO13_OFS              (26)                            /* !< DIO13 Offset */
+#define GPIO_POLARITY15_0_DIO13_MASK             ((uint32_t)0x0C000000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO13. */
+#define GPIO_POLARITY15_0_DIO13_DISABLE          ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO13_RISE             ((uint32_t)0x04000000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO13_FALL             ((uint32_t)0x08000000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO13_RISE_FALL        ((uint32_t)0x0C000000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO14] Bits */
+#define GPIO_POLARITY15_0_DIO14_OFS              (28)                            /* !< DIO14 Offset */
+#define GPIO_POLARITY15_0_DIO14_MASK             ((uint32_t)0x30000000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO14. */
+#define GPIO_POLARITY15_0_DIO14_DISABLE          ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO14_RISE             ((uint32_t)0x10000000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO14_FALL             ((uint32_t)0x20000000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO14_RISE_FALL        ((uint32_t)0x30000000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY15_0[DIO15] Bits */
+#define GPIO_POLARITY15_0_DIO15_OFS              (30)                            /* !< DIO15 Offset */
+#define GPIO_POLARITY15_0_DIO15_MASK             ((uint32_t)0xC0000000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO15. */
+#define GPIO_POLARITY15_0_DIO15_DISABLE          ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY15_0_DIO15_RISE             ((uint32_t)0x40000000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY15_0_DIO15_FALL             ((uint32_t)0x80000000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY15_0_DIO15_RISE_FALL        ((uint32_t)0xC0000000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+
+/* GPIO_POLARITY31_16 Bits */
+/* GPIO_POLARITY31_16[DIO16] Bits */
+#define GPIO_POLARITY31_16_DIO16_OFS             (0)                             /* !< DIO16 Offset */
+#define GPIO_POLARITY31_16_DIO16_MASK            ((uint32_t)0x00000003U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO16. */
+#define GPIO_POLARITY31_16_DIO16_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO16_RISE            ((uint32_t)0x00000001U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO16_FALL            ((uint32_t)0x00000002U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO16_RISE_FALL       ((uint32_t)0x00000003U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO17] Bits */
+#define GPIO_POLARITY31_16_DIO17_OFS             (2)                             /* !< DIO17 Offset */
+#define GPIO_POLARITY31_16_DIO17_MASK            ((uint32_t)0x0000000CU)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO17. */
+#define GPIO_POLARITY31_16_DIO17_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO17_RISE            ((uint32_t)0x00000004U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO17_FALL            ((uint32_t)0x00000008U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO17_RISE_FALL       ((uint32_t)0x0000000CU)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO18] Bits */
+#define GPIO_POLARITY31_16_DIO18_OFS             (4)                             /* !< DIO18 Offset */
+#define GPIO_POLARITY31_16_DIO18_MASK            ((uint32_t)0x00000030U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO18. */
+#define GPIO_POLARITY31_16_DIO18_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO18_RISE            ((uint32_t)0x00000010U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO18_FALL            ((uint32_t)0x00000020U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO18_RISE_FALL       ((uint32_t)0x00000030U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO19] Bits */
+#define GPIO_POLARITY31_16_DIO19_OFS             (6)                             /* !< DIO19 Offset */
+#define GPIO_POLARITY31_16_DIO19_MASK            ((uint32_t)0x000000C0U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO19. */
+#define GPIO_POLARITY31_16_DIO19_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO19_RISE            ((uint32_t)0x00000040U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO19_FALL            ((uint32_t)0x00000080U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO19_RISE_FALL       ((uint32_t)0x000000C0U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO20] Bits */
+#define GPIO_POLARITY31_16_DIO20_OFS             (8)                             /* !< DIO20 Offset */
+#define GPIO_POLARITY31_16_DIO20_MASK            ((uint32_t)0x00000300U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO20. */
+#define GPIO_POLARITY31_16_DIO20_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO20_RISE            ((uint32_t)0x00000100U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO20_FALL            ((uint32_t)0x00000200U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO20_RISE_FALL       ((uint32_t)0x00000300U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO21] Bits */
+#define GPIO_POLARITY31_16_DIO21_OFS             (10)                            /* !< DIO21 Offset */
+#define GPIO_POLARITY31_16_DIO21_MASK            ((uint32_t)0x00000C00U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO21. */
+#define GPIO_POLARITY31_16_DIO21_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO21_RISE            ((uint32_t)0x00000400U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO21_FALL            ((uint32_t)0x00000800U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO21_RISE_FALL       ((uint32_t)0x00000C00U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO22] Bits */
+#define GPIO_POLARITY31_16_DIO22_OFS             (12)                            /* !< DIO22 Offset */
+#define GPIO_POLARITY31_16_DIO22_MASK            ((uint32_t)0x00003000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO22. */
+#define GPIO_POLARITY31_16_DIO22_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO22_RISE            ((uint32_t)0x00001000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO22_FALL            ((uint32_t)0x00002000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO22_RISE_FALL       ((uint32_t)0x00003000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO23] Bits */
+#define GPIO_POLARITY31_16_DIO23_OFS             (14)                            /* !< DIO23 Offset */
+#define GPIO_POLARITY31_16_DIO23_MASK            ((uint32_t)0x0000C000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO23. */
+#define GPIO_POLARITY31_16_DIO23_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO23_RISE            ((uint32_t)0x00004000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO23_FALL            ((uint32_t)0x00008000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO23_RISE_FALL       ((uint32_t)0x0000C000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO24] Bits */
+#define GPIO_POLARITY31_16_DIO24_OFS             (16)                            /* !< DIO24 Offset */
+#define GPIO_POLARITY31_16_DIO24_MASK            ((uint32_t)0x00030000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO24. */
+#define GPIO_POLARITY31_16_DIO24_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO24_RISE            ((uint32_t)0x00010000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO24_FALL            ((uint32_t)0x00020000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO24_RISE_FALL       ((uint32_t)0x00030000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO25] Bits */
+#define GPIO_POLARITY31_16_DIO25_OFS             (18)                            /* !< DIO25 Offset */
+#define GPIO_POLARITY31_16_DIO25_MASK            ((uint32_t)0x000C0000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO25. */
+#define GPIO_POLARITY31_16_DIO25_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO25_RISE            ((uint32_t)0x00040000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO25_FALL            ((uint32_t)0x00080000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO25_RISE_FALL       ((uint32_t)0x000C0000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO26] Bits */
+#define GPIO_POLARITY31_16_DIO26_OFS             (20)                            /* !< DIO26 Offset */
+#define GPIO_POLARITY31_16_DIO26_MASK            ((uint32_t)0x00300000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO26. */
+#define GPIO_POLARITY31_16_DIO26_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO26_RISE            ((uint32_t)0x00100000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO26_FALL            ((uint32_t)0x00200000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO26_RISE_FALL       ((uint32_t)0x00300000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO27] Bits */
+#define GPIO_POLARITY31_16_DIO27_OFS             (22)                            /* !< DIO27 Offset */
+#define GPIO_POLARITY31_16_DIO27_MASK            ((uint32_t)0x00C00000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO27. */
+#define GPIO_POLARITY31_16_DIO27_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO27_RISE            ((uint32_t)0x00400000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO27_FALL            ((uint32_t)0x00800000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO27_RISE_FALL       ((uint32_t)0x00C00000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO28] Bits */
+#define GPIO_POLARITY31_16_DIO28_OFS             (24)                            /* !< DIO28 Offset */
+#define GPIO_POLARITY31_16_DIO28_MASK            ((uint32_t)0x03000000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO28. */
+#define GPIO_POLARITY31_16_DIO28_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO28_RISE            ((uint32_t)0x01000000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO28_FALL            ((uint32_t)0x02000000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO28_RISE_FALL       ((uint32_t)0x03000000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO29] Bits */
+#define GPIO_POLARITY31_16_DIO29_OFS             (26)                            /* !< DIO29 Offset */
+#define GPIO_POLARITY31_16_DIO29_MASK            ((uint32_t)0x0C000000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO29. */
+#define GPIO_POLARITY31_16_DIO29_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO29_RISE            ((uint32_t)0x04000000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO29_FALL            ((uint32_t)0x08000000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO29_RISE_FALL       ((uint32_t)0x0C000000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO30] Bits */
+#define GPIO_POLARITY31_16_DIO30_OFS             (28)                            /* !< DIO30 Offset */
+#define GPIO_POLARITY31_16_DIO30_MASK            ((uint32_t)0x30000000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO30. */
+#define GPIO_POLARITY31_16_DIO30_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO30_RISE            ((uint32_t)0x10000000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO30_FALL            ((uint32_t)0x20000000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO30_RISE_FALL       ((uint32_t)0x30000000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* GPIO_POLARITY31_16[DIO31] Bits */
+#define GPIO_POLARITY31_16_DIO31_OFS             (30)                            /* !< DIO31 Offset */
+#define GPIO_POLARITY31_16_DIO31_MASK            ((uint32_t)0xC0000000U)         /* !< Enables and configures edge
+                                                                                    detection polarity for DIO31. */
+#define GPIO_POLARITY31_16_DIO31_DISABLE         ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define GPIO_POLARITY31_16_DIO31_RISE            ((uint32_t)0x40000000U)         /* !< Detects rising edge of input event */
+#define GPIO_POLARITY31_16_DIO31_FALL            ((uint32_t)0x80000000U)         /* !< Detects falling edge of input event */
+#define GPIO_POLARITY31_16_DIO31_RISE_FALL       ((uint32_t)0xC0000000U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+
+/* GPIO_CTL Bits */
+/* GPIO_CTL[FASTWAKEONLY] Bits */
+#define GPIO_CTL_FASTWAKEONLY_OFS                (0)                             /* !< FASTWAKEONLY Offset */
+#define GPIO_CTL_FASTWAKEONLY_MASK               ((uint32_t)0x00000001U)         /* !< FASTWAKEONLY for the global control
+                                                                                    of fastwake */
+#define GPIO_CTL_FASTWAKEONLY_NOT_GLOBAL_EN      ((uint32_t)0x00000000U)         /* !< The global control of fastwake is
+                                                                                    not enabled, per bit fast wake
+                                                                                    feature depends on FASTWAKE.DIN */
+#define GPIO_CTL_FASTWAKEONLY_GLOBAL_EN          ((uint32_t)0x00000001U)         /* !< The global control of fastwake is
+                                                                                    enabled */
+
+/* GPIO_FASTWAKE Bits */
+/* GPIO_FASTWAKE[DIN0] Bits */
+#define GPIO_FASTWAKE_DIN0_OFS                   (0)                             /* !< DIN0 Offset */
+#define GPIO_FASTWAKE_DIN0_MASK                  ((uint32_t)0x00000001U)         /* !< Enable fastwake feature for DIN0 */
+#define GPIO_FASTWAKE_DIN0_DISABLE               ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN0_ENABLE                ((uint32_t)0x00000001U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN1] Bits */
+#define GPIO_FASTWAKE_DIN1_OFS                   (1)                             /* !< DIN1 Offset */
+#define GPIO_FASTWAKE_DIN1_MASK                  ((uint32_t)0x00000002U)         /* !< Enable fastwake feature for DIN1 */
+#define GPIO_FASTWAKE_DIN1_DISABLE               ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN1_ENABLE                ((uint32_t)0x00000002U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN2] Bits */
+#define GPIO_FASTWAKE_DIN2_OFS                   (2)                             /* !< DIN2 Offset */
+#define GPIO_FASTWAKE_DIN2_MASK                  ((uint32_t)0x00000004U)         /* !< Enable fastwake feature for DIN2 */
+#define GPIO_FASTWAKE_DIN2_DISABLE               ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN2_ENABLE                ((uint32_t)0x00000004U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN3] Bits */
+#define GPIO_FASTWAKE_DIN3_OFS                   (3)                             /* !< DIN3 Offset */
+#define GPIO_FASTWAKE_DIN3_MASK                  ((uint32_t)0x00000008U)         /* !< Enable fastwake feature for DIN3 */
+#define GPIO_FASTWAKE_DIN3_DISABLE               ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN3_ENABLE                ((uint32_t)0x00000008U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN4] Bits */
+#define GPIO_FASTWAKE_DIN4_OFS                   (4)                             /* !< DIN4 Offset */
+#define GPIO_FASTWAKE_DIN4_MASK                  ((uint32_t)0x00000010U)         /* !< Enable fastwake feature for DIN4 */
+#define GPIO_FASTWAKE_DIN4_DISABLE               ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN4_ENABLE                ((uint32_t)0x00000010U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN5] Bits */
+#define GPIO_FASTWAKE_DIN5_OFS                   (5)                             /* !< DIN5 Offset */
+#define GPIO_FASTWAKE_DIN5_MASK                  ((uint32_t)0x00000020U)         /* !< Enable fastwake feature for DIN5 */
+#define GPIO_FASTWAKE_DIN5_DISABLE               ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN5_ENABLE                ((uint32_t)0x00000020U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN6] Bits */
+#define GPIO_FASTWAKE_DIN6_OFS                   (6)                             /* !< DIN6 Offset */
+#define GPIO_FASTWAKE_DIN6_MASK                  ((uint32_t)0x00000040U)         /* !< Enable fastwake feature for DIN6 */
+#define GPIO_FASTWAKE_DIN6_DISABLE               ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN6_ENABLE                ((uint32_t)0x00000040U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN7] Bits */
+#define GPIO_FASTWAKE_DIN7_OFS                   (7)                             /* !< DIN7 Offset */
+#define GPIO_FASTWAKE_DIN7_MASK                  ((uint32_t)0x00000080U)         /* !< Enable fastwake feature for DIN7 */
+#define GPIO_FASTWAKE_DIN7_DISABLE               ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN7_ENABLE                ((uint32_t)0x00000080U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN8] Bits */
+#define GPIO_FASTWAKE_DIN8_OFS                   (8)                             /* !< DIN8 Offset */
+#define GPIO_FASTWAKE_DIN8_MASK                  ((uint32_t)0x00000100U)         /* !< Enable fastwake feature for DIN8 */
+#define GPIO_FASTWAKE_DIN8_DISABLE               ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN8_ENABLE                ((uint32_t)0x00000100U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN9] Bits */
+#define GPIO_FASTWAKE_DIN9_OFS                   (9)                             /* !< DIN9 Offset */
+#define GPIO_FASTWAKE_DIN9_MASK                  ((uint32_t)0x00000200U)         /* !< Enable fastwake feature for DIN9 */
+#define GPIO_FASTWAKE_DIN9_DISABLE               ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN9_ENABLE                ((uint32_t)0x00000200U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN10] Bits */
+#define GPIO_FASTWAKE_DIN10_OFS                  (10)                            /* !< DIN10 Offset */
+#define GPIO_FASTWAKE_DIN10_MASK                 ((uint32_t)0x00000400U)         /* !< Enable fastwake feature for DIN10 */
+#define GPIO_FASTWAKE_DIN10_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN10_ENABLE               ((uint32_t)0x00000400U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN11] Bits */
+#define GPIO_FASTWAKE_DIN11_OFS                  (11)                            /* !< DIN11 Offset */
+#define GPIO_FASTWAKE_DIN11_MASK                 ((uint32_t)0x00000800U)         /* !< Enable fastwake feature for DIN11 */
+#define GPIO_FASTWAKE_DIN11_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN11_ENABLE               ((uint32_t)0x00000800U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN12] Bits */
+#define GPIO_FASTWAKE_DIN12_OFS                  (12)                            /* !< DIN12 Offset */
+#define GPIO_FASTWAKE_DIN12_MASK                 ((uint32_t)0x00001000U)         /* !< Enable fastwake feature for DIN12 */
+#define GPIO_FASTWAKE_DIN12_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN12_ENABLE               ((uint32_t)0x00001000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN13] Bits */
+#define GPIO_FASTWAKE_DIN13_OFS                  (13)                            /* !< DIN13 Offset */
+#define GPIO_FASTWAKE_DIN13_MASK                 ((uint32_t)0x00002000U)         /* !< Enable fastwake feature for DIN13 */
+#define GPIO_FASTWAKE_DIN13_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN13_ENABLE               ((uint32_t)0x00002000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN14] Bits */
+#define GPIO_FASTWAKE_DIN14_OFS                  (14)                            /* !< DIN14 Offset */
+#define GPIO_FASTWAKE_DIN14_MASK                 ((uint32_t)0x00004000U)         /* !< Enable fastwake feature for DIN14 */
+#define GPIO_FASTWAKE_DIN14_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN14_ENABLE               ((uint32_t)0x00004000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN15] Bits */
+#define GPIO_FASTWAKE_DIN15_OFS                  (15)                            /* !< DIN15 Offset */
+#define GPIO_FASTWAKE_DIN15_MASK                 ((uint32_t)0x00008000U)         /* !< Enable fastwake feature for DIN15 */
+#define GPIO_FASTWAKE_DIN15_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN15_ENABLE               ((uint32_t)0x00008000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN16] Bits */
+#define GPIO_FASTWAKE_DIN16_OFS                  (16)                            /* !< DIN16 Offset */
+#define GPIO_FASTWAKE_DIN16_MASK                 ((uint32_t)0x00010000U)         /* !< Enable fastwake feature for DIN16 */
+#define GPIO_FASTWAKE_DIN16_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN16_ENABLE               ((uint32_t)0x00010000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN17] Bits */
+#define GPIO_FASTWAKE_DIN17_OFS                  (17)                            /* !< DIN17 Offset */
+#define GPIO_FASTWAKE_DIN17_MASK                 ((uint32_t)0x00020000U)         /* !< Enable fastwake feature for DIN17 */
+#define GPIO_FASTWAKE_DIN17_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN17_ENABLE               ((uint32_t)0x00020000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN18] Bits */
+#define GPIO_FASTWAKE_DIN18_OFS                  (18)                            /* !< DIN18 Offset */
+#define GPIO_FASTWAKE_DIN18_MASK                 ((uint32_t)0x00040000U)         /* !< Enable fastwake feature for DIN18 */
+#define GPIO_FASTWAKE_DIN18_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN18_ENABLE               ((uint32_t)0x00040000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN19] Bits */
+#define GPIO_FASTWAKE_DIN19_OFS                  (19)                            /* !< DIN19 Offset */
+#define GPIO_FASTWAKE_DIN19_MASK                 ((uint32_t)0x00080000U)         /* !< Enable fastwake feature for DIN19 */
+#define GPIO_FASTWAKE_DIN19_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN19_ENABLE               ((uint32_t)0x00080000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN20] Bits */
+#define GPIO_FASTWAKE_DIN20_OFS                  (20)                            /* !< DIN20 Offset */
+#define GPIO_FASTWAKE_DIN20_MASK                 ((uint32_t)0x00100000U)         /* !< Enable fastwake feature for DIN20 */
+#define GPIO_FASTWAKE_DIN20_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN20_ENABLE               ((uint32_t)0x00100000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN21] Bits */
+#define GPIO_FASTWAKE_DIN21_OFS                  (21)                            /* !< DIN21 Offset */
+#define GPIO_FASTWAKE_DIN21_MASK                 ((uint32_t)0x00200000U)         /* !< Enable fastwake feature for DIN21 */
+#define GPIO_FASTWAKE_DIN21_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN21_ENABLE               ((uint32_t)0x00200000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN22] Bits */
+#define GPIO_FASTWAKE_DIN22_OFS                  (22)                            /* !< DIN22 Offset */
+#define GPIO_FASTWAKE_DIN22_MASK                 ((uint32_t)0x00400000U)         /* !< Enable fastwake feature for DIN22 */
+#define GPIO_FASTWAKE_DIN22_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN22_ENABLE               ((uint32_t)0x00400000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN23] Bits */
+#define GPIO_FASTWAKE_DIN23_OFS                  (23)                            /* !< DIN23 Offset */
+#define GPIO_FASTWAKE_DIN23_MASK                 ((uint32_t)0x00800000U)         /* !< Enable fastwake feature for DIN23 */
+#define GPIO_FASTWAKE_DIN23_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN23_ENABLE               ((uint32_t)0x00800000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN24] Bits */
+#define GPIO_FASTWAKE_DIN24_OFS                  (24)                            /* !< DIN24 Offset */
+#define GPIO_FASTWAKE_DIN24_MASK                 ((uint32_t)0x01000000U)         /* !< Enable fastwake feature for DIN24 */
+#define GPIO_FASTWAKE_DIN24_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN24_ENABLE               ((uint32_t)0x01000000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN25] Bits */
+#define GPIO_FASTWAKE_DIN25_OFS                  (25)                            /* !< DIN25 Offset */
+#define GPIO_FASTWAKE_DIN25_MASK                 ((uint32_t)0x02000000U)         /* !< Enable fastwake feature for DIN25 */
+#define GPIO_FASTWAKE_DIN25_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN25_ENABLE               ((uint32_t)0x02000000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN26] Bits */
+#define GPIO_FASTWAKE_DIN26_OFS                  (26)                            /* !< DIN26 Offset */
+#define GPIO_FASTWAKE_DIN26_MASK                 ((uint32_t)0x04000000U)         /* !< Enable fastwake feature for DIN26 */
+#define GPIO_FASTWAKE_DIN26_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN26_ENABLE               ((uint32_t)0x04000000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN27] Bits */
+#define GPIO_FASTWAKE_DIN27_OFS                  (27)                            /* !< DIN27 Offset */
+#define GPIO_FASTWAKE_DIN27_MASK                 ((uint32_t)0x08000000U)         /* !< Enable fastwake feature for DIN27 */
+#define GPIO_FASTWAKE_DIN27_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN27_ENABLE               ((uint32_t)0x08000000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN28] Bits */
+#define GPIO_FASTWAKE_DIN28_OFS                  (28)                            /* !< DIN28 Offset */
+#define GPIO_FASTWAKE_DIN28_MASK                 ((uint32_t)0x10000000U)         /* !< Enable fastwake feature for DIN29 */
+#define GPIO_FASTWAKE_DIN28_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN28_ENABLE               ((uint32_t)0x10000000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN29] Bits */
+#define GPIO_FASTWAKE_DIN29_OFS                  (29)                            /* !< DIN29 Offset */
+#define GPIO_FASTWAKE_DIN29_MASK                 ((uint32_t)0x20000000U)         /* !< Enable fastwake feature for DIN29 */
+#define GPIO_FASTWAKE_DIN29_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN29_ENABLE               ((uint32_t)0x20000000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN30] Bits */
+#define GPIO_FASTWAKE_DIN30_OFS                  (30)                            /* !< DIN30 Offset */
+#define GPIO_FASTWAKE_DIN30_MASK                 ((uint32_t)0x40000000U)         /* !< Enable fastwake feature for DIN30 */
+#define GPIO_FASTWAKE_DIN30_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN30_ENABLE               ((uint32_t)0x40000000U)         /* !< fastwake feature is enabled */
+/* GPIO_FASTWAKE[DIN31] Bits */
+#define GPIO_FASTWAKE_DIN31_OFS                  (31)                            /* !< DIN31 Offset */
+#define GPIO_FASTWAKE_DIN31_MASK                 ((uint32_t)0x80000000U)         /* !< Enable fastwake feature for DIN31 */
+#define GPIO_FASTWAKE_DIN31_DISABLE              ((uint32_t)0x00000000U)         /* !< fastwake feature is disabled */
+#define GPIO_FASTWAKE_DIN31_ENABLE               ((uint32_t)0x80000000U)         /* !< fastwake feature is enabled */
+
+/* GPIO_SUB0CFG Bits */
+/* GPIO_SUB0CFG[ENABLE] Bits */
+#define GPIO_SUB0CFG_ENABLE_OFS                  (0)                             /* !< ENABLE Offset */
+#define GPIO_SUB0CFG_ENABLE_MASK                 ((uint32_t)0x00000001U)         /* !< This bit is used to enable
+                                                                                    subscriber 0 event. */
+#define GPIO_SUB0CFG_ENABLE_CLR                  ((uint32_t)0x00000000U)         /* !< Subscriber 0 event is disabled */
+#define GPIO_SUB0CFG_ENABLE_SET                  ((uint32_t)0x00000001U)         /* !< Subscriber 0 event is enabled */
+/* GPIO_SUB0CFG[OUTPOLICY] Bits */
+#define GPIO_SUB0CFG_OUTPOLICY_OFS               (8)                             /* !< OUTPOLICY Offset */
+#define GPIO_SUB0CFG_OUTPOLICY_MASK              ((uint32_t)0x00000300U)         /* !< These bits configure the output
+                                                                                    policy for subscriber 0 event. */
+#define GPIO_SUB0CFG_OUTPOLICY_SET               ((uint32_t)0x00000000U)         /* !< Selected DIO pins are set */
+#define GPIO_SUB0CFG_OUTPOLICY_CLR               ((uint32_t)0x00000100U)         /* !< Selected DIO pins are cleared */
+#define GPIO_SUB0CFG_OUTPOLICY_TOGGLE            ((uint32_t)0x00000200U)         /* !< Selected DIO pins are toggled */
+/* GPIO_SUB0CFG[INDEX] Bits */
+#define GPIO_SUB0CFG_INDEX_OFS                   (16)                            /* !< INDEX Offset */
+#define GPIO_SUB0CFG_INDEX_MASK                  ((uint32_t)0x000F0000U)         /* !< Indicates the specific bit among
+                                                                                    lower 16 bits that is targeted by the
+                                                                                    subscriber action */
+#define GPIO_SUB0CFG_INDEX_MIN                   ((uint32_t)0x00000000U)         /* !< specific bit targeted by the
+                                                                                    subscriber action is bit0 */
+#define GPIO_SUB0CFG_INDEX_MAX                   ((uint32_t)0x000F0000U)         /* !< specific bit targeted by the
+                                                                                    subscriber action is bit15 */
+
+/* GPIO_FILTEREN15_0 Bits */
+/* GPIO_FILTEREN15_0[DIN0] Bits */
+#define GPIO_FILTEREN15_0_DIN0_OFS               (0)                             /* !< DIN0 Offset */
+#define GPIO_FILTEREN15_0_DIN0_MASK              ((uint32_t)0x00000003U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN0 */
+#define GPIO_FILTEREN15_0_DIN0_DISABLE           ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN0_ONE_CYCLE         ((uint32_t)0x00000001U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN0_THREE_CYCLE       ((uint32_t)0x00000002U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN0_EIGHT_CYCLE       ((uint32_t)0x00000003U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN1] Bits */
+#define GPIO_FILTEREN15_0_DIN1_OFS               (2)                             /* !< DIN1 Offset */
+#define GPIO_FILTEREN15_0_DIN1_MASK              ((uint32_t)0x0000000CU)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN1 */
+#define GPIO_FILTEREN15_0_DIN1_DISABLE           ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN1_ONE_CYCLE         ((uint32_t)0x00000004U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN1_THREE_CYCLE       ((uint32_t)0x00000008U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN1_EIGHT_CYCLE       ((uint32_t)0x0000000CU)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN2] Bits */
+#define GPIO_FILTEREN15_0_DIN2_OFS               (4)                             /* !< DIN2 Offset */
+#define GPIO_FILTEREN15_0_DIN2_MASK              ((uint32_t)0x00000030U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN2 */
+#define GPIO_FILTEREN15_0_DIN2_DISABLE           ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN2_ONE_CYCLE         ((uint32_t)0x00000010U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN2_THREE_CYCLE       ((uint32_t)0x00000020U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN2_EIGHT_CYCLE       ((uint32_t)0x00000030U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN3] Bits */
+#define GPIO_FILTEREN15_0_DIN3_OFS               (6)                             /* !< DIN3 Offset */
+#define GPIO_FILTEREN15_0_DIN3_MASK              ((uint32_t)0x000000C0U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN3 */
+#define GPIO_FILTEREN15_0_DIN3_DISABLE           ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN3_ONE_CYCLE         ((uint32_t)0x00000040U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN3_THREE_CYCLE       ((uint32_t)0x00000080U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN3_EIGHT_CYCLE       ((uint32_t)0x000000C0U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN4] Bits */
+#define GPIO_FILTEREN15_0_DIN4_OFS               (8)                             /* !< DIN4 Offset */
+#define GPIO_FILTEREN15_0_DIN4_MASK              ((uint32_t)0x00000300U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN4 */
+#define GPIO_FILTEREN15_0_DIN4_DISABLE           ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN4_ONE_CYCLE         ((uint32_t)0x00000100U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN4_THREE_CYCLE       ((uint32_t)0x00000200U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN4_EIGHT_CYCLE       ((uint32_t)0x00000300U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN5] Bits */
+#define GPIO_FILTEREN15_0_DIN5_OFS               (10)                            /* !< DIN5 Offset */
+#define GPIO_FILTEREN15_0_DIN5_MASK              ((uint32_t)0x00000C00U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN5 */
+#define GPIO_FILTEREN15_0_DIN5_DISABLE           ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN5_ONE_CYCLE         ((uint32_t)0x00000400U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN5_THREE_CYCLE       ((uint32_t)0x00000800U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN5_EIGHT_CYCLE       ((uint32_t)0x00000C00U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN6] Bits */
+#define GPIO_FILTEREN15_0_DIN6_OFS               (12)                            /* !< DIN6 Offset */
+#define GPIO_FILTEREN15_0_DIN6_MASK              ((uint32_t)0x00003000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN6 */
+#define GPIO_FILTEREN15_0_DIN6_DISABLE           ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN6_ONE_CYCLE         ((uint32_t)0x00001000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN6_THREE_CYCLE       ((uint32_t)0x00002000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN6_EIGHT_CYCLE       ((uint32_t)0x00003000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN7] Bits */
+#define GPIO_FILTEREN15_0_DIN7_OFS               (14)                            /* !< DIN7 Offset */
+#define GPIO_FILTEREN15_0_DIN7_MASK              ((uint32_t)0x0000C000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN7 */
+#define GPIO_FILTEREN15_0_DIN7_DISABLE           ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN7_ONE_CYCLE         ((uint32_t)0x00004000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN7_THREE_CYCLE       ((uint32_t)0x00008000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN7_EIGHT_CYCLE       ((uint32_t)0x0000C000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN8] Bits */
+#define GPIO_FILTEREN15_0_DIN8_OFS               (16)                            /* !< DIN8 Offset */
+#define GPIO_FILTEREN15_0_DIN8_MASK              ((uint32_t)0x00030000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN8 */
+#define GPIO_FILTEREN15_0_DIN8_DISABLE           ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN8_ONE_CYCLE         ((uint32_t)0x00010000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN8_THREE_CYCLE       ((uint32_t)0x00020000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN8_EIGHT_CYCLE       ((uint32_t)0x00030000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN9] Bits */
+#define GPIO_FILTEREN15_0_DIN9_OFS               (18)                            /* !< DIN9 Offset */
+#define GPIO_FILTEREN15_0_DIN9_MASK              ((uint32_t)0x000C0000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN9 */
+#define GPIO_FILTEREN15_0_DIN9_DISABLE           ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN9_ONE_CYCLE         ((uint32_t)0x00040000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN9_THREE_CYCLE       ((uint32_t)0x00080000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN9_EIGHT_CYCLE       ((uint32_t)0x000C0000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN10] Bits */
+#define GPIO_FILTEREN15_0_DIN10_OFS              (20)                            /* !< DIN10 Offset */
+#define GPIO_FILTEREN15_0_DIN10_MASK             ((uint32_t)0x00300000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN10 */
+#define GPIO_FILTEREN15_0_DIN10_DISABLE          ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN10_ONE_CYCLE        ((uint32_t)0x00100000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN10_THREE_CYCLE      ((uint32_t)0x00200000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN10_EIGHT_CYCLE      ((uint32_t)0x00300000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN11] Bits */
+#define GPIO_FILTEREN15_0_DIN11_OFS              (22)                            /* !< DIN11 Offset */
+#define GPIO_FILTEREN15_0_DIN11_MASK             ((uint32_t)0x00C00000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN11 */
+#define GPIO_FILTEREN15_0_DIN11_DISABLE          ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN11_ONE_CYCLE        ((uint32_t)0x00400000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN11_THREE_CYCLE      ((uint32_t)0x00800000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN11_EIGHT_CYCLE      ((uint32_t)0x00C00000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN12] Bits */
+#define GPIO_FILTEREN15_0_DIN12_OFS              (24)                            /* !< DIN12 Offset */
+#define GPIO_FILTEREN15_0_DIN12_MASK             ((uint32_t)0x03000000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN12 */
+#define GPIO_FILTEREN15_0_DIN12_DISABLE          ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN12_ONE_CYCLE        ((uint32_t)0x01000000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN12_THREE_CYCLE      ((uint32_t)0x02000000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN12_EIGHT_CYCLE      ((uint32_t)0x03000000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN13] Bits */
+#define GPIO_FILTEREN15_0_DIN13_OFS              (26)                            /* !< DIN13 Offset */
+#define GPIO_FILTEREN15_0_DIN13_MASK             ((uint32_t)0x0C000000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN13 */
+#define GPIO_FILTEREN15_0_DIN13_DISABLE          ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN13_ONE_CYCLE        ((uint32_t)0x04000000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN13_THREE_CYCLE      ((uint32_t)0x08000000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN13_EIGHT_CYCLE      ((uint32_t)0x0C000000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN14] Bits */
+#define GPIO_FILTEREN15_0_DIN14_OFS              (28)                            /* !< DIN14 Offset */
+#define GPIO_FILTEREN15_0_DIN14_MASK             ((uint32_t)0x30000000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN14 */
+#define GPIO_FILTEREN15_0_DIN14_DISABLE          ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN14_ONE_CYCLE        ((uint32_t)0x10000000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN14_THREE_CYCLE      ((uint32_t)0x20000000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN14_EIGHT_CYCLE      ((uint32_t)0x30000000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN15_0[DIN15] Bits */
+#define GPIO_FILTEREN15_0_DIN15_OFS              (30)                            /* !< DIN15 Offset */
+#define GPIO_FILTEREN15_0_DIN15_MASK             ((uint32_t)0xC0000000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN15 */
+#define GPIO_FILTEREN15_0_DIN15_DISABLE          ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN15_0_DIN15_ONE_CYCLE        ((uint32_t)0x40000000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN15_THREE_CYCLE      ((uint32_t)0x80000000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN15_0_DIN15_EIGHT_CYCLE      ((uint32_t)0xC0000000U)         /* !< 8 ULPCLK minimum sample */
+
+/* GPIO_FILTEREN31_16 Bits */
+/* GPIO_FILTEREN31_16[DIN16] Bits */
+#define GPIO_FILTEREN31_16_DIN16_OFS             (0)                             /* !< DIN16 Offset */
+#define GPIO_FILTEREN31_16_DIN16_MASK            ((uint32_t)0x00000003U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN16 */
+#define GPIO_FILTEREN31_16_DIN16_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN16_ONE_CYCLE       ((uint32_t)0x00000001U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN16_THREE_CYCLE     ((uint32_t)0x00000002U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN16_EIGHT_CYCLE     ((uint32_t)0x00000003U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN17] Bits */
+#define GPIO_FILTEREN31_16_DIN17_OFS             (2)                             /* !< DIN17 Offset */
+#define GPIO_FILTEREN31_16_DIN17_MASK            ((uint32_t)0x0000000CU)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN17 */
+#define GPIO_FILTEREN31_16_DIN17_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN17_ONE_CYCLE       ((uint32_t)0x00000004U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN17_THREE_CYCLE     ((uint32_t)0x00000008U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN17_EIGHT_CYCLE     ((uint32_t)0x0000000CU)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN18] Bits */
+#define GPIO_FILTEREN31_16_DIN18_OFS             (4)                             /* !< DIN18 Offset */
+#define GPIO_FILTEREN31_16_DIN18_MASK            ((uint32_t)0x00000030U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN18 */
+#define GPIO_FILTEREN31_16_DIN18_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN18_ONE_CYCLE       ((uint32_t)0x00000010U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN18_THREE_CYCLE     ((uint32_t)0x00000020U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN18_EIGHT_CYCLE     ((uint32_t)0x00000030U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN19] Bits */
+#define GPIO_FILTEREN31_16_DIN19_OFS             (6)                             /* !< DIN19 Offset */
+#define GPIO_FILTEREN31_16_DIN19_MASK            ((uint32_t)0x000000C0U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN19 */
+#define GPIO_FILTEREN31_16_DIN19_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN19_ONE_CYCLE       ((uint32_t)0x00000040U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN19_THREE_CYCLE     ((uint32_t)0x00000080U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN19_EIGHT_CYCLE     ((uint32_t)0x000000C0U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN20] Bits */
+#define GPIO_FILTEREN31_16_DIN20_OFS             (8)                             /* !< DIN20 Offset */
+#define GPIO_FILTEREN31_16_DIN20_MASK            ((uint32_t)0x00000300U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN20 */
+#define GPIO_FILTEREN31_16_DIN20_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN20_ONE_CYCLE       ((uint32_t)0x00000100U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN20_THREE_CYCLE     ((uint32_t)0x00000200U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN20_EIGHT_CYCLE     ((uint32_t)0x00000300U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN21] Bits */
+#define GPIO_FILTEREN31_16_DIN21_OFS             (10)                            /* !< DIN21 Offset */
+#define GPIO_FILTEREN31_16_DIN21_MASK            ((uint32_t)0x00000C00U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN21 */
+#define GPIO_FILTEREN31_16_DIN21_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN21_ONE_CYCLE       ((uint32_t)0x00000400U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN21_THREE_CYCLE     ((uint32_t)0x00000800U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN21_EIGHT_CYCLE     ((uint32_t)0x00000C00U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN22] Bits */
+#define GPIO_FILTEREN31_16_DIN22_OFS             (12)                            /* !< DIN22 Offset */
+#define GPIO_FILTEREN31_16_DIN22_MASK            ((uint32_t)0x00003000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN22 */
+#define GPIO_FILTEREN31_16_DIN22_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN22_ONE_CYCLE       ((uint32_t)0x00001000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN22_THREE_CYCLE     ((uint32_t)0x00002000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN22_EIGHT_CYCLE     ((uint32_t)0x00003000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN23] Bits */
+#define GPIO_FILTEREN31_16_DIN23_OFS             (14)                            /* !< DIN23 Offset */
+#define GPIO_FILTEREN31_16_DIN23_MASK            ((uint32_t)0x0000C000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN23 */
+#define GPIO_FILTEREN31_16_DIN23_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN23_ONE_CYCLE       ((uint32_t)0x00004000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN23_THREE_CYCLE     ((uint32_t)0x00008000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN23_EIGHT_CYCLE     ((uint32_t)0x0000C000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN24] Bits */
+#define GPIO_FILTEREN31_16_DIN24_OFS             (16)                            /* !< DIN24 Offset */
+#define GPIO_FILTEREN31_16_DIN24_MASK            ((uint32_t)0x00030000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN24 */
+#define GPIO_FILTEREN31_16_DIN24_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN24_ONE_CYCLE       ((uint32_t)0x00010000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN24_THREE_CYCLE     ((uint32_t)0x00020000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN24_EIGHT_CYCLE     ((uint32_t)0x00030000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN25] Bits */
+#define GPIO_FILTEREN31_16_DIN25_OFS             (18)                            /* !< DIN25 Offset */
+#define GPIO_FILTEREN31_16_DIN25_MASK            ((uint32_t)0x000C0000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN25 */
+#define GPIO_FILTEREN31_16_DIN25_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN25_ONE_CYCLE       ((uint32_t)0x00040000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN25_THREE_CYCLE     ((uint32_t)0x00080000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN25_EIGHT_CYCLE     ((uint32_t)0x000C0000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN26] Bits */
+#define GPIO_FILTEREN31_16_DIN26_OFS             (20)                            /* !< DIN26 Offset */
+#define GPIO_FILTEREN31_16_DIN26_MASK            ((uint32_t)0x00300000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN26 */
+#define GPIO_FILTEREN31_16_DIN26_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN26_ONE_CYCLE       ((uint32_t)0x00100000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN26_THREE_CYCLE     ((uint32_t)0x00200000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN26_EIGHT_CYCLE     ((uint32_t)0x00300000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN27] Bits */
+#define GPIO_FILTEREN31_16_DIN27_OFS             (22)                            /* !< DIN27 Offset */
+#define GPIO_FILTEREN31_16_DIN27_MASK            ((uint32_t)0x00C00000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN27 */
+#define GPIO_FILTEREN31_16_DIN27_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN27_ONE_CYCLE       ((uint32_t)0x00400000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN27_THREE_CYCLE     ((uint32_t)0x00800000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN27_EIGHT_CYCLE     ((uint32_t)0x00C00000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN28] Bits */
+#define GPIO_FILTEREN31_16_DIN28_OFS             (24)                            /* !< DIN28 Offset */
+#define GPIO_FILTEREN31_16_DIN28_MASK            ((uint32_t)0x03000000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN28 */
+#define GPIO_FILTEREN31_16_DIN28_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN28_ONE_CYCLE       ((uint32_t)0x01000000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN28_THREE_CYCLE     ((uint32_t)0x02000000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN28_EIGHT_CYCLE     ((uint32_t)0x03000000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN29] Bits */
+#define GPIO_FILTEREN31_16_DIN29_OFS             (26)                            /* !< DIN29 Offset */
+#define GPIO_FILTEREN31_16_DIN29_MASK            ((uint32_t)0x0C000000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN29 */
+#define GPIO_FILTEREN31_16_DIN29_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN29_ONE_CYCLE       ((uint32_t)0x04000000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN29_THREE_CYCLE     ((uint32_t)0x08000000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN29_EIGHT_CYCLE     ((uint32_t)0x0C000000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN30] Bits */
+#define GPIO_FILTEREN31_16_DIN30_OFS             (28)                            /* !< DIN30 Offset */
+#define GPIO_FILTEREN31_16_DIN30_MASK            ((uint32_t)0x30000000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN30 */
+#define GPIO_FILTEREN31_16_DIN30_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN30_ONE_CYCLE       ((uint32_t)0x10000000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN30_THREE_CYCLE     ((uint32_t)0x20000000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN30_EIGHT_CYCLE     ((uint32_t)0x30000000U)         /* !< 8 ULPCLK minimum sample */
+/* GPIO_FILTEREN31_16[DIN31] Bits */
+#define GPIO_FILTEREN31_16_DIN31_OFS             (30)                            /* !< DIN31 Offset */
+#define GPIO_FILTEREN31_16_DIN31_MASK            ((uint32_t)0xC0000000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for DIN31 */
+#define GPIO_FILTEREN31_16_DIN31_DISABLE         ((uint32_t)0x00000000U)         /* !< No additional filter beyond the CDC
+                                                                                    synchronization sample */
+#define GPIO_FILTEREN31_16_DIN31_ONE_CYCLE       ((uint32_t)0x40000000U)         /* !< 1 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN31_THREE_CYCLE     ((uint32_t)0x80000000U)         /* !< 3 ULPCLK minimum sample */
+#define GPIO_FILTEREN31_16_DIN31_EIGHT_CYCLE     ((uint32_t)0xC0000000U)         /* !< 8 ULPCLK minimum sample */
+
+/* GPIO_DMAMASK Bits */
+/* GPIO_DMAMASK[DOUT0] Bits */
+#define GPIO_DMAMASK_DOUT0_OFS                   (0)                             /* !< DOUT0 Offset */
+#define GPIO_DMAMASK_DOUT0_MASK                  ((uint32_t)0x00000001U)         /* !< DMA is allowed to modify DOUT0 */
+#define GPIO_DMAMASK_DOUT0_DISABLE               ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT0_ENABLE                ((uint32_t)0x00000001U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT1] Bits */
+#define GPIO_DMAMASK_DOUT1_OFS                   (1)                             /* !< DOUT1 Offset */
+#define GPIO_DMAMASK_DOUT1_MASK                  ((uint32_t)0x00000002U)         /* !< DMA is allowed to modify DOUT1 */
+#define GPIO_DMAMASK_DOUT1_DISABLE               ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT1_ENABLE                ((uint32_t)0x00000002U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT2] Bits */
+#define GPIO_DMAMASK_DOUT2_OFS                   (2)                             /* !< DOUT2 Offset */
+#define GPIO_DMAMASK_DOUT2_MASK                  ((uint32_t)0x00000004U)         /* !< DMA is allowed to modify DOUT2 */
+#define GPIO_DMAMASK_DOUT2_DISABLE               ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT2_ENABLE                ((uint32_t)0x00000004U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT3] Bits */
+#define GPIO_DMAMASK_DOUT3_OFS                   (3)                             /* !< DOUT3 Offset */
+#define GPIO_DMAMASK_DOUT3_MASK                  ((uint32_t)0x00000008U)         /* !< DMA is allowed to modify DOUT3 */
+#define GPIO_DMAMASK_DOUT3_DISABLE               ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT3_ENABLE                ((uint32_t)0x00000008U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT4] Bits */
+#define GPIO_DMAMASK_DOUT4_OFS                   (4)                             /* !< DOUT4 Offset */
+#define GPIO_DMAMASK_DOUT4_MASK                  ((uint32_t)0x00000010U)         /* !< DMA is allowed to modify DOUT4 */
+#define GPIO_DMAMASK_DOUT4_DISABLE               ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT4_ENABLE                ((uint32_t)0x00000010U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT5] Bits */
+#define GPIO_DMAMASK_DOUT5_OFS                   (5)                             /* !< DOUT5 Offset */
+#define GPIO_DMAMASK_DOUT5_MASK                  ((uint32_t)0x00000020U)         /* !< DMA is allowed to modify DOUT5 */
+#define GPIO_DMAMASK_DOUT5_DISABLE               ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT5_ENABLE                ((uint32_t)0x00000020U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT6] Bits */
+#define GPIO_DMAMASK_DOUT6_OFS                   (6)                             /* !< DOUT6 Offset */
+#define GPIO_DMAMASK_DOUT6_MASK                  ((uint32_t)0x00000040U)         /* !< DMA is allowed to modify DOUT6 */
+#define GPIO_DMAMASK_DOUT6_DISABLE               ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT6_ENABLE                ((uint32_t)0x00000040U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT7] Bits */
+#define GPIO_DMAMASK_DOUT7_OFS                   (7)                             /* !< DOUT7 Offset */
+#define GPIO_DMAMASK_DOUT7_MASK                  ((uint32_t)0x00000080U)         /* !< DMA is allowed to modify DOUT7 */
+#define GPIO_DMAMASK_DOUT7_DISABLE               ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT7_ENABLE                ((uint32_t)0x00000080U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT8] Bits */
+#define GPIO_DMAMASK_DOUT8_OFS                   (8)                             /* !< DOUT8 Offset */
+#define GPIO_DMAMASK_DOUT8_MASK                  ((uint32_t)0x00000100U)         /* !< DMA is allowed to modify DOUT8 */
+#define GPIO_DMAMASK_DOUT8_DISABLE               ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT8_ENABLE                ((uint32_t)0x00000100U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT9] Bits */
+#define GPIO_DMAMASK_DOUT9_OFS                   (9)                             /* !< DOUT9 Offset */
+#define GPIO_DMAMASK_DOUT9_MASK                  ((uint32_t)0x00000200U)         /* !< DMA is allowed to modify DOUT9 */
+#define GPIO_DMAMASK_DOUT9_DISABLE               ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT9_ENABLE                ((uint32_t)0x00000200U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT10] Bits */
+#define GPIO_DMAMASK_DOUT10_OFS                  (10)                            /* !< DOUT10 Offset */
+#define GPIO_DMAMASK_DOUT10_MASK                 ((uint32_t)0x00000400U)         /* !< DMA is allowed to modify DOUT10 */
+#define GPIO_DMAMASK_DOUT10_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT10_ENABLE               ((uint32_t)0x00000400U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT11] Bits */
+#define GPIO_DMAMASK_DOUT11_OFS                  (11)                            /* !< DOUT11 Offset */
+#define GPIO_DMAMASK_DOUT11_MASK                 ((uint32_t)0x00000800U)         /* !< DMA is allowed to modify DOUT11 */
+#define GPIO_DMAMASK_DOUT11_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT11_ENABLE               ((uint32_t)0x00000800U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT12] Bits */
+#define GPIO_DMAMASK_DOUT12_OFS                  (12)                            /* !< DOUT12 Offset */
+#define GPIO_DMAMASK_DOUT12_MASK                 ((uint32_t)0x00001000U)         /* !< DMA is allowed to modify DOUT12 */
+#define GPIO_DMAMASK_DOUT12_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT12_ENABLE               ((uint32_t)0x00001000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT13] Bits */
+#define GPIO_DMAMASK_DOUT13_OFS                  (13)                            /* !< DOUT13 Offset */
+#define GPIO_DMAMASK_DOUT13_MASK                 ((uint32_t)0x00002000U)         /* !< DMA is allowed to modify DOUT13 */
+#define GPIO_DMAMASK_DOUT13_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT13_ENABLE               ((uint32_t)0x00002000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT14] Bits */
+#define GPIO_DMAMASK_DOUT14_OFS                  (14)                            /* !< DOUT14 Offset */
+#define GPIO_DMAMASK_DOUT14_MASK                 ((uint32_t)0x00004000U)         /* !< DMA is allowed to modify DOUT14 */
+#define GPIO_DMAMASK_DOUT14_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT14_ENABLE               ((uint32_t)0x00004000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT15] Bits */
+#define GPIO_DMAMASK_DOUT15_OFS                  (15)                            /* !< DOUT15 Offset */
+#define GPIO_DMAMASK_DOUT15_MASK                 ((uint32_t)0x00008000U)         /* !< DMA is allowed to modify DOUT15 */
+#define GPIO_DMAMASK_DOUT15_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT15_ENABLE               ((uint32_t)0x00008000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT16] Bits */
+#define GPIO_DMAMASK_DOUT16_OFS                  (16)                            /* !< DOUT16 Offset */
+#define GPIO_DMAMASK_DOUT16_MASK                 ((uint32_t)0x00010000U)         /* !< DMA is allowed to modify DOUT16 */
+#define GPIO_DMAMASK_DOUT16_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT16_ENABLE               ((uint32_t)0x00010000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT17] Bits */
+#define GPIO_DMAMASK_DOUT17_OFS                  (17)                            /* !< DOUT17 Offset */
+#define GPIO_DMAMASK_DOUT17_MASK                 ((uint32_t)0x00020000U)         /* !< DMA is allowed to modify DOUT17 */
+#define GPIO_DMAMASK_DOUT17_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT17_ENABLE               ((uint32_t)0x00020000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT18] Bits */
+#define GPIO_DMAMASK_DOUT18_OFS                  (18)                            /* !< DOUT18 Offset */
+#define GPIO_DMAMASK_DOUT18_MASK                 ((uint32_t)0x00040000U)         /* !< DMA is allowed to modify DOUT18 */
+#define GPIO_DMAMASK_DOUT18_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT18_ENABLE               ((uint32_t)0x00040000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT19] Bits */
+#define GPIO_DMAMASK_DOUT19_OFS                  (19)                            /* !< DOUT19 Offset */
+#define GPIO_DMAMASK_DOUT19_MASK                 ((uint32_t)0x00080000U)         /* !< DMA is allowed to modify DOUT19 */
+#define GPIO_DMAMASK_DOUT19_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT19_ENABLE               ((uint32_t)0x00080000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT20] Bits */
+#define GPIO_DMAMASK_DOUT20_OFS                  (20)                            /* !< DOUT20 Offset */
+#define GPIO_DMAMASK_DOUT20_MASK                 ((uint32_t)0x00100000U)         /* !< DMA is allowed to modify DOUT20 */
+#define GPIO_DMAMASK_DOUT20_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT20_ENABLE               ((uint32_t)0x00100000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT21] Bits */
+#define GPIO_DMAMASK_DOUT21_OFS                  (21)                            /* !< DOUT21 Offset */
+#define GPIO_DMAMASK_DOUT21_MASK                 ((uint32_t)0x00200000U)         /* !< DMA is allowed to modify DOUT21 */
+#define GPIO_DMAMASK_DOUT21_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT21_ENABLE               ((uint32_t)0x00200000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT22] Bits */
+#define GPIO_DMAMASK_DOUT22_OFS                  (22)                            /* !< DOUT22 Offset */
+#define GPIO_DMAMASK_DOUT22_MASK                 ((uint32_t)0x00400000U)         /* !< DMA is allowed to modify DOUT22 */
+#define GPIO_DMAMASK_DOUT22_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT22_ENABLE               ((uint32_t)0x00400000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT23] Bits */
+#define GPIO_DMAMASK_DOUT23_OFS                  (23)                            /* !< DOUT23 Offset */
+#define GPIO_DMAMASK_DOUT23_MASK                 ((uint32_t)0x00800000U)         /* !< DMA is allowed to modify DOUT23 */
+#define GPIO_DMAMASK_DOUT23_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT23_ENABLE               ((uint32_t)0x00800000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT24] Bits */
+#define GPIO_DMAMASK_DOUT24_OFS                  (24)                            /* !< DOUT24 Offset */
+#define GPIO_DMAMASK_DOUT24_MASK                 ((uint32_t)0x01000000U)         /* !< DMA is allowed to modify DOUT24 */
+#define GPIO_DMAMASK_DOUT24_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT24_ENABLE               ((uint32_t)0x01000000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT25] Bits */
+#define GPIO_DMAMASK_DOUT25_OFS                  (25)                            /* !< DOUT25 Offset */
+#define GPIO_DMAMASK_DOUT25_MASK                 ((uint32_t)0x02000000U)         /* !< DMA is allowed to modify DOUT25 */
+#define GPIO_DMAMASK_DOUT25_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT25_ENABLE               ((uint32_t)0x02000000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT26] Bits */
+#define GPIO_DMAMASK_DOUT26_OFS                  (26)                            /* !< DOUT26 Offset */
+#define GPIO_DMAMASK_DOUT26_MASK                 ((uint32_t)0x04000000U)         /* !< DMA is allowed to modify DOUT26 */
+#define GPIO_DMAMASK_DOUT26_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT26_ENABLE               ((uint32_t)0x04000000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT27] Bits */
+#define GPIO_DMAMASK_DOUT27_OFS                  (27)                            /* !< DOUT27 Offset */
+#define GPIO_DMAMASK_DOUT27_MASK                 ((uint32_t)0x08000000U)         /* !< DMA is allowed to modify DOUT27 */
+#define GPIO_DMAMASK_DOUT27_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT27_ENABLE               ((uint32_t)0x08000000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT28] Bits */
+#define GPIO_DMAMASK_DOUT28_OFS                  (28)                            /* !< DOUT28 Offset */
+#define GPIO_DMAMASK_DOUT28_MASK                 ((uint32_t)0x10000000U)         /* !< DMA is allowed to modify DOUT28 */
+#define GPIO_DMAMASK_DOUT28_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT28_ENABLE               ((uint32_t)0x10000000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT29] Bits */
+#define GPIO_DMAMASK_DOUT29_OFS                  (29)                            /* !< DOUT29 Offset */
+#define GPIO_DMAMASK_DOUT29_MASK                 ((uint32_t)0x20000000U)         /* !< DMA is allowed to modify DOUT29 */
+#define GPIO_DMAMASK_DOUT29_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT29_ENABLE               ((uint32_t)0x20000000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT30] Bits */
+#define GPIO_DMAMASK_DOUT30_OFS                  (30)                            /* !< DOUT30 Offset */
+#define GPIO_DMAMASK_DOUT30_MASK                 ((uint32_t)0x40000000U)         /* !< DMA is allowed to modify DOUT30 */
+#define GPIO_DMAMASK_DOUT30_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT30_ENABLE               ((uint32_t)0x40000000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+/* GPIO_DMAMASK[DOUT31] Bits */
+#define GPIO_DMAMASK_DOUT31_OFS                  (31)                            /* !< DOUT31 Offset */
+#define GPIO_DMAMASK_DOUT31_MASK                 ((uint32_t)0x80000000U)         /* !< DMA is allowed to modify DOUT31 */
+#define GPIO_DMAMASK_DOUT31_DISABLE              ((uint32_t)0x00000000U)         /* !< DMA is not allowed to modify this
+                                                                                    bit lane */
+#define GPIO_DMAMASK_DOUT31_ENABLE               ((uint32_t)0x80000000U)         /* !< DMA is allowed to modify this bit
+                                                                                    lane */
+
+/* GPIO_SUB1CFG Bits */
+/* GPIO_SUB1CFG[ENABLE] Bits */
+#define GPIO_SUB1CFG_ENABLE_OFS                  (0)                             /* !< ENABLE Offset */
+#define GPIO_SUB1CFG_ENABLE_MASK                 ((uint32_t)0x00000001U)         /* !< This bit is used to enable
+                                                                                    subscriber 1 event. */
+#define GPIO_SUB1CFG_ENABLE_CLR                  ((uint32_t)0x00000000U)         /* !< Subscriber 1 event is disabled */
+#define GPIO_SUB1CFG_ENABLE_SET                  ((uint32_t)0x00000001U)         /* !< Subscriber 1 event is enabled */
+/* GPIO_SUB1CFG[OUTPOLICY] Bits */
+#define GPIO_SUB1CFG_OUTPOLICY_OFS               (8)                             /* !< OUTPOLICY Offset */
+#define GPIO_SUB1CFG_OUTPOLICY_MASK              ((uint32_t)0x00000300U)         /* !< These bits configure the output
+                                                                                    policy for subscriber 1 event. */
+#define GPIO_SUB1CFG_OUTPOLICY_SET               ((uint32_t)0x00000000U)         /* !< Selected DIO pins are set */
+#define GPIO_SUB1CFG_OUTPOLICY_CLR               ((uint32_t)0x00000100U)         /* !< Selected DIO pins are cleared */
+#define GPIO_SUB1CFG_OUTPOLICY_TOGGLE            ((uint32_t)0x00000200U)         /* !< Selected DIO pins are toggled */
+/* GPIO_SUB1CFG[INDEX] Bits */
+#define GPIO_SUB1CFG_INDEX_OFS                   (16)                            /* !< INDEX Offset */
+#define GPIO_SUB1CFG_INDEX_MASK                  ((uint32_t)0x000F0000U)         /* !< indicates the specific bit in the
+                                                                                    upper 16 bits that is targeted by the
+                                                                                    subscriber action */
+#define GPIO_SUB1CFG_INDEX_MIN                   ((uint32_t)0x00000000U)         /* !< specific bit targeted by the
+                                                                                    subscriber action is bit16 */
+#define GPIO_SUB1CFG_INDEX_MAX                   ((uint32_t)0x000F0000U)         /* !< specific bit targeted by the
+                                                                                    subscriber action is bit31 */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_gpio__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_gptimer.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_gptimer.h
@@ -1,0 +1,3768 @@
+/*****************************************************************************
+
+  Copyright (C) 2024 Texas Instruments Incorporated - http://www.ti.com/ 
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+   Redistributions of source code must retain the above copyright 
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the   
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_gptimer__include
+#define ti_devices_msp_peripherals_hw_gptimer__include
+
+/* Filename: hw_gptimer.h */
+/* Revised: 2024-01-19 11:03:20 */
+/* Revision: 29b8b3088aa08ebbb32546ae377f5951d9da7d26 */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* GPTIMER Registers
+******************************************************************************/
+#define GPTIMER_COUNTERREGS_OFS                  ((uint32_t)0x00001800U)
+#define GPTIMER_COMMONREGS_OFS                   ((uint32_t)0x00001100U)
+#define GPTIMER_GEN_EVENT1_OFS                   ((uint32_t)0x00001080U)
+#define GPTIMER_GEN_EVENT0_OFS                   ((uint32_t)0x00001050U)
+#define GPTIMER_CPU_INT_OFS                      ((uint32_t)0x00001020U)
+#define GPTIMER_GPRCM_OFS                        ((uint32_t)0x00000800U)
+
+
+/** @addtogroup GPTIMER_COUNTERREGS
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t CTR;                               /* !< (@ 0x00001800) Counter Register */
+  __IO uint32_t CTRCTL;                            /* !< (@ 0x00001804) Counter Control Register */
+  __IO uint32_t LOAD;                              /* !< (@ 0x00001808) Load Register */
+       uint32_t RESERVED0;
+  __IO uint32_t CC_01[2];                          /* !< (@ 0x00001810) Capture or Compare Register 0/1 */
+  __IO uint32_t CC_23[2];                          /* !< (@ 0x00001818) Capture or Compare Register 2/3 */
+  __IO uint32_t CC_45[2];                          /* !< (@ 0x00001820) The CC_45 register are a registers which can be
+                                                      used as compare to the current CTR to create an events CC4U, CC4D,
+                                                      CC5U and CC5D. */
+       uint32_t RESERVED1[2];
+  __IO uint32_t CCCTL_01[2];                       /* !< (@ 0x00001830) Capture or Compare Control Registers 0/1 */
+  __IO uint32_t CCCTL_23[2];                       /* !< (@ 0x00001838) Capture or Compare Control Registers 2/3 */
+  __IO uint32_t CCCTL_45[2];                       /* !< (@ 0x00001840) Capture or Compare Control Registers 4/5 */
+       uint32_t RESERVED2[2];
+  __IO uint32_t OCTL_01[2];                        /* !< (@ 0x00001850) CCP Output Control Registers 0/1 */
+  __IO uint32_t OCTL_23[2];                        /* !< (@ 0x00001858) CCP Output Control Registers 2/3 */
+       uint32_t RESERVED3[4];
+  __IO uint32_t CCACT_01[2];                       /* !< (@ 0x00001870) Capture or Compare Action Registers 0/1 */
+  __IO uint32_t CCACT_23[2];                       /* !< (@ 0x00001878) Capture or Compare Action Registers 2/3 */
+  __IO uint32_t IFCTL_01[2];                       /* !< (@ 0x00001880) Input Filter Control Register 0/1 */
+  __IO uint32_t IFCTL_23[2];                       /* !< (@ 0x00001888) Input Filter Control Register 2/3 */
+       uint32_t RESERVED4[4];
+  __IO uint32_t PL;                                /* !< (@ 0x000018A0) Phase Load Register */
+  __IO uint32_t DBCTL;                             /* !< (@ 0x000018A4) Dead Band insertion control register */
+       uint32_t RESERVED5[2];
+  __IO uint32_t TSEL;                              /* !< (@ 0x000018B0) Trigger Select Register */
+  __I  uint32_t RC;                                /* !< (@ 0x000018B4) Repeat counter Register */
+  __IO uint32_t RCLD;                              /* !< (@ 0x000018B8) Repeat counter load Register */
+  __I  uint32_t QDIR;                              /* !< (@ 0x000018BC) QEI Count Direction Register */
+       uint32_t RESERVED6[4];
+  __IO uint32_t FCTL;                              /* !< (@ 0x000018D0) Fault Control Register */
+  __IO uint32_t FIFCTL;                            /* !< (@ 0x000018D4) Fault input Filter control register */
+} GPTIMER_COUNTERREGS_Regs;
+
+/*@}*/ /* end of group GPTIMER_COUNTERREGS */
+
+/** @addtogroup GPTIMER_COMMONREGS
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t CCPD;                              /* !< (@ 0x00001100) CCP Direction */
+  __IO uint32_t ODIS;                              /* !< (@ 0x00001104) Output Disable */
+  __IO uint32_t CCLKCTL;                           /* !< (@ 0x00001108) Counter Clock Control Register */
+  __IO uint32_t CPS;                               /* !< (@ 0x0000110C) Clock Prescale Register */
+  __I  uint32_t CPSV;                              /* !< (@ 0x00001110) Clock prescale count status register */
+  __IO uint32_t CTTRIGCTL;                         /* !< (@ 0x00001114) Timer Cross Trigger Control Register */
+       uint32_t RESERVED0;
+  __O  uint32_t CTTRIG;                            /* !< (@ 0x0000111C) Timer Cross Trigger Register */
+  __IO uint32_t FSCTL;                             /* !< (@ 0x00001120) Fault Source Control */
+  __IO uint32_t GCTL;                              /* !< (@ 0x00001124) Global control register */
+} GPTIMER_COMMONREGS_Regs;
+
+/*@}*/ /* end of group GPTIMER_COMMONREGS */
+
+/** @addtogroup GPTIMER_GEN_EVENT1
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001080) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001088) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001090) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001098) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x000010A0) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x000010A8) Interrupt clear */
+} GPTIMER_GEN_EVENT1_Regs;
+
+/*@}*/ /* end of group GPTIMER_GEN_EVENT1 */
+
+/** @addtogroup GPTIMER_GEN_EVENT0
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001050) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001058) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001060) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001068) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001070) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001078) Interrupt clear */
+} GPTIMER_GEN_EVENT0_Regs;
+
+/*@}*/ /* end of group GPTIMER_GEN_EVENT0 */
+
+/** @addtogroup GPTIMER_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} GPTIMER_CPU_INT_Regs;
+
+/*@}*/ /* end of group GPTIMER_CPU_INT */
+
+/** @addtogroup GPTIMER_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} GPTIMER_GPRCM_Regs;
+
+/*@}*/ /* end of group GPTIMER_GPRCM */
+
+/** @addtogroup GPTIMER
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[256];
+  __IO uint32_t FSUB_0;                            /* !< (@ 0x00000400) Subsciber Port 0 */
+  __IO uint32_t FSUB_1;                            /* !< (@ 0x00000404) Subscriber Port 1 */
+       uint32_t RESERVED1[15];
+  __IO uint32_t FPUB_0;                            /* !< (@ 0x00000444) Publisher Port 0 */
+  __IO uint32_t FPUB_1;                            /* !< (@ 0x00000448) Publisher Port 1 */
+       uint32_t RESERVED2[237];
+  GPTIMER_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED3[506];
+  __IO uint32_t CLKDIV;                            /* !< (@ 0x00001000) Clock Divider */
+       uint32_t RESERVED4;
+  __IO uint32_t CLKSEL;                            /* !< (@ 0x00001008) Clock Select for Ultra Low Power peripherals */
+       uint32_t RESERVED5[3];
+  __IO uint32_t PDBGCTL;                           /* !< (@ 0x00001018) Peripheral Debug Control */
+       uint32_t RESERVED6;
+  GPTIMER_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED7;
+  GPTIMER_GEN_EVENT0_Regs  GEN_EVENT0;                        /* !< (@ 0x00001050) */
+       uint32_t RESERVED8;
+  GPTIMER_GEN_EVENT1_Regs  GEN_EVENT1;                        /* !< (@ 0x00001080) */
+       uint32_t RESERVED9[13];
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED10[6];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Module Description */
+  GPTIMER_COMMONREGS_Regs  COMMONREGS;                        /* !< (@ 0x00001100) */
+       uint32_t RESERVED11[438];
+  GPTIMER_COUNTERREGS_Regs  COUNTERREGS;                       /* !< (@ 0x00001800) */
+} GPTIMER_Regs;
+
+/*@}*/ /* end of group GPTIMER */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* GPTIMER Register Control Bits
+******************************************************************************/
+
+/* GPTIMER_CTR Bits */
+/* GPTIMER_CTR[CCTR] Bits */
+#define GPTIMER_CTR_CCTR_OFS                     (0)                             /* !< CCTR Offset */
+#define GPTIMER_CTR_CCTR_MASK                    ((uint32_t)0x0000FFFFU)         /* !< Current Counter value */
+#define GPTIMER_CTR_CCTR_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define GPTIMER_CTR_CCTR_MAXIMUM                 ((uint32_t)0x00FFFFFFU)         /* !< Maximum Value */
+
+/* GPTIMER_CTRCTL Bits */
+/* GPTIMER_CTRCTL[EN] Bits */
+#define GPTIMER_CTRCTL_EN_OFS                    (0)                             /* !< EN Offset */
+#define GPTIMER_CTRCTL_EN_MASK                   ((uint32_t)0x00000001U)         /* !< Counter Enable.  This bit allows
+                                                                                    the timer to advance  This bit is
+                                                                                    automatically cleared if REPEAT=0 (do
+                                                                                    not automatically reload) and the
+                                                                                    counter value equals zero.  CPU
+                                                                                    Write: A register write that sets the
+                                                                                    EN bit, the counter value is set per
+                                                                                    the CVAE value. Hardware: This bit
+                                                                                    may also be set as the result of an
+                                                                                    LCOND or ZCOND condition being met
+                                                                                    and the counter value changed to the
+                                                                                    load value or zero value,
+                                                                                    respectively. */
+#define GPTIMER_CTRCTL_EN_DISABLED               ((uint32_t)0x00000000U)         /* !< Disabled */
+#define GPTIMER_CTRCTL_EN_ENABLED                ((uint32_t)0x00000001U)         /* !< Enabled */
+/* GPTIMER_CTRCTL[REPEAT] Bits */
+#define GPTIMER_CTRCTL_REPEAT_OFS                (1)                             /* !< REPEAT Offset */
+#define GPTIMER_CTRCTL_REPEAT_MASK               ((uint32_t)0x0000000EU)         /* !< Repeat.  The repeat bit controls
+                                                                                    whether the counter continues to
+                                                                                    advance following a zero event, or
+                                                                                    the exiting of a debug or fault
+                                                                                    condition.  If counting down, a zero
+                                                                                    event is followed by a load at the
+                                                                                    next advance condition. If counting
+                                                                                    up-down, a zero event is followed by
+                                                                                    an advance event (+1). The intent of
+                                                                                    encoding 3 is that if the debug
+                                                                                    condition is in effect, the
+                                                                                    generation of the load pulse is
+                                                                                    deferred until the debug condition is
+                                                                                    over. This allows the counter to
+                                                                                    reach zero before counting is
+                                                                                    suspended. */
+#define GPTIMER_CTRCTL_REPEAT_REPEAT_0           ((uint32_t)0x00000000U)         /* !< Does not automatically advance
+                                                                                    following a zero event. */
+#define GPTIMER_CTRCTL_REPEAT_REPEAT_1           ((uint32_t)0x00000002U)         /* !< Continues to advance following a
+                                                                                    zero event. */
+#define GPTIMER_CTRCTL_REPEAT_REPEAT_2           ((uint32_t)0x00000004U)         /* !< Reserved */
+#define GPTIMER_CTRCTL_REPEAT_REPEAT_3           ((uint32_t)0x00000006U)         /* !< Continues to advance following a
+                                                                                    zero event if the debug mode is not
+                                                                                    in effect, or following the release
+                                                                                    of the debug mode. */
+#define GPTIMER_CTRCTL_REPEAT_REPEAT_4           ((uint32_t)0x00000008U)         /* !< Reserved */
+/* GPTIMER_CTRCTL[CM] Bits */
+#define GPTIMER_CTRCTL_CM_OFS                    (4)                             /* !< CM Offset */
+#define GPTIMER_CTRCTL_CM_MASK                   ((uint32_t)0x00000030U)         /* !< Count Mode */
+#define GPTIMER_CTRCTL_CM_DOWN                   ((uint32_t)0x00000000U)         /* !< Down */
+#define GPTIMER_CTRCTL_CM_UP_DOWN                ((uint32_t)0x00000010U)         /* !< Up/Down */
+#define GPTIMER_CTRCTL_CM_UP                     ((uint32_t)0x00000020U)         /* !< Counter counts up. */
+/* GPTIMER_CTRCTL[CVAE] Bits */
+#define GPTIMER_CTRCTL_CVAE_OFS                  (28)                            /* !< CVAE Offset */
+#define GPTIMER_CTRCTL_CVAE_MASK                 ((uint32_t)0x30000000U)         /* !< Counter Value After Enable.  This
+                                                                                    field specifies the initialization
+                                                                                    condition of the counter when the EN
+                                                                                    bit is changed from 0 to 1 by a write
+                                                                                    to the CTRCTL register. Note that an
+                                                                                    external event can also cause the EN
+                                                                                    bit to go active. */
+#define GPTIMER_CTRCTL_CVAE_LDVAL                ((uint32_t)0x00000000U)         /* !< The counter is set to the LOAD
+                                                                                    register value */
+#define GPTIMER_CTRCTL_CVAE_NOCHANGE             ((uint32_t)0x10000000U)         /* !< The counter value is unchanged from
+                                                                                    its current value which could have
+                                                                                    been initialized by software */
+#define GPTIMER_CTRCTL_CVAE_ZEROVAL              ((uint32_t)0x20000000U)         /* !< The counter is set to zero */
+/* GPTIMER_CTRCTL[DRB] Bits */
+#define GPTIMER_CTRCTL_DRB_OFS                   (17)                            /* !< DRB Offset */
+#define GPTIMER_CTRCTL_DRB_MASK                  ((uint32_t)0x00020000U)         /* !< Debug Resume Behavior This bit
+                                                                                    specifies what the device does
+                                                                                    following the release/exit of debug
+                                                                                    mode. */
+#define GPTIMER_CTRCTL_DRB_RESUME                ((uint32_t)0x00000000U)         /* !< Resume counting */
+#define GPTIMER_CTRCTL_DRB_CVAE_ACTION           ((uint32_t)0x00020000U)         /* !< Perform the action as specified by
+                                                                                    the CVAE field. */
+/* GPTIMER_CTRCTL[FB] Bits */
+#define GPTIMER_CTRCTL_FB_OFS                    (18)                            /* !< FB Offset */
+#define GPTIMER_CTRCTL_FB_MASK                   ((uint32_t)0x00040000U)         /* !< Fault Behavior This bit specifies
+                                                                                    whether the counter continues running
+                                                                                    or suspends during a fault mode.
+                                                                                    There is a separate control under
+                                                                                    REPEAT to indicate whether counting
+                                                                                    is to suspend at next Counter==0 */
+#define GPTIMER_CTRCTL_FB_CONT_COUNT             ((uint32_t)0x00000000U)         /* !< Continues counting */
+#define GPTIMER_CTRCTL_FB_SUSP_COUNT             ((uint32_t)0x00040000U)         /* !< Suspends counting */
+/* GPTIMER_CTRCTL[FRB] Bits */
+#define GPTIMER_CTRCTL_FRB_OFS                   (19)                            /* !< FRB Offset */
+#define GPTIMER_CTRCTL_FRB_MASK                  ((uint32_t)0x00080000U)         /* !< Fault Resume Behavior This bit
+                                                                                    specifies what the device does
+                                                                                    following the release/exit of fault
+                                                                                    condition. */
+#define GPTIMER_CTRCTL_FRB_RESUME                ((uint32_t)0x00000000U)         /* !< Resume counting */
+#define GPTIMER_CTRCTL_FRB_CVAE_ACTION           ((uint32_t)0x00080000U)         /* !< Perform the action as specified by
+                                                                                    the CVAE field. */
+/* GPTIMER_CTRCTL[PLEN] Bits */
+#define GPTIMER_CTRCTL_PLEN_OFS                  (24)                            /* !< PLEN Offset */
+#define GPTIMER_CTRCTL_PLEN_MASK                 ((uint32_t)0x01000000U)         /* !< Phase Load Enable.  This bit allows
+                                                                                    the timer to have phase load feature. */
+#define GPTIMER_CTRCTL_PLEN_DISABLED             ((uint32_t)0x00000000U)         /* !< Disabled */
+#define GPTIMER_CTRCTL_PLEN_ENABLED              ((uint32_t)0x01000000U)         /* !< Enabled */
+/* GPTIMER_CTRCTL[SLZERCNEZ] Bits */
+#define GPTIMER_CTRCTL_SLZERCNEZ_OFS             (23)                            /* !< SLZERCNEZ Offset */
+#define GPTIMER_CTRCTL_SLZERCNEZ_MASK            ((uint32_t)0x00800000U)         /* !< Suppress Load and Zero Events if
+                                                                                    Repeat Counter is Not Equal to Zero.
+                                                                                    This bit suppresses the generation of
+                                                                                    the Z (zero) and L (load) events from
+                                                                                    the counter when the repeat counter
+                                                                                    (RC) value is not 0. */
+#define GPTIMER_CTRCTL_SLZERCNEZ_DISABLED        ((uint32_t)0x00000000U)         /* !< Disabled. Z and L events are always
+                                                                                    generated from the counter when their
+                                                                                    conditions are generated. */
+#define GPTIMER_CTRCTL_SLZERCNEZ_ENABLED         ((uint32_t)0x00800000U)         /* !< Enabled. Z and L events are
+                                                                                    generated from the counter when their
+                                                                                    conditions are generated and the RC
+                                                                                    register value is 0. */
+/* GPTIMER_CTRCTL[CLC] Bits */
+#define GPTIMER_CTRCTL_CLC_OFS                   (7)                             /* !< CLC Offset */
+#define GPTIMER_CTRCTL_CLC_MASK                  ((uint32_t)0x00000380U)         /* !< Counter Load Control.  This field
+                                                                                    specifies what controls the counter
+                                                                                    operation with respect to setting the
+                                                                                    counter to the LD register value.
+                                                                                    Encodings 1-3 are present based on
+                                                                                    the CCPC parameter value. Bits 4-5
+                                                                                    are present based on the HQEI
+                                                                                    parameter value. Any encodings not
+                                                                                    provided are documented as reserved. */
+#define GPTIMER_CTRCTL_CLC_CCCTL0_LCOND          ((uint32_t)0x00000000U)         /* !< CCCTL_0 LCOND */
+#define GPTIMER_CTRCTL_CLC_CCCTL1_LCOND          ((uint32_t)0x00000080U)         /* !< CCCTL_1 LCOND */
+#define GPTIMER_CTRCTL_CLC_CCCTL2_LCOND          ((uint32_t)0x00000100U)         /* !< CCCTL_2 LCOND This value exists
+                                                                                    when there are 4 channels. */
+#define GPTIMER_CTRCTL_CLC_CCCTL3_LCOND          ((uint32_t)0x00000180U)         /* !< CCCTL_3 LCOND This value exists
+                                                                                    when there are 4 channels. */
+#define GPTIMER_CTRCTL_CLC_QEI_2INP              ((uint32_t)0x00000200U)         /* !< Controlled by 2 input QEI mode.
+                                                                                    This value exists when TIMER support
+                                                                                    QEI feature. */
+#define GPTIMER_CTRCTL_CLC_QEI_3INP              ((uint32_t)0x00000280U)         /* !< Controlled by 3 input QEI mode.
+                                                                                    This value exists when TIMER support
+                                                                                    QEI feature. */
+/* GPTIMER_CTRCTL[CAC] Bits */
+#define GPTIMER_CTRCTL_CAC_OFS                   (10)                            /* !< CAC Offset */
+#define GPTIMER_CTRCTL_CAC_MASK                  ((uint32_t)0x00001C00U)         /* !< Counter Advance Control.  This
+                                                                                    field specifies what controls the
+                                                                                    counter operation with respect to
+                                                                                    advancing (incrementing or
+                                                                                    decrementing) the counter value.
+                                                                                    Encodings 1-3 are present based on
+                                                                                    the CCPC parameter value. Bits 4-5
+                                                                                    are present based on the HQEI
+                                                                                    parameter value. Any encodings not
+                                                                                    provided are documented as reserved. */
+#define GPTIMER_CTRCTL_CAC_CCCTL0_ACOND          ((uint32_t)0x00000000U)         /* !< CCCTL_0 ACOND */
+#define GPTIMER_CTRCTL_CAC_CCCTL1_ACOND          ((uint32_t)0x00000400U)         /* !< CCCTL_1 ACOND */
+#define GPTIMER_CTRCTL_CAC_CCCTL2_ACOND          ((uint32_t)0x00000800U)         /* !< CCCTL_2 ACOND This value exists
+                                                                                    when there are 4 channels. */
+#define GPTIMER_CTRCTL_CAC_CCCTL3_ACOND          ((uint32_t)0x00000C00U)         /* !< CCCTL_3 ACOND This value exists
+                                                                                    when there are 4 channels. */
+#define GPTIMER_CTRCTL_CAC_QEI_2INP              ((uint32_t)0x00001000U)         /* !< Controlled by 2-input QEI mode
+                                                                                    This value exists when TIMER support
+                                                                                    QEI feature. */
+#define GPTIMER_CTRCTL_CAC_QEI_3INP              ((uint32_t)0x00001400U)         /* !< Controlled by 3-input QEI mode
+                                                                                    This value exists when TIMER support
+                                                                                    QEI feature. */
+/* GPTIMER_CTRCTL[CZC] Bits */
+#define GPTIMER_CTRCTL_CZC_OFS                   (13)                            /* !< CZC Offset */
+#define GPTIMER_CTRCTL_CZC_MASK                  ((uint32_t)0x0000E000U)         /* !< Counter Zero Control This field
+                                                                                    specifies what controls the counter
+                                                                                    operation with respect to zeroing the
+                                                                                    counter value.    Encodings 1-3 are
+                                                                                    present based on the CCPC parameter
+                                                                                    value. Bits 4-5 are present based on
+                                                                                    the HQEI parameter value. Any
+                                                                                    encodings not provided are documented
+                                                                                    as reserved. */
+#define GPTIMER_CTRCTL_CZC_CCCTL0_ZCOND          ((uint32_t)0x00000000U)         /* !< CCCTL_0 ZCOND */
+#define GPTIMER_CTRCTL_CZC_CCCTL1_ZCOND          ((uint32_t)0x00002000U)         /* !< CCCTL_1 ZCOND */
+#define GPTIMER_CTRCTL_CZC_CCCTL2_ZCOND          ((uint32_t)0x00004000U)         /* !< CCCTL_2 ZCOND This value exists
+                                                                                    when there are 4 channels. */
+#define GPTIMER_CTRCTL_CZC_CCCTL3_ZCOND          ((uint32_t)0x00006000U)         /* !< CCCTL_3 ZCOND This value exists
+                                                                                    when there are 4 channels. */
+#define GPTIMER_CTRCTL_CZC_QEI_2INP              ((uint32_t)0x00008000U)         /* !< Controlled by 2-input QEI mode
+                                                                                    This value exists when TIMER support
+                                                                                    QEI feature. */
+#define GPTIMER_CTRCTL_CZC_QEI_3INP              ((uint32_t)0x0000A000U)         /* !< Controlled by 3-input QEI mode
+                                                                                    This value exists when TIMER support
+                                                                                    QEI feature. */
+
+/* GPTIMER_LOAD Bits */
+/* GPTIMER_LOAD[LD] Bits */
+#define GPTIMER_LOAD_LD_OFS                      (0)                             /* !< LD Offset */
+#define GPTIMER_LOAD_LD_MASK                     ((uint32_t)0x0000FFFFU)         /* !< Load Value */
+#define GPTIMER_LOAD_LD_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define GPTIMER_LOAD_LD_MAXIMUM                  ((uint32_t)0x00FFFFFFU)         /* !< Maximum Value */
+
+/* GPTIMER_CC_01 Bits */
+/* GPTIMER_CC_01[CCVAL] Bits */
+#define GPTIMER_CC_01_CCVAL_OFS                  (0)                             /* !< CCVAL Offset */
+#define GPTIMER_CC_01_CCVAL_MASK                 ((uint32_t)0x0000FFFFU)         /* !< Capture or compare value */
+#define GPTIMER_CC_01_CCVAL_MINIMUM              ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define GPTIMER_CC_01_CCVAL_MAXIMUM              ((uint32_t)0x0000FFFFU)         /* !< Maximum Value */
+
+/* GPTIMER_CC_23 Bits */
+/* GPTIMER_CC_23[CCVAL] Bits */
+#define GPTIMER_CC_23_CCVAL_OFS                  (0)                             /* !< CCVAL Offset */
+#define GPTIMER_CC_23_CCVAL_MASK                 ((uint32_t)0x0000FFFFU)         /* !< Capture or compare value */
+#define GPTIMER_CC_23_CCVAL_MINIMUM              ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define GPTIMER_CC_23_CCVAL_MAXIMUM              ((uint32_t)0x0000FFFFU)         /* !< Maximum Value */
+
+/* GPTIMER_CC_45 Bits */
+/* GPTIMER_CC_45[CCVAL] Bits */
+#define GPTIMER_CC_45_CCVAL_OFS                  (0)                             /* !< CCVAL Offset */
+#define GPTIMER_CC_45_CCVAL_MASK                 ((uint32_t)0x0000FFFFU)         /* !< Capture or compare value */
+#define GPTIMER_CC_45_CCVAL_MINIMUM              ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define GPTIMER_CC_45_CCVAL_MAXIMUM              ((uint32_t)0x0000FFFFU)         /* !< Maximum Value */
+
+/* GPTIMER_CCCTL_01 Bits */
+/* GPTIMER_CCCTL_01[CCOND] Bits */
+#define GPTIMER_CCCTL_01_CCOND_OFS               (0)                             /* !< CCOND Offset */
+#define GPTIMER_CCCTL_01_CCOND_MASK              ((uint32_t)0x00000007U)         /* !< Capture Condition. #br# Specifies
+                                                                                    the condition that generates a
+                                                                                    capture pulse. */
+#define GPTIMER_CCCTL_01_CCOND_NOCAPTURE         ((uint32_t)0x00000000U)         /* !< None (never captures) */
+#define GPTIMER_CCCTL_01_CCOND_CC_TRIG_RISE      ((uint32_t)0x00000001U)         /* !< Rising edge of CCP or trigger
+                                                                                    assertion edge */
+#define GPTIMER_CCCTL_01_CCOND_CC_TRIG_FALL      ((uint32_t)0x00000002U)         /* !< Falling edge of CCP or trigger
+                                                                                    de-assertion edge */
+#define GPTIMER_CCCTL_01_CCOND_CC_TRIG_EDGE      ((uint32_t)0x00000003U)         /* !< Either edge of CCP or trigger
+                                                                                    change (assertion/de-assertion edge) */
+/* GPTIMER_CCCTL_01[ACOND] Bits */
+#define GPTIMER_CCCTL_01_ACOND_OFS               (4)                             /* !< ACOND Offset */
+#define GPTIMER_CCCTL_01_ACOND_MASK              ((uint32_t)0x00000070U)         /* !< Advance Condition. #br# Specifies
+                                                                                    the condition that generates an
+                                                                                    advance pulse. */
+#define GPTIMER_CCCTL_01_ACOND_TIMCLK            ((uint32_t)0x00000000U)         /* !< Each TIMCLK */
+#define GPTIMER_CCCTL_01_ACOND_CC_TRIG_RISE      ((uint32_t)0x00000010U)         /* !< Rising edge of CCP or trigger
+                                                                                    assertion edge */
+#define GPTIMER_CCCTL_01_ACOND_CC_TRIG_FALL      ((uint32_t)0x00000020U)         /* !< Falling edge of CCP or trigger
+                                                                                    de-assertion edge */
+#define GPTIMER_CCCTL_01_ACOND_CC_TRIG_EDGE      ((uint32_t)0x00000030U)         /* !< Either edge of CCP or trigger
+                                                                                    change (assertion/de-assertion edge) */
+#define GPTIMER_CCCTL_01_ACOND_CC_TRIG_HIGH      ((uint32_t)0x00000050U)         /* !< CCP High or Trigger assertion
+                                                                                    (level) */
+/* GPTIMER_CCCTL_01[LCOND] Bits */
+#define GPTIMER_CCCTL_01_LCOND_OFS               (8)                             /* !< LCOND Offset */
+#define GPTIMER_CCCTL_01_LCOND_MASK              ((uint32_t)0x00000700U)         /* !< Load Condition. #br# Specifies the
+                                                                                    condition that generates a load
+                                                                                    pulse. */
+#define GPTIMER_CCCTL_01_LCOND_CC_TRIG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< CCP edges have no effect */
+#define GPTIMER_CCCTL_01_LCOND_CC_TRIG_RISE      ((uint32_t)0x00000100U)         /* !< Rising edge of CCP or trigger
+                                                                                    assertion edge */
+#define GPTIMER_CCCTL_01_LCOND_CC_TRIG_FALL      ((uint32_t)0x00000200U)         /* !< Falling edge of CCP or trigger
+                                                                                    de-assertion edge */
+#define GPTIMER_CCCTL_01_LCOND_CC_TRIG_EDGE      ((uint32_t)0x00000300U)         /* !< Either edge of CCP or trigger
+                                                                                    change (assertion/de-assertion edge) */
+/* GPTIMER_CCCTL_01[ZCOND] Bits */
+#define GPTIMER_CCCTL_01_ZCOND_OFS               (12)                            /* !< ZCOND Offset */
+#define GPTIMER_CCCTL_01_ZCOND_MASK              ((uint32_t)0x00007000U)         /* !< Zero Condition. #br# This field
+                                                                                    specifies the condition that
+                                                                                    generates a zero pulse. */
+#define GPTIMER_CCCTL_01_ZCOND_CC_TRIG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< CCP edges have no effect */
+#define GPTIMER_CCCTL_01_ZCOND_CC_TRIG_RISE      ((uint32_t)0x00001000U)         /* !< Rising edge of CCP or trigger
+                                                                                    assertion edge */
+#define GPTIMER_CCCTL_01_ZCOND_CC_TRIG_FALL      ((uint32_t)0x00002000U)         /* !< Falling edge of CCP or trigger
+                                                                                    de-assertion edge */
+#define GPTIMER_CCCTL_01_ZCOND_CC_TRIG_EDGE      ((uint32_t)0x00003000U)         /* !< Either edge of CCP or trigger
+                                                                                    change (assertion/de-assertion edge) */
+/* GPTIMER_CCCTL_01[COC] Bits */
+#define GPTIMER_CCCTL_01_COC_OFS                 (17)                            /* !< COC Offset */
+#define GPTIMER_CCCTL_01_COC_MASK                ((uint32_t)0x00020000U)         /* !< Capture or Compare. #br# Specifies
+                                                                                    whether the corresponding CC register
+                                                                                    is used as a capture register or a
+                                                                                    compare register (never both). */
+#define GPTIMER_CCCTL_01_COC_COMPARE             ((uint32_t)0x00000000U)         /* !< Compare */
+#define GPTIMER_CCCTL_01_COC_CAPTURE             ((uint32_t)0x00020000U)         /* !< Capture */
+/* GPTIMER_CCCTL_01[SCERCNEZ] Bits */
+#define GPTIMER_CCCTL_01_SCERCNEZ_OFS            (25)                            /* !< SCERCNEZ Offset */
+#define GPTIMER_CCCTL_01_SCERCNEZ_MASK           ((uint32_t)0x02000000U)         /* !< Suppress Compare Event if Repeat
+                                                                                    Counter is Not Equal to Zero This bit
+                                                                                    suppresses the generation of the
+                                                                                    compare (CCD, CCU and RC) events from
+                                                                                    the counter when the repeat counter
+                                                                                    (RC) value is not 0. */
+#define GPTIMER_CCCTL_01_SCERCNEZ_DISABLED       ((uint32_t)0x00000000U)         /* !< CCD, CCU  and RC events are always
+                                                                                    generated from the counter when their
+                                                                                    conditions are generated. */
+#define GPTIMER_CCCTL_01_SCERCNEZ_ENABLED        ((uint32_t)0x02000000U)         /* !< CCD, CCU and RC events are
+                                                                                    generated from the counter when their
+                                                                                    conditions are generated and the RC
+                                                                                    register value is 0. */
+/* GPTIMER_CCCTL_01[CCUPD] Bits */
+#define GPTIMER_CCCTL_01_CCUPD_OFS               (18)                            /* !< CCUPD Offset */
+#define GPTIMER_CCCTL_01_CCUPD_MASK              ((uint32_t)0x001C0000U)         /* !< Capture and Compare Update Method
+                                                                                    This field controls how updates to
+                                                                                    the shadow capture and compare
+                                                                                    register are performed (when
+                                                                                    operating in compare mode, COC=0). */
+#define GPTIMER_CCCTL_01_CCUPD_IMMEDIATELY       ((uint32_t)0x00000000U)         /* !< Writes to the CCx_y register is
+                                                                                    written to the register directly and
+                                                                                    has immediate effect. */
+#define GPTIMER_CCCTL_01_CCUPD_ZERO_EVT          ((uint32_t)0x00040000U)         /* !< Following a zero event (CTR=0)
+                                                                                    Writes to the CCx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCx_y in the TIMCLK
+                                                                                    cycle following CTR equals 0. */
+#define GPTIMER_CCCTL_01_CCUPD_COMPARE_DOWN_EVT  ((uint32_t)0x00080000U)         /* !< Following a CCD event (CTR=CC_xy)
+                                                                                    Writes to the CCx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCx_y in the TIMCLK
+                                                                                    cycle following CTR equals the CCx_y
+                                                                                    register value. */
+#define GPTIMER_CCCTL_01_CCUPD_COMPARE_UP_EVT    ((uint32_t)0x000C0000U)         /* !< Following a CCU event (CTR=CC_xy)
+                                                                                    Writes to the CCx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCx_y in the TIMCLK
+                                                                                    cycle following CTR equals the CCx_y
+                                                                                    register value. */
+#define GPTIMER_CCCTL_01_CCUPD_ZERO_LOAD_EVT     ((uint32_t)0x00100000U)         /* !< Following a zero event(CTR=0) or
+                                                                                    load event (CTR=LOAD) Writes to the
+                                                                                    CCx_y register are stored in shadow
+                                                                                    register and transferred to ECCx_y in
+                                                                                    the TIMCLK cycle following CTR equals
+                                                                                    0 or CTR. Equals LD.  Note this
+                                                                                    update mechanism is defined for use
+                                                                                    only in configurations using up/down
+                                                                                    counting. This mode is not intended
+                                                                                    for use in down count configurations. */
+#define GPTIMER_CCCTL_01_CCUPD_ZERO_RC_ZERO_EVT  ((uint32_t)0x00140000U)         /* !< Following a zero event (CTR=0) with
+                                                                                    repeat count also zero (RC=0).
+                                                                                    Writes to the CCx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCx_y in the TIMCLK
+                                                                                    cycle following CTR equals 0 and if
+                                                                                    RC equal 0. */
+#define GPTIMER_CCCTL_01_CCUPD_TRIG              ((uint32_t)0x00180000U)         /* !< Following a TRIG pulse.  Writes to
+                                                                                    the CCx_y register are stored in
+                                                                                    shadow register and transferred to
+                                                                                    CCx_y */
+/* GPTIMER_CCCTL_01[CCACTUPD] Bits */
+#define GPTIMER_CCCTL_01_CCACTUPD_OFS            (26)                            /* !< CCACTUPD Offset */
+#define GPTIMER_CCCTL_01_CCACTUPD_MASK           ((uint32_t)0x1C000000U)         /* !< CCACT shadow register Update Method
+                                                                                    This field controls how updates to
+                                                                                    the CCACT shadow register are
+                                                                                    performed */
+#define GPTIMER_CCCTL_01_CCACTUPD_IMMEDIATELY    ((uint32_t)0x00000000U)         /* !< Value written to the CCACT register
+                                                                                    has immediate effect. */
+#define GPTIMER_CCCTL_01_CCACTUPD_ZERO_EVT       ((uint32_t)0x04000000U)         /* !< Following a zero event (CTR=0)
+                                                                                    Writes to the CCACTx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCACTx_y in the TIMCLK
+                                                                                    cycle following CTR equals 0. */
+#define GPTIMER_CCCTL_01_CCACTUPD_COMPARE_DOWN_EVT ((uint32_t)0x08000000U)         /* !< Following a CCD event (CTR=CC_xy)
+                                                                                    Writes to the CCACTx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCACTx_y in the TIMCLK
+                                                                                    cycle following CTR equals the CCx_y
+                                                                                    register value. */
+#define GPTIMER_CCCTL_01_CCACTUPD_COMPARE_UP_EVT ((uint32_t)0x0C000000U)         /* !< Following a CCU event (CTR=CC_xy)
+                                                                                    Writes to the CCACTx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCACTx_y in the TIMCLK
+                                                                                    cycle following CTR equals the CCx_y
+                                                                                    register value. */
+#define GPTIMER_CCCTL_01_CCACTUPD_ZERO_LOAD_EVT  ((uint32_t)0x10000000U)         /* !< Following a zero event (CTR=0) or
+                                                                                    load event (CTR = LOAD) Writes to the
+                                                                                    CCACTx_y register are stored in
+                                                                                    shadow register and transferred to
+                                                                                    CCACTx_y in the TIMCLK cycle
+                                                                                    following CTR equals 0 or CTR. Equals
+                                                                                    LDn.  Note this update mechanism is
+                                                                                    defined for use only in
+                                                                                    configurations using up/down
+                                                                                    counting. This mode is not intended
+                                                                                    for use in down count configurations. */
+#define GPTIMER_CCCTL_01_CCACTUPD_ZERO_RC_ZERO_EVT ((uint32_t)0x14000000U)         /* !< Following a zero event (CTR=0) with
+                                                                                    repeat count also zero (RC=0).
+                                                                                    Writes to the CCACTx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCACTx_y in the TIMCLK
+                                                                                    cycle following CTR equals 0 and if
+                                                                                    RC equal 0. */
+#define GPTIMER_CCCTL_01_CCACTUPD_TRIG           ((uint32_t)0x18000000U)         /* !< On a TRIG pulse, the value stored
+                                                                                    in CCACT_xy shadow register is loaded
+                                                                                    into CCACT_xy register. */
+/* GPTIMER_CCCTL_01[CC2SELU] Bits */
+#define GPTIMER_CCCTL_01_CC2SELU_OFS             (22)                            /* !< CC2SELU Offset */
+#define GPTIMER_CCCTL_01_CC2SELU_MASK            ((uint32_t)0x01C00000U)         /* !< Selects the source second CCU
+                                                                                    event. */
+#define GPTIMER_CCCTL_01_CC2SELU_SEL_CCU0        ((uint32_t)0x00000000U)         /* !< Selects CCU from CC0. */
+#define GPTIMER_CCCTL_01_CC2SELU_SEL_CCU1        ((uint32_t)0x00400000U)         /* !< Selects CCU from CC1. */
+#define GPTIMER_CCCTL_01_CC2SELU_SEL_CCU2        ((uint32_t)0x00800000U)         /* !< Selects CCU from CC2. */
+#define GPTIMER_CCCTL_01_CC2SELU_SEL_CCU3        ((uint32_t)0x00C00000U)         /* !< Selects CCU from CC3. */
+#define GPTIMER_CCCTL_01_CC2SELU_SEL_CCU4        ((uint32_t)0x01000000U)         /* !< Selects CCU from CC4. */
+#define GPTIMER_CCCTL_01_CC2SELU_SEL_CCU5        ((uint32_t)0x01400000U)         /* !< Selects CCU from CC5. */
+/* GPTIMER_CCCTL_01[CC2SELD] Bits */
+#define GPTIMER_CCCTL_01_CC2SELD_OFS             (29)                            /* !< CC2SELD Offset */
+#define GPTIMER_CCCTL_01_CC2SELD_MASK            ((uint32_t)0xE0000000U)         /* !< Selects the source second CCD
+                                                                                    event. */
+#define GPTIMER_CCCTL_01_CC2SELD_SEL_CCD0        ((uint32_t)0x00000000U)         /* !< Selects CCD from CC0. */
+#define GPTIMER_CCCTL_01_CC2SELD_SEL_CCD1        ((uint32_t)0x20000000U)         /* !< Selects CCD from CC1. */
+#define GPTIMER_CCCTL_01_CC2SELD_SEL_CCD2        ((uint32_t)0x40000000U)         /* !< Selects CCD from CC2. */
+#define GPTIMER_CCCTL_01_CC2SELD_SEL_CCD3        ((uint32_t)0x60000000U)         /* !< Selects CCD from CC3. */
+#define GPTIMER_CCCTL_01_CC2SELD_SEL_CCD4        ((uint32_t)0x80000000U)         /* !< Selects CCD from CC4. */
+#define GPTIMER_CCCTL_01_CC2SELD_SEL_CCD5        ((uint32_t)0xA0000000U)         /* !< Selects CCD from CC5. */
+
+/* GPTIMER_CCCTL_23 Bits */
+/* GPTIMER_CCCTL_23[CCOND] Bits */
+#define GPTIMER_CCCTL_23_CCOND_OFS               (0)                             /* !< CCOND Offset */
+#define GPTIMER_CCCTL_23_CCOND_MASK              ((uint32_t)0x00000007U)         /* !< Capture Condition. #br# Specifies
+                                                                                    the condition that generates a
+                                                                                    capture pulse. 4h-Fh = Reserved */
+#define GPTIMER_CCCTL_23_CCOND_NOCAPTURE         ((uint32_t)0x00000000U)         /* !< None (never captures) */
+#define GPTIMER_CCCTL_23_CCOND_CC_TRIG_RISE      ((uint32_t)0x00000001U)         /* !< Rising edge of CCP or trigger
+                                                                                    assertion edge */
+#define GPTIMER_CCCTL_23_CCOND_CC_TRIG_FALL      ((uint32_t)0x00000002U)         /* !< Falling edge of CCP or trigger
+                                                                                    de-assertion edge */
+#define GPTIMER_CCCTL_23_CCOND_CC_TRIG_EDGE      ((uint32_t)0x00000003U)         /* !< Either edge of CCP or trigger
+                                                                                    change (assertion/de-assertion edge) */
+/* GPTIMER_CCCTL_23[ACOND] Bits */
+#define GPTIMER_CCCTL_23_ACOND_OFS               (4)                             /* !< ACOND Offset */
+#define GPTIMER_CCCTL_23_ACOND_MASK              ((uint32_t)0x00000070U)         /* !< Advance Condition. #br# Specifies
+                                                                                    the condition that generates an
+                                                                                    advance pulse. 6h-Fh = Reserved */
+#define GPTIMER_CCCTL_23_ACOND_TIMCLK            ((uint32_t)0x00000000U)         /* !< Each TIMCLK */
+#define GPTIMER_CCCTL_23_ACOND_CC_TRIG_RISE      ((uint32_t)0x00000010U)         /* !< Rising edge of CCP or trigger
+                                                                                    assertion edge */
+#define GPTIMER_CCCTL_23_ACOND_CC_TRIG_FALL      ((uint32_t)0x00000020U)         /* !< Falling edge of CCP or trigger
+                                                                                    de-assertion edge */
+#define GPTIMER_CCCTL_23_ACOND_CC_TRIG_EDGE      ((uint32_t)0x00000030U)         /* !< Either edge of CCP or trigger
+                                                                                    change (assertion/de-assertion edge) */
+#define GPTIMER_CCCTL_23_ACOND_CC_TRIG_HIGH      ((uint32_t)0x00000050U)         /* !< CCP High or Trigger assertion
+                                                                                    (level) */
+/* GPTIMER_CCCTL_23[LCOND] Bits */
+#define GPTIMER_CCCTL_23_LCOND_OFS               (8)                             /* !< LCOND Offset */
+#define GPTIMER_CCCTL_23_LCOND_MASK              ((uint32_t)0x00000700U)         /* !< Load Condition. #br# Specifies the
+                                                                                    condition that generates a load
+                                                                                    pulse.  4h-Fh = Reserved */
+#define GPTIMER_CCCTL_23_LCOND_CC_TRIG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< CCP edges have no effect */
+#define GPTIMER_CCCTL_23_LCOND_CC_TRIG_RISE      ((uint32_t)0x00000100U)         /* !< Rising edge of CCP or trigger
+                                                                                    assertion edge */
+#define GPTIMER_CCCTL_23_LCOND_CC_TRIG_FALL      ((uint32_t)0x00000200U)         /* !< Falling edge of CCP or trigger
+                                                                                    de-assertion edge */
+#define GPTIMER_CCCTL_23_LCOND_CC_TRIG_EDGE      ((uint32_t)0x00000300U)         /* !< Either edge of CCP or trigger
+                                                                                    change (assertion/de-assertion edge) */
+/* GPTIMER_CCCTL_23[ZCOND] Bits */
+#define GPTIMER_CCCTL_23_ZCOND_OFS               (12)                            /* !< ZCOND Offset */
+#define GPTIMER_CCCTL_23_ZCOND_MASK              ((uint32_t)0x00007000U)         /* !< Zero Condition. #br# This field
+                                                                                    specifies the condition that
+                                                                                    generates a zero pulse. 4h-Fh =
+                                                                                    Reserved */
+#define GPTIMER_CCCTL_23_ZCOND_CC_TRIG_NO_EFFECT ((uint32_t)0x00000000U)         /* !< CCP edges have no effect */
+#define GPTIMER_CCCTL_23_ZCOND_CC_TRIG_RISE      ((uint32_t)0x00001000U)         /* !< Rising edge of CCP or trigger
+                                                                                    assertion edge */
+#define GPTIMER_CCCTL_23_ZCOND_CC_TRIG_FALL      ((uint32_t)0x00002000U)         /* !< Falling edge of CCP or trigger
+                                                                                    de-assertion edge */
+#define GPTIMER_CCCTL_23_ZCOND_CC_TRIG_EDGE      ((uint32_t)0x00003000U)         /* !< Either edge of CCP or trigger
+                                                                                    change (assertion/de-assertion edge) */
+/* GPTIMER_CCCTL_23[COC] Bits */
+#define GPTIMER_CCCTL_23_COC_OFS                 (17)                            /* !< COC Offset */
+#define GPTIMER_CCCTL_23_COC_MASK                ((uint32_t)0x00020000U)         /* !< Capture or Compare. #br# Specifies
+                                                                                    whether the corresponding CC register
+                                                                                    is used as a capture register or a
+                                                                                    compare register (never both). */
+#define GPTIMER_CCCTL_23_COC_COMPARE             ((uint32_t)0x00000000U)         /* !< Compare */
+#define GPTIMER_CCCTL_23_COC_CAPTURE             ((uint32_t)0x00020000U)         /* !< Capture */
+/* GPTIMER_CCCTL_23[SCERCNEZ] Bits */
+#define GPTIMER_CCCTL_23_SCERCNEZ_OFS            (25)                            /* !< SCERCNEZ Offset */
+#define GPTIMER_CCCTL_23_SCERCNEZ_MASK           ((uint32_t)0x02000000U)         /* !< Suppress Compare Event if Repeat
+                                                                                    Counter is Not Equal to Zero This bit
+                                                                                    suppresses the generation of the
+                                                                                    compare (CCD, CCU and RC) events from
+                                                                                    the counter when the repeat counter
+                                                                                    (RCn) value is not 0. */
+#define GPTIMER_CCCTL_23_SCERCNEZ_DISABLED       ((uint32_t)0x00000000U)         /* !< CCD, CCU and RC events are always
+                                                                                    generated from the counter when their
+                                                                                    conditions are generated. */
+#define GPTIMER_CCCTL_23_SCERCNEZ_ENABLED        ((uint32_t)0x02000000U)         /* !< CCD, CCU and RC events are
+                                                                                    generated from the counter when their
+                                                                                    conditions are generated and the RC
+                                                                                    register value is 0. */
+/* GPTIMER_CCCTL_23[CCUPD] Bits */
+#define GPTIMER_CCCTL_23_CCUPD_OFS               (18)                            /* !< CCUPD Offset */
+#define GPTIMER_CCCTL_23_CCUPD_MASK              ((uint32_t)0x001C0000U)         /* !< Capture and Compare Update Method
+                                                                                    This field controls how updates to
+                                                                                    the shadow capture and compare
+                                                                                    register are performed (when
+                                                                                    operating in compare mode, COC=0). */
+#define GPTIMER_CCCTL_23_CCUPD_IMMEDIATELY       ((uint32_t)0x00000000U)         /* !< Writes to the CCx_y register is
+                                                                                    written to the register directly and
+                                                                                    has immediate effect. */
+#define GPTIMER_CCCTL_23_CCUPD_ZERO_EVT          ((uint32_t)0x00040000U)         /* !< Following a zero event (CTR=0)
+                                                                                    Writes to the CCx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCx_y in the TIMCLK
+                                                                                    cycle following CTR equals 0. */
+#define GPTIMER_CCCTL_23_CCUPD_COMPARE_DOWN_EVT  ((uint32_t)0x00080000U)         /* !< Following a CCD event (CTR=CC_xy)
+                                                                                    Writes to the CCx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCx_y in the TIMCLK
+                                                                                    cycle following CTR equals the CCx_y
+                                                                                    register value. */
+#define GPTIMER_CCCTL_23_CCUPD_COMPARE_UP_EVT    ((uint32_t)0x000C0000U)         /* !< Following a CCU event (CTR=CC_xy)
+                                                                                    Writes to the CCx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCx_y in the TIMCLK
+                                                                                    cycle following CTR equals the CCx_y
+                                                                                    register value. */
+#define GPTIMER_CCCTL_23_CCUPD_ZERO_LOAD_EVT     ((uint32_t)0x00100000U)         /* !< Following a zero or load event
+                                                                                    Writes to the CCx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCx_y in the TIMCLK
+                                                                                    cycle following CTR equals 0 or CTR.
+                                                                                    Equals LDn.  Note this update
+                                                                                    mechanism is defined for use only in
+                                                                                    configurations using up/down
+                                                                                    counting. This mode is not intended
+                                                                                    for use in down count configurations. */
+#define GPTIMER_CCCTL_23_CCUPD_ZERO_RC_ZERO_EVT  ((uint32_t)0x00140000U)         /* !< Following a zero event (CTR=0) with
+                                                                                    repeat count also zero (RC=0).
+                                                                                    Writes to the CCx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCx_y in the TIMCLK
+                                                                                    cycle following CTR equals 0 and if
+                                                                                    RC equal 0. */
+#define GPTIMER_CCCTL_23_CCUPD_TRIG              ((uint32_t)0x00180000U)         /* !< Following a TRIG pulse.  Writes to
+                                                                                    the CCx_y register are stored in
+                                                                                    shadow register and transferred to
+                                                                                    CCx_y #xD; 0. */
+/* GPTIMER_CCCTL_23[CCACTUPD] Bits */
+#define GPTIMER_CCCTL_23_CCACTUPD_OFS            (26)                            /* !< CCACTUPD Offset */
+#define GPTIMER_CCCTL_23_CCACTUPD_MASK           ((uint32_t)0x1C000000U)         /* !< CCACT shadow register Update Method
+                                                                                    This field controls how updates to
+                                                                                    the CCCACT shadow register are
+                                                                                    performed */
+#define GPTIMER_CCCTL_23_CCACTUPD_IMMEDIATELY    ((uint32_t)0x00000000U)         /* !< Value written to the CCACTx_y
+                                                                                    register has immediate effect. */
+#define GPTIMER_CCCTL_23_CCACTUPD_ZERO_EVT       ((uint32_t)0x04000000U)         /* !< Following a zero event (CTR=0)
+                                                                                    Writes to the CCACTx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCACTx_y in the TIMCLK
+                                                                                    cycle following CTR equals 0. */
+#define GPTIMER_CCCTL_23_CCACTUPD_COMPARE_DOWN_EVT ((uint32_t)0x08000000U)         /* !< Following a CCD event (CTR=CC_xy)
+                                                                                    Writes to the CCACTx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCACTx_y in the TIMCLK
+                                                                                    cycle following CTR equals the CCx_y
+                                                                                    register value. */
+#define GPTIMER_CCCTL_23_CCACTUPD_COMPARE_UP_EVT ((uint32_t)0x0C000000U)         /* !< Following a CCU event (CTR=cc_xy)
+                                                                                    Writes to the CCACTx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCACTx_y in the TIMCLK
+                                                                                    cycle following CTR equals the CCx_y
+                                                                                    register value. */
+#define GPTIMER_CCCTL_23_CCACTUPD_ZERO_LOAD_EVT  ((uint32_t)0x10000000U)         /* !< Following a zero event (CTR=0) or
+                                                                                    load event (CTR=LOAD) Writes to the
+                                                                                    CCACTx_y register are stored in
+                                                                                    shadow register and transferred to
+                                                                                    CCACTx_y in the TIMCLK cycle
+                                                                                    following CTR equals 0 or CTR. Equals
+                                                                                    LDn.  Note this update mechanism is
+                                                                                    defined for use only in
+                                                                                    configurations using up/down
+                                                                                    counting. This mode is not intended
+                                                                                    for use in down count configurations. */
+#define GPTIMER_CCCTL_23_CCACTUPD_ZERO_RC_ZERO_EVT ((uint32_t)0x14000000U)         /* !< Following a zero event (CTR=0) with
+                                                                                    repeat count also zero (RC=0).
+                                                                                    Writes to the CCACTx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCACTx_y in the TIMCLK
+                                                                                    cycle following CTR equals 0 and if
+                                                                                    RC equal 0. */
+#define GPTIMER_CCCTL_23_CCACTUPD_TRIG           ((uint32_t)0x18000000U)         /* !< On a TRIG pulse, the value stored
+                                                                                    in CCACTx_y shadow register is loaded
+                                                                                    into CCACTx_y active register. */
+/* GPTIMER_CCCTL_23[CC2SELU] Bits */
+#define GPTIMER_CCCTL_23_CC2SELU_OFS             (22)                            /* !< CC2SELU Offset */
+#define GPTIMER_CCCTL_23_CC2SELU_MASK            ((uint32_t)0x01C00000U)         /* !< Selects the source second CCU
+                                                                                    event. */
+#define GPTIMER_CCCTL_23_CC2SELU_SEL_CCU0        ((uint32_t)0x00000000U)         /* !< Selects CCU from CC0. */
+#define GPTIMER_CCCTL_23_CC2SELU_SEL_CCU1        ((uint32_t)0x00400000U)         /* !< Selects CCU from CC1. */
+#define GPTIMER_CCCTL_23_CC2SELU_SEL_CCU2        ((uint32_t)0x00800000U)         /* !< Selects CCU from CC2. */
+#define GPTIMER_CCCTL_23_CC2SELU_SEL_CCU3        ((uint32_t)0x00C00000U)         /* !< Selects CCU from CC3. */
+#define GPTIMER_CCCTL_23_CC2SELU_SEL_CCU4        ((uint32_t)0x01000000U)         /* !< Selects CCU from CC4. */
+#define GPTIMER_CCCTL_23_CC2SELU_SEL_CCU5        ((uint32_t)0x01400000U)         /* !< Selects CCU from CC5. */
+/* GPTIMER_CCCTL_23[CC2SELD] Bits */
+#define GPTIMER_CCCTL_23_CC2SELD_OFS             (29)                            /* !< CC2SELD Offset */
+#define GPTIMER_CCCTL_23_CC2SELD_MASK            ((uint32_t)0xE0000000U)         /* !< Selects the source second CCD
+                                                                                    event. */
+#define GPTIMER_CCCTL_23_CC2SELD_SEL_CCD0        ((uint32_t)0x00000000U)         /* !< Selects CCD from CC0. */
+#define GPTIMER_CCCTL_23_CC2SELD_SEL_CCD1        ((uint32_t)0x20000000U)         /* !< Selects CCD from CC1. */
+#define GPTIMER_CCCTL_23_CC2SELD_SEL_CCD2        ((uint32_t)0x40000000U)         /* !< Selects CCD from CC2. */
+#define GPTIMER_CCCTL_23_CC2SELD_SEL_CCD3        ((uint32_t)0x60000000U)         /* !< Selects CCD from CC3. */
+#define GPTIMER_CCCTL_23_CC2SELD_SEL_CCD4        ((uint32_t)0x80000000U)         /* !< Selects CCD from CC4. */
+#define GPTIMER_CCCTL_23_CC2SELD_SEL_CCD5        ((uint32_t)0xA0000000U)         /* !< Selects CCD from CC5. */
+
+/* GPTIMER_CCCTL_45 Bits */
+/* GPTIMER_CCCTL_45[SCERCNEZ] Bits */
+#define GPTIMER_CCCTL_45_SCERCNEZ_OFS            (25)                            /* !< SCERCNEZ Offset */
+#define GPTIMER_CCCTL_45_SCERCNEZ_MASK           ((uint32_t)0x02000000U)         /* !< Suppress Compare Event if Repeat
+                                                                                    Counter is Not Equal to Zero This bit
+                                                                                    suppresses the generation of the
+                                                                                    compare (CCD, CCU and RC) events from
+                                                                                    the counter when the repeat counter
+                                                                                    (RC) value is not 0. */
+#define GPTIMER_CCCTL_45_SCERCNEZ_DISABLED       ((uint32_t)0x00000000U)         /* !< CCD, CCU and RC events are always
+                                                                                    generated from the counter when their
+                                                                                    conditions are generated. */
+#define GPTIMER_CCCTL_45_SCERCNEZ_ENABLED        ((uint32_t)0x02000000U)         /* !< CCD, CCU and RC events are
+                                                                                    generated from the counter when their
+                                                                                    conditions are generated and the RC
+                                                                                    register value is 0. */
+/* GPTIMER_CCCTL_45[CCUPD] Bits */
+#define GPTIMER_CCCTL_45_CCUPD_OFS               (18)                            /* !< CCUPD Offset */
+#define GPTIMER_CCCTL_45_CCUPD_MASK              ((uint32_t)0x001C0000U)         /* !< Capture and Compare Update Method
+                                                                                    This field controls how updates to
+                                                                                    the shadow capture and compare
+                                                                                    register are performed (when
+                                                                                    operating in compare mode, COC=0). */
+#define GPTIMER_CCCTL_45_CCUPD_IMMEDIATELY       ((uint32_t)0x00000000U)         /* !< Writes to the CCx_y register is
+                                                                                    written to the register directly and
+                                                                                    has immediate effect. */
+#define GPTIMER_CCCTL_45_CCUPD_ZERO_EVT          ((uint32_t)0x00040000U)         /* !< Following a zero event (CTR=0)
+                                                                                    Writes to the CCx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to ECCx_y in the TIMCLK
+                                                                                    cycle following CTR equals 0. */
+#define GPTIMER_CCCTL_45_CCUPD_COMPARE_DOWN_EVT  ((uint32_t)0x00080000U)         /* !< Following a CCD event (CTR=CC_xy)
+                                                                                    Writes to the CCx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCx_y in the TIMCLK
+                                                                                    cycle following CTR equals the CCx_y
+                                                                                    register value. */
+#define GPTIMER_CCCTL_45_CCUPD_COMPARE_UP_EVT    ((uint32_t)0x000C0000U)         /* !< Following a CCU event (CTR=CC_xy)
+                                                                                    Writes to the CCx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCx_y in the TIMCLK
+                                                                                    cycle following CTR equals the CCx_y
+                                                                                    register value. */
+#define GPTIMER_CCCTL_45_CCUPD_ZERO_LOAD_EVT     ((uint32_t)0x00100000U)         /* !< Following a zero event (CTR=0) or
+                                                                                    load event (CTR=LOAD) Writes to the
+                                                                                    CCx_y register are stored in shadow
+                                                                                    register and transferred to CCx_y in
+                                                                                    the TIMCLK cycle following CTR equals
+                                                                                    0 or CTR. Equals LD.  Note this
+                                                                                    update mechanism is defined for use
+                                                                                    only in configurations using up/down
+                                                                                    counting. This mode is not intended
+                                                                                    for use in down count configurations. */
+#define GPTIMER_CCCTL_45_CCUPD_ZERO_RC_ZERO_EVT  ((uint32_t)0x00140000U)         /* !< Following a zero event (CTR=0) with
+                                                                                    repeat count also zero (RC=0).
+                                                                                    Writes to the CCx_y register are
+                                                                                    stored in shadow register and
+                                                                                    transferred to CCx_y in the TIMCLK
+                                                                                    cycle following CTR equals 0 and if
+                                                                                    RC equal 0. */
+#define GPTIMER_CCCTL_45_CCUPD_TRIG              ((uint32_t)0x00180000U)         /* !< Following a TRIG pulse.  Writes to
+                                                                                    the CCx_y register are stored in
+                                                                                    shadow register and transferred to
+                                                                                    CCx_y #xD; 0. */
+
+/* GPTIMER_OCTL_01 Bits */
+/* GPTIMER_OCTL_01[CCPOINV] Bits */
+#define GPTIMER_OCTL_01_CCPOINV_OFS              (4)                             /* !< CCPOINV Offset */
+#define GPTIMER_OCTL_01_CCPOINV_MASK             ((uint32_t)0x00000010U)         /* !< CCP Output Invert The output as
+                                                                                    selected by CCPO is conditionally
+                                                                                    inverted. */
+#define GPTIMER_OCTL_01_CCPOINV_NOINV            ((uint32_t)0x00000000U)         /* !< No inversion */
+#define GPTIMER_OCTL_01_CCPOINV_INV              ((uint32_t)0x00000010U)         /* !< Invert */
+/* GPTIMER_OCTL_01[CCPIV] Bits */
+#define GPTIMER_OCTL_01_CCPIV_OFS                (5)                             /* !< CCPIV Offset */
+#define GPTIMER_OCTL_01_CCPIV_MASK               ((uint32_t)0x00000020U)         /* !< CCP Initial Value This bit
+                                                                                    specifies the logical value put on
+                                                                                    the signal generator state while the
+                                                                                    counter is disabled (CTRCTL.EN == 0). */
+#define GPTIMER_OCTL_01_CCPIV_LOW                ((uint32_t)0x00000000U)         /* !< Low */
+#define GPTIMER_OCTL_01_CCPIV_HIGH               ((uint32_t)0x00000020U)         /* !< High */
+/* GPTIMER_OCTL_01[CCPO] Bits */
+#define GPTIMER_OCTL_01_CCPO_OFS                 (0)                             /* !< CCPO Offset */
+#define GPTIMER_OCTL_01_CCPO_MASK                ((uint32_t)0x0000000FU)         /* !< CCP Output Source */
+#define GPTIMER_OCTL_01_CCPO_FUNCVAL             ((uint32_t)0x00000000U)         /* !< Signal generator value (for
+                                                                                    example, PWM, triggered PWM) */
+#define GPTIMER_OCTL_01_CCPO_LOAD                ((uint32_t)0x00000001U)         /* !< Load event */
+#define GPTIMER_OCTL_01_CCPO_CMPVAL              ((uint32_t)0x00000002U)         /* !< CCU event or CCD event */
+#define GPTIMER_OCTL_01_CCPO_ZERO                ((uint32_t)0x00000004U)         /* !< Zero event */
+#define GPTIMER_OCTL_01_CCPO_CAPCOND             ((uint32_t)0x00000005U)         /* !< Capture event */
+#define GPTIMER_OCTL_01_CCPO_FAULTCOND           ((uint32_t)0x00000006U)         /* !< Fault condition */
+#define GPTIMER_OCTL_01_CCPO_CC0_MIRROR_ALL      ((uint32_t)0x00000008U)         /* !< Mirror CCP of first capture and
+                                                                                    compare register to other capture
+                                                                                    compare blocks */
+#define GPTIMER_OCTL_01_CCPO_CC1_MIRROR_ALL      ((uint32_t)0x00000009U)         /* !< Mirror CCP of second capture and
+                                                                                    compare register in other capture
+                                                                                    compare blocks */
+#define GPTIMER_OCTL_01_CCPO_DEADBAND            ((uint32_t)0x0000000CU)         /* !< Signal generator output after
+                                                                                    deadband insertion */
+#define GPTIMER_OCTL_01_CCPO_CNTDIR              ((uint32_t)0x0000000DU)         /* !< Counter direction */
+
+/* GPTIMER_OCTL_23 Bits */
+/* GPTIMER_OCTL_23[CCPOINV] Bits */
+#define GPTIMER_OCTL_23_CCPOINV_OFS              (4)                             /* !< CCPOINV Offset */
+#define GPTIMER_OCTL_23_CCPOINV_MASK             ((uint32_t)0x00000010U)         /* !< CCP Output Invert The output as
+                                                                                    selected by CCPO is conditionally
+                                                                                    inverted. */
+#define GPTIMER_OCTL_23_CCPOINV_NOINV            ((uint32_t)0x00000000U)         /* !< No inversion */
+#define GPTIMER_OCTL_23_CCPOINV_INV              ((uint32_t)0x00000010U)         /* !< Invert */
+/* GPTIMER_OCTL_23[CCPIV] Bits */
+#define GPTIMER_OCTL_23_CCPIV_OFS                (5)                             /* !< CCPIV Offset */
+#define GPTIMER_OCTL_23_CCPIV_MASK               ((uint32_t)0x00000020U)         /* !< CCP Initial Value This bit
+                                                                                    specifies the logical value put on
+                                                                                    the signal generator state while the
+                                                                                    counter is disabled (CTRCTL.EN == 0). */
+#define GPTIMER_OCTL_23_CCPIV_LOW                ((uint32_t)0x00000000U)         /* !< Low */
+#define GPTIMER_OCTL_23_CCPIV_HIGH               ((uint32_t)0x00000020U)         /* !< High */
+/* GPTIMER_OCTL_23[CCPO] Bits */
+#define GPTIMER_OCTL_23_CCPO_OFS                 (0)                             /* !< CCPO Offset */
+#define GPTIMER_OCTL_23_CCPO_MASK                ((uint32_t)0x0000000FU)         /* !< CCP Output Source */
+#define GPTIMER_OCTL_23_CCPO_FUNCVAL             ((uint32_t)0x00000000U)         /* !< Signal generator value (for
+                                                                                    example, PWM, triggered PWM) */
+#define GPTIMER_OCTL_23_CCPO_LOAD                ((uint32_t)0x00000001U)         /* !< Load condition */
+#define GPTIMER_OCTL_23_CCPO_CMPVAL              ((uint32_t)0x00000002U)         /* !< CCU event or CCD event */
+#define GPTIMER_OCTL_23_CCPO_ZERO                ((uint32_t)0x00000004U)         /* !< Zero event */
+#define GPTIMER_OCTL_23_CCPO_CAPCOND             ((uint32_t)0x00000005U)         /* !< Capture event */
+#define GPTIMER_OCTL_23_CCPO_FAULTCOND           ((uint32_t)0x00000006U)         /* !< Fault Condition */
+#define GPTIMER_OCTL_23_CCPO_CC0_MIRROR_ALL      ((uint32_t)0x00000008U)         /* !< Mirror CCP of first capture and
+                                                                                    compare register in other capture
+                                                                                    compare blocks */
+#define GPTIMER_OCTL_23_CCPO_CC1_MIRROR_ALL      ((uint32_t)0x00000009U)         /* !< Mirror CCP of second capture and
+                                                                                    compare register in other capture
+                                                                                    compare blocksi /bn,. */
+#define GPTIMER_OCTL_23_CCPO_DEADBAND            ((uint32_t)0x0000000CU)         /* !< Deadband Inserted Output */
+#define GPTIMER_OCTL_23_CCPO_CNTDIR              ((uint32_t)0x0000000DU)         /* !< Counter direction */
+
+/* GPTIMER_CCACT_01 Bits */
+/* GPTIMER_CCACT_01[ZACT] Bits */
+#define GPTIMER_CCACT_01_ZACT_OFS                (0)                             /* !< ZACT Offset */
+#define GPTIMER_CCACT_01_ZACT_MASK               ((uint32_t)0x00000003U)         /* !< CCP Output Action on Zero
+                                                                                    Specifies what changes occur to CCP
+                                                                                    output as the result of a zero event. */
+#define GPTIMER_CCACT_01_ZACT_DISABLED           ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_01_ZACT_CCP_HIGH           ((uint32_t)0x00000001U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_01_ZACT_CCP_LOW            ((uint32_t)0x00000002U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_01_ZACT_CCP_TOGGLE         ((uint32_t)0x00000003U)         /* !< CCP output value is toggled */
+/* GPTIMER_CCACT_01[LACT] Bits */
+#define GPTIMER_CCACT_01_LACT_OFS                (3)                             /* !< LACT Offset */
+#define GPTIMER_CCACT_01_LACT_MASK               ((uint32_t)0x00000018U)         /* !< CCP Output Action on Load
+                                                                                    Specifies what changes occur to CCP
+                                                                                    output as the result of a load event. */
+#define GPTIMER_CCACT_01_LACT_DISABLED           ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_01_LACT_CCP_HIGH           ((uint32_t)0x00000008U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_01_LACT_CCP_LOW            ((uint32_t)0x00000010U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_01_LACT_CCP_TOGGLE         ((uint32_t)0x00000018U)         /* !< CCP output value is toggled */
+/* GPTIMER_CCACT_01[CDACT] Bits */
+#define GPTIMER_CCACT_01_CDACT_OFS               (6)                             /* !< CDACT Offset */
+#define GPTIMER_CCACT_01_CDACT_MASK              ((uint32_t)0x000000C0U)         /* !< CCP Output Action on Compare (Down)
+                                                                                    This field describes the resulting
+                                                                                    action of the signal generator upon
+                                                                                    detecting a compare event while
+                                                                                    counting down. */
+#define GPTIMER_CCACT_01_CDACT_DISABLED          ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_01_CDACT_CCP_HIGH          ((uint32_t)0x00000040U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_01_CDACT_CCP_LOW           ((uint32_t)0x00000080U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_01_CDACT_CCP_TOGGLE        ((uint32_t)0x000000C0U)         /* !< CCP output value is toggled */
+/* GPTIMER_CCACT_01[CUACT] Bits */
+#define GPTIMER_CCACT_01_CUACT_OFS               (9)                             /* !< CUACT Offset */
+#define GPTIMER_CCACT_01_CUACT_MASK              ((uint32_t)0x00000600U)         /* !< CCP Output Action on Compare (Up)
+                                                                                    This field describes the resulting
+                                                                                    action of the signal generator upon
+                                                                                    detecting a compare event while
+                                                                                    counting up. */
+#define GPTIMER_CCACT_01_CUACT_DISABLED          ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_01_CUACT_CCP_HIGH          ((uint32_t)0x00000200U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_01_CUACT_CCP_LOW           ((uint32_t)0x00000400U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_01_CUACT_CCP_TOGGLE        ((uint32_t)0x00000600U)         /* !< CCP output value is toggled */
+/* GPTIMER_CCACT_01[CC2DACT] Bits */
+#define GPTIMER_CCACT_01_CC2DACT_OFS             (12)                            /* !< CC2DACT Offset */
+#define GPTIMER_CCACT_01_CC2DACT_MASK            ((uint32_t)0x00003000U)         /* !< CCP Output Action on CC2D event. */
+#define GPTIMER_CCACT_01_CC2DACT_DISABLED        ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_01_CC2DACT_CCP_HIGH        ((uint32_t)0x00001000U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_01_CC2DACT_CCP_LOW         ((uint32_t)0x00002000U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_01_CC2DACT_CCP_TOGGLE      ((uint32_t)0x00003000U)         /* !< CCP output value is toggled */
+/* GPTIMER_CCACT_01[CC2UACT] Bits */
+#define GPTIMER_CCACT_01_CC2UACT_OFS             (15)                            /* !< CC2UACT Offset */
+#define GPTIMER_CCACT_01_CC2UACT_MASK            ((uint32_t)0x00018000U)         /* !< CCP Output Action on CC2U event. */
+#define GPTIMER_CCACT_01_CC2UACT_DISABLED        ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_01_CC2UACT_CCP_HIGH        ((uint32_t)0x00008000U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_01_CC2UACT_CCP_LOW         ((uint32_t)0x00010000U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_01_CC2UACT_CCP_TOGGLE      ((uint32_t)0x00018000U)         /* !< CCP output value is toggled */
+/* GPTIMER_CCACT_01[FENACT] Bits */
+#define GPTIMER_CCACT_01_FENACT_OFS              (22)                            /* !< FENACT Offset */
+#define GPTIMER_CCACT_01_FENACT_MASK             ((uint32_t)0x01C00000U)         /* !< CCP Output Action on Fault Entry
+                                                                                    This field describes the resulting
+                                                                                    action of the signal generator upon
+                                                                                    detecting a fault. */
+#define GPTIMER_CCACT_01_FENACT_DISABLED         ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_01_FENACT_CCP_HIGH         ((uint32_t)0x00400000U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_01_FENACT_CCP_LOW          ((uint32_t)0x00800000U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_01_FENACT_CCP_TOGGLE       ((uint32_t)0x00C00000U)         /* !< CCP output value is toggled */
+#define GPTIMER_CCACT_01_FENACT_CCP_HIGHZ        ((uint32_t)0x01000000U)         /* !< CCP output value is tristated */
+/* GPTIMER_CCACT_01[FEXACT] Bits */
+#define GPTIMER_CCACT_01_FEXACT_OFS              (25)                            /* !< FEXACT Offset */
+#define GPTIMER_CCACT_01_FEXACT_MASK             ((uint32_t)0x0E000000U)         /* !< CCP Output Action on Fault Exit
+                                                                                    This field describes the resulting
+                                                                                    action of the signal generator upon
+                                                                                    exiting the fault condition. */
+#define GPTIMER_CCACT_01_FEXACT_DISABLED         ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_01_FEXACT_CCP_HIGH         ((uint32_t)0x02000000U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_01_FEXACT_CCP_LOW          ((uint32_t)0x04000000U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_01_FEXACT_CCP_TOGGLE       ((uint32_t)0x06000000U)         /* !< CCP output value is toggled */
+#define GPTIMER_CCACT_01_FEXACT_CCP_HIGHZ        ((uint32_t)0x08000000U)         /* !< CCP output value is tristated */
+/* GPTIMER_CCACT_01[SWFRCACT] Bits */
+#define GPTIMER_CCACT_01_SWFRCACT_OFS            (28)                            /* !< SWFRCACT Offset */
+#define GPTIMER_CCACT_01_SWFRCACT_MASK           ((uint32_t)0x30000000U)         /* !< CCP Output Action on Software Force
+                                                                                    Output  This field describes the
+                                                                                    resulting action of software force.
+                                                                                    This action has a shadow register,
+                                                                                    which will be updated under specific
+                                                                                    condition.  So that this register
+                                                                                    cannot take into effect immediately. */
+#define GPTIMER_CCACT_01_SWFRCACT_DISABLED       ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_01_SWFRCACT_CCP_HIGH       ((uint32_t)0x10000000U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_01_SWFRCACT_CCP_LOW        ((uint32_t)0x20000000U)         /* !< CCP output value is set low */
+/* GPTIMER_CCACT_01[SWFRCACT_CMPL] Bits */
+#define GPTIMER_CCACT_01_SWFRCACT_CMPL_OFS       (30)                            /* !< SWFRCACT_CMPL Offset */
+#define GPTIMER_CCACT_01_SWFRCACT_CMPL_MASK      ((uint32_t)0xC0000000U)         /* !< CCP Complimentary output Action on
+                                                                                    Software Force Output  This field
+                                                                                    describes the resulting action of
+                                                                                    software force.  This action has a
+                                                                                    shadow register, which will be
+                                                                                    updated under specific condition.  So
+                                                                                    that this register cannot take into
+                                                                                    effect immediately. */
+#define GPTIMER_CCACT_01_SWFRCACT_CMPL_DISABLED  ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_01_SWFRCACT_CMPL_CCP_HIGH  ((uint32_t)0x40000000U)         /* !< CCP Complimentary output value is
+                                                                                    set high */
+#define GPTIMER_CCACT_01_SWFRCACT_CMPL_CCP_LOW   ((uint32_t)0x80000000U)         /* !< CCP Complimentary output value is
+                                                                                    set low */
+
+/* GPTIMER_CCACT_23 Bits */
+/* GPTIMER_CCACT_23[ZACT] Bits */
+#define GPTIMER_CCACT_23_ZACT_OFS                (0)                             /* !< ZACT Offset */
+#define GPTIMER_CCACT_23_ZACT_MASK               ((uint32_t)0x00000003U)         /* !< CCP Output Action on Zero
+                                                                                    Specifies what changes occur to CCP
+                                                                                    output as the result of a zero event. */
+#define GPTIMER_CCACT_23_ZACT_DISABLED           ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_23_ZACT_CCP_HIGH           ((uint32_t)0x00000001U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_23_ZACT_CCP_LOW            ((uint32_t)0x00000002U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_23_ZACT_CCP_TOGGLE         ((uint32_t)0x00000003U)         /* !< CCP output value is toggled */
+/* GPTIMER_CCACT_23[LACT] Bits */
+#define GPTIMER_CCACT_23_LACT_OFS                (3)                             /* !< LACT Offset */
+#define GPTIMER_CCACT_23_LACT_MASK               ((uint32_t)0x00000018U)         /* !< CCP Output Action on Load
+                                                                                    Specifies what changes occur to CCP
+                                                                                    output as the result of a load event. */
+#define GPTIMER_CCACT_23_LACT_DISABLED           ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_23_LACT_CCP_HIGH           ((uint32_t)0x00000008U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_23_LACT_CCP_LOW            ((uint32_t)0x00000010U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_23_LACT_CCP_TOGGLE         ((uint32_t)0x00000018U)         /* !< CCP output value is toggled */
+/* GPTIMER_CCACT_23[CDACT] Bits */
+#define GPTIMER_CCACT_23_CDACT_OFS               (6)                             /* !< CDACT Offset */
+#define GPTIMER_CCACT_23_CDACT_MASK              ((uint32_t)0x000000C0U)         /* !< CCP Output Action on Compare (Down)
+                                                                                    This field describes the resulting
+                                                                                    action of the signal generator upon
+                                                                                    detecting a compare event while
+                                                                                    counting down. */
+#define GPTIMER_CCACT_23_CDACT_DISABLED          ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_23_CDACT_CCP_HIGH          ((uint32_t)0x00000040U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_23_CDACT_CCP_LOW           ((uint32_t)0x00000080U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_23_CDACT_CCP_TOGGLE        ((uint32_t)0x000000C0U)         /* !< CCP output value is toggled */
+/* GPTIMER_CCACT_23[CUACT] Bits */
+#define GPTIMER_CCACT_23_CUACT_OFS               (9)                             /* !< CUACT Offset */
+#define GPTIMER_CCACT_23_CUACT_MASK              ((uint32_t)0x00000600U)         /* !< CCP Output Action on Compare (Up)
+                                                                                    This field describes the resulting
+                                                                                    action of the signal generator upon
+                                                                                    detecting a compare event while
+                                                                                    counting up. */
+#define GPTIMER_CCACT_23_CUACT_DISABLED          ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_23_CUACT_CCP_HIGH          ((uint32_t)0x00000200U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_23_CUACT_CCP_LOW           ((uint32_t)0x00000400U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_23_CUACT_CCP_TOGGLE        ((uint32_t)0x00000600U)         /* !< CCP output value is toggled */
+/* GPTIMER_CCACT_23[CC2DACT] Bits */
+#define GPTIMER_CCACT_23_CC2DACT_OFS             (12)                            /* !< CC2DACT Offset */
+#define GPTIMER_CCACT_23_CC2DACT_MASK            ((uint32_t)0x00003000U)         /* !< CCP Output Action on CC2D event. */
+#define GPTIMER_CCACT_23_CC2DACT_DISABLED        ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_23_CC2DACT_CCP_HIGH        ((uint32_t)0x00001000U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_23_CC2DACT_CCP_LOW         ((uint32_t)0x00002000U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_23_CC2DACT_CCP_TOGGLE      ((uint32_t)0x00003000U)         /* !< CCP output value is toggled */
+/* GPTIMER_CCACT_23[CC2UACT] Bits */
+#define GPTIMER_CCACT_23_CC2UACT_OFS             (15)                            /* !< CC2UACT Offset */
+#define GPTIMER_CCACT_23_CC2UACT_MASK            ((uint32_t)0x00018000U)         /* !< CCP Output Action on CC2U event. */
+#define GPTIMER_CCACT_23_CC2UACT_DISABLED        ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_23_CC2UACT_CCP_HIGH        ((uint32_t)0x00008000U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_23_CC2UACT_CCP_LOW         ((uint32_t)0x00010000U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_23_CC2UACT_CCP_TOGGLE      ((uint32_t)0x00018000U)         /* !< CCP output value is toggled */
+/* GPTIMER_CCACT_23[FENACT] Bits */
+#define GPTIMER_CCACT_23_FENACT_OFS              (22)                            /* !< FENACT Offset */
+#define GPTIMER_CCACT_23_FENACT_MASK             ((uint32_t)0x01C00000U)         /* !< CCP Output Action on Fault Entry
+                                                                                    This field describes the resulting
+                                                                                    action of the signal generator upon
+                                                                                    detecting a fault. */
+#define GPTIMER_CCACT_23_FENACT_DISABLED         ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_23_FENACT_CCP_HIGH         ((uint32_t)0x00400000U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_23_FENACT_CCP_LOW          ((uint32_t)0x00800000U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_23_FENACT_CCP_TOGGLE       ((uint32_t)0x00C00000U)         /* !< CCP output value is toggled */
+#define GPTIMER_CCACT_23_FENACT_CCP_HIGHZ        ((uint32_t)0x01000000U)         /* !< CCP output value is tristated */
+/* GPTIMER_CCACT_23[FEXACT] Bits */
+#define GPTIMER_CCACT_23_FEXACT_OFS              (25)                            /* !< FEXACT Offset */
+#define GPTIMER_CCACT_23_FEXACT_MASK             ((uint32_t)0x0E000000U)         /* !< CCP Output Action on Fault Exit
+                                                                                    This field describes the resulting
+                                                                                    action of the signal generator upon
+                                                                                    exiting the fault condition. */
+#define GPTIMER_CCACT_23_FEXACT_DISABLED         ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_23_FEXACT_CCP_HIGH         ((uint32_t)0x02000000U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_23_FEXACT_CCP_LOW          ((uint32_t)0x04000000U)         /* !< CCP output value is set low */
+#define GPTIMER_CCACT_23_FEXACT_CCP_TOGGLE       ((uint32_t)0x06000000U)         /* !< CCP output value is toggled */
+#define GPTIMER_CCACT_23_FEXACT_CCP_HIGHZ        ((uint32_t)0x08000000U)         /* !< CCP output value is tristated */
+/* GPTIMER_CCACT_23[SWFRCACT] Bits */
+#define GPTIMER_CCACT_23_SWFRCACT_OFS            (28)                            /* !< SWFRCACT Offset */
+#define GPTIMER_CCACT_23_SWFRCACT_MASK           ((uint32_t)0x30000000U)         /* !< CCP Output Action on Software Force
+                                                                                    Output  This field describes the
+                                                                                    resulting action of software force.
+                                                                                    This action has a shadow register,
+                                                                                    which will be updated under specific
+                                                                                    condition.  So that this register
+                                                                                    cannot take into effect immediately. */
+#define GPTIMER_CCACT_23_SWFRCACT_DISABLED       ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_23_SWFRCACT_CCP_HIGH       ((uint32_t)0x10000000U)         /* !< CCP output value is set high */
+#define GPTIMER_CCACT_23_SWFRCACT_CCP_LOW        ((uint32_t)0x20000000U)         /* !< CCP output value is set low */
+/* GPTIMER_CCACT_23[SWFRCACT_CMPL] Bits */
+#define GPTIMER_CCACT_23_SWFRCACT_CMPL_OFS       (30)                            /* !< SWFRCACT_CMPL Offset */
+#define GPTIMER_CCACT_23_SWFRCACT_CMPL_MASK      ((uint32_t)0xC0000000U)         /* !< CCP Complimentary Output Action on
+                                                                                    Software Force Output  This field
+                                                                                    describes the resulting action of
+                                                                                    software force.  This action has a
+                                                                                    shadow register, which will be
+                                                                                    updated under specific condition.  So
+                                                                                    that this register cannot take into
+                                                                                    effect immediately. */
+#define GPTIMER_CCACT_23_SWFRCACT_CMPL_DISABLED  ((uint32_t)0x00000000U)         /* !< This event is disabled and a lower
+                                                                                    priority event is selected if
+                                                                                    asserting. The CCP output value is
+                                                                                    unaffected by the event. */
+#define GPTIMER_CCACT_23_SWFRCACT_CMPL_CCP_HIGH  ((uint32_t)0x40000000U)         /* !< CCP Complimentary output value is
+                                                                                    set high */
+#define GPTIMER_CCACT_23_SWFRCACT_CMPL_CCP_LOW   ((uint32_t)0x80000000U)         /* !< CCP Complimentary output value is
+                                                                                    set low */
+
+/* GPTIMER_IFCTL_01 Bits */
+/* GPTIMER_IFCTL_01[ISEL] Bits */
+#define GPTIMER_IFCTL_01_ISEL_OFS                (0)                             /* !< ISEL Offset */
+#define GPTIMER_IFCTL_01_ISEL_MASK               ((uint32_t)0x0000000FU)         /* !< Input Select (CCP0)  This field
+                                                                                    selects the input source to the
+                                                                                    filter input. 4h-7h = Reserved */
+#define GPTIMER_IFCTL_01_ISEL_CCPX_INPUT         ((uint32_t)0x00000000U)         /* !< CCP of the corresponding capture
+                                                                                    compare unit */
+#define GPTIMER_IFCTL_01_ISEL_CCPX_INPUT_PAIR    ((uint32_t)0x00000001U)         /* !< Input pair CCPX of the capture
+                                                                                    compare unit. For CCP0 input pair is
+                                                                                    CCP1 and for CCP1 input pair is CCP0. */
+#define GPTIMER_IFCTL_01_ISEL_CCP0_INPUT         ((uint32_t)0x00000002U)         /* !< CCP0 of the counter */
+#define GPTIMER_IFCTL_01_ISEL_TRIG_INPUT         ((uint32_t)0x00000003U)         /* !< Trigger */
+#define GPTIMER_IFCTL_01_ISEL_CCP_XOR            ((uint32_t)0x00000004U)         /* !< XOR of CCP inputs as input source
+                                                                                    (Used in Hall input mode). */
+#define GPTIMER_IFCTL_01_ISEL_FSUB0              ((uint32_t)0x00000005U)         /* !< subscriber 0 event as input source. */
+#define GPTIMER_IFCTL_01_ISEL_FSUB1              ((uint32_t)0x00000006U)         /* !< subscriber 1 event as input source. */
+#define GPTIMER_IFCTL_01_ISEL_COMP0              ((uint32_t)0x00000007U)         /* !< Comparator 0 output. */
+#define GPTIMER_IFCTL_01_ISEL_COMP1              ((uint32_t)0x00000008U)         /* !< Comparator 1 output. */
+#define GPTIMER_IFCTL_01_ISEL_COMP2              ((uint32_t)0x00000009U)         /* !< Comparator 2 output. */
+/* GPTIMER_IFCTL_01[INV] Bits */
+#define GPTIMER_IFCTL_01_INV_OFS                 (7)                             /* !< INV Offset */
+#define GPTIMER_IFCTL_01_INV_MASK                ((uint32_t)0x00000080U)         /* !< Input Inversion This bit controls
+                                                                                    whether the selected input is
+                                                                                    inverted. */
+#define GPTIMER_IFCTL_01_INV_NOINVERT            ((uint32_t)0x00000000U)         /* !< Noninverted */
+#define GPTIMER_IFCTL_01_INV_INVERT              ((uint32_t)0x00000080U)         /* !< Inverted */
+/* GPTIMER_IFCTL_01[FP] Bits */
+#define GPTIMER_IFCTL_01_FP_OFS                  (8)                             /* !< FP Offset */
+#define GPTIMER_IFCTL_01_FP_MASK                 ((uint32_t)0x00000300U)         /* !< Filter Period. This field specifies
+                                                                                    the sample period for the input
+                                                                                    filter. I.e. The input is sampled for
+                                                                                    FP timer clocks during filtering. */
+#define GPTIMER_IFCTL_01_FP__3                   ((uint32_t)0x00000000U)         /* !< The division factor is 3 */
+#define GPTIMER_IFCTL_01_FP__5                   ((uint32_t)0x00000100U)         /* !< The division factor is 5 */
+#define GPTIMER_IFCTL_01_FP__8                   ((uint32_t)0x00000200U)         /* !< The division factor is 8 */
+/* GPTIMER_IFCTL_01[CPV] Bits */
+#define GPTIMER_IFCTL_01_CPV_OFS                 (11)                            /* !< CPV Offset */
+#define GPTIMER_IFCTL_01_CPV_MASK                ((uint32_t)0x00000800U)         /* !< Consecutive Period/Voting Select
+                                                                                    This bit controls whether the input
+                                                                                    filter uses a stricter consecutive
+                                                                                    period count or majority voting. */
+#define GPTIMER_IFCTL_01_CPV_CONSECUTIVE         ((uint32_t)0x00000000U)         /* !< Consecutive Periods The input must
+                                                                                    be at a specific logic level for the
+                                                                                    period defined by FP before it is
+                                                                                    passed to the filter output. */
+#define GPTIMER_IFCTL_01_CPV_VOTING              ((uint32_t)0x00000800U)         /* !< Voting  The filter ignores one
+                                                                                    clock of opposite logic over the
+                                                                                    filter period. I.e. Over FP samples
+                                                                                    of the input, up to 1 sample may be
+                                                                                    of an opposite logic value (glitch)
+                                                                                    without affecting the output. */
+/* GPTIMER_IFCTL_01[FE] Bits */
+#define GPTIMER_IFCTL_01_FE_OFS                  (12)                            /* !< FE Offset */
+#define GPTIMER_IFCTL_01_FE_MASK                 ((uint32_t)0x00001000U)         /* !< Filter Enable This bit controls
+                                                                                    whether the input is filtered by the
+                                                                                    input filter or bypasses to the edge
+                                                                                    detect. */
+#define GPTIMER_IFCTL_01_FE_DISABLED             ((uint32_t)0x00000000U)         /* !< Bypass. */
+#define GPTIMER_IFCTL_01_FE_ENABLED              ((uint32_t)0x00001000U)         /* !< Filtered. */
+
+/* GPTIMER_IFCTL_23 Bits */
+/* GPTIMER_IFCTL_23[ISEL] Bits */
+#define GPTIMER_IFCTL_23_ISEL_OFS                (0)                             /* !< ISEL Offset */
+#define GPTIMER_IFCTL_23_ISEL_MASK               ((uint32_t)0x0000000FU)         /* !< Input Select (CCP0)  This field
+                                                                                    selects the input source to the
+                                                                                    filter input. 4h-7h = Reserved */
+#define GPTIMER_IFCTL_23_ISEL_CCPX_INPUT         ((uint32_t)0x00000000U)         /* !< CCP of the corresponding capture
+                                                                                    compare unit */
+#define GPTIMER_IFCTL_23_ISEL_CCPX_INPUT_PAIR    ((uint32_t)0x00000001U)         /* !< Input pair CCPX of the capture
+                                                                                    compare unit. For CCP0 input pair is
+                                                                                    CCP1 and for CCP1 input pair is CCP0. */
+#define GPTIMER_IFCTL_23_ISEL_CCP0_INPUT         ((uint32_t)0x00000002U)         /* !< CCP0 of the counter */
+#define GPTIMER_IFCTL_23_ISEL_TRIG_INPUT         ((uint32_t)0x00000003U)         /* !< Trigger */
+#define GPTIMER_IFCTL_23_ISEL_CCP_XOR            ((uint32_t)0x00000004U)         /* !< XOR of CCP inputs as input source
+                                                                                    (Used in Hall input mode). */
+#define GPTIMER_IFCTL_23_ISEL_FSUB0              ((uint32_t)0x00000005U)         /* !< subscriber 0 event as input source. */
+#define GPTIMER_IFCTL_23_ISEL_FSUB1              ((uint32_t)0x00000006U)         /* !< subscriber 1 event as input source. */
+#define GPTIMER_IFCTL_23_ISEL_COMP0              ((uint32_t)0x00000007U)         /* !< Comparator 0 output. */
+#define GPTIMER_IFCTL_23_ISEL_COMP1              ((uint32_t)0x00000008U)         /* !< Comparator 1 output. */
+#define GPTIMER_IFCTL_23_ISEL_COMP2              ((uint32_t)0x00000009U)         /* !< Comparator 2 output. */
+/* GPTIMER_IFCTL_23[INV] Bits */
+#define GPTIMER_IFCTL_23_INV_OFS                 (7)                             /* !< INV Offset */
+#define GPTIMER_IFCTL_23_INV_MASK                ((uint32_t)0x00000080U)         /* !< Input Inversion This bit controls
+                                                                                    whether the selected input is
+                                                                                    inverted. */
+#define GPTIMER_IFCTL_23_INV_NOINVERT            ((uint32_t)0x00000000U)         /* !< Noninverted */
+#define GPTIMER_IFCTL_23_INV_INVERT              ((uint32_t)0x00000080U)         /* !< Inverted */
+/* GPTIMER_IFCTL_23[FP] Bits */
+#define GPTIMER_IFCTL_23_FP_OFS                  (8)                             /* !< FP Offset */
+#define GPTIMER_IFCTL_23_FP_MASK                 ((uint32_t)0x00000300U)         /* !< Filter Period. This field specifies
+                                                                                    the sample period for the input
+                                                                                    filter. I.e. The input is sampled for
+                                                                                    FP timer clocks during filtering. */
+#define GPTIMER_IFCTL_23_FP__3                   ((uint32_t)0x00000000U)         /* !< The division factor is 3 */
+#define GPTIMER_IFCTL_23_FP__5                   ((uint32_t)0x00000100U)         /* !< The division factor is 5 */
+#define GPTIMER_IFCTL_23_FP__8                   ((uint32_t)0x00000200U)         /* !< The division factor is 8 */
+/* GPTIMER_IFCTL_23[CPV] Bits */
+#define GPTIMER_IFCTL_23_CPV_OFS                 (11)                            /* !< CPV Offset */
+#define GPTIMER_IFCTL_23_CPV_MASK                ((uint32_t)0x00000800U)         /* !< Consecutive Period/Voting Select
+                                                                                    This bit controls whether the input
+                                                                                    filter uses a stricter consecutive
+                                                                                    period count or majority voting. */
+#define GPTIMER_IFCTL_23_CPV_CONSECUTIVE         ((uint32_t)0x00000000U)         /* !< Consecutive Periods The input must
+                                                                                    be at a specific logic level for the
+                                                                                    period defined by FP before it is
+                                                                                    passed to the filter output. */
+#define GPTIMER_IFCTL_23_CPV_VOTING              ((uint32_t)0x00000800U)         /* !< Voting  The filter ignores one
+                                                                                    clock of opposite logic over the
+                                                                                    filter period. I.e. Over FP samples
+                                                                                    of the input, up to 1 sample may be
+                                                                                    of an opposite logic value (glitch)
+                                                                                    without affecting the output. */
+/* GPTIMER_IFCTL_23[FE] Bits */
+#define GPTIMER_IFCTL_23_FE_OFS                  (12)                            /* !< FE Offset */
+#define GPTIMER_IFCTL_23_FE_MASK                 ((uint32_t)0x00001000U)         /* !< Filter Enable This bit controls
+                                                                                    whether the input is filtered by the
+                                                                                    input filter or bypasses to the edge
+                                                                                    detect. */
+#define GPTIMER_IFCTL_23_FE_DISABLED             ((uint32_t)0x00000000U)         /* !< Bypass. */
+#define GPTIMER_IFCTL_23_FE_ENABLED              ((uint32_t)0x00001000U)         /* !< Filtered. */
+
+/* GPTIMER_PL Bits */
+/* GPTIMER_PL[PHASE] Bits */
+#define GPTIMER_PL_PHASE_OFS                     (0)                             /* !< PHASE Offset */
+#define GPTIMER_PL_PHASE_MASK                    ((uint32_t)0x0000FFFFU)         /* !< Phase Load value */
+#define GPTIMER_PL_PHASE_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define GPTIMER_PL_PHASE_MAXIMUM                 ((uint32_t)0x00FFFFFFU)         /* !< Maximum Value */
+
+/* GPTIMER_DBCTL Bits */
+/* GPTIMER_DBCTL[RISEDELAY] Bits */
+#define GPTIMER_DBCTL_RISEDELAY_OFS              (0)                             /* !< RISEDELAY Offset */
+#define GPTIMER_DBCTL_RISEDELAY_MASK             ((uint32_t)0x00000FFFU)         /* !< Rise Delay The number of TIMCLK
+                                                                                    periods inserted between the fall
+                                                                                    edge of CCP signal and the rise edge
+                                                                                    of CCP complimentary signal. */
+#define GPTIMER_DBCTL_RISEDELAY_MINIMUM          ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define GPTIMER_DBCTL_RISEDELAY_MAXIMUM          ((uint32_t)0x00000FFFU)         /* !< Maximum Value */
+/* GPTIMER_DBCTL[FALLDELAY] Bits */
+#define GPTIMER_DBCTL_FALLDELAY_OFS              (16)                            /* !< FALLDELAY Offset */
+#define GPTIMER_DBCTL_FALLDELAY_MASK             ((uint32_t)0x0FFF0000U)         /* !< Fall Delay The number of TIMCLK
+                                                                                    periods inserted between the fall
+                                                                                    edge of CCP signal and the rise edge
+                                                                                    of CCP complimentary signal. */
+#define GPTIMER_DBCTL_FALLDELAY_MINIMUM          ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define GPTIMER_DBCTL_FALLDELAY_MAXIMUM          ((uint32_t)0x0FFF0000U)         /* !< Maximum Value */
+/* GPTIMER_DBCTL[M1_ENABLE] Bits */
+#define GPTIMER_DBCTL_M1_ENABLE_OFS              (12)                            /* !< M1_ENABLE Offset */
+#define GPTIMER_DBCTL_M1_ENABLE_MASK             ((uint32_t)0x00001000U)         /* !< Dead Band Mode 1 Enable. */
+#define GPTIMER_DBCTL_M1_ENABLE_DISABLED         ((uint32_t)0x00000000U)         /* !< Disabled */
+#define GPTIMER_DBCTL_M1_ENABLE_ENABLED          ((uint32_t)0x00001000U)         /* !< Enabled */
+
+/* GPTIMER_TSEL Bits */
+/* GPTIMER_TSEL[ETSEL] Bits */
+#define GPTIMER_TSEL_ETSEL_OFS                   (0)                             /* !< ETSEL Offset */
+#define GPTIMER_TSEL_ETSEL_MASK                  ((uint32_t)0x0000001FU)         /* !< External Trigger Select. #br# This
+                                                                                    selects which System Event is used if
+                                                                                    the input filter selects trigger.
+                                                                                    Triggers 0-15 are used to connect
+                                                                                    triggers generated by other timer
+                                                                                    modules. Refer to the SoC datasheet
+                                                                                    for details related to timer trigger
+                                                                                    sources. Triggers 16 and  17 are
+                                                                                    connected to event manager subscriber
+                                                                                    ports. Event lines 18-31 are reserved
+                                                                                    for future use. */
+#define GPTIMER_TSEL_ETSEL_TRIG0                 ((uint32_t)0x00000000U)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG1                 ((uint32_t)0x00000001U)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG2                 ((uint32_t)0x00000002U)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG3                 ((uint32_t)0x00000003U)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG4                 ((uint32_t)0x00000004U)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG5                 ((uint32_t)0x00000005U)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG6                 ((uint32_t)0x00000006U)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG7                 ((uint32_t)0x00000007U)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG8                 ((uint32_t)0x00000008U)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG9                 ((uint32_t)0x00000009U)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG10                ((uint32_t)0x0000000AU)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG11                ((uint32_t)0x0000000BU)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG12                ((uint32_t)0x0000000CU)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG13                ((uint32_t)0x0000000DU)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG14                ((uint32_t)0x0000000EU)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG15                ((uint32_t)0x0000000FU)         /* !< TRIGx = External trigger input from
+                                                                                    TIM x. */
+#define GPTIMER_TSEL_ETSEL_TRIG_SUB0             ((uint32_t)0x00000010U)         /* !< TRIG_SUBx = External trigger input
+                                                                                    from subscriber port x. */
+#define GPTIMER_TSEL_ETSEL_TRIG_SUB1             ((uint32_t)0x00000011U)         /* !< TRIG_SUBx = External trigger input
+                                                                                    from subscriber port x. */
+/* GPTIMER_TSEL[TE] Bits */
+#define GPTIMER_TSEL_TE_OFS                      (9)                             /* !< TE Offset */
+#define GPTIMER_TSEL_TE_MASK                     ((uint32_t)0x00000200U)         /* !< Trigger Enable. This selects
+                                                                                    whether a trigger is enabled or not
+                                                                                    for this counter   0x0 = Triggers are
+                                                                                    not used  0x1 = Triggers are used as
+                                                                                    selected by the ETSEL field */
+#define GPTIMER_TSEL_TE_DISABLED                 ((uint32_t)0x00000000U)         /* !< Triggers are not used. */
+#define GPTIMER_TSEL_TE_ENABLED                  ((uint32_t)0x00000200U)         /* !< Triggers are used as selected by
+                                                                                    the IE, ITSEL and ETSEL fields. */
+
+/* GPTIMER_RC Bits */
+/* GPTIMER_RC[RC] Bits */
+#define GPTIMER_RC_RC_OFS                        (0)                             /* !< RC Offset */
+#define GPTIMER_RC_RC_MASK                       ((uint32_t)0x000000FFU)         /* !< Repeat Counter Value */
+#define GPTIMER_RC_RC_MINIMUM                    ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define GPTIMER_RC_RC_MAXIMUM                    ((uint32_t)0x000000FFU)         /* !< Maximum Value */
+
+/* GPTIMER_RCLD Bits */
+/* GPTIMER_RCLD[RCLD] Bits */
+#define GPTIMER_RCLD_RCLD_OFS                    (0)                             /* !< RCLD Offset */
+#define GPTIMER_RCLD_RCLD_MASK                   ((uint32_t)0x000000FFU)         /* !< Repeat Counter Load Value This
+                                                                                    field provides the value loaded into
+                                                                                    the repeat counter at a load event
+                                                                                    following the repeat counter value
+                                                                                    equaling 0. */
+#define GPTIMER_RCLD_RCLD_MINIMUM                ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define GPTIMER_RCLD_RCLD_MAXIMUM                ((uint32_t)0x000000FFU)         /* !< Maximum Value */
+
+/* GPTIMER_QDIR Bits */
+/* GPTIMER_QDIR[DIR] Bits */
+#define GPTIMER_QDIR_DIR_OFS                     (0)                             /* !< DIR Offset */
+#define GPTIMER_QDIR_DIR_MASK                    ((uint32_t)0x00000001U)         /* !< Direction of count */
+#define GPTIMER_QDIR_DIR_DOWN                    ((uint32_t)0x00000000U)         /* !< Down (Phase B leads Phase A) */
+#define GPTIMER_QDIR_DIR_UP                      ((uint32_t)0x00000001U)         /* !< Up (Phase A leads Phase B) */
+
+/* GPTIMER_FCTL Bits */
+/* GPTIMER_FCTL[FIEN] Bits */
+#define GPTIMER_FCTL_FIEN_OFS                    (0)                             /* !< FIEN Offset */
+#define GPTIMER_FCTL_FIEN_MASK                   ((uint32_t)0x00000001U)         /* !< Fault Input Enable This bit enables
+                                                                                    the input for fault detection. */
+#define GPTIMER_FCTL_FIEN_DISABLED               ((uint32_t)0x00000000U)         /* !< Fault Input Disabled */
+#define GPTIMER_FCTL_FIEN_ENABLED                ((uint32_t)0x00000001U)         /* !< Fault Input Enabled */
+/* GPTIMER_FCTL[FI] Bits */
+#define GPTIMER_FCTL_FI_OFS                      (2)                             /* !< FI Offset */
+#define GPTIMER_FCTL_FI_MASK                     ((uint32_t)0x00000004U)         /* !< Fault Input Specifies whether the
+                                                                                    overall fault condition is dependent
+                                                                                    on the sensed fault pin. */
+#define GPTIMER_FCTL_FI_INDEPENDENT              ((uint32_t)0x00000000U)         /* !< Overall Fault condition is not
+                                                                                    dependent on sensed input. */
+#define GPTIMER_FCTL_FI_DEPENDENT                ((uint32_t)0x00000004U)         /* !< Overall Fault condition is
+                                                                                    dependent on sensed input. */
+/* GPTIMER_FCTL[TFIM] Bits */
+#define GPTIMER_FCTL_TFIM_OFS                    (7)                             /* !< TFIM Offset */
+#define GPTIMER_FCTL_TFIM_MASK                   ((uint32_t)0x00000080U)         /* !< Trigger Fault Input Mask Specifies
+                                                                                    whether the selected trigger
+                                                                                    participates as a fault input. If
+                                                                                    enabled and the trigger asserts, the
+                                                                                    trigger is treated as a fault. */
+#define GPTIMER_FCTL_TFIM_DISABLED               ((uint32_t)0x00000000U)         /* !< Selected trigger does not
+                                                                                    participate in fault condition
+                                                                                    generation */
+#define GPTIMER_FCTL_TFIM_ENABLED                ((uint32_t)0x00000080U)         /* !< Selected trigger participates in
+                                                                                    fault condition generation */
+/* GPTIMER_FCTL[FL] Bits */
+#define GPTIMER_FCTL_FL_OFS                      (3)                             /* !< FL Offset */
+#define GPTIMER_FCTL_FL_MASK                     ((uint32_t)0x00000018U)         /* !< Fault Latch mode Specifies whether
+                                                                                    the fault condition is latched and
+                                                                                    configures the latch clear
+                                                                                    conditions. */
+#define GPTIMER_FCTL_FL_NO_LATCH                 ((uint32_t)0x00000000U)         /* !< Overall fault condition is not
+                                                                                    dependent on the F bit in RIS */
+#define GPTIMER_FCTL_FL_LATCH_SW_CLR             ((uint32_t)0x00000008U)         /* !< Overall fault condition is
+                                                                                    dependent on the F bit in RIS */
+#define GPTIMER_FCTL_FL_LATCH_Z_CLR              ((uint32_t)0x00000010U)         /* !< Fault condition is latched. Fault
+                                                                                    condition is cleared on a zero event
+                                                                                    if the fault input is 0. */
+#define GPTIMER_FCTL_FL_LATCH_LD_CLR             ((uint32_t)0x00000018U)         /* !< Fault condition is latched. Fault
+                                                                                    condition is cleared on a load event
+                                                                                    if the fault input is 0. */
+/* GPTIMER_FCTL[FSENAC0] Bits */
+#define GPTIMER_FCTL_FSENAC0_OFS                 (8)                             /* !< FSENAC0 Offset */
+#define GPTIMER_FCTL_FSENAC0_MASK                ((uint32_t)0x00000100U)         /* !< Specifies whether the COMP0 output
+                                                                                    high/low is treated as fault
+                                                                                    condition. */
+#define GPTIMER_FCTL_FSENAC0_LOWCTIVE            ((uint32_t)0x00000000U)         /* !< Fault Input is active low. */
+#define GPTIMER_FCTL_FSENAC0_HIGHACTIVE          ((uint32_t)0x00000100U)         /* !< Fault Input is active high. */
+/* GPTIMER_FCTL[FSENAC1] Bits */
+#define GPTIMER_FCTL_FSENAC1_OFS                 (9)                             /* !< FSENAC1 Offset */
+#define GPTIMER_FCTL_FSENAC1_MASK                ((uint32_t)0x00000200U)         /* !< Specifies whether the COMP1 output
+                                                                                    high/low is treated as fault
+                                                                                    condition. */
+#define GPTIMER_FCTL_FSENAC1_LOWCTIVE            ((uint32_t)0x00000000U)         /* !< Fault Input is active low. */
+#define GPTIMER_FCTL_FSENAC1_HIGHACTIVE          ((uint32_t)0x00000200U)         /* !< Fault Input is active high. */
+/* GPTIMER_FCTL[FSENAC2] Bits */
+#define GPTIMER_FCTL_FSENAC2_OFS                 (10)                            /* !< FSENAC2 Offset */
+#define GPTIMER_FCTL_FSENAC2_MASK                ((uint32_t)0x00000400U)         /* !< Specifies whether the COMP2 output
+                                                                                    high/low is treated as fault
+                                                                                    condition. */
+#define GPTIMER_FCTL_FSENAC2_LOWCTIVE            ((uint32_t)0x00000000U)         /* !< Fault Input is active low. */
+#define GPTIMER_FCTL_FSENAC2_HIGHACTIVE          ((uint32_t)0x00000400U)         /* !< Fault Input is active high. */
+/* GPTIMER_FCTL[FSENEXT0] Bits */
+#define GPTIMER_FCTL_FSENEXT0_OFS                (11)                            /* !< FSENEXT0 Offset */
+#define GPTIMER_FCTL_FSENEXT0_MASK               ((uint32_t)0x00000800U)         /* !< Specifies whether the external
+                                                                                    fault pin0 high/low is treated as
+                                                                                    fault condition. */
+#define GPTIMER_FCTL_FSENEXT0_LOWCTIVE           ((uint32_t)0x00000000U)         /* !< Fault Input is active low. */
+#define GPTIMER_FCTL_FSENEXT0_HIGHACTIVE         ((uint32_t)0x00000800U)         /* !< Fault Input is active high. */
+/* GPTIMER_FCTL[FSENEXT1] Bits */
+#define GPTIMER_FCTL_FSENEXT1_OFS                (12)                            /* !< FSENEXT1 Offset */
+#define GPTIMER_FCTL_FSENEXT1_MASK               ((uint32_t)0x00001000U)         /* !< Specifies whether the external
+                                                                                    fault pin1 high/low is treated as
+                                                                                    fault condition. */
+#define GPTIMER_FCTL_FSENEXT1_LOWCTIVE           ((uint32_t)0x00000000U)         /* !< Fault Input is active low. */
+#define GPTIMER_FCTL_FSENEXT1_HIGHACTIVE         ((uint32_t)0x00001000U)         /* !< Fault Input is active high. */
+/* GPTIMER_FCTL[FSENEXT2] Bits */
+#define GPTIMER_FCTL_FSENEXT2_OFS                (13)                            /* !< FSENEXT2 Offset */
+#define GPTIMER_FCTL_FSENEXT2_MASK               ((uint32_t)0x00002000U)         /* !< Specifies whether the external
+                                                                                    fault pin2 high/low is treated as
+                                                                                    fault condition. */
+#define GPTIMER_FCTL_FSENEXT2_LOWCTIVE           ((uint32_t)0x00000000U)         /* !< Fault Input is active low. */
+#define GPTIMER_FCTL_FSENEXT2_HIGHACTIVE         ((uint32_t)0x00002000U)         /* !< Fault Input is active high. */
+
+/* GPTIMER_FIFCTL Bits */
+/* GPTIMER_FIFCTL[FP] Bits */
+#define GPTIMER_FIFCTL_FP_OFS                    (0)                             /* !< FP Offset */
+#define GPTIMER_FIFCTL_FP_MASK                   ((uint32_t)0x00000003U)         /* !< Filter Period This field specifies
+                                                                                    the sample period for the input
+                                                                                    filter.  I.e. The input is sampled
+                                                                                    for FP timer clocks during filtering. */
+#define GPTIMER_FIFCTL_FP_PER_3                  ((uint32_t)0x00000000U)         /* !< Filter Period 3 */
+#define GPTIMER_FIFCTL_FP_PER_5                  ((uint32_t)0x00000001U)         /* !< Filter Period 5 */
+#define GPTIMER_FIFCTL_FP_PER_8                  ((uint32_t)0x00000002U)         /* !< Filter Period 8 */
+/* GPTIMER_FIFCTL[CPV] Bits */
+#define GPTIMER_FIFCTL_CPV_OFS                   (3)                             /* !< CPV Offset */
+#define GPTIMER_FIFCTL_CPV_MASK                  ((uint32_t)0x00000008U)         /* !< Consecutive Period/Voting Select
+                                                                                    This bit controls whether the input
+                                                                                    filter uses a stricter consecutive
+                                                                                    period count or majority voting. */
+#define GPTIMER_FIFCTL_CPV_CONSEC_PER            ((uint32_t)0x00000000U)         /* !< Consecutive Periods. The input must
+                                                                                    be at a specific logic level for the
+                                                                                    period defined by FP before it is
+                                                                                    passed to the filter output. */
+#define GPTIMER_FIFCTL_CPV_VOTING                ((uint32_t)0x00000008U)         /* !< Voting. The filter ignores one
+                                                                                    clock of opposite logic over the
+                                                                                    filter period. I.e. Over FP samples
+                                                                                    of the input, up to 1 sample may be
+                                                                                    of an opposite logic value (glitch)
+                                                                                    without affecting the output */
+/* GPTIMER_FIFCTL[FILTEN] Bits */
+#define GPTIMER_FIFCTL_FILTEN_OFS                (4)                             /* !< FILTEN Offset */
+#define GPTIMER_FIFCTL_FILTEN_MASK               ((uint32_t)0x00000010U)         /* !< Filter Enable This bit controls
+                                                                                    whether the input is filtered by the
+                                                                                    input filter or bypasses to go
+                                                                                    directly to the optional pre-scale
+                                                                                    filter and then to the edge detect. */
+#define GPTIMER_FIFCTL_FILTEN_BYPASS             ((uint32_t)0x00000000U)         /* !< Bypass */
+#define GPTIMER_FIFCTL_FILTEN_FILTERED           ((uint32_t)0x00000010U)         /* !< Filtered. */
+
+/* GPTIMER_CCPD Bits */
+/* GPTIMER_CCPD[C0CCP0] Bits */
+#define GPTIMER_CCPD_C0CCP0_OFS                  (0)                             /* !< C0CCP0 Offset */
+#define GPTIMER_CCPD_C0CCP0_MASK                 ((uint32_t)0x00000001U)         /* !< CCP0 direction */
+#define GPTIMER_CCPD_C0CCP0_INPUT                ((uint32_t)0x00000000U)         /* !< Input */
+#define GPTIMER_CCPD_C0CCP0_OUTPUT               ((uint32_t)0x00000001U)         /* !< Output */
+/* GPTIMER_CCPD[C0CCP1] Bits */
+#define GPTIMER_CCPD_C0CCP1_OFS                  (1)                             /* !< C0CCP1 Offset */
+#define GPTIMER_CCPD_C0CCP1_MASK                 ((uint32_t)0x00000002U)         /* !< CCP1 direction */
+#define GPTIMER_CCPD_C0CCP1_INPUT                ((uint32_t)0x00000000U)         /* !< Input */
+#define GPTIMER_CCPD_C0CCP1_OUTPUT               ((uint32_t)0x00000002U)         /* !< Output */
+/* GPTIMER_CCPD[C0CCP2] Bits */
+#define GPTIMER_CCPD_C0CCP2_OFS                  (2)                             /* !< C0CCP2 Offset */
+#define GPTIMER_CCPD_C0CCP2_MASK                 ((uint32_t)0x00000004U)         /* !< CCP2 direction */
+#define GPTIMER_CCPD_C0CCP2_INPUT                ((uint32_t)0x00000000U)         /* !< input */
+#define GPTIMER_CCPD_C0CCP2_OUTPUT               ((uint32_t)0x00000004U)         /* !< Output */
+/* GPTIMER_CCPD[C0CCP3] Bits */
+#define GPTIMER_CCPD_C0CCP3_OFS                  (3)                             /* !< C0CCP3 Offset */
+#define GPTIMER_CCPD_C0CCP3_MASK                 ((uint32_t)0x00000008U)         /* !< CCP3 direction */
+#define GPTIMER_CCPD_C0CCP3_INPUT                ((uint32_t)0x00000000U)         /* !< Input */
+#define GPTIMER_CCPD_C0CCP3_OUTPUT               ((uint32_t)0x00000008U)         /* !< Output */
+
+/* GPTIMER_ODIS Bits */
+/* GPTIMER_ODIS[C0CCP0] Bits */
+#define GPTIMER_ODIS_C0CCP0_OFS                  (0)                             /* !< C0CCP0 Offset */
+#define GPTIMER_ODIS_C0CCP0_MASK                 ((uint32_t)0x00000001U)         /* !< Counter CCP0 Disable Mask Defines
+                                                                                    whether CCP0 of Counter n is forced
+                                                                                    low or not */
+#define GPTIMER_ODIS_C0CCP0_CCP_OUTPUT_OCTL      ((uint32_t)0x00000000U)         /* !< Output function as selected by the
+                                                                                    OCTL register CCPO field are provided
+                                                                                    to output inversion block. */
+#define GPTIMER_ODIS_C0CCP0_CCP_OUTPUT_LOW       ((uint32_t)0x00000001U)         /* !< CCP output occpout[0] is forced
+                                                                                    low. */
+/* GPTIMER_ODIS[C0CCP1] Bits */
+#define GPTIMER_ODIS_C0CCP1_OFS                  (1)                             /* !< C0CCP1 Offset */
+#define GPTIMER_ODIS_C0CCP1_MASK                 ((uint32_t)0x00000002U)         /* !< Counter CCP1 Disable Mask Defines
+                                                                                    whether CCP0 of Counter n is forced
+                                                                                    low or not */
+#define GPTIMER_ODIS_C0CCP1_CCP_OUTPUT_OCTL      ((uint32_t)0x00000000U)         /* !< Output function as selected by the
+                                                                                    OCTL register CCPO field are provided
+                                                                                    to output inversion block. */
+#define GPTIMER_ODIS_C0CCP1_CCP_OUTPUT_LOW       ((uint32_t)0x00000002U)         /* !< CCP output occpout[1] is forced
+                                                                                    low. */
+/* GPTIMER_ODIS[C0CCP2] Bits */
+#define GPTIMER_ODIS_C0CCP2_OFS                  (2)                             /* !< C0CCP2 Offset */
+#define GPTIMER_ODIS_C0CCP2_MASK                 ((uint32_t)0x00000004U)         /* !< Counter CCP2 Disable Mask Defines
+                                                                                    whether CCP2 of Counter n is forced
+                                                                                    low or not */
+#define GPTIMER_ODIS_C0CCP2_CCP_OUTPUT_OCTL      ((uint32_t)0x00000000U)         /* !< Output function as selected by the
+                                                                                    OCTL register CCPO field are provided
+                                                                                    to output inversion block. */
+#define GPTIMER_ODIS_C0CCP2_CCP_OUTPUT_LOW       ((uint32_t)0x00000004U)         /* !< CCP output occpout[2] is forced
+                                                                                    low. */
+/* GPTIMER_ODIS[C0CCP3] Bits */
+#define GPTIMER_ODIS_C0CCP3_OFS                  (3)                             /* !< C0CCP3 Offset */
+#define GPTIMER_ODIS_C0CCP3_MASK                 ((uint32_t)0x00000008U)         /* !< Counter CCP3 Disable Mask Defines
+                                                                                    whether CCP3 of Counter n is forced
+                                                                                    low or not */
+#define GPTIMER_ODIS_C0CCP3_CCP_OUTPUT_OCTL      ((uint32_t)0x00000000U)         /* !< Output function as selected by the
+                                                                                    OCTL register CCPO field are provided
+                                                                                    to occpout[2]. */
+#define GPTIMER_ODIS_C0CCP3_CCP_OUTPUT_LOW       ((uint32_t)0x00000008U)         /* !< CCP output occpout[3] is forced
+                                                                                    low. */
+
+/* GPTIMER_CCLKCTL Bits */
+/* GPTIMER_CCLKCTL[CLKEN] Bits */
+#define GPTIMER_CCLKCTL_CLKEN_OFS                (0)                             /* !< CLKEN Offset */
+#define GPTIMER_CCLKCTL_CLKEN_MASK               ((uint32_t)0x00000001U)         /* !< Clock Enable Disables the clock
+                                                                                    gating to the module. SW has to
+                                                                                    explicitly program the value  to 0 to
+                                                                                    gate the clock. */
+#define GPTIMER_CCLKCTL_CLKEN_DISABLED           ((uint32_t)0x00000000U)         /* !< Clock is disabled. */
+#define GPTIMER_CCLKCTL_CLKEN_ENABLED            ((uint32_t)0x00000001U)         /* !< Clock is enabled */
+
+/* GPTIMER_CPS Bits */
+/* GPTIMER_CPS[PCNT] Bits */
+#define GPTIMER_CPS_PCNT_OFS                     (0)                             /* !< PCNT Offset */
+#define GPTIMER_CPS_PCNT_MASK                    ((uint32_t)0x000000FFU)         /* !< Pre-Scale Count This field
+                                                                                    specifies the pre-scale count value.
+                                                                                    The selected TIMCLK source is divided
+                                                                                    by a value of (PCNT+1).  A PCNT value
+                                                                                    of 0 divides TIMCLK by 1, effectively
+                                                                                    bypassing the divider. A PCNT value
+                                                                                    of greater than 0 divides the TIMCLK
+                                                                                    source generating a slower clock */
+#define GPTIMER_CPS_PCNT_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define GPTIMER_CPS_PCNT_MAXIMUM                 ((uint32_t)0x000000FFU)         /* !< Maximum Value */
+
+/* GPTIMER_CPSV Bits */
+/* GPTIMER_CPSV[CPSVAL] Bits */
+#define GPTIMER_CPSV_CPSVAL_OFS                  (0)                             /* !< CPSVAL Offset */
+#define GPTIMER_CPSV_CPSVAL_MASK                 ((uint32_t)0x000000FFU)         /* !< Current Prescale Count Value */
+#define GPTIMER_CPSV_CPSVAL_MINIMUM              ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define GPTIMER_CPSV_CPSVAL_MAXIMUM              ((uint32_t)0x000000FFU)         /* !< Maximum Value */
+
+/* GPTIMER_CTTRIGCTL Bits */
+/* GPTIMER_CTTRIGCTL[CTEN] Bits */
+#define GPTIMER_CTTRIGCTL_CTEN_OFS               (0)                             /* !< CTEN Offset */
+#define GPTIMER_CTTRIGCTL_CTEN_MASK              ((uint32_t)0x00000001U)         /* !< Timer Cross trigger enable. This
+                                                                                    field is used to enable whether the
+                                                                                    SW or HW logic can generate a timer
+                                                                                    cross trigger event in the system.
+                                                                                    These cross triggers are connected to
+                                                                                    the respective timer trigger in of
+                                                                                    the other timer IPs in the SOC power
+                                                                                    domain.  The timer cross trigger is
+                                                                                    essentially the combined logic of the
+                                                                                    HW and SW conditions controlling EN
+                                                                                    bit in the CTRCTL register. */
+#define GPTIMER_CTTRIGCTL_CTEN_DISABLED          ((uint32_t)0x00000000U)         /* !< Cross trigger generation disabled. */
+#define GPTIMER_CTTRIGCTL_CTEN_ENABLE            ((uint32_t)0x00000001U)         /* !< Cross trigger generation enabled */
+/* GPTIMER_CTTRIGCTL[EVTCTEN] Bits */
+#define GPTIMER_CTTRIGCTL_EVTCTEN_OFS            (1)                             /* !< EVTCTEN Offset */
+#define GPTIMER_CTTRIGCTL_EVTCTEN_MASK           ((uint32_t)0x00000002U)         /* !< Enable the Input Trigger Conditions
+                                                                                    to the Timer module as a condition
+                                                                                    for Cross Triggers. */
+#define GPTIMER_CTTRIGCTL_EVTCTEN_DISABLED       ((uint32_t)0x00000000U)         /* !< Cross trigger generation disabled. */
+#define GPTIMER_CTTRIGCTL_EVTCTEN_ENABLE         ((uint32_t)0x00000002U)         /* !< Cross trigger generation enabled */
+/* GPTIMER_CTTRIGCTL[EVTCTTRIGSEL] Bits */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_OFS       (16)                            /* !< EVTCTTRIGSEL Offset */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_MASK      ((uint32_t)0x000F0000U)         /* !< Used to Select the subscriber port
+                                                                                    that should be used for input cross
+                                                                                    trigger. */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_FSUB0     ((uint32_t)0x00000000U)         /* !< Use FSUB0 as cross trigger source. */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_FSUB1     ((uint32_t)0x00010000U)         /* !< Use FSUB1 as cross trigger source. */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_Z         ((uint32_t)0x00020000U)         /* !< Use Zero event  as cross trigger
+                                                                                    source. */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_L         ((uint32_t)0x00030000U)         /* !< Use Load event as cross trigger
+                                                                                    source. */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCD0      ((uint32_t)0x00040000U)         /* !< Use CCD0 event  as cross trigger
+                                                                                    source. */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCD1      ((uint32_t)0x00050000U)         /* !< Use CCD1 event  as cross trigger
+                                                                                    source. */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCD2      ((uint32_t)0x00060000U)         /* !< Use CCD2 event  as cross trigger
+                                                                                    source. */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCD3      ((uint32_t)0x00070000U)         /* !< Use CCD3 event  as cross trigger
+                                                                                    source. */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCU0      ((uint32_t)0x00080000U)         /* !< Use CCU0 event  as cross trigger
+                                                                                    source. */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCU1      ((uint32_t)0x00090000U)         /* !< Use CCU1 event  as cross trigger
+                                                                                    source. */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCU2      ((uint32_t)0x000A0000U)         /* !< Use CCU2 event  as cross trigger
+                                                                                    source. */
+#define GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCU3      ((uint32_t)0x000B0000U)         /* !< Use CCU3 event  as cross trigger
+                                                                                    source. */
+
+/* GPTIMER_CTTRIG Bits */
+/* GPTIMER_CTTRIG[TRIG] Bits */
+#define GPTIMER_CTTRIG_TRIG_OFS                  (0)                             /* !< TRIG Offset */
+#define GPTIMER_CTTRIG_TRIG_MASK                 ((uint32_t)0x00000001U)         /* !< Generate Cross Trigger This bit
+                                                                                    when programmed will generate a
+                                                                                    synchronized trigger condition all
+                                                                                    the cross trigger enabled Timer
+                                                                                    instances including current timer
+                                                                                    instance. */
+#define GPTIMER_CTTRIG_TRIG_DISABLED             ((uint32_t)0x00000000U)         /* !< Cross trigger generation disabled */
+#define GPTIMER_CTTRIG_TRIG_GENERATE             ((uint32_t)0x00000001U)         /* !< Generate Cross trigger pulse */
+
+/* GPTIMER_FSCTL Bits */
+/* GPTIMER_FSCTL[FCEN] Bits */
+#define GPTIMER_FSCTL_FCEN_OFS                   (0)                             /* !< FCEN Offset */
+#define GPTIMER_FSCTL_FCEN_MASK                  ((uint32_t)0x00000001U)         /* !< This field controls whether the
+                                                                                    fault is caused by the system clock
+                                                                                    fault. */
+#define GPTIMER_FSCTL_FCEN_DISABLE               ((uint32_t)0x00000000U)         /* !< Disable */
+#define GPTIMER_FSCTL_FCEN_ENABLE                ((uint32_t)0x00000001U)         /* !< Enable */
+/* GPTIMER_FSCTL[FAC0EN] Bits */
+#define GPTIMER_FSCTL_FAC0EN_OFS                 (1)                             /* !< FAC0EN Offset */
+#define GPTIMER_FSCTL_FAC0EN_MASK                ((uint32_t)0x00000002U)         /* !< This field controls whether the
+                                                                                    fault signal is caused by COMP0
+                                                                                    output. */
+#define GPTIMER_FSCTL_FAC0EN_DISABLE             ((uint32_t)0x00000000U)         /* !< Disable */
+#define GPTIMER_FSCTL_FAC0EN_ENABLE              ((uint32_t)0x00000002U)         /* !< Enable */
+/* GPTIMER_FSCTL[FAC1EN] Bits */
+#define GPTIMER_FSCTL_FAC1EN_OFS                 (2)                             /* !< FAC1EN Offset */
+#define GPTIMER_FSCTL_FAC1EN_MASK                ((uint32_t)0x00000004U)         /* !< This field controls whether the
+                                                                                    fault is caused by COMP1 output. */
+#define GPTIMER_FSCTL_FAC1EN_DISABLE             ((uint32_t)0x00000000U)         /* !< Disable */
+#define GPTIMER_FSCTL_FAC1EN_ENABLE              ((uint32_t)0x00000004U)         /* !< Enable */
+/* GPTIMER_FSCTL[FAC2EN] Bits */
+#define GPTIMER_FSCTL_FAC2EN_OFS                 (3)                             /* !< FAC2EN Offset */
+#define GPTIMER_FSCTL_FAC2EN_MASK                ((uint32_t)0x00000008U)         /* !< This field controls whether the
+                                                                                    fault is caused by COMP2 output. */
+#define GPTIMER_FSCTL_FAC2EN_DISABLE             ((uint32_t)0x00000000U)         /* !< Disable */
+#define GPTIMER_FSCTL_FAC2EN_ENABLE              ((uint32_t)0x00000008U)         /* !< Enable */
+/* GPTIMER_FSCTL[FEX0EN] Bits */
+#define GPTIMER_FSCTL_FEX0EN_OFS                 (4)                             /* !< FEX0EN Offset */
+#define GPTIMER_FSCTL_FEX0EN_MASK                ((uint32_t)0x00000010U)         /* !< This field controls whether the
+                                                                                    fault is caused by external fault pin
+                                                                                    0. */
+#define GPTIMER_FSCTL_FEX0EN_DISABLE             ((uint32_t)0x00000000U)         /* !< Disable */
+#define GPTIMER_FSCTL_FEX0EN_ENABLE              ((uint32_t)0x00000010U)         /* !< Enable */
+/* GPTIMER_FSCTL[FEX1EN] Bits */
+#define GPTIMER_FSCTL_FEX1EN_OFS                 (5)                             /* !< FEX1EN Offset */
+#define GPTIMER_FSCTL_FEX1EN_MASK                ((uint32_t)0x00000020U)         /* !< This field controls whether the
+                                                                                    fault is caused by external fault pin
+                                                                                    1. */
+#define GPTIMER_FSCTL_FEX1EN_DISABLE             ((uint32_t)0x00000000U)         /* !< Disable */
+#define GPTIMER_FSCTL_FEX1EN_ENABLE              ((uint32_t)0x00000020U)         /* !< Enable */
+/* GPTIMER_FSCTL[FEX2EN] Bits */
+#define GPTIMER_FSCTL_FEX2EN_OFS                 (6)                             /* !< FEX2EN Offset */
+#define GPTIMER_FSCTL_FEX2EN_MASK                ((uint32_t)0x00000040U)         /* !< This field controls whether the
+                                                                                    fault is caused by external fault pin
+                                                                                    2. */
+#define GPTIMER_FSCTL_FEX2EN_DISABLE             ((uint32_t)0x00000000U)         /* !< Disable */
+#define GPTIMER_FSCTL_FEX2EN_ENABLE              ((uint32_t)0x00000040U)         /* !< Enable */
+
+/* GPTIMER_GCTL Bits */
+/* GPTIMER_GCTL[SHDWLDEN] Bits */
+#define GPTIMER_GCTL_SHDWLDEN_OFS                (0)                             /* !< SHDWLDEN Offset */
+#define GPTIMER_GCTL_SHDWLDEN_MASK               ((uint32_t)0x00000001U)         /* !< Enables shadow to active load of
+                                                                                    bufferred registers and register
+                                                                                    fields. */
+#define GPTIMER_GCTL_SHDWLDEN_DISABLE            ((uint32_t)0x00000000U)         /* !< Disable */
+#define GPTIMER_GCTL_SHDWLDEN_ENABLE             ((uint32_t)0x00000001U)         /* !< Enable */
+
+/* GPTIMER_GEN_EVENT1_IIDX Bits */
+/* GPTIMER_GEN_EVENT1_IIDX[STAT] Bits */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_OFS         (0)                             /* !< STAT Offset */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_MASK        ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_NO_INTR     ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_Z           ((uint32_t)0x00000001U)         /* !< Interrupt Source: Zero event (Z) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_L           ((uint32_t)0x00000002U)         /* !< nterrupt Source: Load event (L) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_CCD0        ((uint32_t)0x00000005U)         /* !< Interrupt Source: Capture or
+                                                                                    compare down event (CCD0) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_CCD1        ((uint32_t)0x00000006U)         /* !< Interrupt Source: Capture or
+                                                                                    compare down event (CCD1) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_CCD2        ((uint32_t)0x00000007U)         /* !< Interrupt Source: Capture or
+                                                                                    compare down event (CCD2) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_CCD3        ((uint32_t)0x00000008U)         /* !< Interrupt Source: Capture or
+                                                                                    compare down event (CCD3) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_CCU0        ((uint32_t)0x00000009U)         /* !< Interrupt Source: Capture or
+                                                                                    compare up event (CCU0) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_CCU1        ((uint32_t)0x0000000AU)         /* !< Interrupt Source: Capture or
+                                                                                    compare up event (CCU1) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_CCU2        ((uint32_t)0x0000000BU)         /* !< Interrupt Source: Capture or
+                                                                                    compare up event (CCU2) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_CCU3        ((uint32_t)0x0000000CU)         /* !< Interrupt Source: Capture or
+                                                                                    compare up event (CCU3) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_CCD4        ((uint32_t)0x0000000DU)         /* !< Interrupt Source: Compare down
+                                                                                    event (CCD4) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_CCD5        ((uint32_t)0x0000000EU)         /* !< Interrupt Source: Compare down
+                                                                                    event (CCD5) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_CCU4        ((uint32_t)0x0000000FU)         /* !< Interrupt Source: Compare down
+                                                                                    event (CCU4) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_CCU5        ((uint32_t)0x00000010U)         /* !< Interrupt Source: Compare down
+                                                                                    event (CCU5) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_F           ((uint32_t)0x00000019U)         /* !< Interrupt Source: Fault Event
+                                                                                    generated an interrupt. (F) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_TOV         ((uint32_t)0x0000001AU)         /* !< Interrupt Source: Trigger overflow
+                                                                                    (TOV) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_REPC        ((uint32_t)0x0000001BU)         /* !< Interrupt Source: Repeat Counter
+                                                                                    Zero (REPC) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_DC          ((uint32_t)0x0000001CU)         /* !< Interrupt Source: Direction Change
+                                                                                    (DC) */
+#define GPTIMER_GEN_EVENT1_IIDX_STAT_QEIERR      ((uint32_t)0x0000001DU)         /* !< Interrupt Source:QEI Incorrect
+                                                                                    state transition error (QEIERR) */
+
+/* GPTIMER_GEN_EVENT1_IMASK Bits */
+/* GPTIMER_GEN_EVENT1_IMASK[Z] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_Z_OFS           (0)                             /* !< Z Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_Z_MASK          ((uint32_t)0x00000001U)         /* !< Zero Event mask */
+#define GPTIMER_GEN_EVENT1_IMASK_Z_CLR           ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_GEN_EVENT1_IMASK_Z_SET           ((uint32_t)0x00000001U)         /* !< Enable Event */
+/* GPTIMER_GEN_EVENT1_IMASK[L] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_L_OFS           (1)                             /* !< L Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_L_MASK          ((uint32_t)0x00000002U)         /* !< Load Event mask */
+#define GPTIMER_GEN_EVENT1_IMASK_L_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT1_IMASK_L_SET           ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT1_IMASK[CCD0] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD0_OFS        (4)                             /* !< CCD0 Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD0_MASK       ((uint32_t)0x00000010U)         /* !< Capture or Compare DN event mask
+                                                                                    CCP0 */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD0_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD0_SET        ((uint32_t)0x00000010U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT1_IMASK[CCD1] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD1_OFS        (5)                             /* !< CCD1 Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD1_MASK       ((uint32_t)0x00000020U)         /* !< Capture or Compare DN event mask
+                                                                                    CCP1 */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD1_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD1_SET        ((uint32_t)0x00000020U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT1_IMASK[CCU0] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU0_OFS        (8)                             /* !< CCU0 Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU0_MASK       ((uint32_t)0x00000100U)         /* !< Capture or Compare UP event mask
+                                                                                    CCP0 */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU0_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU0_SET        ((uint32_t)0x00000100U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT1_IMASK[CCU1] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU1_OFS        (9)                             /* !< CCU1 Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU1_MASK       ((uint32_t)0x00000200U)         /* !< Capture or Compare UP event mask
+                                                                                    CCP1 */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU1_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU1_SET        ((uint32_t)0x00000200U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT1_IMASK[F] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_F_OFS           (24)                            /* !< F Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_F_MASK          ((uint32_t)0x01000000U)         /* !< Fault Event mask */
+#define GPTIMER_GEN_EVENT1_IMASK_F_CLR           ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_GEN_EVENT1_IMASK_F_SET           ((uint32_t)0x01000000U)         /* !< Enable Event */
+/* GPTIMER_GEN_EVENT1_IMASK[TOV] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_TOV_OFS         (25)                            /* !< TOV Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_TOV_MASK        ((uint32_t)0x02000000U)         /* !< Trigger Overflow Event mask */
+#define GPTIMER_GEN_EVENT1_IMASK_TOV_CLR         ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_GEN_EVENT1_IMASK_TOV_SET         ((uint32_t)0x02000000U)         /* !< Enable Event */
+/* GPTIMER_GEN_EVENT1_IMASK[DC] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_DC_OFS          (27)                            /* !< DC Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_DC_MASK         ((uint32_t)0x08000000U)         /* !< Direction Change Event mask */
+#define GPTIMER_GEN_EVENT1_IMASK_DC_CLR          ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_GEN_EVENT1_IMASK_DC_SET          ((uint32_t)0x08000000U)         /* !< Enable Event */
+/* GPTIMER_GEN_EVENT1_IMASK[QEIERR] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_QEIERR_OFS      (28)                            /* !< QEIERR Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_QEIERR_MASK     ((uint32_t)0x10000000U)         /* !< QEIERR Event mask */
+#define GPTIMER_GEN_EVENT1_IMASK_QEIERR_CLR      ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_GEN_EVENT1_IMASK_QEIERR_SET      ((uint32_t)0x10000000U)         /* !< Enable Event */
+/* GPTIMER_GEN_EVENT1_IMASK[CCD2] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD2_OFS        (6)                             /* !< CCD2 Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD2_MASK       ((uint32_t)0x00000040U)         /* !< Capture or Compare DN event mask
+                                                                                    CCP2 */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD2_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD2_SET        ((uint32_t)0x00000040U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT1_IMASK[CCD3] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD3_OFS        (7)                             /* !< CCD3 Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD3_MASK       ((uint32_t)0x00000080U)         /* !< Capture or Compare DN event mask
+                                                                                    CCP3 */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD3_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD3_SET        ((uint32_t)0x00000080U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT1_IMASK[CCU2] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU2_OFS        (10)                            /* !< CCU2 Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU2_MASK       ((uint32_t)0x00000400U)         /* !< Capture or Compare UP event mask
+                                                                                    CCP2 */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU2_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU2_SET        ((uint32_t)0x00000400U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT1_IMASK[CCU3] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU3_OFS        (11)                            /* !< CCU3 Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU3_MASK       ((uint32_t)0x00000800U)         /* !< Capture or Compare UP event mask
+                                                                                    CCP3 */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU3_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU3_SET        ((uint32_t)0x00000800U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT1_IMASK[CCD4] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD4_OFS        (12)                            /* !< CCD4 Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD4_MASK       ((uint32_t)0x00001000U)         /* !< Compare DN event mask CCP4 */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD4_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD4_SET        ((uint32_t)0x00001000U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT1_IMASK[CCD5] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD5_OFS        (13)                            /* !< CCD5 Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD5_MASK       ((uint32_t)0x00002000U)         /* !< Compare DN event mask CCP5 */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD5_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT1_IMASK_CCD5_SET        ((uint32_t)0x00002000U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT1_IMASK[CCU4] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU4_OFS        (14)                            /* !< CCU4 Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU4_MASK       ((uint32_t)0x00004000U)         /* !< Compare UP event mask CCP4 */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU4_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU4_SET        ((uint32_t)0x00004000U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT1_IMASK[CCU5] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU5_OFS        (15)                            /* !< CCU5 Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU5_MASK       ((uint32_t)0x00008000U)         /* !< Compare UP event mask CCP5 */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU5_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT1_IMASK_CCU5_SET        ((uint32_t)0x00008000U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT1_IMASK[REPC] Bits */
+#define GPTIMER_GEN_EVENT1_IMASK_REPC_OFS        (26)                            /* !< REPC Offset */
+#define GPTIMER_GEN_EVENT1_IMASK_REPC_MASK       ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero Event mask */
+#define GPTIMER_GEN_EVENT1_IMASK_REPC_CLR        ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_GEN_EVENT1_IMASK_REPC_SET        ((uint32_t)0x04000000U)         /* !< Enable Event */
+
+/* GPTIMER_GEN_EVENT1_RIS Bits */
+/* GPTIMER_GEN_EVENT1_RIS[Z] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_Z_OFS             (0)                             /* !< Z Offset */
+#define GPTIMER_GEN_EVENT1_RIS_Z_MASK            ((uint32_t)0x00000001U)         /* !< Zero event generated an interrupt. */
+#define GPTIMER_GEN_EVENT1_RIS_Z_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_Z_SET             ((uint32_t)0x00000001U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[L] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_L_OFS             (1)                             /* !< L Offset */
+#define GPTIMER_GEN_EVENT1_RIS_L_MASK            ((uint32_t)0x00000002U)         /* !< Load event generated an interrupt. */
+#define GPTIMER_GEN_EVENT1_RIS_L_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_L_SET             ((uint32_t)0x00000002U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[CCD0] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_CCD0_OFS          (4)                             /* !< CCD0 Offset */
+#define GPTIMER_GEN_EVENT1_RIS_CCD0_MASK         ((uint32_t)0x00000010U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP0 */
+#define GPTIMER_GEN_EVENT1_RIS_CCD0_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_CCD0_SET          ((uint32_t)0x00000010U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[CCD1] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_CCD1_OFS          (5)                             /* !< CCD1 Offset */
+#define GPTIMER_GEN_EVENT1_RIS_CCD1_MASK         ((uint32_t)0x00000020U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP1 */
+#define GPTIMER_GEN_EVENT1_RIS_CCD1_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_CCD1_SET          ((uint32_t)0x00000020U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[CCU0] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_CCU0_OFS          (8)                             /* !< CCU0 Offset */
+#define GPTIMER_GEN_EVENT1_RIS_CCU0_MASK         ((uint32_t)0x00000100U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP0 */
+#define GPTIMER_GEN_EVENT1_RIS_CCU0_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_CCU0_SET          ((uint32_t)0x00000100U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[CCU1] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_CCU1_OFS          (9)                             /* !< CCU1 Offset */
+#define GPTIMER_GEN_EVENT1_RIS_CCU1_MASK         ((uint32_t)0x00000200U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP1 */
+#define GPTIMER_GEN_EVENT1_RIS_CCU1_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_CCU1_SET          ((uint32_t)0x00000200U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[TOV] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_TOV_OFS           (25)                            /* !< TOV Offset */
+#define GPTIMER_GEN_EVENT1_RIS_TOV_MASK          ((uint32_t)0x02000000U)         /* !< Trigger overflow */
+#define GPTIMER_GEN_EVENT1_RIS_TOV_CLR           ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_TOV_SET           ((uint32_t)0x02000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[F] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_F_OFS             (24)                            /* !< F Offset */
+#define GPTIMER_GEN_EVENT1_RIS_F_MASK            ((uint32_t)0x01000000U)         /* !< Fault */
+#define GPTIMER_GEN_EVENT1_RIS_F_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_F_SET             ((uint32_t)0x01000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[DC] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_DC_OFS            (27)                            /* !< DC Offset */
+#define GPTIMER_GEN_EVENT1_RIS_DC_MASK           ((uint32_t)0x08000000U)         /* !< Direction Change */
+#define GPTIMER_GEN_EVENT1_RIS_DC_CLR            ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_DC_SET            ((uint32_t)0x08000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[QEIERR] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_QEIERR_OFS        (28)                            /* !< QEIERR Offset */
+#define GPTIMER_GEN_EVENT1_RIS_QEIERR_MASK       ((uint32_t)0x10000000U)         /* !< QEIERR, set on an incorrect state
+                                                                                    transition on the encoder interface. */
+#define GPTIMER_GEN_EVENT1_RIS_QEIERR_CLR        ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_QEIERR_SET        ((uint32_t)0x10000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[CCD2] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_CCD2_OFS          (6)                             /* !< CCD2 Offset */
+#define GPTIMER_GEN_EVENT1_RIS_CCD2_MASK         ((uint32_t)0x00000040U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP2 */
+#define GPTIMER_GEN_EVENT1_RIS_CCD2_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_CCD2_SET          ((uint32_t)0x00000040U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[CCD3] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_CCD3_OFS          (7)                             /* !< CCD3 Offset */
+#define GPTIMER_GEN_EVENT1_RIS_CCD3_MASK         ((uint32_t)0x00000080U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP3 */
+#define GPTIMER_GEN_EVENT1_RIS_CCD3_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_CCD3_SET          ((uint32_t)0x00000080U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[CCU2] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_CCU2_OFS          (10)                            /* !< CCU2 Offset */
+#define GPTIMER_GEN_EVENT1_RIS_CCU2_MASK         ((uint32_t)0x00000400U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP2 */
+#define GPTIMER_GEN_EVENT1_RIS_CCU2_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_CCU2_SET          ((uint32_t)0x00000400U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[CCU3] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_CCU3_OFS          (11)                            /* !< CCU3 Offset */
+#define GPTIMER_GEN_EVENT1_RIS_CCU3_MASK         ((uint32_t)0x00000800U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP3 */
+#define GPTIMER_GEN_EVENT1_RIS_CCU3_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_CCU3_SET          ((uint32_t)0x00000800U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[CCD4] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_CCD4_OFS          (12)                            /* !< CCD4 Offset */
+#define GPTIMER_GEN_EVENT1_RIS_CCD4_MASK         ((uint32_t)0x00001000U)         /* !< Compare down event generated an
+                                                                                    interrupt CCD4 */
+#define GPTIMER_GEN_EVENT1_RIS_CCD4_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_CCD4_SET          ((uint32_t)0x00001000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[CCD5] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_CCD5_OFS          (13)                            /* !< CCD5 Offset */
+#define GPTIMER_GEN_EVENT1_RIS_CCD5_MASK         ((uint32_t)0x00002000U)         /* !< Compare down event generated an
+                                                                                    interrupt CCD5 */
+#define GPTIMER_GEN_EVENT1_RIS_CCD5_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_CCD5_SET          ((uint32_t)0x00002000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[CCU4] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_CCU4_OFS          (14)                            /* !< CCU4 Offset */
+#define GPTIMER_GEN_EVENT1_RIS_CCU4_MASK         ((uint32_t)0x00004000U)         /* !< Compare up event generated an
+                                                                                    interrupt CCU4 */
+#define GPTIMER_GEN_EVENT1_RIS_CCU4_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_CCU4_SET          ((uint32_t)0x00004000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[CCU5] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_CCU5_OFS          (15)                            /* !< CCU5 Offset */
+#define GPTIMER_GEN_EVENT1_RIS_CCU5_MASK         ((uint32_t)0x00008000U)         /* !< Compare up event generated an
+                                                                                    interrupt CCP5 */
+#define GPTIMER_GEN_EVENT1_RIS_CCU5_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_CCU5_SET          ((uint32_t)0x00008000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_RIS[REPC] Bits */
+#define GPTIMER_GEN_EVENT1_RIS_REPC_OFS          (26)                            /* !< REPC Offset */
+#define GPTIMER_GEN_EVENT1_RIS_REPC_MASK         ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero */
+#define GPTIMER_GEN_EVENT1_RIS_REPC_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_RIS_REPC_SET          ((uint32_t)0x04000000U)         /* !< Event Set */
+
+/* GPTIMER_GEN_EVENT1_MIS Bits */
+/* GPTIMER_GEN_EVENT1_MIS[Z] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_Z_OFS             (0)                             /* !< Z Offset */
+#define GPTIMER_GEN_EVENT1_MIS_Z_MASK            ((uint32_t)0x00000001U)         /* !< Zero event generated an interrupt. */
+#define GPTIMER_GEN_EVENT1_MIS_Z_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_Z_SET             ((uint32_t)0x00000001U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[L] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_L_OFS             (1)                             /* !< L Offset */
+#define GPTIMER_GEN_EVENT1_MIS_L_MASK            ((uint32_t)0x00000002U)         /* !< Load event generated an interrupt. */
+#define GPTIMER_GEN_EVENT1_MIS_L_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_L_SET             ((uint32_t)0x00000002U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[CCD0] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_CCD0_OFS          (4)                             /* !< CCD0 Offset */
+#define GPTIMER_GEN_EVENT1_MIS_CCD0_MASK         ((uint32_t)0x00000010U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP0 */
+#define GPTIMER_GEN_EVENT1_MIS_CCD0_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_CCD0_SET          ((uint32_t)0x00000010U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[CCD1] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_CCD1_OFS          (5)                             /* !< CCD1 Offset */
+#define GPTIMER_GEN_EVENT1_MIS_CCD1_MASK         ((uint32_t)0x00000020U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP1 */
+#define GPTIMER_GEN_EVENT1_MIS_CCD1_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_CCD1_SET          ((uint32_t)0x00000020U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[CCU0] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_CCU0_OFS          (8)                             /* !< CCU0 Offset */
+#define GPTIMER_GEN_EVENT1_MIS_CCU0_MASK         ((uint32_t)0x00000100U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP0 */
+#define GPTIMER_GEN_EVENT1_MIS_CCU0_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_CCU0_SET          ((uint32_t)0x00000100U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[CCU1] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_CCU1_OFS          (9)                             /* !< CCU1 Offset */
+#define GPTIMER_GEN_EVENT1_MIS_CCU1_MASK         ((uint32_t)0x00000200U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP1 */
+#define GPTIMER_GEN_EVENT1_MIS_CCU1_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_CCU1_SET          ((uint32_t)0x00000200U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[F] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_F_OFS             (24)                            /* !< F Offset */
+#define GPTIMER_GEN_EVENT1_MIS_F_MASK            ((uint32_t)0x01000000U)         /* !< Fault */
+#define GPTIMER_GEN_EVENT1_MIS_F_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_F_SET             ((uint32_t)0x01000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[TOV] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_TOV_OFS           (25)                            /* !< TOV Offset */
+#define GPTIMER_GEN_EVENT1_MIS_TOV_MASK          ((uint32_t)0x02000000U)         /* !< Trigger overflow */
+#define GPTIMER_GEN_EVENT1_MIS_TOV_CLR           ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_TOV_SET           ((uint32_t)0x02000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[DC] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_DC_OFS            (27)                            /* !< DC Offset */
+#define GPTIMER_GEN_EVENT1_MIS_DC_MASK           ((uint32_t)0x08000000U)         /* !< Direction Change */
+#define GPTIMER_GEN_EVENT1_MIS_DC_CLR            ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_DC_SET            ((uint32_t)0x08000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[QEIERR] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_QEIERR_OFS        (28)                            /* !< QEIERR Offset */
+#define GPTIMER_GEN_EVENT1_MIS_QEIERR_MASK       ((uint32_t)0x10000000U)         /* !< QEIERR */
+#define GPTIMER_GEN_EVENT1_MIS_QEIERR_CLR        ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_QEIERR_SET        ((uint32_t)0x10000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[CCD2] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_CCD2_OFS          (6)                             /* !< CCD2 Offset */
+#define GPTIMER_GEN_EVENT1_MIS_CCD2_MASK         ((uint32_t)0x00000040U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP2 */
+#define GPTIMER_GEN_EVENT1_MIS_CCD2_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_CCD2_SET          ((uint32_t)0x00000040U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[CCD3] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_CCD3_OFS          (7)                             /* !< CCD3 Offset */
+#define GPTIMER_GEN_EVENT1_MIS_CCD3_MASK         ((uint32_t)0x00000080U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP3 */
+#define GPTIMER_GEN_EVENT1_MIS_CCD3_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_CCD3_SET          ((uint32_t)0x00000080U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[CCU2] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_CCU2_OFS          (10)                            /* !< CCU2 Offset */
+#define GPTIMER_GEN_EVENT1_MIS_CCU2_MASK         ((uint32_t)0x00000400U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP2 */
+#define GPTIMER_GEN_EVENT1_MIS_CCU2_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_CCU2_SET          ((uint32_t)0x00000400U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[CCU3] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_CCU3_OFS          (11)                            /* !< CCU3 Offset */
+#define GPTIMER_GEN_EVENT1_MIS_CCU3_MASK         ((uint32_t)0x00000800U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP3 */
+#define GPTIMER_GEN_EVENT1_MIS_CCU3_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_CCU3_SET          ((uint32_t)0x00000800U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[CCD4] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_CCD4_OFS          (12)                            /* !< CCD4 Offset */
+#define GPTIMER_GEN_EVENT1_MIS_CCD4_MASK         ((uint32_t)0x00001000U)         /* !< Compare down event generated an
+                                                                                    interrupt CCP4 */
+#define GPTIMER_GEN_EVENT1_MIS_CCD4_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_CCD4_SET          ((uint32_t)0x00001000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[CCD5] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_CCD5_OFS          (13)                            /* !< CCD5 Offset */
+#define GPTIMER_GEN_EVENT1_MIS_CCD5_MASK         ((uint32_t)0x00002000U)         /* !< Compare down event generated an
+                                                                                    interrupt CCP5 */
+#define GPTIMER_GEN_EVENT1_MIS_CCD5_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_CCD5_SET          ((uint32_t)0x00002000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[CCU4] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_CCU4_OFS          (14)                            /* !< CCU4 Offset */
+#define GPTIMER_GEN_EVENT1_MIS_CCU4_MASK         ((uint32_t)0x00004000U)         /* !< Compare up event generated an
+                                                                                    interrupt CCP4 */
+#define GPTIMER_GEN_EVENT1_MIS_CCU4_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_CCU4_SET          ((uint32_t)0x00004000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[CCU5] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_CCU5_OFS          (15)                            /* !< CCU5 Offset */
+#define GPTIMER_GEN_EVENT1_MIS_CCU5_MASK         ((uint32_t)0x00008000U)         /* !< Compare up event generated an
+                                                                                    interrupt CCP5 */
+#define GPTIMER_GEN_EVENT1_MIS_CCU5_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_CCU5_SET          ((uint32_t)0x00008000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_MIS[REPC] Bits */
+#define GPTIMER_GEN_EVENT1_MIS_REPC_OFS          (26)                            /* !< REPC Offset */
+#define GPTIMER_GEN_EVENT1_MIS_REPC_MASK         ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero */
+#define GPTIMER_GEN_EVENT1_MIS_REPC_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT1_MIS_REPC_SET          ((uint32_t)0x04000000U)         /* !< Event Set */
+
+/* GPTIMER_GEN_EVENT1_ISET Bits */
+/* GPTIMER_GEN_EVENT1_ISET[Z] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_Z_OFS            (0)                             /* !< Z Offset */
+#define GPTIMER_GEN_EVENT1_ISET_Z_MASK           ((uint32_t)0x00000001U)         /* !< Zero event SET */
+#define GPTIMER_GEN_EVENT1_ISET_Z_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_Z_SET            ((uint32_t)0x00000001U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[L] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_L_OFS            (1)                             /* !< L Offset */
+#define GPTIMER_GEN_EVENT1_ISET_L_MASK           ((uint32_t)0x00000002U)         /* !< Load event SET */
+#define GPTIMER_GEN_EVENT1_ISET_L_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_L_SET            ((uint32_t)0x00000002U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[CCD0] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_CCD0_OFS         (4)                             /* !< CCD0 Offset */
+#define GPTIMER_GEN_EVENT1_ISET_CCD0_MASK        ((uint32_t)0x00000010U)         /* !< Capture or compare down event SET */
+#define GPTIMER_GEN_EVENT1_ISET_CCD0_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_CCD0_SET         ((uint32_t)0x00000010U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[CCD1] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_CCD1_OFS         (5)                             /* !< CCD1 Offset */
+#define GPTIMER_GEN_EVENT1_ISET_CCD1_MASK        ((uint32_t)0x00000020U)         /* !< Capture or compare down event SET */
+#define GPTIMER_GEN_EVENT1_ISET_CCD1_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_CCD1_SET         ((uint32_t)0x00000020U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[CCU0] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_CCU0_OFS         (8)                             /* !< CCU0 Offset */
+#define GPTIMER_GEN_EVENT1_ISET_CCU0_MASK        ((uint32_t)0x00000100U)         /* !< Capture or compare up event SET */
+#define GPTIMER_GEN_EVENT1_ISET_CCU0_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_CCU0_SET         ((uint32_t)0x00000100U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[CCU1] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_CCU1_OFS         (9)                             /* !< CCU1 Offset */
+#define GPTIMER_GEN_EVENT1_ISET_CCU1_MASK        ((uint32_t)0x00000200U)         /* !< Capture or compare up event SET */
+#define GPTIMER_GEN_EVENT1_ISET_CCU1_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_CCU1_SET         ((uint32_t)0x00000200U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[F] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_F_OFS            (24)                            /* !< F Offset */
+#define GPTIMER_GEN_EVENT1_ISET_F_MASK           ((uint32_t)0x01000000U)         /* !< Fault event SET */
+#define GPTIMER_GEN_EVENT1_ISET_F_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_F_SET            ((uint32_t)0x01000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[TOV] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_TOV_OFS          (25)                            /* !< TOV Offset */
+#define GPTIMER_GEN_EVENT1_ISET_TOV_MASK         ((uint32_t)0x02000000U)         /* !< Trigger Overflow event SET */
+#define GPTIMER_GEN_EVENT1_ISET_TOV_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_TOV_SET          ((uint32_t)0x02000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[DC] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_DC_OFS           (27)                            /* !< DC Offset */
+#define GPTIMER_GEN_EVENT1_ISET_DC_MASK          ((uint32_t)0x08000000U)         /* !< Direction Change event SET */
+#define GPTIMER_GEN_EVENT1_ISET_DC_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_DC_SET           ((uint32_t)0x08000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[QEIERR] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_QEIERR_OFS       (28)                            /* !< QEIERR Offset */
+#define GPTIMER_GEN_EVENT1_ISET_QEIERR_MASK      ((uint32_t)0x10000000U)         /* !< QEIERR event SET */
+#define GPTIMER_GEN_EVENT1_ISET_QEIERR_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_QEIERR_SET       ((uint32_t)0x10000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[CCD2] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_CCD2_OFS         (6)                             /* !< CCD2 Offset */
+#define GPTIMER_GEN_EVENT1_ISET_CCD2_MASK        ((uint32_t)0x00000040U)         /* !< Capture or compare down event SET */
+#define GPTIMER_GEN_EVENT1_ISET_CCD2_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_CCD2_SET         ((uint32_t)0x00000040U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[CCD3] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_CCD3_OFS         (7)                             /* !< CCD3 Offset */
+#define GPTIMER_GEN_EVENT1_ISET_CCD3_MASK        ((uint32_t)0x00000080U)         /* !< Capture or compare down event SET */
+#define GPTIMER_GEN_EVENT1_ISET_CCD3_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_CCD3_SET         ((uint32_t)0x00000080U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[CCU2] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_CCU2_OFS         (10)                            /* !< CCU2 Offset */
+#define GPTIMER_GEN_EVENT1_ISET_CCU2_MASK        ((uint32_t)0x00000400U)         /* !< Capture or compare up event SET */
+#define GPTIMER_GEN_EVENT1_ISET_CCU2_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_CCU2_SET         ((uint32_t)0x00000400U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[CCU3] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_CCU3_OFS         (11)                            /* !< CCU3 Offset */
+#define GPTIMER_GEN_EVENT1_ISET_CCU3_MASK        ((uint32_t)0x00000800U)         /* !< Capture or compare up event SET */
+#define GPTIMER_GEN_EVENT1_ISET_CCU3_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_CCU3_SET         ((uint32_t)0x00000800U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[CCD4] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_CCD4_OFS         (12)                            /* !< CCD4 Offset */
+#define GPTIMER_GEN_EVENT1_ISET_CCD4_MASK        ((uint32_t)0x00001000U)         /* !< Compare down event 4 SET */
+#define GPTIMER_GEN_EVENT1_ISET_CCD4_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_CCD4_SET         ((uint32_t)0x00001000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[CCD5] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_CCD5_OFS         (13)                            /* !< CCD5 Offset */
+#define GPTIMER_GEN_EVENT1_ISET_CCD5_MASK        ((uint32_t)0x00002000U)         /* !< Compare down event 5 SET */
+#define GPTIMER_GEN_EVENT1_ISET_CCD5_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_CCD5_SET         ((uint32_t)0x00002000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[CCU4] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_CCU4_OFS         (14)                            /* !< CCU4 Offset */
+#define GPTIMER_GEN_EVENT1_ISET_CCU4_MASK        ((uint32_t)0x00004000U)         /* !< Compare up event 4 SET */
+#define GPTIMER_GEN_EVENT1_ISET_CCU4_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_CCU4_SET         ((uint32_t)0x00004000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[CCU5] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_CCU5_OFS         (15)                            /* !< CCU5 Offset */
+#define GPTIMER_GEN_EVENT1_ISET_CCU5_MASK        ((uint32_t)0x00008000U)         /* !< Compare up event 5 SET */
+#define GPTIMER_GEN_EVENT1_ISET_CCU5_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_CCU5_SET         ((uint32_t)0x00008000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT1_ISET[REPC] Bits */
+#define GPTIMER_GEN_EVENT1_ISET_REPC_OFS         (26)                            /* !< REPC Offset */
+#define GPTIMER_GEN_EVENT1_ISET_REPC_MASK        ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero event SET */
+#define GPTIMER_GEN_EVENT1_ISET_REPC_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ISET_REPC_SET         ((uint32_t)0x04000000U)         /* !< Event Set */
+
+/* GPTIMER_GEN_EVENT1_ICLR Bits */
+/* GPTIMER_GEN_EVENT1_ICLR[Z] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_Z_OFS            (0)                             /* !< Z Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_Z_MASK           ((uint32_t)0x00000001U)         /* !< Zero event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_Z_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_Z_CLR            ((uint32_t)0x00000001U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[L] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_L_OFS            (1)                             /* !< L Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_L_MASK           ((uint32_t)0x00000002U)         /* !< Load event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_L_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_L_CLR            ((uint32_t)0x00000002U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[CCD0] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD0_OFS         (4)                             /* !< CCD0 Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD0_MASK        ((uint32_t)0x00000010U)         /* !< Capture or compare down event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD0_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD0_CLR         ((uint32_t)0x00000010U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[CCD1] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD1_OFS         (5)                             /* !< CCD1 Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD1_MASK        ((uint32_t)0x00000020U)         /* !< Capture or compare down event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD1_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD1_CLR         ((uint32_t)0x00000020U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[CCU0] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU0_OFS         (8)                             /* !< CCU0 Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU0_MASK        ((uint32_t)0x00000100U)         /* !< Capture or compare up event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU0_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU0_CLR         ((uint32_t)0x00000100U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[CCU1] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU1_OFS         (9)                             /* !< CCU1 Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU1_MASK        ((uint32_t)0x00000200U)         /* !< Capture or compare up event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU1_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU1_CLR         ((uint32_t)0x00000200U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[F] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_F_OFS            (24)                            /* !< F Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_F_MASK           ((uint32_t)0x01000000U)         /* !< Fault event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_F_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_F_CLR            ((uint32_t)0x01000000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[TOV] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_TOV_OFS          (25)                            /* !< TOV Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_TOV_MASK         ((uint32_t)0x02000000U)         /* !< Trigger Overflow event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_TOV_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_TOV_CLR          ((uint32_t)0x02000000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[DC] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_DC_OFS           (27)                            /* !< DC Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_DC_MASK          ((uint32_t)0x08000000U)         /* !< Direction Change event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_DC_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_DC_CLR           ((uint32_t)0x08000000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[QEIERR] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_QEIERR_OFS       (28)                            /* !< QEIERR Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_QEIERR_MASK      ((uint32_t)0x10000000U)         /* !< QEIERR event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_QEIERR_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_QEIERR_CLR       ((uint32_t)0x10000000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[CCD2] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD2_OFS         (6)                             /* !< CCD2 Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD2_MASK        ((uint32_t)0x00000040U)         /* !< Capture or compare down event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD2_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD2_CLR         ((uint32_t)0x00000040U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[CCD3] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD3_OFS         (7)                             /* !< CCD3 Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD3_MASK        ((uint32_t)0x00000080U)         /* !< Capture or compare down event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD3_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD3_CLR         ((uint32_t)0x00000080U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[CCU2] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU2_OFS         (10)                            /* !< CCU2 Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU2_MASK        ((uint32_t)0x00000400U)         /* !< Capture or compare up event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU2_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU2_CLR         ((uint32_t)0x00000400U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[CCU3] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU3_OFS         (11)                            /* !< CCU3 Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU3_MASK        ((uint32_t)0x00000800U)         /* !< Capture or compare up event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU3_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU3_CLR         ((uint32_t)0x00000800U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[CCD4] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD4_OFS         (12)                            /* !< CCD4 Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD4_MASK        ((uint32_t)0x00001000U)         /* !< Compare down event 4 CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD4_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD4_CLR         ((uint32_t)0x00001000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[CCD5] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD5_OFS         (13)                            /* !< CCD5 Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD5_MASK        ((uint32_t)0x00002000U)         /* !< Compare down event 5 CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD5_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_CCD5_CLR         ((uint32_t)0x00002000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[CCU4] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU4_OFS         (14)                            /* !< CCU4 Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU4_MASK        ((uint32_t)0x00004000U)         /* !< Compare up event 4 CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU4_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU4_CLR         ((uint32_t)0x00004000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[CCU5] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU5_OFS         (15)                            /* !< CCU5 Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU5_MASK        ((uint32_t)0x00008000U)         /* !< Compare up event 5 CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU5_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_CCU5_CLR         ((uint32_t)0x00008000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT1_ICLR[REPC] Bits */
+#define GPTIMER_GEN_EVENT1_ICLR_REPC_OFS         (26)                            /* !< REPC Offset */
+#define GPTIMER_GEN_EVENT1_ICLR_REPC_MASK        ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero event CLEAR */
+#define GPTIMER_GEN_EVENT1_ICLR_REPC_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT1_ICLR_REPC_CLR         ((uint32_t)0x04000000U)         /* !< Event Clear */
+
+/* GPTIMER_GEN_EVENT0_IIDX Bits */
+/* GPTIMER_GEN_EVENT0_IIDX[STAT] Bits */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_OFS         (0)                             /* !< STAT Offset */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_MASK        ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_NO_INTR     ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_Z           ((uint32_t)0x00000001U)         /* !< Interrupt Source: Zero event (Z) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_L           ((uint32_t)0x00000002U)         /* !< nterrupt Source: Load event (L) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_CCD0        ((uint32_t)0x00000005U)         /* !< Interrupt Source: Capture or
+                                                                                    compare down event (CCD0) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_CCD1        ((uint32_t)0x00000006U)         /* !< Interrupt Source: Capture or
+                                                                                    compare down event (CCD1) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_CCD2        ((uint32_t)0x00000007U)         /* !< Interrupt Source: Capture or
+                                                                                    compare down event (CCD2) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_CCD3        ((uint32_t)0x00000008U)         /* !< Interrupt Source: Capture or
+                                                                                    compare down event (CCD3) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_CCU0        ((uint32_t)0x00000009U)         /* !< Interrupt Source: Capture or
+                                                                                    compare up event (CCU0) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_CCU1        ((uint32_t)0x0000000AU)         /* !< Interrupt Source: Capture or
+                                                                                    compare up event (CCU1) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_CCU2        ((uint32_t)0x0000000BU)         /* !< Interrupt Source: Capture or
+                                                                                    compare up event (CCU2) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_CCU3        ((uint32_t)0x0000000CU)         /* !< Interrupt Source: Capture or
+                                                                                    compare up event (CCU3) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_CCD4        ((uint32_t)0x0000000DU)         /* !< Interrupt Source: Compare down
+                                                                                    event (CCD4) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_CCD5        ((uint32_t)0x0000000EU)         /* !< Interrupt Source: Compare down
+                                                                                    event (CCD5) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_CCU4        ((uint32_t)0x0000000FU)         /* !< Interrupt Source: Compare down
+                                                                                    event (CCU4) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_CCU5        ((uint32_t)0x00000010U)         /* !< Interrupt Source: Compare down
+                                                                                    event (CCU5) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_F           ((uint32_t)0x00000019U)         /* !< Interrupt Source: Fault Event
+                                                                                    generated an interrupt. (F) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_TOV         ((uint32_t)0x0000001AU)         /* !< Interrupt Source: Trigger overflow
+                                                                                    (TOV) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_REPC        ((uint32_t)0x0000001BU)         /* !< Interrupt Source: Repeat Counter
+                                                                                    Zero (REPC) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_DC          ((uint32_t)0x0000001CU)         /* !< Interrupt Source: Direction Change
+                                                                                    (DC) */
+#define GPTIMER_GEN_EVENT0_IIDX_STAT_QEIERR      ((uint32_t)0x0000001DU)         /* !< Interrupt Source:QEI Incorrect
+                                                                                    state transition error (QEIERR) */
+
+/* GPTIMER_GEN_EVENT0_IMASK Bits */
+/* GPTIMER_GEN_EVENT0_IMASK[Z] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_Z_OFS           (0)                             /* !< Z Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_Z_MASK          ((uint32_t)0x00000001U)         /* !< Zero Event mask */
+#define GPTIMER_GEN_EVENT0_IMASK_Z_CLR           ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_GEN_EVENT0_IMASK_Z_SET           ((uint32_t)0x00000001U)         /* !< Enable Event */
+/* GPTIMER_GEN_EVENT0_IMASK[L] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_L_OFS           (1)                             /* !< L Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_L_MASK          ((uint32_t)0x00000002U)         /* !< Load Event mask */
+#define GPTIMER_GEN_EVENT0_IMASK_L_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT0_IMASK_L_SET           ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT0_IMASK[CCD0] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD0_OFS        (4)                             /* !< CCD0 Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD0_MASK       ((uint32_t)0x00000010U)         /* !< Capture or Compare DN event mask
+                                                                                    CCP0 */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD0_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD0_SET        ((uint32_t)0x00000010U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT0_IMASK[CCD1] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD1_OFS        (5)                             /* !< CCD1 Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD1_MASK       ((uint32_t)0x00000020U)         /* !< Capture or Compare DN event mask
+                                                                                    CCP1 */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD1_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD1_SET        ((uint32_t)0x00000020U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT0_IMASK[CCU0] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU0_OFS        (8)                             /* !< CCU0 Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU0_MASK       ((uint32_t)0x00000100U)         /* !< Capture or Compare UP event mask
+                                                                                    CCP0 */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU0_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU0_SET        ((uint32_t)0x00000100U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT0_IMASK[CCU1] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU1_OFS        (9)                             /* !< CCU1 Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU1_MASK       ((uint32_t)0x00000200U)         /* !< Capture or Compare UP event mask
+                                                                                    CCP1 */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU1_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU1_SET        ((uint32_t)0x00000200U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT0_IMASK[F] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_F_OFS           (24)                            /* !< F Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_F_MASK          ((uint32_t)0x01000000U)         /* !< Fault Event mask */
+#define GPTIMER_GEN_EVENT0_IMASK_F_CLR           ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_GEN_EVENT0_IMASK_F_SET           ((uint32_t)0x01000000U)         /* !< Enable Event */
+/* GPTIMER_GEN_EVENT0_IMASK[TOV] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_TOV_OFS         (25)                            /* !< TOV Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_TOV_MASK        ((uint32_t)0x02000000U)         /* !< Trigger Overflow Event mask */
+#define GPTIMER_GEN_EVENT0_IMASK_TOV_CLR         ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_GEN_EVENT0_IMASK_TOV_SET         ((uint32_t)0x02000000U)         /* !< Enable Event */
+/* GPTIMER_GEN_EVENT0_IMASK[DC] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_DC_OFS          (27)                            /* !< DC Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_DC_MASK         ((uint32_t)0x08000000U)         /* !< Direction Change Event mask */
+#define GPTIMER_GEN_EVENT0_IMASK_DC_CLR          ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_GEN_EVENT0_IMASK_DC_SET          ((uint32_t)0x08000000U)         /* !< Enable Event */
+/* GPTIMER_GEN_EVENT0_IMASK[QEIERR] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_QEIERR_OFS      (28)                            /* !< QEIERR Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_QEIERR_MASK     ((uint32_t)0x10000000U)         /* !< QEIERR Event mask */
+#define GPTIMER_GEN_EVENT0_IMASK_QEIERR_CLR      ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_GEN_EVENT0_IMASK_QEIERR_SET      ((uint32_t)0x10000000U)         /* !< Enable Event */
+/* GPTIMER_GEN_EVENT0_IMASK[CCD2] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD2_OFS        (6)                             /* !< CCD2 Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD2_MASK       ((uint32_t)0x00000040U)         /* !< Capture or Compare DN event mask
+                                                                                    CCP2 */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD2_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD2_SET        ((uint32_t)0x00000040U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT0_IMASK[CCD3] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD3_OFS        (7)                             /* !< CCD3 Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD3_MASK       ((uint32_t)0x00000080U)         /* !< Capture or Compare DN event mask
+                                                                                    CCP3 */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD3_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD3_SET        ((uint32_t)0x00000080U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT0_IMASK[CCU2] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU2_OFS        (10)                            /* !< CCU2 Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU2_MASK       ((uint32_t)0x00000400U)         /* !< Capture or Compare UP event mask
+                                                                                    CCP2 */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU2_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU2_SET        ((uint32_t)0x00000400U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT0_IMASK[CCU3] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU3_OFS        (11)                            /* !< CCU3 Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU3_MASK       ((uint32_t)0x00000800U)         /* !< Capture or Compare UP event mask
+                                                                                    CCP3 */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU3_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU3_SET        ((uint32_t)0x00000800U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT0_IMASK[CCD4] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD4_OFS        (12)                            /* !< CCD4 Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD4_MASK       ((uint32_t)0x00001000U)         /* !< Compare DN event mask CCP4 */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD4_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD4_SET        ((uint32_t)0x00001000U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT0_IMASK[CCD5] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD5_OFS        (13)                            /* !< CCD5 Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD5_MASK       ((uint32_t)0x00002000U)         /* !< Compare DN event mask CCP5 */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD5_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT0_IMASK_CCD5_SET        ((uint32_t)0x00002000U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT0_IMASK[CCU4] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU4_OFS        (14)                            /* !< CCU4 Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU4_MASK       ((uint32_t)0x00004000U)         /* !< Compare UP event mask CCP4 */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU4_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU4_SET        ((uint32_t)0x00004000U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT0_IMASK[CCU5] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU5_OFS        (15)                            /* !< CCU5 Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU5_MASK       ((uint32_t)0x00008000U)         /* !< Compare UP event mask CCP5 */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU5_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_GEN_EVENT0_IMASK_CCU5_SET        ((uint32_t)0x00008000U)         /* !< Set Interrupt Mask */
+/* GPTIMER_GEN_EVENT0_IMASK[REPC] Bits */
+#define GPTIMER_GEN_EVENT0_IMASK_REPC_OFS        (26)                            /* !< REPC Offset */
+#define GPTIMER_GEN_EVENT0_IMASK_REPC_MASK       ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero Event mask */
+#define GPTIMER_GEN_EVENT0_IMASK_REPC_CLR        ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_GEN_EVENT0_IMASK_REPC_SET        ((uint32_t)0x04000000U)         /* !< Enable Event */
+
+/* GPTIMER_GEN_EVENT0_RIS Bits */
+/* GPTIMER_GEN_EVENT0_RIS[Z] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_Z_OFS             (0)                             /* !< Z Offset */
+#define GPTIMER_GEN_EVENT0_RIS_Z_MASK            ((uint32_t)0x00000001U)         /* !< Zero event generated an interrupt. */
+#define GPTIMER_GEN_EVENT0_RIS_Z_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_Z_SET             ((uint32_t)0x00000001U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[L] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_L_OFS             (1)                             /* !< L Offset */
+#define GPTIMER_GEN_EVENT0_RIS_L_MASK            ((uint32_t)0x00000002U)         /* !< Load event generated an interrupt. */
+#define GPTIMER_GEN_EVENT0_RIS_L_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_L_SET             ((uint32_t)0x00000002U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[CCD0] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_CCD0_OFS          (4)                             /* !< CCD0 Offset */
+#define GPTIMER_GEN_EVENT0_RIS_CCD0_MASK         ((uint32_t)0x00000010U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP0 */
+#define GPTIMER_GEN_EVENT0_RIS_CCD0_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_CCD0_SET          ((uint32_t)0x00000010U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[CCD1] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_CCD1_OFS          (5)                             /* !< CCD1 Offset */
+#define GPTIMER_GEN_EVENT0_RIS_CCD1_MASK         ((uint32_t)0x00000020U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP1 */
+#define GPTIMER_GEN_EVENT0_RIS_CCD1_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_CCD1_SET          ((uint32_t)0x00000020U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[CCU0] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_CCU0_OFS          (8)                             /* !< CCU0 Offset */
+#define GPTIMER_GEN_EVENT0_RIS_CCU0_MASK         ((uint32_t)0x00000100U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP0 */
+#define GPTIMER_GEN_EVENT0_RIS_CCU0_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_CCU0_SET          ((uint32_t)0x00000100U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[CCU1] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_CCU1_OFS          (9)                             /* !< CCU1 Offset */
+#define GPTIMER_GEN_EVENT0_RIS_CCU1_MASK         ((uint32_t)0x00000200U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP1 */
+#define GPTIMER_GEN_EVENT0_RIS_CCU1_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_CCU1_SET          ((uint32_t)0x00000200U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[TOV] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_TOV_OFS           (25)                            /* !< TOV Offset */
+#define GPTIMER_GEN_EVENT0_RIS_TOV_MASK          ((uint32_t)0x02000000U)         /* !< Trigger overflow */
+#define GPTIMER_GEN_EVENT0_RIS_TOV_CLR           ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_TOV_SET           ((uint32_t)0x02000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[F] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_F_OFS             (24)                            /* !< F Offset */
+#define GPTIMER_GEN_EVENT0_RIS_F_MASK            ((uint32_t)0x01000000U)         /* !< Fault */
+#define GPTIMER_GEN_EVENT0_RIS_F_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_F_SET             ((uint32_t)0x01000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[DC] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_DC_OFS            (27)                            /* !< DC Offset */
+#define GPTIMER_GEN_EVENT0_RIS_DC_MASK           ((uint32_t)0x08000000U)         /* !< Direction Change */
+#define GPTIMER_GEN_EVENT0_RIS_DC_CLR            ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_DC_SET            ((uint32_t)0x08000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[QEIERR] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_QEIERR_OFS        (28)                            /* !< QEIERR Offset */
+#define GPTIMER_GEN_EVENT0_RIS_QEIERR_MASK       ((uint32_t)0x10000000U)         /* !< QEIERR, set on an incorrect state
+                                                                                    transition on the encoder interface. */
+#define GPTIMER_GEN_EVENT0_RIS_QEIERR_CLR        ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_QEIERR_SET        ((uint32_t)0x10000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[CCD2] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_CCD2_OFS          (6)                             /* !< CCD2 Offset */
+#define GPTIMER_GEN_EVENT0_RIS_CCD2_MASK         ((uint32_t)0x00000040U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP2 */
+#define GPTIMER_GEN_EVENT0_RIS_CCD2_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_CCD2_SET          ((uint32_t)0x00000040U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[CCD3] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_CCD3_OFS          (7)                             /* !< CCD3 Offset */
+#define GPTIMER_GEN_EVENT0_RIS_CCD3_MASK         ((uint32_t)0x00000080U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP3 */
+#define GPTIMER_GEN_EVENT0_RIS_CCD3_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_CCD3_SET          ((uint32_t)0x00000080U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[CCU2] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_CCU2_OFS          (10)                            /* !< CCU2 Offset */
+#define GPTIMER_GEN_EVENT0_RIS_CCU2_MASK         ((uint32_t)0x00000400U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP2 */
+#define GPTIMER_GEN_EVENT0_RIS_CCU2_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_CCU2_SET          ((uint32_t)0x00000400U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[CCU3] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_CCU3_OFS          (11)                            /* !< CCU3 Offset */
+#define GPTIMER_GEN_EVENT0_RIS_CCU3_MASK         ((uint32_t)0x00000800U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP3 */
+#define GPTIMER_GEN_EVENT0_RIS_CCU3_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_CCU3_SET          ((uint32_t)0x00000800U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[CCD4] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_CCD4_OFS          (12)                            /* !< CCD4 Offset */
+#define GPTIMER_GEN_EVENT0_RIS_CCD4_MASK         ((uint32_t)0x00001000U)         /* !< Compare down event generated an
+                                                                                    interrupt CCD4 */
+#define GPTIMER_GEN_EVENT0_RIS_CCD4_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_CCD4_SET          ((uint32_t)0x00001000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[CCD5] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_CCD5_OFS          (13)                            /* !< CCD5 Offset */
+#define GPTIMER_GEN_EVENT0_RIS_CCD5_MASK         ((uint32_t)0x00002000U)         /* !< Compare down event generated an
+                                                                                    interrupt CCD5 */
+#define GPTIMER_GEN_EVENT0_RIS_CCD5_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_CCD5_SET          ((uint32_t)0x00002000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[CCU4] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_CCU4_OFS          (14)                            /* !< CCU4 Offset */
+#define GPTIMER_GEN_EVENT0_RIS_CCU4_MASK         ((uint32_t)0x00004000U)         /* !< Compare up event generated an
+                                                                                    interrupt CCU4 */
+#define GPTIMER_GEN_EVENT0_RIS_CCU4_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_CCU4_SET          ((uint32_t)0x00004000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[CCU5] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_CCU5_OFS          (15)                            /* !< CCU5 Offset */
+#define GPTIMER_GEN_EVENT0_RIS_CCU5_MASK         ((uint32_t)0x00008000U)         /* !< Compare up event generated an
+                                                                                    interrupt CCP5 */
+#define GPTIMER_GEN_EVENT0_RIS_CCU5_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_CCU5_SET          ((uint32_t)0x00008000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_RIS[REPC] Bits */
+#define GPTIMER_GEN_EVENT0_RIS_REPC_OFS          (26)                            /* !< REPC Offset */
+#define GPTIMER_GEN_EVENT0_RIS_REPC_MASK         ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero */
+#define GPTIMER_GEN_EVENT0_RIS_REPC_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_RIS_REPC_SET          ((uint32_t)0x04000000U)         /* !< Event Set */
+
+/* GPTIMER_GEN_EVENT0_MIS Bits */
+/* GPTIMER_GEN_EVENT0_MIS[Z] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_Z_OFS             (0)                             /* !< Z Offset */
+#define GPTIMER_GEN_EVENT0_MIS_Z_MASK            ((uint32_t)0x00000001U)         /* !< Zero event generated an interrupt. */
+#define GPTIMER_GEN_EVENT0_MIS_Z_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_Z_SET             ((uint32_t)0x00000001U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[L] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_L_OFS             (1)                             /* !< L Offset */
+#define GPTIMER_GEN_EVENT0_MIS_L_MASK            ((uint32_t)0x00000002U)         /* !< Load event generated an interrupt. */
+#define GPTIMER_GEN_EVENT0_MIS_L_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_L_SET             ((uint32_t)0x00000002U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[CCD0] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_CCD0_OFS          (4)                             /* !< CCD0 Offset */
+#define GPTIMER_GEN_EVENT0_MIS_CCD0_MASK         ((uint32_t)0x00000010U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP0 */
+#define GPTIMER_GEN_EVENT0_MIS_CCD0_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_CCD0_SET          ((uint32_t)0x00000010U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[CCD1] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_CCD1_OFS          (5)                             /* !< CCD1 Offset */
+#define GPTIMER_GEN_EVENT0_MIS_CCD1_MASK         ((uint32_t)0x00000020U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP1 */
+#define GPTIMER_GEN_EVENT0_MIS_CCD1_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_CCD1_SET          ((uint32_t)0x00000020U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[CCU0] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_CCU0_OFS          (8)                             /* !< CCU0 Offset */
+#define GPTIMER_GEN_EVENT0_MIS_CCU0_MASK         ((uint32_t)0x00000100U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP0 */
+#define GPTIMER_GEN_EVENT0_MIS_CCU0_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_CCU0_SET          ((uint32_t)0x00000100U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[CCU1] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_CCU1_OFS          (9)                             /* !< CCU1 Offset */
+#define GPTIMER_GEN_EVENT0_MIS_CCU1_MASK         ((uint32_t)0x00000200U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP1 */
+#define GPTIMER_GEN_EVENT0_MIS_CCU1_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_CCU1_SET          ((uint32_t)0x00000200U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[F] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_F_OFS             (24)                            /* !< F Offset */
+#define GPTIMER_GEN_EVENT0_MIS_F_MASK            ((uint32_t)0x01000000U)         /* !< Fault */
+#define GPTIMER_GEN_EVENT0_MIS_F_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_F_SET             ((uint32_t)0x01000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[TOV] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_TOV_OFS           (25)                            /* !< TOV Offset */
+#define GPTIMER_GEN_EVENT0_MIS_TOV_MASK          ((uint32_t)0x02000000U)         /* !< Trigger overflow */
+#define GPTIMER_GEN_EVENT0_MIS_TOV_CLR           ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_TOV_SET           ((uint32_t)0x02000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[DC] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_DC_OFS            (27)                            /* !< DC Offset */
+#define GPTIMER_GEN_EVENT0_MIS_DC_MASK           ((uint32_t)0x08000000U)         /* !< Direction Change */
+#define GPTIMER_GEN_EVENT0_MIS_DC_CLR            ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_DC_SET            ((uint32_t)0x08000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[QEIERR] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_QEIERR_OFS        (28)                            /* !< QEIERR Offset */
+#define GPTIMER_GEN_EVENT0_MIS_QEIERR_MASK       ((uint32_t)0x10000000U)         /* !< QEIERR */
+#define GPTIMER_GEN_EVENT0_MIS_QEIERR_CLR        ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_QEIERR_SET        ((uint32_t)0x10000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[CCD2] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_CCD2_OFS          (6)                             /* !< CCD2 Offset */
+#define GPTIMER_GEN_EVENT0_MIS_CCD2_MASK         ((uint32_t)0x00000040U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP2 */
+#define GPTIMER_GEN_EVENT0_MIS_CCD2_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_CCD2_SET          ((uint32_t)0x00000040U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[CCD3] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_CCD3_OFS          (7)                             /* !< CCD3 Offset */
+#define GPTIMER_GEN_EVENT0_MIS_CCD3_MASK         ((uint32_t)0x00000080U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP3 */
+#define GPTIMER_GEN_EVENT0_MIS_CCD3_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_CCD3_SET          ((uint32_t)0x00000080U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[CCU2] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_CCU2_OFS          (10)                            /* !< CCU2 Offset */
+#define GPTIMER_GEN_EVENT0_MIS_CCU2_MASK         ((uint32_t)0x00000400U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP2 */
+#define GPTIMER_GEN_EVENT0_MIS_CCU2_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_CCU2_SET          ((uint32_t)0x00000400U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[CCU3] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_CCU3_OFS          (11)                            /* !< CCU3 Offset */
+#define GPTIMER_GEN_EVENT0_MIS_CCU3_MASK         ((uint32_t)0x00000800U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP3 */
+#define GPTIMER_GEN_EVENT0_MIS_CCU3_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_CCU3_SET          ((uint32_t)0x00000800U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[CCD4] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_CCD4_OFS          (12)                            /* !< CCD4 Offset */
+#define GPTIMER_GEN_EVENT0_MIS_CCD4_MASK         ((uint32_t)0x00001000U)         /* !< Compare down event generated an
+                                                                                    interrupt CCP4 */
+#define GPTIMER_GEN_EVENT0_MIS_CCD4_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_CCD4_SET          ((uint32_t)0x00001000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[CCD5] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_CCD5_OFS          (13)                            /* !< CCD5 Offset */
+#define GPTIMER_GEN_EVENT0_MIS_CCD5_MASK         ((uint32_t)0x00002000U)         /* !< Compare down event generated an
+                                                                                    interrupt CCP5 */
+#define GPTIMER_GEN_EVENT0_MIS_CCD5_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_CCD5_SET          ((uint32_t)0x00002000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[CCU4] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_CCU4_OFS          (14)                            /* !< CCU4 Offset */
+#define GPTIMER_GEN_EVENT0_MIS_CCU4_MASK         ((uint32_t)0x00004000U)         /* !< Compare up event generated an
+                                                                                    interrupt CCP4 */
+#define GPTIMER_GEN_EVENT0_MIS_CCU4_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_CCU4_SET          ((uint32_t)0x00004000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[CCU5] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_CCU5_OFS          (15)                            /* !< CCU5 Offset */
+#define GPTIMER_GEN_EVENT0_MIS_CCU5_MASK         ((uint32_t)0x00008000U)         /* !< Compare up event generated an
+                                                                                    interrupt CCP5 */
+#define GPTIMER_GEN_EVENT0_MIS_CCU5_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_CCU5_SET          ((uint32_t)0x00008000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_MIS[REPC] Bits */
+#define GPTIMER_GEN_EVENT0_MIS_REPC_OFS          (26)                            /* !< REPC Offset */
+#define GPTIMER_GEN_EVENT0_MIS_REPC_MASK         ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero */
+#define GPTIMER_GEN_EVENT0_MIS_REPC_CLR          ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_GEN_EVENT0_MIS_REPC_SET          ((uint32_t)0x04000000U)         /* !< Event Set */
+
+/* GPTIMER_GEN_EVENT0_ISET Bits */
+/* GPTIMER_GEN_EVENT0_ISET[Z] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_Z_OFS            (0)                             /* !< Z Offset */
+#define GPTIMER_GEN_EVENT0_ISET_Z_MASK           ((uint32_t)0x00000001U)         /* !< Zero event SET */
+#define GPTIMER_GEN_EVENT0_ISET_Z_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_Z_SET            ((uint32_t)0x00000001U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[L] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_L_OFS            (1)                             /* !< L Offset */
+#define GPTIMER_GEN_EVENT0_ISET_L_MASK           ((uint32_t)0x00000002U)         /* !< Load event SET */
+#define GPTIMER_GEN_EVENT0_ISET_L_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_L_SET            ((uint32_t)0x00000002U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[CCD0] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_CCD0_OFS         (4)                             /* !< CCD0 Offset */
+#define GPTIMER_GEN_EVENT0_ISET_CCD0_MASK        ((uint32_t)0x00000010U)         /* !< Capture or compare down event SET */
+#define GPTIMER_GEN_EVENT0_ISET_CCD0_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_CCD0_SET         ((uint32_t)0x00000010U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[CCD1] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_CCD1_OFS         (5)                             /* !< CCD1 Offset */
+#define GPTIMER_GEN_EVENT0_ISET_CCD1_MASK        ((uint32_t)0x00000020U)         /* !< Capture or compare down event SET */
+#define GPTIMER_GEN_EVENT0_ISET_CCD1_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_CCD1_SET         ((uint32_t)0x00000020U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[CCU0] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_CCU0_OFS         (8)                             /* !< CCU0 Offset */
+#define GPTIMER_GEN_EVENT0_ISET_CCU0_MASK        ((uint32_t)0x00000100U)         /* !< Capture or compare up event SET */
+#define GPTIMER_GEN_EVENT0_ISET_CCU0_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_CCU0_SET         ((uint32_t)0x00000100U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[CCU1] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_CCU1_OFS         (9)                             /* !< CCU1 Offset */
+#define GPTIMER_GEN_EVENT0_ISET_CCU1_MASK        ((uint32_t)0x00000200U)         /* !< Capture or compare up event SET */
+#define GPTIMER_GEN_EVENT0_ISET_CCU1_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_CCU1_SET         ((uint32_t)0x00000200U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[F] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_F_OFS            (24)                            /* !< F Offset */
+#define GPTIMER_GEN_EVENT0_ISET_F_MASK           ((uint32_t)0x01000000U)         /* !< Fault event SET */
+#define GPTIMER_GEN_EVENT0_ISET_F_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_F_SET            ((uint32_t)0x01000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[TOV] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_TOV_OFS          (25)                            /* !< TOV Offset */
+#define GPTIMER_GEN_EVENT0_ISET_TOV_MASK         ((uint32_t)0x02000000U)         /* !< Trigger Overflow event SET */
+#define GPTIMER_GEN_EVENT0_ISET_TOV_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_TOV_SET          ((uint32_t)0x02000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[DC] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_DC_OFS           (27)                            /* !< DC Offset */
+#define GPTIMER_GEN_EVENT0_ISET_DC_MASK          ((uint32_t)0x08000000U)         /* !< Direction Change event SET */
+#define GPTIMER_GEN_EVENT0_ISET_DC_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_DC_SET           ((uint32_t)0x08000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[QEIERR] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_QEIERR_OFS       (28)                            /* !< QEIERR Offset */
+#define GPTIMER_GEN_EVENT0_ISET_QEIERR_MASK      ((uint32_t)0x10000000U)         /* !< QEIERR event SET */
+#define GPTIMER_GEN_EVENT0_ISET_QEIERR_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_QEIERR_SET       ((uint32_t)0x10000000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[CCD2] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_CCD2_OFS         (6)                             /* !< CCD2 Offset */
+#define GPTIMER_GEN_EVENT0_ISET_CCD2_MASK        ((uint32_t)0x00000040U)         /* !< Capture or compare down event SET */
+#define GPTIMER_GEN_EVENT0_ISET_CCD2_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_CCD2_SET         ((uint32_t)0x00000040U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[CCD3] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_CCD3_OFS         (7)                             /* !< CCD3 Offset */
+#define GPTIMER_GEN_EVENT0_ISET_CCD3_MASK        ((uint32_t)0x00000080U)         /* !< Capture or compare down event SET */
+#define GPTIMER_GEN_EVENT0_ISET_CCD3_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_CCD3_SET         ((uint32_t)0x00000080U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[CCU2] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_CCU2_OFS         (10)                            /* !< CCU2 Offset */
+#define GPTIMER_GEN_EVENT0_ISET_CCU2_MASK        ((uint32_t)0x00000400U)         /* !< Capture or compare up event SET */
+#define GPTIMER_GEN_EVENT0_ISET_CCU2_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_CCU2_SET         ((uint32_t)0x00000400U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[CCU3] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_CCU3_OFS         (11)                            /* !< CCU3 Offset */
+#define GPTIMER_GEN_EVENT0_ISET_CCU3_MASK        ((uint32_t)0x00000800U)         /* !< Capture or compare up event SET */
+#define GPTIMER_GEN_EVENT0_ISET_CCU3_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_CCU3_SET         ((uint32_t)0x00000800U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[CCD4] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_CCD4_OFS         (12)                            /* !< CCD4 Offset */
+#define GPTIMER_GEN_EVENT0_ISET_CCD4_MASK        ((uint32_t)0x00001000U)         /* !< Compare down event 4 SET */
+#define GPTIMER_GEN_EVENT0_ISET_CCD4_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_CCD4_SET         ((uint32_t)0x00001000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[CCD5] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_CCD5_OFS         (13)                            /* !< CCD5 Offset */
+#define GPTIMER_GEN_EVENT0_ISET_CCD5_MASK        ((uint32_t)0x00002000U)         /* !< Compare down event 5 SET */
+#define GPTIMER_GEN_EVENT0_ISET_CCD5_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_CCD5_SET         ((uint32_t)0x00002000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[CCU4] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_CCU4_OFS         (14)                            /* !< CCU4 Offset */
+#define GPTIMER_GEN_EVENT0_ISET_CCU4_MASK        ((uint32_t)0x00004000U)         /* !< Compare up event 4 SET */
+#define GPTIMER_GEN_EVENT0_ISET_CCU4_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_CCU4_SET         ((uint32_t)0x00004000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[CCU5] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_CCU5_OFS         (15)                            /* !< CCU5 Offset */
+#define GPTIMER_GEN_EVENT0_ISET_CCU5_MASK        ((uint32_t)0x00008000U)         /* !< Compare up event 5 SET */
+#define GPTIMER_GEN_EVENT0_ISET_CCU5_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_CCU5_SET         ((uint32_t)0x00008000U)         /* !< Event Set */
+/* GPTIMER_GEN_EVENT0_ISET[REPC] Bits */
+#define GPTIMER_GEN_EVENT0_ISET_REPC_OFS         (26)                            /* !< REPC Offset */
+#define GPTIMER_GEN_EVENT0_ISET_REPC_MASK        ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero event SET */
+#define GPTIMER_GEN_EVENT0_ISET_REPC_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ISET_REPC_SET         ((uint32_t)0x04000000U)         /* !< Event Set */
+
+/* GPTIMER_GEN_EVENT0_ICLR Bits */
+/* GPTIMER_GEN_EVENT0_ICLR[Z] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_Z_OFS            (0)                             /* !< Z Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_Z_MASK           ((uint32_t)0x00000001U)         /* !< Zero event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_Z_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_Z_CLR            ((uint32_t)0x00000001U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[L] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_L_OFS            (1)                             /* !< L Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_L_MASK           ((uint32_t)0x00000002U)         /* !< Load event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_L_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_L_CLR            ((uint32_t)0x00000002U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[CCD0] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD0_OFS         (4)                             /* !< CCD0 Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD0_MASK        ((uint32_t)0x00000010U)         /* !< Capture or compare down event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD0_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD0_CLR         ((uint32_t)0x00000010U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[CCD1] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD1_OFS         (5)                             /* !< CCD1 Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD1_MASK        ((uint32_t)0x00000020U)         /* !< Capture or compare down event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD1_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD1_CLR         ((uint32_t)0x00000020U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[CCU0] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU0_OFS         (8)                             /* !< CCU0 Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU0_MASK        ((uint32_t)0x00000100U)         /* !< Capture or compare up event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU0_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU0_CLR         ((uint32_t)0x00000100U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[CCU1] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU1_OFS         (9)                             /* !< CCU1 Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU1_MASK        ((uint32_t)0x00000200U)         /* !< Capture or compare up event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU1_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU1_CLR         ((uint32_t)0x00000200U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[F] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_F_OFS            (24)                            /* !< F Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_F_MASK           ((uint32_t)0x01000000U)         /* !< Fault event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_F_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_F_CLR            ((uint32_t)0x01000000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[TOV] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_TOV_OFS          (25)                            /* !< TOV Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_TOV_MASK         ((uint32_t)0x02000000U)         /* !< Trigger Overflow event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_TOV_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_TOV_CLR          ((uint32_t)0x02000000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[DC] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_DC_OFS           (27)                            /* !< DC Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_DC_MASK          ((uint32_t)0x08000000U)         /* !< Direction Change event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_DC_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_DC_CLR           ((uint32_t)0x08000000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[QEIERR] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_QEIERR_OFS       (28)                            /* !< QEIERR Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_QEIERR_MASK      ((uint32_t)0x10000000U)         /* !< QEIERR event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_QEIERR_NO_EFFECT ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_QEIERR_CLR       ((uint32_t)0x10000000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[CCD2] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD2_OFS         (6)                             /* !< CCD2 Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD2_MASK        ((uint32_t)0x00000040U)         /* !< Capture or compare down event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD2_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD2_CLR         ((uint32_t)0x00000040U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[CCD3] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD3_OFS         (7)                             /* !< CCD3 Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD3_MASK        ((uint32_t)0x00000080U)         /* !< Capture or compare down event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD3_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD3_CLR         ((uint32_t)0x00000080U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[CCU2] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU2_OFS         (10)                            /* !< CCU2 Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU2_MASK        ((uint32_t)0x00000400U)         /* !< Capture or compare up event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU2_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU2_CLR         ((uint32_t)0x00000400U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[CCU3] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU3_OFS         (11)                            /* !< CCU3 Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU3_MASK        ((uint32_t)0x00000800U)         /* !< Capture or compare up event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU3_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU3_CLR         ((uint32_t)0x00000800U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[CCD4] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD4_OFS         (12)                            /* !< CCD4 Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD4_MASK        ((uint32_t)0x00001000U)         /* !< Compare down event 4 CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD4_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD4_CLR         ((uint32_t)0x00001000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[CCD5] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD5_OFS         (13)                            /* !< CCD5 Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD5_MASK        ((uint32_t)0x00002000U)         /* !< Compare down event 5 CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD5_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_CCD5_CLR         ((uint32_t)0x00002000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[CCU4] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU4_OFS         (14)                            /* !< CCU4 Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU4_MASK        ((uint32_t)0x00004000U)         /* !< Compare up event 4 CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU4_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU4_CLR         ((uint32_t)0x00004000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[CCU5] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU5_OFS         (15)                            /* !< CCU5 Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU5_MASK        ((uint32_t)0x00008000U)         /* !< Compare up event 5 CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU5_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_CCU5_CLR         ((uint32_t)0x00008000U)         /* !< Event Clear */
+/* GPTIMER_GEN_EVENT0_ICLR[REPC] Bits */
+#define GPTIMER_GEN_EVENT0_ICLR_REPC_OFS         (26)                            /* !< REPC Offset */
+#define GPTIMER_GEN_EVENT0_ICLR_REPC_MASK        ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero event CLEAR */
+#define GPTIMER_GEN_EVENT0_ICLR_REPC_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_GEN_EVENT0_ICLR_REPC_CLR         ((uint32_t)0x04000000U)         /* !< Event Clear */
+
+/* GPTIMER_CPU_INT_IIDX Bits */
+/* GPTIMER_CPU_INT_IIDX[STAT] Bits */
+#define GPTIMER_CPU_INT_IIDX_STAT_OFS            (0)                             /* !< STAT Offset */
+#define GPTIMER_CPU_INT_IIDX_STAT_MASK           ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define GPTIMER_CPU_INT_IIDX_STAT_NO_INTR        ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define GPTIMER_CPU_INT_IIDX_STAT_Z              ((uint32_t)0x00000001U)         /* !< Interrupt Source: Zero event (Z) */
+#define GPTIMER_CPU_INT_IIDX_STAT_L              ((uint32_t)0x00000002U)         /* !< nterrupt Source: Load event (L) */
+#define GPTIMER_CPU_INT_IIDX_STAT_CCD0           ((uint32_t)0x00000005U)         /* !< Interrupt Source: Capture or
+                                                                                    compare down event (CCD0) */
+#define GPTIMER_CPU_INT_IIDX_STAT_CCD1           ((uint32_t)0x00000006U)         /* !< Interrupt Source: Capture or
+                                                                                    compare down event (CCD1) */
+#define GPTIMER_CPU_INT_IIDX_STAT_CCD2           ((uint32_t)0x00000007U)         /* !< Interrupt Source: Capture or
+                                                                                    compare down event (CCD2) */
+#define GPTIMER_CPU_INT_IIDX_STAT_CCD3           ((uint32_t)0x00000008U)         /* !< Interrupt Source: Capture or
+                                                                                    compare down event (CCD3) */
+#define GPTIMER_CPU_INT_IIDX_STAT_CCU0           ((uint32_t)0x00000009U)         /* !< Interrupt Source: Capture or
+                                                                                    compare up event (CCU0) */
+#define GPTIMER_CPU_INT_IIDX_STAT_CCU1           ((uint32_t)0x0000000AU)         /* !< Interrupt Source: Capture or
+                                                                                    compare up event (CCU1) */
+#define GPTIMER_CPU_INT_IIDX_STAT_CCU2           ((uint32_t)0x0000000BU)         /* !< Interrupt Source: Capture or
+                                                                                    compare up event (CCU2) */
+#define GPTIMER_CPU_INT_IIDX_STAT_CCU3           ((uint32_t)0x0000000CU)         /* !< Interrupt Source: Capture or
+                                                                                    compare up event (CCU3) */
+#define GPTIMER_CPU_INT_IIDX_STAT_CCD4           ((uint32_t)0x0000000DU)         /* !< Interrupt Source: Compare down
+                                                                                    event (CCD4) */
+#define GPTIMER_CPU_INT_IIDX_STAT_CCD5           ((uint32_t)0x0000000EU)         /* !< Interrupt Source: Compare down
+                                                                                    event (CCD5) */
+#define GPTIMER_CPU_INT_IIDX_STAT_CCU4           ((uint32_t)0x0000000FU)         /* !< Interrupt Source: Compare down
+                                                                                    event (CCU4) */
+#define GPTIMER_CPU_INT_IIDX_STAT_CCU5           ((uint32_t)0x00000010U)         /* !< Interrupt Source: Compare down
+                                                                                    event (CCU5) */
+#define GPTIMER_CPU_INT_IIDX_STAT_F              ((uint32_t)0x00000019U)         /* !< Interrupt Source: Fault Event
+                                                                                    generated an interrupt. (F) */
+#define GPTIMER_CPU_INT_IIDX_STAT_TOV            ((uint32_t)0x0000001AU)         /* !< Interrupt Source: Trigger overflow
+                                                                                    (TOV) */
+#define GPTIMER_CPU_INT_IIDX_STAT_REPC           ((uint32_t)0x0000001BU)         /* !< Interrupt Source: Repeat Counter
+                                                                                    Zero (REPC) */
+#define GPTIMER_CPU_INT_IIDX_STAT_DC             ((uint32_t)0x0000001CU)         /* !< Interrupt Source: Direction Change
+                                                                                    (DC) */
+#define GPTIMER_CPU_INT_IIDX_STAT_QEIERR         ((uint32_t)0x0000001DU)         /* !< Interrupt Source:QEI Incorrect
+                                                                                    state transition error (QEIERR) */
+
+/* GPTIMER_CPU_INT_IMASK Bits */
+/* GPTIMER_CPU_INT_IMASK[Z] Bits */
+#define GPTIMER_CPU_INT_IMASK_Z_OFS              (0)                             /* !< Z Offset */
+#define GPTIMER_CPU_INT_IMASK_Z_MASK             ((uint32_t)0x00000001U)         /* !< Zero Event mask */
+#define GPTIMER_CPU_INT_IMASK_Z_CLR              ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_CPU_INT_IMASK_Z_SET              ((uint32_t)0x00000001U)         /* !< Enable Event */
+/* GPTIMER_CPU_INT_IMASK[L] Bits */
+#define GPTIMER_CPU_INT_IMASK_L_OFS              (1)                             /* !< L Offset */
+#define GPTIMER_CPU_INT_IMASK_L_MASK             ((uint32_t)0x00000002U)         /* !< Load Event mask */
+#define GPTIMER_CPU_INT_IMASK_L_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_CPU_INT_IMASK_L_SET              ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* GPTIMER_CPU_INT_IMASK[CCD0] Bits */
+#define GPTIMER_CPU_INT_IMASK_CCD0_OFS           (4)                             /* !< CCD0 Offset */
+#define GPTIMER_CPU_INT_IMASK_CCD0_MASK          ((uint32_t)0x00000010U)         /* !< Capture or Compare DN event mask
+                                                                                    CCP0 */
+#define GPTIMER_CPU_INT_IMASK_CCD0_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_CPU_INT_IMASK_CCD0_SET           ((uint32_t)0x00000010U)         /* !< Set Interrupt Mask */
+/* GPTIMER_CPU_INT_IMASK[CCD1] Bits */
+#define GPTIMER_CPU_INT_IMASK_CCD1_OFS           (5)                             /* !< CCD1 Offset */
+#define GPTIMER_CPU_INT_IMASK_CCD1_MASK          ((uint32_t)0x00000020U)         /* !< Capture or Compare DN event mask
+                                                                                    CCP1 */
+#define GPTIMER_CPU_INT_IMASK_CCD1_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_CPU_INT_IMASK_CCD1_SET           ((uint32_t)0x00000020U)         /* !< Set Interrupt Mask */
+/* GPTIMER_CPU_INT_IMASK[CCU0] Bits */
+#define GPTIMER_CPU_INT_IMASK_CCU0_OFS           (8)                             /* !< CCU0 Offset */
+#define GPTIMER_CPU_INT_IMASK_CCU0_MASK          ((uint32_t)0x00000100U)         /* !< Capture or Compare UP event mask
+                                                                                    CCP0 */
+#define GPTIMER_CPU_INT_IMASK_CCU0_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_CPU_INT_IMASK_CCU0_SET           ((uint32_t)0x00000100U)         /* !< Set Interrupt Mask */
+/* GPTIMER_CPU_INT_IMASK[CCU1] Bits */
+#define GPTIMER_CPU_INT_IMASK_CCU1_OFS           (9)                             /* !< CCU1 Offset */
+#define GPTIMER_CPU_INT_IMASK_CCU1_MASK          ((uint32_t)0x00000200U)         /* !< Capture or Compare UP event mask
+                                                                                    CCP1 */
+#define GPTIMER_CPU_INT_IMASK_CCU1_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_CPU_INT_IMASK_CCU1_SET           ((uint32_t)0x00000200U)         /* !< Set Interrupt Mask */
+/* GPTIMER_CPU_INT_IMASK[F] Bits */
+#define GPTIMER_CPU_INT_IMASK_F_OFS              (24)                            /* !< F Offset */
+#define GPTIMER_CPU_INT_IMASK_F_MASK             ((uint32_t)0x01000000U)         /* !< Fault Event mask */
+#define GPTIMER_CPU_INT_IMASK_F_CLR              ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_CPU_INT_IMASK_F_SET              ((uint32_t)0x01000000U)         /* !< Enable Event */
+/* GPTIMER_CPU_INT_IMASK[TOV] Bits */
+#define GPTIMER_CPU_INT_IMASK_TOV_OFS            (25)                            /* !< TOV Offset */
+#define GPTIMER_CPU_INT_IMASK_TOV_MASK           ((uint32_t)0x02000000U)         /* !< Trigger Overflow Event mask */
+#define GPTIMER_CPU_INT_IMASK_TOV_CLR            ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_CPU_INT_IMASK_TOV_SET            ((uint32_t)0x02000000U)         /* !< Enable Event */
+/* GPTIMER_CPU_INT_IMASK[DC] Bits */
+#define GPTIMER_CPU_INT_IMASK_DC_OFS             (27)                            /* !< DC Offset */
+#define GPTIMER_CPU_INT_IMASK_DC_MASK            ((uint32_t)0x08000000U)         /* !< Direction Change Event mask */
+#define GPTIMER_CPU_INT_IMASK_DC_CLR             ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_CPU_INT_IMASK_DC_SET             ((uint32_t)0x08000000U)         /* !< Enable Event */
+/* GPTIMER_CPU_INT_IMASK[QEIERR] Bits */
+#define GPTIMER_CPU_INT_IMASK_QEIERR_OFS         (28)                            /* !< QEIERR Offset */
+#define GPTIMER_CPU_INT_IMASK_QEIERR_MASK        ((uint32_t)0x10000000U)         /* !< QEIERR Event mask */
+#define GPTIMER_CPU_INT_IMASK_QEIERR_CLR         ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_CPU_INT_IMASK_QEIERR_SET         ((uint32_t)0x10000000U)         /* !< Enable Event */
+/* GPTIMER_CPU_INT_IMASK[CCD2] Bits */
+#define GPTIMER_CPU_INT_IMASK_CCD2_OFS           (6)                             /* !< CCD2 Offset */
+#define GPTIMER_CPU_INT_IMASK_CCD2_MASK          ((uint32_t)0x00000040U)         /* !< Capture or Compare DN event mask
+                                                                                    CCP2 */
+#define GPTIMER_CPU_INT_IMASK_CCD2_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_CPU_INT_IMASK_CCD2_SET           ((uint32_t)0x00000040U)         /* !< Set Interrupt Mask */
+/* GPTIMER_CPU_INT_IMASK[CCD3] Bits */
+#define GPTIMER_CPU_INT_IMASK_CCD3_OFS           (7)                             /* !< CCD3 Offset */
+#define GPTIMER_CPU_INT_IMASK_CCD3_MASK          ((uint32_t)0x00000080U)         /* !< Capture or Compare DN event mask
+                                                                                    CCP3 */
+#define GPTIMER_CPU_INT_IMASK_CCD3_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_CPU_INT_IMASK_CCD3_SET           ((uint32_t)0x00000080U)         /* !< Set Interrupt Mask */
+/* GPTIMER_CPU_INT_IMASK[CCU2] Bits */
+#define GPTIMER_CPU_INT_IMASK_CCU2_OFS           (10)                            /* !< CCU2 Offset */
+#define GPTIMER_CPU_INT_IMASK_CCU2_MASK          ((uint32_t)0x00000400U)         /* !< Capture or Compare UP event mask
+                                                                                    CCP2 */
+#define GPTIMER_CPU_INT_IMASK_CCU2_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_CPU_INT_IMASK_CCU2_SET           ((uint32_t)0x00000400U)         /* !< Set Interrupt Mask */
+/* GPTIMER_CPU_INT_IMASK[CCU3] Bits */
+#define GPTIMER_CPU_INT_IMASK_CCU3_OFS           (11)                            /* !< CCU3 Offset */
+#define GPTIMER_CPU_INT_IMASK_CCU3_MASK          ((uint32_t)0x00000800U)         /* !< Capture or Compare UP event mask
+                                                                                    CCP3 */
+#define GPTIMER_CPU_INT_IMASK_CCU3_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_CPU_INT_IMASK_CCU3_SET           ((uint32_t)0x00000800U)         /* !< Set Interrupt Mask */
+/* GPTIMER_CPU_INT_IMASK[CCD4] Bits */
+#define GPTIMER_CPU_INT_IMASK_CCD4_OFS           (12)                            /* !< CCD4 Offset */
+#define GPTIMER_CPU_INT_IMASK_CCD4_MASK          ((uint32_t)0x00001000U)         /* !< Compare DN event mask CCP4 */
+#define GPTIMER_CPU_INT_IMASK_CCD4_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_CPU_INT_IMASK_CCD4_SET           ((uint32_t)0x00001000U)         /* !< Set Interrupt Mask */
+/* GPTIMER_CPU_INT_IMASK[CCD5] Bits */
+#define GPTIMER_CPU_INT_IMASK_CCD5_OFS           (13)                            /* !< CCD5 Offset */
+#define GPTIMER_CPU_INT_IMASK_CCD5_MASK          ((uint32_t)0x00002000U)         /* !< Compare DN event mask CCP5 */
+#define GPTIMER_CPU_INT_IMASK_CCD5_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_CPU_INT_IMASK_CCD5_SET           ((uint32_t)0x00002000U)         /* !< Set Interrupt Mask */
+/* GPTIMER_CPU_INT_IMASK[CCU4] Bits */
+#define GPTIMER_CPU_INT_IMASK_CCU4_OFS           (14)                            /* !< CCU4 Offset */
+#define GPTIMER_CPU_INT_IMASK_CCU4_MASK          ((uint32_t)0x00004000U)         /* !< Compare UP event mask CCP4 */
+#define GPTIMER_CPU_INT_IMASK_CCU4_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_CPU_INT_IMASK_CCU4_SET           ((uint32_t)0x00004000U)         /* !< Set Interrupt Mask */
+/* GPTIMER_CPU_INT_IMASK[CCU5] Bits */
+#define GPTIMER_CPU_INT_IMASK_CCU5_OFS           (15)                            /* !< CCU5 Offset */
+#define GPTIMER_CPU_INT_IMASK_CCU5_MASK          ((uint32_t)0x00008000U)         /* !< Compare UP event mask CCP5 */
+#define GPTIMER_CPU_INT_IMASK_CCU5_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define GPTIMER_CPU_INT_IMASK_CCU5_SET           ((uint32_t)0x00008000U)         /* !< Set Interrupt Mask */
+/* GPTIMER_CPU_INT_IMASK[REPC] Bits */
+#define GPTIMER_CPU_INT_IMASK_REPC_OFS           (26)                            /* !< REPC Offset */
+#define GPTIMER_CPU_INT_IMASK_REPC_MASK          ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero Event mask */
+#define GPTIMER_CPU_INT_IMASK_REPC_CLR           ((uint32_t)0x00000000U)         /* !< Disable Event */
+#define GPTIMER_CPU_INT_IMASK_REPC_SET           ((uint32_t)0x04000000U)         /* !< Enable Event */
+
+/* GPTIMER_CPU_INT_RIS Bits */
+/* GPTIMER_CPU_INT_RIS[Z] Bits */
+#define GPTIMER_CPU_INT_RIS_Z_OFS                (0)                             /* !< Z Offset */
+#define GPTIMER_CPU_INT_RIS_Z_MASK               ((uint32_t)0x00000001U)         /* !< Zero event generated an interrupt. */
+#define GPTIMER_CPU_INT_RIS_Z_CLR                ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_Z_SET                ((uint32_t)0x00000001U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[L] Bits */
+#define GPTIMER_CPU_INT_RIS_L_OFS                (1)                             /* !< L Offset */
+#define GPTIMER_CPU_INT_RIS_L_MASK               ((uint32_t)0x00000002U)         /* !< Load event generated an interrupt. */
+#define GPTIMER_CPU_INT_RIS_L_CLR                ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_L_SET                ((uint32_t)0x00000002U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[CCD0] Bits */
+#define GPTIMER_CPU_INT_RIS_CCD0_OFS             (4)                             /* !< CCD0 Offset */
+#define GPTIMER_CPU_INT_RIS_CCD0_MASK            ((uint32_t)0x00000010U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP0 */
+#define GPTIMER_CPU_INT_RIS_CCD0_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_CCD0_SET             ((uint32_t)0x00000010U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[CCD1] Bits */
+#define GPTIMER_CPU_INT_RIS_CCD1_OFS             (5)                             /* !< CCD1 Offset */
+#define GPTIMER_CPU_INT_RIS_CCD1_MASK            ((uint32_t)0x00000020U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP1 */
+#define GPTIMER_CPU_INT_RIS_CCD1_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_CCD1_SET             ((uint32_t)0x00000020U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[CCU0] Bits */
+#define GPTIMER_CPU_INT_RIS_CCU0_OFS             (8)                             /* !< CCU0 Offset */
+#define GPTIMER_CPU_INT_RIS_CCU0_MASK            ((uint32_t)0x00000100U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP0 */
+#define GPTIMER_CPU_INT_RIS_CCU0_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_CCU0_SET             ((uint32_t)0x00000100U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[CCU1] Bits */
+#define GPTIMER_CPU_INT_RIS_CCU1_OFS             (9)                             /* !< CCU1 Offset */
+#define GPTIMER_CPU_INT_RIS_CCU1_MASK            ((uint32_t)0x00000200U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP1 */
+#define GPTIMER_CPU_INT_RIS_CCU1_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_CCU1_SET             ((uint32_t)0x00000200U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[TOV] Bits */
+#define GPTIMER_CPU_INT_RIS_TOV_OFS              (25)                            /* !< TOV Offset */
+#define GPTIMER_CPU_INT_RIS_TOV_MASK             ((uint32_t)0x02000000U)         /* !< Trigger overflow */
+#define GPTIMER_CPU_INT_RIS_TOV_CLR              ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_TOV_SET              ((uint32_t)0x02000000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[F] Bits */
+#define GPTIMER_CPU_INT_RIS_F_OFS                (24)                            /* !< F Offset */
+#define GPTIMER_CPU_INT_RIS_F_MASK               ((uint32_t)0x01000000U)         /* !< Fault */
+#define GPTIMER_CPU_INT_RIS_F_CLR                ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_F_SET                ((uint32_t)0x01000000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[DC] Bits */
+#define GPTIMER_CPU_INT_RIS_DC_OFS               (27)                            /* !< DC Offset */
+#define GPTIMER_CPU_INT_RIS_DC_MASK              ((uint32_t)0x08000000U)         /* !< Direction Change */
+#define GPTIMER_CPU_INT_RIS_DC_CLR               ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_DC_SET               ((uint32_t)0x08000000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[QEIERR] Bits */
+#define GPTIMER_CPU_INT_RIS_QEIERR_OFS           (28)                            /* !< QEIERR Offset */
+#define GPTIMER_CPU_INT_RIS_QEIERR_MASK          ((uint32_t)0x10000000U)         /* !< QEIERR, set on an incorrect state
+                                                                                    transition on the encoder interface. */
+#define GPTIMER_CPU_INT_RIS_QEIERR_CLR           ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_QEIERR_SET           ((uint32_t)0x10000000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[CCD2] Bits */
+#define GPTIMER_CPU_INT_RIS_CCD2_OFS             (6)                             /* !< CCD2 Offset */
+#define GPTIMER_CPU_INT_RIS_CCD2_MASK            ((uint32_t)0x00000040U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP2 */
+#define GPTIMER_CPU_INT_RIS_CCD2_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_CCD2_SET             ((uint32_t)0x00000040U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[CCD3] Bits */
+#define GPTIMER_CPU_INT_RIS_CCD3_OFS             (7)                             /* !< CCD3 Offset */
+#define GPTIMER_CPU_INT_RIS_CCD3_MASK            ((uint32_t)0x00000080U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP3 */
+#define GPTIMER_CPU_INT_RIS_CCD3_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_CCD3_SET             ((uint32_t)0x00000080U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[CCU2] Bits */
+#define GPTIMER_CPU_INT_RIS_CCU2_OFS             (10)                            /* !< CCU2 Offset */
+#define GPTIMER_CPU_INT_RIS_CCU2_MASK            ((uint32_t)0x00000400U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP2 */
+#define GPTIMER_CPU_INT_RIS_CCU2_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_CCU2_SET             ((uint32_t)0x00000400U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[CCU3] Bits */
+#define GPTIMER_CPU_INT_RIS_CCU3_OFS             (11)                            /* !< CCU3 Offset */
+#define GPTIMER_CPU_INT_RIS_CCU3_MASK            ((uint32_t)0x00000800U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP3 */
+#define GPTIMER_CPU_INT_RIS_CCU3_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_CCU3_SET             ((uint32_t)0x00000800U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[CCD4] Bits */
+#define GPTIMER_CPU_INT_RIS_CCD4_OFS             (12)                            /* !< CCD4 Offset */
+#define GPTIMER_CPU_INT_RIS_CCD4_MASK            ((uint32_t)0x00001000U)         /* !< Compare down event generated an
+                                                                                    interrupt CCD4 */
+#define GPTIMER_CPU_INT_RIS_CCD4_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_CCD4_SET             ((uint32_t)0x00001000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[CCD5] Bits */
+#define GPTIMER_CPU_INT_RIS_CCD5_OFS             (13)                            /* !< CCD5 Offset */
+#define GPTIMER_CPU_INT_RIS_CCD5_MASK            ((uint32_t)0x00002000U)         /* !< Compare down event generated an
+                                                                                    interrupt CCD5 */
+#define GPTIMER_CPU_INT_RIS_CCD5_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_CCD5_SET             ((uint32_t)0x00002000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[CCU4] Bits */
+#define GPTIMER_CPU_INT_RIS_CCU4_OFS             (14)                            /* !< CCU4 Offset */
+#define GPTIMER_CPU_INT_RIS_CCU4_MASK            ((uint32_t)0x00004000U)         /* !< Compare up event generated an
+                                                                                    interrupt CCU4 */
+#define GPTIMER_CPU_INT_RIS_CCU4_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_CCU4_SET             ((uint32_t)0x00004000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[CCU5] Bits */
+#define GPTIMER_CPU_INT_RIS_CCU5_OFS             (15)                            /* !< CCU5 Offset */
+#define GPTIMER_CPU_INT_RIS_CCU5_MASK            ((uint32_t)0x00008000U)         /* !< Compare up event generated an
+                                                                                    interrupt CCP5 */
+#define GPTIMER_CPU_INT_RIS_CCU5_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_CCU5_SET             ((uint32_t)0x00008000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_RIS[REPC] Bits */
+#define GPTIMER_CPU_INT_RIS_REPC_OFS             (26)                            /* !< REPC Offset */
+#define GPTIMER_CPU_INT_RIS_REPC_MASK            ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero */
+#define GPTIMER_CPU_INT_RIS_REPC_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_RIS_REPC_SET             ((uint32_t)0x04000000U)         /* !< Event Set */
+
+/* GPTIMER_CPU_INT_MIS Bits */
+/* GPTIMER_CPU_INT_MIS[Z] Bits */
+#define GPTIMER_CPU_INT_MIS_Z_OFS                (0)                             /* !< Z Offset */
+#define GPTIMER_CPU_INT_MIS_Z_MASK               ((uint32_t)0x00000001U)         /* !< Zero event generated an interrupt. */
+#define GPTIMER_CPU_INT_MIS_Z_CLR                ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_Z_SET                ((uint32_t)0x00000001U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[L] Bits */
+#define GPTIMER_CPU_INT_MIS_L_OFS                (1)                             /* !< L Offset */
+#define GPTIMER_CPU_INT_MIS_L_MASK               ((uint32_t)0x00000002U)         /* !< Load event generated an interrupt. */
+#define GPTIMER_CPU_INT_MIS_L_CLR                ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_L_SET                ((uint32_t)0x00000002U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[CCD0] Bits */
+#define GPTIMER_CPU_INT_MIS_CCD0_OFS             (4)                             /* !< CCD0 Offset */
+#define GPTIMER_CPU_INT_MIS_CCD0_MASK            ((uint32_t)0x00000010U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP0 */
+#define GPTIMER_CPU_INT_MIS_CCD0_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_CCD0_SET             ((uint32_t)0x00000010U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[CCD1] Bits */
+#define GPTIMER_CPU_INT_MIS_CCD1_OFS             (5)                             /* !< CCD1 Offset */
+#define GPTIMER_CPU_INT_MIS_CCD1_MASK            ((uint32_t)0x00000020U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP1 */
+#define GPTIMER_CPU_INT_MIS_CCD1_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_CCD1_SET             ((uint32_t)0x00000020U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[CCU0] Bits */
+#define GPTIMER_CPU_INT_MIS_CCU0_OFS             (8)                             /* !< CCU0 Offset */
+#define GPTIMER_CPU_INT_MIS_CCU0_MASK            ((uint32_t)0x00000100U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP0 */
+#define GPTIMER_CPU_INT_MIS_CCU0_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_CCU0_SET             ((uint32_t)0x00000100U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[CCU1] Bits */
+#define GPTIMER_CPU_INT_MIS_CCU1_OFS             (9)                             /* !< CCU1 Offset */
+#define GPTIMER_CPU_INT_MIS_CCU1_MASK            ((uint32_t)0x00000200U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP1 */
+#define GPTIMER_CPU_INT_MIS_CCU1_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_CCU1_SET             ((uint32_t)0x00000200U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[F] Bits */
+#define GPTIMER_CPU_INT_MIS_F_OFS                (24)                            /* !< F Offset */
+#define GPTIMER_CPU_INT_MIS_F_MASK               ((uint32_t)0x01000000U)         /* !< Fault */
+#define GPTIMER_CPU_INT_MIS_F_CLR                ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_F_SET                ((uint32_t)0x01000000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[TOV] Bits */
+#define GPTIMER_CPU_INT_MIS_TOV_OFS              (25)                            /* !< TOV Offset */
+#define GPTIMER_CPU_INT_MIS_TOV_MASK             ((uint32_t)0x02000000U)         /* !< Trigger overflow */
+#define GPTIMER_CPU_INT_MIS_TOV_CLR              ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_TOV_SET              ((uint32_t)0x02000000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[DC] Bits */
+#define GPTIMER_CPU_INT_MIS_DC_OFS               (27)                            /* !< DC Offset */
+#define GPTIMER_CPU_INT_MIS_DC_MASK              ((uint32_t)0x08000000U)         /* !< Direction Change */
+#define GPTIMER_CPU_INT_MIS_DC_CLR               ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_DC_SET               ((uint32_t)0x08000000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[QEIERR] Bits */
+#define GPTIMER_CPU_INT_MIS_QEIERR_OFS           (28)                            /* !< QEIERR Offset */
+#define GPTIMER_CPU_INT_MIS_QEIERR_MASK          ((uint32_t)0x10000000U)         /* !< QEIERR */
+#define GPTIMER_CPU_INT_MIS_QEIERR_CLR           ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_QEIERR_SET           ((uint32_t)0x10000000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[CCD2] Bits */
+#define GPTIMER_CPU_INT_MIS_CCD2_OFS             (6)                             /* !< CCD2 Offset */
+#define GPTIMER_CPU_INT_MIS_CCD2_MASK            ((uint32_t)0x00000040U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP2 */
+#define GPTIMER_CPU_INT_MIS_CCD2_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_CCD2_SET             ((uint32_t)0x00000040U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[CCD3] Bits */
+#define GPTIMER_CPU_INT_MIS_CCD3_OFS             (7)                             /* !< CCD3 Offset */
+#define GPTIMER_CPU_INT_MIS_CCD3_MASK            ((uint32_t)0x00000080U)         /* !< Capture or compare down event
+                                                                                    generated an interrupt CCP3 */
+#define GPTIMER_CPU_INT_MIS_CCD3_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_CCD3_SET             ((uint32_t)0x00000080U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[CCU2] Bits */
+#define GPTIMER_CPU_INT_MIS_CCU2_OFS             (10)                            /* !< CCU2 Offset */
+#define GPTIMER_CPU_INT_MIS_CCU2_MASK            ((uint32_t)0x00000400U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP2 */
+#define GPTIMER_CPU_INT_MIS_CCU2_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_CCU2_SET             ((uint32_t)0x00000400U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[CCU3] Bits */
+#define GPTIMER_CPU_INT_MIS_CCU3_OFS             (11)                            /* !< CCU3 Offset */
+#define GPTIMER_CPU_INT_MIS_CCU3_MASK            ((uint32_t)0x00000800U)         /* !< Capture or compare up event
+                                                                                    generated an interrupt CCP3 */
+#define GPTIMER_CPU_INT_MIS_CCU3_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_CCU3_SET             ((uint32_t)0x00000800U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[CCD4] Bits */
+#define GPTIMER_CPU_INT_MIS_CCD4_OFS             (12)                            /* !< CCD4 Offset */
+#define GPTIMER_CPU_INT_MIS_CCD4_MASK            ((uint32_t)0x00001000U)         /* !< Compare down event generated an
+                                                                                    interrupt CCP4 */
+#define GPTIMER_CPU_INT_MIS_CCD4_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_CCD4_SET             ((uint32_t)0x00001000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[CCD5] Bits */
+#define GPTIMER_CPU_INT_MIS_CCD5_OFS             (13)                            /* !< CCD5 Offset */
+#define GPTIMER_CPU_INT_MIS_CCD5_MASK            ((uint32_t)0x00002000U)         /* !< Compare down event generated an
+                                                                                    interrupt CCP5 */
+#define GPTIMER_CPU_INT_MIS_CCD5_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_CCD5_SET             ((uint32_t)0x00002000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[CCU4] Bits */
+#define GPTIMER_CPU_INT_MIS_CCU4_OFS             (14)                            /* !< CCU4 Offset */
+#define GPTIMER_CPU_INT_MIS_CCU4_MASK            ((uint32_t)0x00004000U)         /* !< Compare up event generated an
+                                                                                    interrupt CCP4 */
+#define GPTIMER_CPU_INT_MIS_CCU4_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_CCU4_SET             ((uint32_t)0x00004000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[CCU5] Bits */
+#define GPTIMER_CPU_INT_MIS_CCU5_OFS             (15)                            /* !< CCU5 Offset */
+#define GPTIMER_CPU_INT_MIS_CCU5_MASK            ((uint32_t)0x00008000U)         /* !< Compare up event generated an
+                                                                                    interrupt CCP5 */
+#define GPTIMER_CPU_INT_MIS_CCU5_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_CCU5_SET             ((uint32_t)0x00008000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_MIS[REPC] Bits */
+#define GPTIMER_CPU_INT_MIS_REPC_OFS             (26)                            /* !< REPC Offset */
+#define GPTIMER_CPU_INT_MIS_REPC_MASK            ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero */
+#define GPTIMER_CPU_INT_MIS_REPC_CLR             ((uint32_t)0x00000000U)         /* !< Event Cleared */
+#define GPTIMER_CPU_INT_MIS_REPC_SET             ((uint32_t)0x04000000U)         /* !< Event Set */
+
+/* GPTIMER_CPU_INT_ISET Bits */
+/* GPTIMER_CPU_INT_ISET[Z] Bits */
+#define GPTIMER_CPU_INT_ISET_Z_OFS               (0)                             /* !< Z Offset */
+#define GPTIMER_CPU_INT_ISET_Z_MASK              ((uint32_t)0x00000001U)         /* !< Zero event SET */
+#define GPTIMER_CPU_INT_ISET_Z_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_Z_SET               ((uint32_t)0x00000001U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[L] Bits */
+#define GPTIMER_CPU_INT_ISET_L_OFS               (1)                             /* !< L Offset */
+#define GPTIMER_CPU_INT_ISET_L_MASK              ((uint32_t)0x00000002U)         /* !< Load event SET */
+#define GPTIMER_CPU_INT_ISET_L_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_L_SET               ((uint32_t)0x00000002U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[CCD0] Bits */
+#define GPTIMER_CPU_INT_ISET_CCD0_OFS            (4)                             /* !< CCD0 Offset */
+#define GPTIMER_CPU_INT_ISET_CCD0_MASK           ((uint32_t)0x00000010U)         /* !< Capture or compare down event SET */
+#define GPTIMER_CPU_INT_ISET_CCD0_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_CCD0_SET            ((uint32_t)0x00000010U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[CCD1] Bits */
+#define GPTIMER_CPU_INT_ISET_CCD1_OFS            (5)                             /* !< CCD1 Offset */
+#define GPTIMER_CPU_INT_ISET_CCD1_MASK           ((uint32_t)0x00000020U)         /* !< Capture or compare down event SET */
+#define GPTIMER_CPU_INT_ISET_CCD1_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_CCD1_SET            ((uint32_t)0x00000020U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[CCU0] Bits */
+#define GPTIMER_CPU_INT_ISET_CCU0_OFS            (8)                             /* !< CCU0 Offset */
+#define GPTIMER_CPU_INT_ISET_CCU0_MASK           ((uint32_t)0x00000100U)         /* !< Capture or compare up event SET */
+#define GPTIMER_CPU_INT_ISET_CCU0_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_CCU0_SET            ((uint32_t)0x00000100U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[CCU1] Bits */
+#define GPTIMER_CPU_INT_ISET_CCU1_OFS            (9)                             /* !< CCU1 Offset */
+#define GPTIMER_CPU_INT_ISET_CCU1_MASK           ((uint32_t)0x00000200U)         /* !< Capture or compare up event SET */
+#define GPTIMER_CPU_INT_ISET_CCU1_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_CCU1_SET            ((uint32_t)0x00000200U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[F] Bits */
+#define GPTIMER_CPU_INT_ISET_F_OFS               (24)                            /* !< F Offset */
+#define GPTIMER_CPU_INT_ISET_F_MASK              ((uint32_t)0x01000000U)         /* !< Fault event SET */
+#define GPTIMER_CPU_INT_ISET_F_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_F_SET               ((uint32_t)0x01000000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[TOV] Bits */
+#define GPTIMER_CPU_INT_ISET_TOV_OFS             (25)                            /* !< TOV Offset */
+#define GPTIMER_CPU_INT_ISET_TOV_MASK            ((uint32_t)0x02000000U)         /* !< Trigger Overflow event SET */
+#define GPTIMER_CPU_INT_ISET_TOV_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_TOV_SET             ((uint32_t)0x02000000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[DC] Bits */
+#define GPTIMER_CPU_INT_ISET_DC_OFS              (27)                            /* !< DC Offset */
+#define GPTIMER_CPU_INT_ISET_DC_MASK             ((uint32_t)0x08000000U)         /* !< Direction Change event SET */
+#define GPTIMER_CPU_INT_ISET_DC_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_DC_SET              ((uint32_t)0x08000000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[QEIERR] Bits */
+#define GPTIMER_CPU_INT_ISET_QEIERR_OFS          (28)                            /* !< QEIERR Offset */
+#define GPTIMER_CPU_INT_ISET_QEIERR_MASK         ((uint32_t)0x10000000U)         /* !< QEIERR event SET */
+#define GPTIMER_CPU_INT_ISET_QEIERR_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_QEIERR_SET          ((uint32_t)0x10000000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[CCD2] Bits */
+#define GPTIMER_CPU_INT_ISET_CCD2_OFS            (6)                             /* !< CCD2 Offset */
+#define GPTIMER_CPU_INT_ISET_CCD2_MASK           ((uint32_t)0x00000040U)         /* !< Capture or compare down event SET */
+#define GPTIMER_CPU_INT_ISET_CCD2_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_CCD2_SET            ((uint32_t)0x00000040U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[CCD3] Bits */
+#define GPTIMER_CPU_INT_ISET_CCD3_OFS            (7)                             /* !< CCD3 Offset */
+#define GPTIMER_CPU_INT_ISET_CCD3_MASK           ((uint32_t)0x00000080U)         /* !< Capture or compare down event SET */
+#define GPTIMER_CPU_INT_ISET_CCD3_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_CCD3_SET            ((uint32_t)0x00000080U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[CCU2] Bits */
+#define GPTIMER_CPU_INT_ISET_CCU2_OFS            (10)                            /* !< CCU2 Offset */
+#define GPTIMER_CPU_INT_ISET_CCU2_MASK           ((uint32_t)0x00000400U)         /* !< Capture or compare up event SET */
+#define GPTIMER_CPU_INT_ISET_CCU2_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_CCU2_SET            ((uint32_t)0x00000400U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[CCU3] Bits */
+#define GPTIMER_CPU_INT_ISET_CCU3_OFS            (11)                            /* !< CCU3 Offset */
+#define GPTIMER_CPU_INT_ISET_CCU3_MASK           ((uint32_t)0x00000800U)         /* !< Capture or compare up event SET */
+#define GPTIMER_CPU_INT_ISET_CCU3_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_CCU3_SET            ((uint32_t)0x00000800U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[CCD4] Bits */
+#define GPTIMER_CPU_INT_ISET_CCD4_OFS            (12)                            /* !< CCD4 Offset */
+#define GPTIMER_CPU_INT_ISET_CCD4_MASK           ((uint32_t)0x00001000U)         /* !< Compare down event 4 SET */
+#define GPTIMER_CPU_INT_ISET_CCD4_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_CCD4_SET            ((uint32_t)0x00001000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[CCD5] Bits */
+#define GPTIMER_CPU_INT_ISET_CCD5_OFS            (13)                            /* !< CCD5 Offset */
+#define GPTIMER_CPU_INT_ISET_CCD5_MASK           ((uint32_t)0x00002000U)         /* !< Compare down event 5 SET */
+#define GPTIMER_CPU_INT_ISET_CCD5_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_CCD5_SET            ((uint32_t)0x00002000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[CCU4] Bits */
+#define GPTIMER_CPU_INT_ISET_CCU4_OFS            (14)                            /* !< CCU4 Offset */
+#define GPTIMER_CPU_INT_ISET_CCU4_MASK           ((uint32_t)0x00004000U)         /* !< Compare up event 4 SET */
+#define GPTIMER_CPU_INT_ISET_CCU4_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_CCU4_SET            ((uint32_t)0x00004000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[CCU5] Bits */
+#define GPTIMER_CPU_INT_ISET_CCU5_OFS            (15)                            /* !< CCU5 Offset */
+#define GPTIMER_CPU_INT_ISET_CCU5_MASK           ((uint32_t)0x00008000U)         /* !< Compare up event 5 SET */
+#define GPTIMER_CPU_INT_ISET_CCU5_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_CCU5_SET            ((uint32_t)0x00008000U)         /* !< Event Set */
+/* GPTIMER_CPU_INT_ISET[REPC] Bits */
+#define GPTIMER_CPU_INT_ISET_REPC_OFS            (26)                            /* !< REPC Offset */
+#define GPTIMER_CPU_INT_ISET_REPC_MASK           ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero event SET */
+#define GPTIMER_CPU_INT_ISET_REPC_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ISET_REPC_SET            ((uint32_t)0x04000000U)         /* !< Event Set */
+
+/* GPTIMER_CPU_INT_ICLR Bits */
+/* GPTIMER_CPU_INT_ICLR[Z] Bits */
+#define GPTIMER_CPU_INT_ICLR_Z_OFS               (0)                             /* !< Z Offset */
+#define GPTIMER_CPU_INT_ICLR_Z_MASK              ((uint32_t)0x00000001U)         /* !< Zero event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_Z_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_Z_CLR               ((uint32_t)0x00000001U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[L] Bits */
+#define GPTIMER_CPU_INT_ICLR_L_OFS               (1)                             /* !< L Offset */
+#define GPTIMER_CPU_INT_ICLR_L_MASK              ((uint32_t)0x00000002U)         /* !< Load event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_L_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_L_CLR               ((uint32_t)0x00000002U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[CCD0] Bits */
+#define GPTIMER_CPU_INT_ICLR_CCD0_OFS            (4)                             /* !< CCD0 Offset */
+#define GPTIMER_CPU_INT_ICLR_CCD0_MASK           ((uint32_t)0x00000010U)         /* !< Capture or compare down event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_CCD0_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_CCD0_CLR            ((uint32_t)0x00000010U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[CCD1] Bits */
+#define GPTIMER_CPU_INT_ICLR_CCD1_OFS            (5)                             /* !< CCD1 Offset */
+#define GPTIMER_CPU_INT_ICLR_CCD1_MASK           ((uint32_t)0x00000020U)         /* !< Capture or compare down event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_CCD1_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_CCD1_CLR            ((uint32_t)0x00000020U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[CCU0] Bits */
+#define GPTIMER_CPU_INT_ICLR_CCU0_OFS            (8)                             /* !< CCU0 Offset */
+#define GPTIMER_CPU_INT_ICLR_CCU0_MASK           ((uint32_t)0x00000100U)         /* !< Capture or compare up event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_CCU0_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_CCU0_CLR            ((uint32_t)0x00000100U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[CCU1] Bits */
+#define GPTIMER_CPU_INT_ICLR_CCU1_OFS            (9)                             /* !< CCU1 Offset */
+#define GPTIMER_CPU_INT_ICLR_CCU1_MASK           ((uint32_t)0x00000200U)         /* !< Capture or compare up event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_CCU1_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_CCU1_CLR            ((uint32_t)0x00000200U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[F] Bits */
+#define GPTIMER_CPU_INT_ICLR_F_OFS               (24)                            /* !< F Offset */
+#define GPTIMER_CPU_INT_ICLR_F_MASK              ((uint32_t)0x01000000U)         /* !< Fault event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_F_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_F_CLR               ((uint32_t)0x01000000U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[TOV] Bits */
+#define GPTIMER_CPU_INT_ICLR_TOV_OFS             (25)                            /* !< TOV Offset */
+#define GPTIMER_CPU_INT_ICLR_TOV_MASK            ((uint32_t)0x02000000U)         /* !< Trigger Overflow event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_TOV_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_TOV_CLR             ((uint32_t)0x02000000U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[DC] Bits */
+#define GPTIMER_CPU_INT_ICLR_DC_OFS              (27)                            /* !< DC Offset */
+#define GPTIMER_CPU_INT_ICLR_DC_MASK             ((uint32_t)0x08000000U)         /* !< Direction Change event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_DC_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_DC_CLR              ((uint32_t)0x08000000U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[QEIERR] Bits */
+#define GPTIMER_CPU_INT_ICLR_QEIERR_OFS          (28)                            /* !< QEIERR Offset */
+#define GPTIMER_CPU_INT_ICLR_QEIERR_MASK         ((uint32_t)0x10000000U)         /* !< QEIERR event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_QEIERR_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_QEIERR_CLR          ((uint32_t)0x10000000U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[CCD2] Bits */
+#define GPTIMER_CPU_INT_ICLR_CCD2_OFS            (6)                             /* !< CCD2 Offset */
+#define GPTIMER_CPU_INT_ICLR_CCD2_MASK           ((uint32_t)0x00000040U)         /* !< Capture or compare down event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_CCD2_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_CCD2_CLR            ((uint32_t)0x00000040U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[CCD3] Bits */
+#define GPTIMER_CPU_INT_ICLR_CCD3_OFS            (7)                             /* !< CCD3 Offset */
+#define GPTIMER_CPU_INT_ICLR_CCD3_MASK           ((uint32_t)0x00000080U)         /* !< Capture or compare down event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_CCD3_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_CCD3_CLR            ((uint32_t)0x00000080U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[CCU2] Bits */
+#define GPTIMER_CPU_INT_ICLR_CCU2_OFS            (10)                            /* !< CCU2 Offset */
+#define GPTIMER_CPU_INT_ICLR_CCU2_MASK           ((uint32_t)0x00000400U)         /* !< Capture or compare up event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_CCU2_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_CCU2_CLR            ((uint32_t)0x00000400U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[CCU3] Bits */
+#define GPTIMER_CPU_INT_ICLR_CCU3_OFS            (11)                            /* !< CCU3 Offset */
+#define GPTIMER_CPU_INT_ICLR_CCU3_MASK           ((uint32_t)0x00000800U)         /* !< Capture or compare up event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_CCU3_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_CCU3_CLR            ((uint32_t)0x00000800U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[CCD4] Bits */
+#define GPTIMER_CPU_INT_ICLR_CCD4_OFS            (12)                            /* !< CCD4 Offset */
+#define GPTIMER_CPU_INT_ICLR_CCD4_MASK           ((uint32_t)0x00001000U)         /* !< Compare down event 4 CLEAR */
+#define GPTIMER_CPU_INT_ICLR_CCD4_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_CCD4_CLR            ((uint32_t)0x00001000U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[CCD5] Bits */
+#define GPTIMER_CPU_INT_ICLR_CCD5_OFS            (13)                            /* !< CCD5 Offset */
+#define GPTIMER_CPU_INT_ICLR_CCD5_MASK           ((uint32_t)0x00002000U)         /* !< Compare down event 5 CLEAR */
+#define GPTIMER_CPU_INT_ICLR_CCD5_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_CCD5_CLR            ((uint32_t)0x00002000U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[CCU4] Bits */
+#define GPTIMER_CPU_INT_ICLR_CCU4_OFS            (14)                            /* !< CCU4 Offset */
+#define GPTIMER_CPU_INT_ICLR_CCU4_MASK           ((uint32_t)0x00004000U)         /* !< Compare up event 4 CLEAR */
+#define GPTIMER_CPU_INT_ICLR_CCU4_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_CCU4_CLR            ((uint32_t)0x00004000U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[CCU5] Bits */
+#define GPTIMER_CPU_INT_ICLR_CCU5_OFS            (15)                            /* !< CCU5 Offset */
+#define GPTIMER_CPU_INT_ICLR_CCU5_MASK           ((uint32_t)0x00008000U)         /* !< Compare up event 5 CLEAR */
+#define GPTIMER_CPU_INT_ICLR_CCU5_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_CCU5_CLR            ((uint32_t)0x00008000U)         /* !< Event Clear */
+/* GPTIMER_CPU_INT_ICLR[REPC] Bits */
+#define GPTIMER_CPU_INT_ICLR_REPC_OFS            (26)                            /* !< REPC Offset */
+#define GPTIMER_CPU_INT_ICLR_REPC_MASK           ((uint32_t)0x04000000U)         /* !< Repeat Counter Zero event CLEAR */
+#define GPTIMER_CPU_INT_ICLR_REPC_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect. */
+#define GPTIMER_CPU_INT_ICLR_REPC_CLR            ((uint32_t)0x04000000U)         /* !< Event Clear */
+
+/* GPTIMER_PWREN Bits */
+/* GPTIMER_PWREN[ENABLE] Bits */
+#define GPTIMER_PWREN_ENABLE_OFS                 (0)                             /* !< ENABLE Offset */
+#define GPTIMER_PWREN_ENABLE_MASK                ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define GPTIMER_PWREN_ENABLE_DISABLE             ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define GPTIMER_PWREN_ENABLE_ENABLE              ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* GPTIMER_PWREN[KEY] Bits */
+#define GPTIMER_PWREN_KEY_OFS                    (24)                            /* !< KEY Offset */
+#define GPTIMER_PWREN_KEY_MASK                   ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define GPTIMER_PWREN_KEY_UNLOCK_W               ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* GPTIMER_RSTCTL Bits */
+/* GPTIMER_RSTCTL[RESETSTKYCLR] Bits */
+#define GPTIMER_RSTCTL_RESETSTKYCLR_OFS          (1)                             /* !< RESETSTKYCLR Offset */
+#define GPTIMER_RSTCTL_RESETSTKYCLR_MASK         ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define GPTIMER_RSTCTL_RESETSTKYCLR_NOP          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define GPTIMER_RSTCTL_RESETSTKYCLR_CLR          ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* GPTIMER_RSTCTL[RESETASSERT] Bits */
+#define GPTIMER_RSTCTL_RESETASSERT_OFS           (0)                             /* !< RESETASSERT Offset */
+#define GPTIMER_RSTCTL_RESETASSERT_MASK          ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define GPTIMER_RSTCTL_RESETASSERT_NOP           ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define GPTIMER_RSTCTL_RESETASSERT_ASSERT        ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* GPTIMER_RSTCTL[KEY] Bits */
+#define GPTIMER_RSTCTL_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define GPTIMER_RSTCTL_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define GPTIMER_RSTCTL_KEY_UNLOCK_W              ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* GPTIMER_STAT Bits */
+/* GPTIMER_STAT[RESETSTKY] Bits */
+#define GPTIMER_STAT_RESETSTKY_OFS               (16)                            /* !< RESETSTKY Offset */
+#define GPTIMER_STAT_RESETSTKY_MASK              ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define GPTIMER_STAT_RESETSTKY_NORES             ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define GPTIMER_STAT_RESETSTKY_RESET             ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* GPTIMER_FSUB_0 Bits */
+/* GPTIMER_FSUB_0[CHANID] Bits */
+#define GPTIMER_FSUB_0_CHANID_OFS                (0)                             /* !< CHANID Offset */
+#define GPTIMER_FSUB_0_CHANID_MASK               ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define GPTIMER_FSUB_0_CHANID_MNIMUM             ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define GPTIMER_FSUB_0_CHANID_UNCONNECTED        ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define GPTIMER_FSUB_0_CHANID_MAXIMUM            ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* GPTIMER_FSUB_1 Bits */
+/* GPTIMER_FSUB_1[CHANID] Bits */
+#define GPTIMER_FSUB_1_CHANID_OFS                (0)                             /* !< CHANID Offset */
+#define GPTIMER_FSUB_1_CHANID_MASK               ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define GPTIMER_FSUB_1_CHANID_MNIMUM             ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define GPTIMER_FSUB_1_CHANID_UNCONNECTED        ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define GPTIMER_FSUB_1_CHANID_MAXIMUM            ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* GPTIMER_FPUB_0 Bits */
+/* GPTIMER_FPUB_0[CHANID] Bits */
+#define GPTIMER_FPUB_0_CHANID_OFS                (0)                             /* !< CHANID Offset */
+#define GPTIMER_FPUB_0_CHANID_MASK               ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define GPTIMER_FPUB_0_CHANID_MNIMUM             ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define GPTIMER_FPUB_0_CHANID_UNCONNECTED        ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define GPTIMER_FPUB_0_CHANID_MAXIMUM            ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* GPTIMER_FPUB_1 Bits */
+/* GPTIMER_FPUB_1[CHANID] Bits */
+#define GPTIMER_FPUB_1_CHANID_OFS                (0)                             /* !< CHANID Offset */
+#define GPTIMER_FPUB_1_CHANID_MASK               ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define GPTIMER_FPUB_1_CHANID_MNIMUM             ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define GPTIMER_FPUB_1_CHANID_UNCONNECTED        ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define GPTIMER_FPUB_1_CHANID_MAXIMUM            ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* GPTIMER_CLKDIV Bits */
+/* GPTIMER_CLKDIV[RATIO] Bits */
+#define GPTIMER_CLKDIV_RATIO_OFS                 (0)                             /* !< RATIO Offset */
+#define GPTIMER_CLKDIV_RATIO_MASK                ((uint32_t)0x00000007U)         /* !< Selects divide ratio of module
+                                                                                    clock */
+#define GPTIMER_CLKDIV_RATIO_DIV_BY_1            ((uint32_t)0x00000000U)         /* !< Do not divide clock source */
+#define GPTIMER_CLKDIV_RATIO_DIV_BY_2            ((uint32_t)0x00000001U)         /* !< Divide clock source by 2 */
+#define GPTIMER_CLKDIV_RATIO_DIV_BY_3            ((uint32_t)0x00000002U)         /* !< Divide clock source by 3 */
+#define GPTIMER_CLKDIV_RATIO_DIV_BY_4            ((uint32_t)0x00000003U)         /* !< Divide clock source by 4 */
+#define GPTIMER_CLKDIV_RATIO_DIV_BY_5            ((uint32_t)0x00000004U)         /* !< Divide clock source by 5 */
+#define GPTIMER_CLKDIV_RATIO_DIV_BY_6            ((uint32_t)0x00000005U)         /* !< Divide clock source by 6 */
+#define GPTIMER_CLKDIV_RATIO_DIV_BY_7            ((uint32_t)0x00000006U)         /* !< Divide clock source by 7 */
+#define GPTIMER_CLKDIV_RATIO_DIV_BY_8            ((uint32_t)0x00000007U)         /* !< Divide clock source by 8 */
+
+/* GPTIMER_CLKSEL Bits */
+/* GPTIMER_CLKSEL[LFCLK_SEL] Bits */
+#define GPTIMER_CLKSEL_LFCLK_SEL_OFS             (1)                             /* !< LFCLK_SEL Offset */
+#define GPTIMER_CLKSEL_LFCLK_SEL_MASK            ((uint32_t)0x00000002U)         /* !< Selects LFCLK as clock source if
+                                                                                    enabled */
+#define GPTIMER_CLKSEL_LFCLK_SEL_DISABLE         ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define GPTIMER_CLKSEL_LFCLK_SEL_ENABLE          ((uint32_t)0x00000002U)         /* !< Select this clock as a source */
+/* GPTIMER_CLKSEL[MFCLK_SEL] Bits */
+#define GPTIMER_CLKSEL_MFCLK_SEL_OFS             (2)                             /* !< MFCLK_SEL Offset */
+#define GPTIMER_CLKSEL_MFCLK_SEL_MASK            ((uint32_t)0x00000004U)         /* !< Selects MFCLK as clock source if
+                                                                                    enabled */
+#define GPTIMER_CLKSEL_MFCLK_SEL_DISABLE         ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define GPTIMER_CLKSEL_MFCLK_SEL_ENABLE          ((uint32_t)0x00000004U)         /* !< Select this clock as a source */
+/* GPTIMER_CLKSEL[BUSCLK_SEL] Bits */
+#define GPTIMER_CLKSEL_BUSCLK_SEL_OFS            (3)                             /* !< BUSCLK_SEL Offset */
+#define GPTIMER_CLKSEL_BUSCLK_SEL_MASK           ((uint32_t)0x00000008U)         /* !< Selects BUSCLK as clock source if
+                                                                                    enabled */
+#define GPTIMER_CLKSEL_BUSCLK_SEL_DISABLE        ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define GPTIMER_CLKSEL_BUSCLK_SEL_ENABLE         ((uint32_t)0x00000008U)         /* !< Select this clock as a source */
+/* GPTIMER_CLKSEL[BUS2XCLK_SEL] Bits */
+#define GPTIMER_CLKSEL_BUS2XCLK_SEL_OFS          (4)                             /* !< BUS2XCLK_SEL Offset */
+#define GPTIMER_CLKSEL_BUS2XCLK_SEL_MASK         ((uint32_t)0x00000010U)         /* !< Selects 2x BUSCLK as clock source
+                                                                                    if enabled */
+#define GPTIMER_CLKSEL_BUS2XCLK_SEL_DISABLE      ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define GPTIMER_CLKSEL_BUS2XCLK_SEL_ENABLE       ((uint32_t)0x00000010U)         /* !< Select this clock as a source */
+
+/* GPTIMER_PDBGCTL Bits */
+/* GPTIMER_PDBGCTL[FREE] Bits */
+#define GPTIMER_PDBGCTL_FREE_OFS                 (0)                             /* !< FREE Offset */
+#define GPTIMER_PDBGCTL_FREE_MASK                ((uint32_t)0x00000001U)         /* !< Free run control */
+#define GPTIMER_PDBGCTL_FREE_STOP                ((uint32_t)0x00000000U)         /* !< The peripheral freezes
+                                                                                    functionality while the Core Halted
+                                                                                    input is asserted and resumes when it
+                                                                                    is deasserted. */
+#define GPTIMER_PDBGCTL_FREE_RUN                 ((uint32_t)0x00000001U)         /* !< The peripheral ignores the state of
+                                                                                    the Core Halted input */
+/* GPTIMER_PDBGCTL[SOFT] Bits */
+#define GPTIMER_PDBGCTL_SOFT_OFS                 (1)                             /* !< SOFT Offset */
+#define GPTIMER_PDBGCTL_SOFT_MASK                ((uint32_t)0x00000002U)         /* !< Soft halt boundary control. This
+                                                                                    function is only available, if [FREE]
+                                                                                    is set to 'STOP' */
+#define GPTIMER_PDBGCTL_SOFT_IMMEDIATE           ((uint32_t)0x00000000U)         /* !< The peripheral will halt
+                                                                                    immediately, even if the resultant
+                                                                                    state will result in corruption if
+                                                                                    the system is restarted */
+#define GPTIMER_PDBGCTL_SOFT_DELAYED             ((uint32_t)0x00000002U)         /* !< The peripheral blocks the debug
+                                                                                    freeze until it has reached a
+                                                                                    boundary where it can resume without
+                                                                                    corruption */
+
+/* GPTIMER_EVT_MODE Bits */
+/* GPTIMER_EVT_MODE[EVT0_CFG] Bits */
+#define GPTIMER_EVT_MODE_EVT0_CFG_OFS            (0)                             /* !< EVT0_CFG Offset */
+#define GPTIMER_EVT_MODE_EVT0_CFG_MASK           ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to CPU_INT */
+#define GPTIMER_EVT_MODE_EVT0_CFG_DISABLE        ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define GPTIMER_EVT_MODE_EVT0_CFG_SOFTWARE       ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define GPTIMER_EVT_MODE_EVT0_CFG_HARDWARE       ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* GPTIMER_EVT_MODE[EVT1_CFG] Bits */
+#define GPTIMER_EVT_MODE_EVT1_CFG_OFS            (2)                             /* !< EVT1_CFG Offset */
+#define GPTIMER_EVT_MODE_EVT1_CFG_MASK           ((uint32_t)0x0000000CU)         /* !< Event line mode select for event
+                                                                                    corresponding to GEN_EVENT0 */
+#define GPTIMER_EVT_MODE_EVT1_CFG_DISABLE        ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define GPTIMER_EVT_MODE_EVT1_CFG_SOFTWARE       ((uint32_t)0x00000004U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define GPTIMER_EVT_MODE_EVT1_CFG_HARDWARE       ((uint32_t)0x00000008U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* GPTIMER_EVT_MODE[EVT2_CFG] Bits */
+#define GPTIMER_EVT_MODE_EVT2_CFG_OFS            (4)                             /* !< EVT2_CFG Offset */
+#define GPTIMER_EVT_MODE_EVT2_CFG_MASK           ((uint32_t)0x00000030U)         /* !< Event line mode select for event
+                                                                                    corresponding to GEN_EVENT1 */
+#define GPTIMER_EVT_MODE_EVT2_CFG_DISABLE        ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define GPTIMER_EVT_MODE_EVT2_CFG_SOFTWARE       ((uint32_t)0x00000010U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define GPTIMER_EVT_MODE_EVT2_CFG_HARDWARE       ((uint32_t)0x00000020U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* GPTIMER_DESC Bits */
+/* GPTIMER_DESC[MINREV] Bits */
+#define GPTIMER_DESC_MINREV_OFS                  (0)                             /* !< MINREV Offset */
+#define GPTIMER_DESC_MINREV_MASK                 ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+#define GPTIMER_DESC_MINREV_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define GPTIMER_DESC_MINREV_MAXIMUM              ((uint32_t)0x0000000FU)         /* !< Highest possible value */
+/* GPTIMER_DESC[MAJREV] Bits */
+#define GPTIMER_DESC_MAJREV_OFS                  (4)                             /* !< MAJREV Offset */
+#define GPTIMER_DESC_MAJREV_MASK                 ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+#define GPTIMER_DESC_MAJREV_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define GPTIMER_DESC_MAJREV_MAXIMUM              ((uint32_t)0x000000F0U)         /* !< Highest possible value */
+/* GPTIMER_DESC[INSTNUM] Bits */
+#define GPTIMER_DESC_INSTNUM_OFS                 (8)                             /* !< INSTNUM Offset */
+#define GPTIMER_DESC_INSTNUM_MASK                ((uint32_t)0x00000F00U)         /* !< Instance Number within the device.
+                                                                                    This will be a parameter to the RTL
+                                                                                    for modules that can have multiple
+                                                                                    instances */
+#define GPTIMER_DESC_INSTNUM_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define GPTIMER_DESC_INSTNUM_MAXIMUM             ((uint32_t)0x00000F00U)         /* !< Highest possible value */
+/* GPTIMER_DESC[FEATUREVER] Bits */
+#define GPTIMER_DESC_FEATUREVER_OFS              (12)                            /* !< FEATUREVER Offset */
+#define GPTIMER_DESC_FEATUREVER_MASK             ((uint32_t)0x0000F000U)         /* !< Feature Set for the module
+                                                                                    *instance* */
+#define GPTIMER_DESC_FEATUREVER_MINIMUM          ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define GPTIMER_DESC_FEATUREVER_MAXIMUM          ((uint32_t)0x0000F000U)         /* !< Highest possible value */
+/* GPTIMER_DESC[MODULEID] Bits */
+#define GPTIMER_DESC_MODULEID_OFS                (16)                            /* !< MODULEID Offset */
+#define GPTIMER_DESC_MODULEID_MASK               ((uint32_t)0xFFFF0000U)         /* !< Module identification contains a
+                                                                                    unique peripheral identification
+                                                                                    number. The assignments are
+                                                                                    maintained in a central database for
+                                                                                    all of the platform modules to ensure
+                                                                                    uniqueness. */
+#define GPTIMER_DESC_MODULEID_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define GPTIMER_DESC_MODULEID_MAXIMUM            ((uint32_t)0xFFFF0000U)         /* !< Highest possible value */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_gptimer__include */
+

--- a/mspm0/source/ti/devices/msp/peripherals/hw_i2c.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_i2c.h
@@ -1,0 +1,2818 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_i2c__include
+#define ti_devices_msp_peripherals_hw_i2c__include
+
+/* Filename: hw_i2c.h */
+/* Revised: 2023-06-14 10:18:34 */
+/* Revision: 638bba738cb61945408cf5e8bcfecf08798f4b8b */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* I2C Registers
+******************************************************************************/
+#define I2C_SLAVE_OFS                            ((uint32_t)0x00001250U)
+#define I2C_MASTER_OFS                           ((uint32_t)0x00001210U)
+#define I2C_DMA_TRIG0_OFS                        ((uint32_t)0x00001080U)
+#define I2C_DMA_TRIG1_OFS                        ((uint32_t)0x00001050U)
+#define I2C_CPU_INT_OFS                          ((uint32_t)0x00001020U)
+#define I2C_GPRCM_OFS                            ((uint32_t)0x00000800U)
+
+
+/** @addtogroup I2C_SLAVE
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t SOAR;                              /* !< (@ 0x00001250) I2C Target Own Address */
+  __IO uint32_t SOAR2;                             /* !< (@ 0x00001254) I2C Target Own Address 2 */
+  __IO uint32_t SCTR;                              /* !< (@ 0x00001258) I2C Target Control Register */
+  __I  uint32_t SSR;                               /* !< (@ 0x0000125C) I2C Target Status Register */
+  __I  uint32_t SRXDATA;                           /* !< (@ 0x00001260) I2C Target RXData */
+  __IO uint32_t STXDATA;                           /* !< (@ 0x00001264) I2C Target TXData */
+  __IO uint32_t SACKCTL;                           /* !< (@ 0x00001268) I2C Target ACK Control */
+  __IO uint32_t SFIFOCTL;                          /* !< (@ 0x0000126C) I2C Target FIFO Control */
+  __I  uint32_t SFIFOSR;                           /* !< (@ 0x00001270) I2C Target FIFO Status Register */
+  __IO uint32_t TARGET_PECCTL;                     /* !< (@ 0x00001274) I2C Target PEC control register */
+  __I  uint32_t TARGET_PECSR;                      /* !< (@ 0x00001278) I2C Target PEC status register */
+} I2C_SLAVE_Regs;
+
+/*@}*/ /* end of group I2C_SLAVE */
+
+/** @addtogroup I2C_MASTER
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t MSA;                               /* !< (@ 0x00001210) I2C Controller Target Address Register */
+  __IO uint32_t MCTR;                              /* !< (@ 0x00001214) I2C Controller Control Register */
+  __I  uint32_t MSR;                               /* !< (@ 0x00001218) I2C Controller Status Register */
+  __I  uint32_t MRXDATA;                           /* !< (@ 0x0000121C) I2C Controller RXData */
+  __IO uint32_t MTXDATA;                           /* !< (@ 0x00001220) I2C Controller TXData */
+  __IO uint32_t MTPR;                              /* !< (@ 0x00001224) I2C Controller Timer Period */
+  __IO uint32_t MCR;                               /* !< (@ 0x00001228) I2C Controller Configuration */
+       uint32_t RESERVED0[2];
+  __I  uint32_t MBMON;                             /* !< (@ 0x00001234) I2C Controller Bus Monitor */
+  __IO uint32_t MFIFOCTL;                          /* !< (@ 0x00001238) I2C Controller FIFO Control */
+  __I  uint32_t MFIFOSR;                           /* !< (@ 0x0000123C) I2C Controller FIFO Status Register */
+  __IO uint32_t CONTROLLER_I2CPECCTL;              /* !< (@ 0x00001240) I2C Controller PEC control register */
+  __I  uint32_t CONTROLLER_PECSR;                  /* !< (@ 0x00001244) I2C Controller PEC status register */
+} I2C_MASTER_Regs;
+
+/*@}*/ /* end of group I2C_MASTER */
+
+/** @addtogroup I2C_DMA_TRIG0
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001080) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001088) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001090) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001098) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x000010A0) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x000010A8) Interrupt clear */
+} I2C_DMA_TRIG0_Regs;
+
+/*@}*/ /* end of group I2C_DMA_TRIG0 */
+
+/** @addtogroup I2C_DMA_TRIG1
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001050) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001058) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001060) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001068) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001070) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001078) Interrupt clear */
+} I2C_DMA_TRIG1_Regs;
+
+/*@}*/ /* end of group I2C_DMA_TRIG1 */
+
+/** @addtogroup I2C_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} I2C_CPU_INT_Regs;
+
+/*@}*/ /* end of group I2C_CPU_INT */
+
+/** @addtogroup I2C_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00000808) Peripheral Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} I2C_GPRCM_Regs;
+
+/*@}*/ /* end of group I2C_GPRCM */
+
+/** @addtogroup I2C
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  I2C_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED1[506];
+  __IO uint32_t CLKDIV;                            /* !< (@ 0x00001000) Clock Divider */
+  __IO uint32_t CLKSEL;                            /* !< (@ 0x00001004) Clock Select for Ultra Low Power peripherals */
+       uint32_t RESERVED2[4];
+  __IO uint32_t PDBGCTL;                           /* !< (@ 0x00001018) Peripheral Debug Control */
+       uint32_t RESERVED3;
+  I2C_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED4;
+  I2C_DMA_TRIG1_Regs  DMA_TRIG1;                         /* !< (@ 0x00001050) */
+       uint32_t RESERVED5;
+  I2C_DMA_TRIG0_Regs  DMA_TRIG0;                         /* !< (@ 0x00001080) */
+       uint32_t RESERVED6[13];
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+  __IO uint32_t INTCTL;                            /* !< (@ 0x000010E4) Interrupt control register */
+       uint32_t RESERVED7[5];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Module Description */
+       uint32_t RESERVED8[64];
+  __IO uint32_t GFCTL;                             /* !< (@ 0x00001200) I2C Glitch Filter Control */
+  __IO uint32_t TIMEOUT_CTL;                       /* !< (@ 0x00001204) I2C Timeout Count Control Register */
+  __I  uint32_t TIMEOUT_CNT;                       /* !< (@ 0x00001208) I2C Timeout Count Register */
+       uint32_t RESERVED9;
+  I2C_MASTER_Regs  MASTER;                            /* !< (@ 0x00001210) */
+       uint32_t RESERVED10[2];
+  I2C_SLAVE_Regs  SLAVE;                             /* !< (@ 0x00001250) */
+} I2C_Regs;
+
+/*@}*/ /* end of group I2C */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* I2C Register Control Bits
+******************************************************************************/
+
+/* I2C_SOAR Bits */
+/* I2C_SOAR[OAR] Bits */
+#define I2C_SOAR_OAR_OFS                         (0)                             /* !< OAR Offset */
+#define I2C_SOAR_OAR_MASK                        ((uint32_t)0x000003FFU)         /* !< I2C Target Own Address: This field
+                                                                                    specifies bits A9 through A0 of the
+                                                                                    Target address. In 7-bit addressing
+                                                                                    mode as selected by I2CSOAR.MODE bit,
+                                                                                    the top 3 bits are don't care */
+#define I2C_SOAR_OAR_MINIMUM                     ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_SOAR_OAR_MAXIMUM                     ((uint32_t)0x000003FFU)         /* !< Highest possible value */
+/* I2C_SOAR[OAREN] Bits */
+#define I2C_SOAR_OAREN_OFS                       (14)                            /* !< OAREN Offset */
+#define I2C_SOAR_OAREN_MASK                      ((uint32_t)0x00004000U)         /* !< I2C Target Own Address Enable */
+#define I2C_SOAR_OAREN_DISABLE                   ((uint32_t)0x00000000U)         /* !< Disable OAR address */
+#define I2C_SOAR_OAREN_ENABLE                    ((uint32_t)0x00004000U)         /* !< Enable OAR address */
+/* I2C_SOAR[SMODE] Bits */
+#define I2C_SOAR_SMODE_OFS                       (15)                            /* !< SMODE Offset */
+#define I2C_SOAR_SMODE_MASK                      ((uint32_t)0x00008000U)         /* !< This bit selects the adressing mode
+                                                                                    to be used in Target mode. When 0,
+                                                                                    7-bit addressing is used. When 1,
+                                                                                    10-bit addressing is used. */
+#define I2C_SOAR_SMODE_MODE7                     ((uint32_t)0x00000000U)         /* !< Enable 7-bit addressing */
+#define I2C_SOAR_SMODE_MODE10                    ((uint32_t)0x00008000U)         /* !< Enable 10-bit addressing */
+
+/* I2C_SOAR2 Bits */
+/* I2C_SOAR2[OAR2] Bits */
+#define I2C_SOAR2_OAR2_OFS                       (0)                             /* !< OAR2 Offset */
+#define I2C_SOAR2_OAR2_MASK                      ((uint32_t)0x0000007FU)         /* !< I2C Target Own Address 2This field
+                                                                                    specifies the alternate OAR2 address. */
+#define I2C_SOAR2_OAR2_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_SOAR2_OAR2_MAXIMUM                   ((uint32_t)0x0000007FU)         /* !< Highest possible value */
+/* I2C_SOAR2[OAR2EN] Bits */
+#define I2C_SOAR2_OAR2EN_OFS                     (7)                             /* !< OAR2EN Offset */
+#define I2C_SOAR2_OAR2EN_MASK                    ((uint32_t)0x00000080U)         /* !< I2C Target Own Address 2 Enable */
+#define I2C_SOAR2_OAR2EN_DISABLE                 ((uint32_t)0x00000000U)         /* !< The alternate address is disabled. */
+#define I2C_SOAR2_OAR2EN_ENABLE                  ((uint32_t)0x00000080U)         /* !< Enables the use of the alternate
+                                                                                    address in the OAR2 field. */
+/* I2C_SOAR2[OAR2_MASK] Bits */
+#define I2C_SOAR2_OAR2_MASK_OFS                  (16)                            /* !< OAR2_MASK Offset */
+#define I2C_SOAR2_OAR2_MASK_MASK                 ((uint32_t)0x007F0000U)         /* !< I2C Target Own Address 2 Mask: This
+                                                                                    field specifies bits A6 through A0 of
+                                                                                    the Target address. The bits with
+                                                                                    value 1 in SOAR2.OAR2_MASK field will
+                                                                                    make the corresponding incoming
+                                                                                    address bits to match by default
+                                                                                    regardless of the value inside
+                                                                                    SOAR2.OAR2 i.e. corresponding
+                                                                                    SOAR2.OAR2 bit is a dont care. */
+#define I2C_SOAR2_OAR2_MASK_MINIMUM              ((uint32_t)0x00000000U)         /* !< Minimum Value */
+#define I2C_SOAR2_OAR2_MASK_MAXIMUM              ((uint32_t)0x007F0000U)         /* !< Maximum Value */
+
+/* I2C_SCTR Bits */
+/* I2C_SCTR[ACTIVE] Bits */
+#define I2C_SCTR_ACTIVE_OFS                      (0)                             /* !< ACTIVE Offset */
+#define I2C_SCTR_ACTIVE_MASK                     ((uint32_t)0x00000001U)         /* !< Device Active. Setting this bit
+                                                                                    enables the Target functionality. */
+#define I2C_SCTR_ACTIVE_DISABLE                  ((uint32_t)0x00000000U)         /* !< Disables the I2C Target operation. */
+#define I2C_SCTR_ACTIVE_ENABLE                   ((uint32_t)0x00000001U)         /* !< Enables the I2C Target operation. */
+/* I2C_SCTR[GENCALL] Bits */
+#define I2C_SCTR_GENCALL_OFS                     (1)                             /* !< GENCALL Offset */
+#define I2C_SCTR_GENCALL_MASK                    ((uint32_t)0x00000002U)         /* !< General call response enable Modify
+                                                                                    only when UCSWRST = 1. 0b = Do not
+                                                                                    respond to a general call 1b =
+                                                                                    Respond to a general call */
+#define I2C_SCTR_GENCALL_DISABLE                 ((uint32_t)0x00000000U)         /* !< Do not respond to a general call */
+#define I2C_SCTR_GENCALL_ENABLE                  ((uint32_t)0x00000002U)         /* !< Respond to a general call */
+/* I2C_SCTR[SCLKSTRETCH] Bits */
+#define I2C_SCTR_SCLKSTRETCH_OFS                 (2)                             /* !< SCLKSTRETCH Offset */
+#define I2C_SCTR_SCLKSTRETCH_MASK                ((uint32_t)0x00000004U)         /* !< Target Clock Stretch Enable */
+#define I2C_SCTR_SCLKSTRETCH_DISABLE             ((uint32_t)0x00000000U)         /* !< Target clock stretching is disabled */
+#define I2C_SCTR_SCLKSTRETCH_ENABLE              ((uint32_t)0x00000004U)         /* !< Target clock stretching is enabled */
+/* I2C_SCTR[TXEMPTY_ON_TREQ] Bits */
+#define I2C_SCTR_TXEMPTY_ON_TREQ_OFS             (3)                             /* !< TXEMPTY_ON_TREQ Offset */
+#define I2C_SCTR_TXEMPTY_ON_TREQ_MASK            ((uint32_t)0x00000008U)         /* !< Tx Empty Interrupt on TREQ */
+#define I2C_SCTR_TXEMPTY_ON_TREQ_DISABLE         ((uint32_t)0x00000000U)         /* !< When 0, RIS:STXEMPTY will be set
+                                                                                    when only the Target TX FIFO is
+                                                                                    empty. This allows the STXEMPTY
+                                                                                    interrupt to be used to indicate that
+                                                                                    the I2C bus is being clock stretched
+                                                                                    and that Target TX data is required. */
+#define I2C_SCTR_TXEMPTY_ON_TREQ_ENABLE          ((uint32_t)0x00000008U)         /* !< When 1, RIS:STXEMPTY will be set
+                                                                                    when the Target State Machine is in
+                                                                                    the TX_WAIT state which occurs when
+                                                                                    the TX FIFO is empty AND the I2C
+                                                                                    transaction is clock stretched
+                                                                                    waiting for the FIFO to receive data. */
+/* I2C_SCTR[TXTRIG_TXMODE] Bits */
+#define I2C_SCTR_TXTRIG_TXMODE_OFS               (4)                             /* !< TXTRIG_TXMODE Offset */
+#define I2C_SCTR_TXTRIG_TXMODE_MASK              ((uint32_t)0x00000010U)         /* !< Tx Trigger when Target FSM is in Tx
+                                                                                    Mode */
+#define I2C_SCTR_TXTRIG_TXMODE_DISABLE           ((uint32_t)0x00000000U)         /* !< No special behavior */
+#define I2C_SCTR_TXTRIG_TXMODE_ENABLE            ((uint32_t)0x00000010U)         /* !< When 1, RIS:TXFIFOTRG will be set
+                                                                                    when the Target TX FIFO has reached
+                                                                                    the trigger level AND the Target
+                                                                                    State Machine is in the TXMODE as
+                                                                                    defined in the SSR register. When
+                                                                                    cleared RIS:TXFIFOTRG will be set
+                                                                                    when the Target TX FIFO is at or
+                                                                                    above the trigger level. This setting
+                                                                                    can be used to hold off the TX DMA
+                                                                                    until a transaction starts. This
+                                                                                    allows the DMA to be configured when
+                                                                                    the I2C is idle but have it wait till
+                                                                                    the transaction starts to load the
+                                                                                    Target TX FIFO, so it can load from a
+                                                                                    memory buffer that might be changing
+                                                                                    over time. */
+/* I2C_SCTR[TXWAIT_STALE_TXFIFO] Bits */
+#define I2C_SCTR_TXWAIT_STALE_TXFIFO_OFS         (5)                             /* !< TXWAIT_STALE_TXFIFO Offset */
+#define I2C_SCTR_TXWAIT_STALE_TXFIFO_MASK        ((uint32_t)0x00000020U)         /* !< Tx transfer waits when stale data
+                                                                                    in Tx FIFO. This prevents stale bytes
+                                                                                    left in the TX FIFO from
+                                                                                    automatically being sent on the next
+                                                                                    I2C packet. Note: this should be used
+                                                                                    with TXEMPTY_ON_TREQ set to prevent
+                                                                                    the Target State Machine from waiting
+                                                                                    for TX FIFO data without an interrupt
+                                                                                    notification when the FIFO data is
+                                                                                    stale. */
+#define I2C_SCTR_TXWAIT_STALE_TXFIFO_DISABLE     ((uint32_t)0x00000000U)         /* !< When 0, the TX FIFO empty signal to
+                                                                                    the Target State Machine indicates
+                                                                                    that the TX FIFO is empty. */
+#define I2C_SCTR_TXWAIT_STALE_TXFIFO_ENABLE      ((uint32_t)0x00000020U)         /* !< When 1, the TX FIFO empty signal to
+                                                                                    the Target State Machine will
+                                                                                    indicate that the TX FIFO is empty or
+                                                                                    that the TX FIFO data is stale. The
+                                                                                    TX FIFO data is determined to be
+                                                                                    stale when there is data in the TX
+                                                                                    FIFO when the Target State Machine
+                                                                                    leaves the TXMODE as defined in the
+                                                                                    SSR register. This can occur is a
+                                                                                    Stop or timeout occur when there are
+                                                                                    bytes left in the TX FIFO. */
+/* I2C_SCTR[RXFULL_ON_RREQ] Bits */
+#define I2C_SCTR_RXFULL_ON_RREQ_OFS              (6)                             /* !< RXFULL_ON_RREQ Offset */
+#define I2C_SCTR_RXFULL_ON_RREQ_MASK             ((uint32_t)0x00000040U)         /* !< Rx full interrupt generated on RREQ
+                                                                                    condition as indicated in SSR */
+#define I2C_SCTR_RXFULL_ON_RREQ_DISABLE          ((uint32_t)0x00000000U)         /* !< When 0, RIS:SRXFULL will be set
+                                                                                    when only the Target RX FIFO is full.
+                                                                                    This allows the SRXFULL interrupt to
+                                                                                    be used to indicate that the I2C bus
+                                                                                    is being clock stretched and that the
+                                                                                    FW must either read the RX FIFO or
+                                                                                    ACK/NACK the current Rx byte. */
+#define I2C_SCTR_RXFULL_ON_RREQ_ENABLE           ((uint32_t)0x00000040U)         /* !< When 1, RIS:SRXFULL will be set
+                                                                                    when the Target State Machine is in
+                                                                                    the RX_WAIT or RX_ACK_WAIT states
+                                                                                    which occurs when the I2C transaction
+                                                                                    is clock stretched because the RX
+                                                                                    FIFO is full or the ACKOEN has been
+                                                                                    set and the state machine is waiting
+                                                                                    for FW to ACK/NACK the current byte. */
+/* I2C_SCTR[EN_DEFHOSTADR] Bits */
+#define I2C_SCTR_EN_DEFHOSTADR_OFS               (7)                             /* !< EN_DEFHOSTADR Offset */
+#define I2C_SCTR_EN_DEFHOSTADR_MASK              ((uint32_t)0x00000080U)         /* !< Enable Default Host Address */
+#define I2C_SCTR_EN_DEFHOSTADR_DISABLE           ((uint32_t)0x00000000U)         /* !< When this bit is 0, the default
+                                                                                    host address is not matched NOTE: it
+                                                                                    may still be matched if programmed
+                                                                                    inside SOAR/SOAR2 */
+#define I2C_SCTR_EN_DEFHOSTADR_ENABLE            ((uint32_t)0x00000080U)         /* !< When this bit is 1, default host
+                                                                                    address of 7h000_1000 is always
+                                                                                    matched by the Target address match
+                                                                                    logic. */
+/* I2C_SCTR[EN_ALRESPADR] Bits */
+#define I2C_SCTR_EN_ALRESPADR_OFS                (8)                             /* !< EN_ALRESPADR Offset */
+#define I2C_SCTR_EN_ALRESPADR_MASK               ((uint32_t)0x00000100U)         /* !< Enable Alert Response Address */
+#define I2C_SCTR_EN_ALRESPADR_DISABLE            ((uint32_t)0x00000000U)         /* !< When this bit is 0, the alert
+                                                                                    response address is not matched.
+                                                                                    NOTE: it may still be matched if
+                                                                                    programmed inside SOAR/SOAR2 */
+#define I2C_SCTR_EN_ALRESPADR_ENABLE             ((uint32_t)0x00000100U)         /* !< When this bit is 1, alert response
+                                                                                    address of 7h000_1100 is always
+                                                                                    matched by the Target address match
+                                                                                    logic. */
+/* I2C_SCTR[EN_DEFDEVADR] Bits */
+#define I2C_SCTR_EN_DEFDEVADR_OFS                (9)                             /* !< EN_DEFDEVADR Offset */
+#define I2C_SCTR_EN_DEFDEVADR_MASK               ((uint32_t)0x00000200U)         /* !< Enable Deault device address */
+#define I2C_SCTR_EN_DEFDEVADR_DISABLE            ((uint32_t)0x00000000U)         /* !< When this bit is 0, the default
+                                                                                    device address is not matched. NOTE:
+                                                                                    it may still be matched if programmed
+                                                                                    inside SOAR/SOAR2. */
+#define I2C_SCTR_EN_DEFDEVADR_ENABLE             ((uint32_t)0x00000200U)         /* !< When this bit is 1, default device
+                                                                                    address of 7h110_0001 is always
+                                                                                    matched by the Target address match
+                                                                                    logic. */
+/* I2C_SCTR[SWUEN] Bits */
+#define I2C_SCTR_SWUEN_OFS                       (10)                            /* !< SWUEN Offset */
+#define I2C_SCTR_SWUEN_MASK                      ((uint32_t)0x00000400U)         /* !< Target Wakeup Enable */
+#define I2C_SCTR_SWUEN_DISABLE                   ((uint32_t)0x00000000U)         /* !< When 0, the Target is not allowed
+                                                                                    to clock stretch on START detection */
+#define I2C_SCTR_SWUEN_ENABLE                    ((uint32_t)0x00000400U)         /* !< When 1, the Target is allowed to
+                                                                                    clock stretch on START detection and
+                                                                                    wait for faster clock to be
+                                                                                    abvailable. This allows clean wake up
+                                                                                    support for I2C in low power mode use
+                                                                                    cases */
+
+/* I2C_SSR Bits */
+/* I2C_SSR[RREQ] Bits */
+#define I2C_SSR_RREQ_OFS                         (0)                             /* !< RREQ Offset */
+#define I2C_SSR_RREQ_MASK                        ((uint32_t)0x00000001U)         /* !< Receive Request */
+#define I2C_SSR_RREQ_CLEARED                     ((uint32_t)0x00000000U)         /* !< No outstanding receive data. */
+#define I2C_SSR_RREQ_SET                         ((uint32_t)0x00000001U)         /* !< The I2C controller has outstanding
+                                                                                    receive data from the I2C Controller
+                                                                                    and is using clock stretching to
+                                                                                    delay the Controller until the data
+                                                                                    has been read from the SRXDATA FIFO
+                                                                                    (Target RX FIFO is full). */
+/* I2C_SSR[TREQ] Bits */
+#define I2C_SSR_TREQ_OFS                         (1)                             /* !< TREQ Offset */
+#define I2C_SSR_TREQ_MASK                        ((uint32_t)0x00000002U)         /* !< Transmit Request */
+#define I2C_SSR_TREQ_CLEARED                     ((uint32_t)0x00000000U)         /* !< No outstanding transmit request. */
+#define I2C_SSR_TREQ_SET                         ((uint32_t)0x00000002U)         /* !< The I2C controller has been
+                                                                                    addressed as a Target transmitter and
+                                                                                    is using clock stretching to delay
+                                                                                    the Controller until data has been
+                                                                                    written to the STXDATA FIFO (Target
+                                                                                    TX FIFO is empty). */
+/* I2C_SSR[OAR2SEL] Bits */
+#define I2C_SSR_OAR2SEL_OFS                      (3)                             /* !< OAR2SEL Offset */
+#define I2C_SSR_OAR2SEL_MASK                     ((uint32_t)0x00000008U)         /* !< OAR2 Address Matched This bit gets
+                                                                                    reevaluated after every address
+                                                                                    comparison. */
+#define I2C_SSR_OAR2SEL_CLEARED                  ((uint32_t)0x00000000U)         /* !< Either the OAR2 address is not
+                                                                                    matched or the match is in legacy
+                                                                                    mode. */
+#define I2C_SSR_OAR2SEL_SET                      ((uint32_t)0x00000008U)         /* !< OAR2 address matched and ACKed by
+                                                                                    the Target. */
+/* I2C_SSR[QCMDST] Bits */
+#define I2C_SSR_QCMDST_OFS                       (4)                             /* !< QCMDST Offset */
+#define I2C_SSR_QCMDST_MASK                      ((uint32_t)0x00000010U)         /* !< Quick Command Status Value
+                                                                                    Description: 0: The last transaction
+                                                                                    was a normal transaction or a
+                                                                                    transaction has not occurred. 1: The
+                                                                                    last transaction was a Quick Command
+                                                                                    transaction */
+#define I2C_SSR_QCMDST_CLEARED                   ((uint32_t)0x00000000U)         /* !< The last transaction was a normal
+                                                                                    transaction or a transaction has not
+                                                                                    occurred. */
+#define I2C_SSR_QCMDST_SET                       ((uint32_t)0x00000010U)         /* !< The last transaction was a Quick
+                                                                                    Command transaction. */
+/* I2C_SSR[QCMDRW] Bits */
+#define I2C_SSR_QCMDRW_OFS                       (5)                             /* !< QCMDRW Offset */
+#define I2C_SSR_QCMDRW_MASK                      ((uint32_t)0x00000020U)         /* !< Quick Command Read / Write  This
+                                                                                    bit only has meaning when the QCMDST
+                                                                                    bit is set.  Value Description: 0:
+                                                                                    Quick command was a write 1: Quick
+                                                                                    command was a read */
+#define I2C_SSR_QCMDRW_CLEARED                   ((uint32_t)0x00000000U)         /* !< Quick command was a write */
+#define I2C_SSR_QCMDRW_SET                       ((uint32_t)0x00000020U)         /* !< Quick command was a read */
+/* I2C_SSR[RXMODE] Bits */
+#define I2C_SSR_RXMODE_OFS                       (2)                             /* !< RXMODE Offset */
+#define I2C_SSR_RXMODE_MASK                      ((uint32_t)0x00000004U)         /* !< Target FSM is in Rx MODE */
+#define I2C_SSR_RXMODE_CLEARED                   ((uint32_t)0x00000000U)         /* !< The Target State Machine is not in
+                                                                                    the RX_DATA, RX_ACK, RX_WAIT,
+                                                                                    RX_ACK_WAIT or ADDR_ACK state with
+                                                                                    the bus direction set to write. */
+#define I2C_SSR_RXMODE_SET                       ((uint32_t)0x00000004U)         /* !< The Target State Machine is in the
+                                                                                    RX_DATA, RX_ACK, RX_WAIT, RX_ACK_WAIT
+                                                                                    or ADDR_ACK state with the bus
+                                                                                    direction set to write. */
+/* I2C_SSR[BUSBSY] Bits */
+#define I2C_SSR_BUSBSY_OFS                       (6)                             /* !< BUSBSY Offset */
+#define I2C_SSR_BUSBSY_MASK                      ((uint32_t)0x00000040U)         /* !< I2C bus is busy */
+#define I2C_SSR_BUSBSY_CLEARED                   ((uint32_t)0x00000000U)         /* !< The I2C Bus is not busy */
+#define I2C_SSR_BUSBSY_SET                       ((uint32_t)0x00000040U)         /* !< The I2C Bus is busy. This is
+                                                                                    cleared on a timeout. */
+/* I2C_SSR[TXMODE] Bits */
+#define I2C_SSR_TXMODE_OFS                       (7)                             /* !< TXMODE Offset */
+#define I2C_SSR_TXMODE_MASK                      ((uint32_t)0x00000080U)         /* !< Target FSM is in TX MODE */
+#define I2C_SSR_TXMODE_CLEARED                   ((uint32_t)0x00000000U)         /* !< The Target State Machine is not in
+                                                                                    TX_DATA, TX_WAIT, TX_ACK  or ADDR_ACK
+                                                                                    state with the bus direction set to
+                                                                                    read. */
+#define I2C_SSR_TXMODE_SET                       ((uint32_t)0x00000080U)         /* !< The Target State Machine is in
+                                                                                    TX_DATA, TX_WAIT, TX_ACK  or ADDR_ACK
+                                                                                    state with the bus direction set to
+                                                                                    read. */
+/* I2C_SSR[STALE_TXFIFO] Bits */
+#define I2C_SSR_STALE_TXFIFO_OFS                 (8)                             /* !< STALE_TXFIFO Offset */
+#define I2C_SSR_STALE_TXFIFO_MASK                ((uint32_t)0x00000100U)         /* !< Stale Tx FIFO */
+#define I2C_SSR_STALE_TXFIFO_CLEARED             ((uint32_t)0x00000000U)         /* !< Tx FIFO is not stale */
+#define I2C_SSR_STALE_TXFIFO_SET                 ((uint32_t)0x00000100U)         /* !< The TX FIFO is stale. This occurs
+                                                                                    when the TX FIFO was not emptied
+                                                                                    during the previous I2C transaction. */
+/* I2C_SSR[ADDRMATCH] Bits */
+#define I2C_SSR_ADDRMATCH_OFS                    (9)                             /* !< ADDRMATCH Offset */
+#define I2C_SSR_ADDRMATCH_MASK                   ((uint32_t)0x0007FE00U)         /* !< Indicates the address for which
+                                                                                    Target address match happened */
+#define I2C_SSR_ADDRMATCH_MINIMUM                ((uint32_t)0x00000000U)         /* !< Minimum Value */
+#define I2C_SSR_ADDRMATCH_MAXIMUM                ((uint32_t)0x0007FE00U)         /* !< Maximum Value */
+
+/* I2C_SRXDATA Bits */
+/* I2C_SRXDATA[VALUE] Bits */
+#define I2C_SRXDATA_VALUE_OFS                    (0)                             /* !< VALUE Offset */
+#define I2C_SRXDATA_VALUE_MASK                   ((uint32_t)0x000000FFU)         /* !< Received Data.  This field contains
+                                                                                    the last received data. */
+#define I2C_SRXDATA_VALUE_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_SRXDATA_VALUE_MAXIMUM                ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+
+/* I2C_STXDATA Bits */
+/* I2C_STXDATA[VALUE] Bits */
+#define I2C_STXDATA_VALUE_OFS                    (0)                             /* !< VALUE Offset */
+#define I2C_STXDATA_VALUE_MASK                   ((uint32_t)0x000000FFU)         /* !< Transmit Data This byte contains
+                                                                                    the data to be transferred during the
+                                                                                    next transaction. */
+#define I2C_STXDATA_VALUE_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_STXDATA_VALUE_MAXIMUM                ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+
+/* I2C_SACKCTL Bits */
+/* I2C_SACKCTL[ACKOEN] Bits */
+#define I2C_SACKCTL_ACKOEN_OFS                   (0)                             /* !< ACKOEN Offset */
+#define I2C_SACKCTL_ACKOEN_MASK                  ((uint32_t)0x00000001U)         /* !< I2C Target ACK Override Enable */
+#define I2C_SACKCTL_ACKOEN_DISABLE               ((uint32_t)0x00000000U)         /* !< A response in not provided. */
+#define I2C_SACKCTL_ACKOEN_ENABLE                ((uint32_t)0x00000001U)         /* !< An ACK or NACK is sent according to
+                                                                                    the value written to the ACKOVAL bit. */
+/* I2C_SACKCTL[ACKOVAL] Bits */
+#define I2C_SACKCTL_ACKOVAL_OFS                  (1)                             /* !< ACKOVAL Offset */
+#define I2C_SACKCTL_ACKOVAL_MASK                 ((uint32_t)0x00000002U)         /* !< I2C Target ACK Override Value Note:
+                                                                                    for General Call this bit will be
+                                                                                    ignored if set to NACK and Target
+                                                                                    continues to receive data. */
+#define I2C_SACKCTL_ACKOVAL_DISABLE              ((uint32_t)0x00000000U)         /* !< An ACK is sent indicating valid
+                                                                                    data or command. */
+#define I2C_SACKCTL_ACKOVAL_ENABLE               ((uint32_t)0x00000002U)         /* !< A NACK is sent indicating invalid
+                                                                                    data or command. */
+/* I2C_SACKCTL[ACKOEN_ON_START] Bits */
+#define I2C_SACKCTL_ACKOEN_ON_START_OFS          (2)                             /* !< ACKOEN_ON_START Offset */
+#define I2C_SACKCTL_ACKOEN_ON_START_MASK         ((uint32_t)0x00000004U)         /* !< When set this bit will
+                                                                                    automatically turn on the Target
+                                                                                    ACKOEN field following a Start
+                                                                                    Condition. */
+#define I2C_SACKCTL_ACKOEN_ON_START_DISABLE      ((uint32_t)0x00000000U)         /* !< No special behavior */
+#define I2C_SACKCTL_ACKOEN_ON_START_ENABLE       ((uint32_t)0x00000004U)         /* !< When set this bit will
+                                                                                    automatically turn on the Target
+                                                                                    ACKOEN field following a Start
+                                                                                    Condition. */
+/* I2C_SACKCTL[ACKOEN_ON_PECNEXT] Bits */
+#define I2C_SACKCTL_ACKOEN_ON_PECNEXT_OFS        (3)                             /* !< ACKOEN_ON_PECNEXT Offset */
+#define I2C_SACKCTL_ACKOEN_ON_PECNEXT_MASK       ((uint32_t)0x00000008U)         /* !< When set this bit will
+                                                                                    automatically turn on the Target
+                                                                                    ACKOEN field following the ACK/NACK
+                                                                                    of the byte received just prior to
+                                                                                    the PEC byte. Note that when ACKOEN
+                                                                                    is set the PEC byte will not
+                                                                                    automatically be ACKed/NACKed by the
+                                                                                    State Machine and FW must perform
+                                                                                    this function by writing
+                                                                                    Target_SACKCTL. */
+#define I2C_SACKCTL_ACKOEN_ON_PECNEXT_DISABLE    ((uint32_t)0x00000000U)         /* !< No special behavior */
+#define I2C_SACKCTL_ACKOEN_ON_PECNEXT_ENABLE     ((uint32_t)0x00000008U)         /* !< When set this bit will
+                                                                                    automatically turn on the Target
+                                                                                    ACKOEN field following the ACK/NACK
+                                                                                    of the byte received just prior to
+                                                                                    the PEC byte. Note that when ACKOEN
+                                                                                    is set the PEC byte will not
+                                                                                    automatically be ACKed/NACKed by the
+                                                                                    State Machine and FW must perform
+                                                                                    this function by writing
+                                                                                    Target_SACKCTL. */
+/* I2C_SACKCTL[ACKOEN_ON_PECDONE] Bits */
+#define I2C_SACKCTL_ACKOEN_ON_PECDONE_OFS        (4)                             /* !< ACKOEN_ON_PECDONE Offset */
+#define I2C_SACKCTL_ACKOEN_ON_PECDONE_MASK       ((uint32_t)0x00000010U)         /* !< When set this bit will
+                                                                                    automatically turn on the Target
+                                                                                    ACKOEN field following the ACK/NACK
+                                                                                    of the received PEC byte. */
+#define I2C_SACKCTL_ACKOEN_ON_PECDONE_DISABLE    ((uint32_t)0x00000000U)         /* !< No special behavior */
+#define I2C_SACKCTL_ACKOEN_ON_PECDONE_ENABLE     ((uint32_t)0x00000010U)         /* !< When set this bit will
+                                                                                    automatically turn on the Target
+                                                                                    ACKOEN field following the ACK/NACK
+                                                                                    of the received PEC byte. */
+
+/* I2C_SFIFOCTL Bits */
+/* I2C_SFIFOCTL[TXTRIG] Bits */
+#define I2C_SFIFOCTL_TXTRIG_OFS                  (0)                             /* !< TXTRIG Offset */
+#define I2C_SFIFOCTL_TXTRIG_MASK                 ((uint32_t)0x00000007U)         /* !< TX FIFO Trigger Indicates at what
+                                                                                    fill level in the TX FIFO a trigger
+                                                                                    will be generated. */
+#define I2C_SFIFOCTL_TXTRIG_LEVEL_4              ((uint32_t)0x00000004U)         /* !< Trigger when TX FIFO contains  4
+                                                                                    byte */
+#define I2C_SFIFOCTL_TXTRIG_LEVEL_5              ((uint32_t)0x00000005U)         /* !< Trigger when TX FIFO contains  5
+                                                                                    byte */
+#define I2C_SFIFOCTL_TXTRIG_LEVEL_6              ((uint32_t)0x00000006U)         /* !< Trigger when TX FIFO contains  6
+                                                                                    byte */
+#define I2C_SFIFOCTL_TXTRIG_LEVEL_7              ((uint32_t)0x00000007U)         /* !< Trigger when TX FIFO contains  7
+                                                                                    byte */
+/* I2C_SFIFOCTL[TXFLUSH] Bits */
+#define I2C_SFIFOCTL_TXFLUSH_OFS                 (7)                             /* !< TXFLUSH Offset */
+#define I2C_SFIFOCTL_TXFLUSH_MASK                ((uint32_t)0x00000080U)         /* !< TX FIFO Flush Setting this bit will
+                                                                                    Flush the TX FIFO. Before clearing
+                                                                                    this bit to stop Flush the TXFIFOCNT
+                                                                                    should be checked to be 8 and
+                                                                                    indicating that the Flush has
+                                                                                    completed. */
+#define I2C_SFIFOCTL_TXFLUSH_NOFLUSH             ((uint32_t)0x00000000U)         /* !< Do not Flush FIFO */
+#define I2C_SFIFOCTL_TXFLUSH_FLUSH               ((uint32_t)0x00000080U)         /* !< Flush FIFO */
+/* I2C_SFIFOCTL[RXFLUSH] Bits */
+#define I2C_SFIFOCTL_RXFLUSH_OFS                 (15)                            /* !< RXFLUSH Offset */
+#define I2C_SFIFOCTL_RXFLUSH_MASK                ((uint32_t)0x00008000U)         /* !< RX FIFO Flush Setting this bit will
+                                                                                    Flush the RX FIFO. Before clearing
+                                                                                    this bit to stop Flush the RXFIFOCNT
+                                                                                    should be checked to be 0 and
+                                                                                    indicating that the Flush has
+                                                                                    completed. */
+#define I2C_SFIFOCTL_RXFLUSH_NOFLUSH             ((uint32_t)0x00000000U)         /* !< Do not Flush FIFO */
+#define I2C_SFIFOCTL_RXFLUSH_FLUSH               ((uint32_t)0x00008000U)         /* !< Flush FIFO */
+/* I2C_SFIFOCTL[RXTRIG] Bits */
+#define I2C_SFIFOCTL_RXTRIG_OFS                  (8)                             /* !< RXTRIG Offset */
+#define I2C_SFIFOCTL_RXTRIG_MASK                 ((uint32_t)0x00000700U)         /* !< RX FIFO Trigger Indicates at what
+                                                                                    fill level in the RX FIFO a trigger
+                                                                                    will be generated. Note: Programming
+                                                                                    RXTRIG to 0x0 has no effect since no
+                                                                                    data is present to transfer out of RX
+                                                                                    FIFO. */
+#define I2C_SFIFOCTL_RXTRIG_LEVEL_5              ((uint32_t)0x00000400U)         /* !< Trigger when RX FIFO contains >= 5
+                                                                                    byte */
+#define I2C_SFIFOCTL_RXTRIG_LEVEL_6              ((uint32_t)0x00000500U)         /* !< Trigger when RX FIFO contains >= 6
+                                                                                    byte */
+#define I2C_SFIFOCTL_RXTRIG_LEVEL_7              ((uint32_t)0x00000600U)         /* !< Trigger when RX FIFO contains >= 7
+                                                                                    byte */
+#define I2C_SFIFOCTL_RXTRIG_LEVEL_8              ((uint32_t)0x00000700U)         /* !< Trigger when RX FIFO contains >= 8
+                                                                                    byte */
+
+/* I2C_SFIFOSR Bits */
+/* I2C_SFIFOSR[RXFIFOCNT] Bits */
+#define I2C_SFIFOSR_RXFIFOCNT_OFS                (0)                             /* !< RXFIFOCNT Offset */
+#define I2C_SFIFOSR_RXFIFOCNT_MASK               ((uint32_t)0x0000000FU)         /* !< Number of Bytes which could be read
+                                                                                    from the RX FIFO */
+#define I2C_SFIFOSR_RXFIFOCNT_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_SFIFOSR_RXFIFOCNT_MAXIMUM            ((uint32_t)0x00000008U)         /* !< Highest possible value */
+/* I2C_SFIFOSR[TXFIFOCNT] Bits */
+#define I2C_SFIFOSR_TXFIFOCNT_OFS                (8)                             /* !< TXFIFOCNT Offset */
+#define I2C_SFIFOSR_TXFIFOCNT_MASK               ((uint32_t)0x00000F00U)         /* !< Number of Bytes which could be put
+                                                                                    into the TX FIFO */
+#define I2C_SFIFOSR_TXFIFOCNT_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_SFIFOSR_TXFIFOCNT_MAXIMUM            ((uint32_t)0x00000800U)         /* !< Highest possible value */
+/* I2C_SFIFOSR[TXFLUSH] Bits */
+#define I2C_SFIFOSR_TXFLUSH_OFS                  (15)                            /* !< TXFLUSH Offset */
+#define I2C_SFIFOSR_TXFLUSH_MASK                 ((uint32_t)0x00008000U)         /* !< TX FIFO Flush When this bit is set
+                                                                                    a Flush operation for the TX FIFO is
+                                                                                    active. Clear the TXFLUSH bit in the
+                                                                                    control register to stop. */
+#define I2C_SFIFOSR_TXFLUSH_INACTIVE             ((uint32_t)0x00000000U)         /* !< FIFO Flush not active */
+#define I2C_SFIFOSR_TXFLUSH_ACTIVE               ((uint32_t)0x00008000U)         /* !< FIFO Flush active */
+/* I2C_SFIFOSR[RXFLUSH] Bits */
+#define I2C_SFIFOSR_RXFLUSH_OFS                  (7)                             /* !< RXFLUSH Offset */
+#define I2C_SFIFOSR_RXFLUSH_MASK                 ((uint32_t)0x00000080U)         /* !< RX FIFO Flush When this bit is set
+                                                                                    a Flush operation for the RX FIFO is
+                                                                                    active. Clear the RXFLUSH bit in the
+                                                                                    control register to stop. */
+#define I2C_SFIFOSR_RXFLUSH_INACTIVE             ((uint32_t)0x00000000U)         /* !< FIFOFlush not active */
+#define I2C_SFIFOSR_RXFLUSH_ACTIVE               ((uint32_t)0x00000080U)         /* !< FIFO Flush active */
+
+/* I2C_TARGET_PECCTL Bits */
+/* I2C_TARGET_PECCTL[PECCNT] Bits */
+#define I2C_TARGET_PECCTL_PECCNT_OFS             (0)                             /* !< PECCNT Offset */
+#define I2C_TARGET_PECCTL_PECCNT_MASK            ((uint32_t)0x000001FFU)         /* !< When this field is non zero, the
+                                                                                    number of I2C data bytes are counted.
+                                                                                    When the byte count = PECCNT and the
+                                                                                    state machine is transmitting, the
+                                                                                    contents of the LSFR is loaded into
+                                                                                    the shift register instead of the
+                                                                                    byte received from the Tx FIFO. When
+                                                                                    the state machine is receiving, after
+                                                                                    the last bit of this byte is received
+                                                                                    the LSFR is checked and if it is
+                                                                                    non-zero, a PEC RX Error interrupt is
+                                                                                    generated. The I2C packet must be
+                                                                                    padded to include the PEC byte for
+                                                                                    both transmit and receive. In
+                                                                                    transmit mode the FIFO must be loaded
+                                                                                    with a dummy PEC byte. In receive
+                                                                                    mode the PEC byte will be passed to
+                                                                                    the Rx FIFO.  In the normal Target
+                                                                                    use case, FW would set PECEN=1 and
+                                                                                    PECCNT=0 and use the ACKOEN until the
+                                                                                    remaining SMB packet length is known.
+                                                                                    FW would then set the PECCNT to the
+                                                                                    remaining packet length (Including
+                                                                                    PEC bye). FW would then configure DMA
+                                                                                    to allow the packet to complete
+                                                                                    unassisted and exit NoAck mode.  Note
+                                                                                    that when the byte count = PEC CNT,
+                                                                                    the byte count is reset to 0 and
+                                                                                    multiple PEC calculation can
+                                                                                    automatically occur within a single
+                                                                                    I2C transaction */
+#define I2C_TARGET_PECCTL_PECCNT_MINIMUM         ((uint32_t)0x00000000U)         /* !< Minimum Value */
+#define I2C_TARGET_PECCTL_PECCNT_MAXIMUM         ((uint32_t)0x000001FFU)         /* !< Maximum Value */
+/* I2C_TARGET_PECCTL[PECEN] Bits */
+#define I2C_TARGET_PECCTL_PECEN_OFS              (12)                            /* !< PECEN Offset */
+#define I2C_TARGET_PECCTL_PECEN_MASK             ((uint32_t)0x00001000U)         /* !< PEC Enable This bit enables the SMB
+                                                                                    Packet Error Checking (PEC). When
+                                                                                    enabled the PEC is calculated on all
+                                                                                    bits except the Start, Stop, Ack and
+                                                                                    Nack. The PEC LSFR and the Byte
+                                                                                    Counter is set to 0 when the State
+                                                                                    Machine is in the IDLE state, which
+                                                                                    occur following a Stop or when a
+                                                                                    timeout occurs. The Counter is also
+                                                                                    set to 0 after the PEC byte is sent
+                                                                                    or received. Note that the NACK is
+                                                                                    automatically send following a PEC
+                                                                                    byte that results in a PEC error. The
+                                                                                    PEC Polynomial is x^8 + x^2 + x^1 +
+                                                                                    1. */
+#define I2C_TARGET_PECCTL_PECEN_DISABLE          ((uint32_t)0x00000000U)         /* !< PEC transmission and check is
+                                                                                    disabled */
+#define I2C_TARGET_PECCTL_PECEN_ENABLE           ((uint32_t)0x00001000U)         /* !< PEC transmission and check is
+                                                                                    enabled */
+
+/* I2C_TARGET_PECSR Bits */
+/* I2C_TARGET_PECSR[PECBYTECNT] Bits */
+#define I2C_TARGET_PECSR_PECBYTECNT_OFS          (0)                             /* !< PECBYTECNT Offset */
+#define I2C_TARGET_PECSR_PECBYTECNT_MASK         ((uint32_t)0x000001FFU)         /* !< This is the current PEC Byte Count
+                                                                                    of the Target State Machine. */
+#define I2C_TARGET_PECSR_PECBYTECNT_MINIMUM      ((uint32_t)0x00000000U)         /* !< Minimum Value */
+#define I2C_TARGET_PECSR_PECBYTECNT_MAXIMUM      ((uint32_t)0x000001FFU)         /* !< Maximum Value */
+/* I2C_TARGET_PECSR[PECSTS_CHECK] Bits */
+#define I2C_TARGET_PECSR_PECSTS_CHECK_OFS        (16)                            /* !< PECSTS_CHECK Offset */
+#define I2C_TARGET_PECSR_PECSTS_CHECK_MASK       ((uint32_t)0x00010000U)         /* !< This status bit indicates if the
+                                                                                    PEC was checked in the transaction
+                                                                                    that occurred before the last Stop.
+                                                                                    Latched on Stop. */
+#define I2C_TARGET_PECSR_PECSTS_CHECK_CLEARED    ((uint32_t)0x00000000U)         /* !< Indicates PEC was not checked in
+                                                                                    the transaction that occurred before
+                                                                                    the last Stop */
+#define I2C_TARGET_PECSR_PECSTS_CHECK_SET        ((uint32_t)0x00010000U)         /* !< Indicates PEC was checked in the
+                                                                                    transaction that occurred before the
+                                                                                    last Stop */
+/* I2C_TARGET_PECSR[PECSTS_ERROR] Bits */
+#define I2C_TARGET_PECSR_PECSTS_ERROR_OFS        (17)                            /* !< PECSTS_ERROR Offset */
+#define I2C_TARGET_PECSR_PECSTS_ERROR_MASK       ((uint32_t)0x00020000U)         /* !< This status bit indicates if a PEC
+                                                                                    check error occurred in the
+                                                                                    transaction that occurred before the
+                                                                                    last Stop. Latched on Stop. */
+#define I2C_TARGET_PECSR_PECSTS_ERROR_CLEARED    ((uint32_t)0x00000000U)         /* !< Indicates PEC check error did not
+                                                                                    occurr in the transaction that
+                                                                                    occurred before the last Stop */
+#define I2C_TARGET_PECSR_PECSTS_ERROR_SET        ((uint32_t)0x00020000U)         /* !< Indicates PEC check error occurred
+                                                                                    in the transaction that occurred
+                                                                                    before the last Stop */
+
+/* I2C_MSA Bits */
+/* I2C_MSA[DIR] Bits */
+#define I2C_MSA_DIR_OFS                          (0)                             /* !< DIR Offset */
+#define I2C_MSA_DIR_MASK                         ((uint32_t)0x00000001U)         /* !< Receive/Send The DIR bit specifies
+                                                                                    if the next Controller operation is a
+                                                                                    Receive (High) or Transmit (Low). 0h
+                                                                                    = Transmit 1h = Receive */
+#define I2C_MSA_DIR_TRANSMIT                     ((uint32_t)0x00000000U)         /* !< The Controller is in transmit mode. */
+#define I2C_MSA_DIR_RECEIVE                      ((uint32_t)0x00000001U)         /* !< The Controller is in receive mode. */
+/* I2C_MSA[SADDR] Bits */
+#define I2C_MSA_SADDR_OFS                        (1)                             /* !< SADDR Offset */
+#define I2C_MSA_SADDR_MASK                       ((uint32_t)0x000007FEU)         /* !< I2C Target Address This field
+                                                                                    specifies bits A9 through A0 of the
+                                                                                    Target address. In 7-bit addressing
+                                                                                    mode as selected by MSA.MODE bit, the
+                                                                                    top 3 bits are don't care */
+#define I2C_MSA_SADDR_MINIMUM                    ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_MSA_SADDR_MAXIMUM                    ((uint32_t)0x000007FEU)         /* !< Highest possible value */
+/* I2C_MSA[MMODE] Bits */
+#define I2C_MSA_MMODE_OFS                        (15)                            /* !< MMODE Offset */
+#define I2C_MSA_MMODE_MASK                       ((uint32_t)0x00008000U)         /* !< This bit selects the adressing mode
+                                                                                    to be used in Controller mode When 0,
+                                                                                    7-bit addressing is used. When 1,
+                                                                                    10-bit addressing is used. */
+#define I2C_MSA_MMODE_MODE7                      ((uint32_t)0x00000000U)         /* !< 7-bit addressing mode */
+#define I2C_MSA_MMODE_MODE10                     ((uint32_t)0x00008000U)         /* !< 10-bit addressing mode */
+
+/* I2C_MCTR Bits */
+/* I2C_MCTR[BURSTRUN] Bits */
+#define I2C_MCTR_BURSTRUN_OFS                    (0)                             /* !< BURSTRUN Offset */
+#define I2C_MCTR_BURSTRUN_MASK                   ((uint32_t)0x00000001U)         /* !< I2C Controller Enable and start
+                                                                                    transaction */
+#define I2C_MCTR_BURSTRUN_DISABLE                ((uint32_t)0x00000000U)         /* !< In standard mode, this encoding
+                                                                                    means the Controller is unable to
+                                                                                    transmit or receive data. */
+#define I2C_MCTR_BURSTRUN_ENABLE                 ((uint32_t)0x00000001U)         /* !< The Controller is able to transmit
+                                                                                    or receive data. See field decoding
+                                                                                    in Table: MCTR Field decoding. */
+/* I2C_MCTR[START] Bits */
+#define I2C_MCTR_START_OFS                       (1)                             /* !< START Offset */
+#define I2C_MCTR_START_MASK                      ((uint32_t)0x00000002U)         /* !< Generate START */
+#define I2C_MCTR_START_DISABLE                   ((uint32_t)0x00000000U)         /* !< The controller does not generate
+                                                                                    the START condition. */
+#define I2C_MCTR_START_ENABLE                    ((uint32_t)0x00000002U)         /* !< The controller generates the START
+                                                                                    or repeated START condition. See
+                                                                                    field decoding in Table: MCTR Field
+                                                                                    decoding. */
+/* I2C_MCTR[STOP] Bits */
+#define I2C_MCTR_STOP_OFS                        (2)                             /* !< STOP Offset */
+#define I2C_MCTR_STOP_MASK                       ((uint32_t)0x00000004U)         /* !< Generate STOP */
+#define I2C_MCTR_STOP_DISABLE                    ((uint32_t)0x00000000U)         /* !< The controller does not generate
+                                                                                    the STOP condition. */
+#define I2C_MCTR_STOP_ENABLE                     ((uint32_t)0x00000004U)         /* !< The controller generates the STOP
+                                                                                    condition. See field decoding in
+                                                                                    Table: MCTR Field decoding. */
+/* I2C_MCTR[ACK] Bits */
+#define I2C_MCTR_ACK_OFS                         (3)                             /* !< ACK Offset */
+#define I2C_MCTR_ACK_MASK                        ((uint32_t)0x00000008U)         /* !< Data Acknowledge Enable. Software
+                                                                                    needs to configure this bit to send
+                                                                                    the ACK or NACK. See field decoding
+                                                                                    in Table: MCTR Field decoding. */
+#define I2C_MCTR_ACK_DISABLE                     ((uint32_t)0x00000000U)         /* !< The last received data byte of a
+                                                                                    transaction is not acknowledged
+                                                                                    automatically by the Controller. */
+#define I2C_MCTR_ACK_ENABLE                      ((uint32_t)0x00000008U)         /* !< The last received data byte of a
+                                                                                    transaction is acknowledged
+                                                                                    automatically by the Controller. */
+/* I2C_MCTR[MBLEN] Bits */
+#define I2C_MCTR_MBLEN_OFS                       (16)                            /* !< MBLEN Offset */
+#define I2C_MCTR_MBLEN_MASK                      ((uint32_t)0x0FFF0000U)         /* !< I2C transaction length This field
+                                                                                    contains the programmed length of
+                                                                                    bytes of the Transaction. */
+#define I2C_MCTR_MBLEN_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_MCTR_MBLEN_MAXIMUM                   ((uint32_t)0x0FFF0000U)         /* !< Highest possible value */
+/* I2C_MCTR[MACKOEN] Bits */
+#define I2C_MCTR_MACKOEN_OFS                     (4)                             /* !< MACKOEN Offset */
+#define I2C_MCTR_MACKOEN_MASK                    ((uint32_t)0x00000010U)         /* !< Controller ACK overrride Enable */
+#define I2C_MCTR_MACKOEN_DISABLE                 ((uint32_t)0x00000000U)         /* !< No special behavior */
+#define I2C_MCTR_MACKOEN_ENABLE                  ((uint32_t)0x00000010U)         /* !< When 1 and the Controller is
+                                                                                    receiving data and the number of
+                                                                                    bytes indicated in MBLEN have been
+                                                                                    received, the state machine will
+                                                                                    generate an rxdone interrupt and wait
+                                                                                    at the start of the ACK for FW to
+                                                                                    indicate if an ACK or NACK should be
+                                                                                    sent. The ACK or NACK is selected by
+                                                                                    writing the MCTR register and setting
+                                                                                    ACK accordingly. The other fields in
+                                                                                    this register can also be written at
+                                                                                    this time to continue on with the
+                                                                                    transaction. If a NACK is sent the
+                                                                                    state machine will automatically send
+                                                                                    a Stop. */
+/* I2C_MCTR[RD_ON_TXEMPTY] Bits */
+#define I2C_MCTR_RD_ON_TXEMPTY_OFS               (5)                             /* !< RD_ON_TXEMPTY Offset */
+#define I2C_MCTR_RD_ON_TXEMPTY_MASK              ((uint32_t)0x00000020U)         /* !< Read on TX Empty */
+#define I2C_MCTR_RD_ON_TXEMPTY_DISABLE           ((uint32_t)0x00000000U)         /* !< No special behavior */
+#define I2C_MCTR_RD_ON_TXEMPTY_ENABLE            ((uint32_t)0x00000020U)         /* !< When 1 the Controller will transmit
+                                                                                    all bytes from the TX FIFO before
+                                                                                    continuing with the programmed Burst
+                                                                                    Run Read. If the DIR is not set to
+                                                                                    Read in the MSA then this bit is
+                                                                                    ignored. The Start must be set in the
+                                                                                    MCTR for proper I2C protocol. The
+                                                                                    Controller will first send the Start
+                                                                                    Condition, I2C Address with R/W bit
+                                                                                    set to write, before sending the
+                                                                                    bytes in the TX FIFO. When the TX
+                                                                                    FIFO is empty, the I2C transaction
+                                                                                    will continue as programmed in MTCR
+                                                                                    and MSA without sending a Stop
+                                                                                    Condition. This is intended to be
+                                                                                    used to perform simple I2C command
+                                                                                    based reads transition that will
+                                                                                    complete after initiating them
+                                                                                    without having to get an interrupt to
+                                                                                    turn the bus around. */
+
+/* I2C_MSR Bits */
+/* I2C_MSR[BUSY] Bits */
+#define I2C_MSR_BUSY_OFS                         (0)                             /* !< BUSY Offset */
+#define I2C_MSR_BUSY_MASK                        ((uint32_t)0x00000001U)         /* !< I2C Controller FSM Busy The BUSY
+                                                                                    bit is set during an ongoing
+                                                                                    transaction, so is set during the
+                                                                                    transmit/receive of the amount of
+                                                                                    data set in MBLEN including START,
+                                                                                    RESTART, Address and STOP signal
+                                                                                    generation when required for the
+                                                                                    current transaction. */
+#define I2C_MSR_BUSY_CLEARED                     ((uint32_t)0x00000000U)         /* !< The controller is idle. */
+#define I2C_MSR_BUSY_SET                         ((uint32_t)0x00000001U)         /* !< The controller is busy. */
+/* I2C_MSR[ERR] Bits */
+#define I2C_MSR_ERR_OFS                          (1)                             /* !< ERR Offset */
+#define I2C_MSR_ERR_MASK                         ((uint32_t)0x00000002U)         /* !< Error  The error can be from the
+                                                                                    Target address not being acknowledged
+                                                                                    or the transmit data not being
+                                                                                    acknowledged. */
+#define I2C_MSR_ERR_CLEARED                      ((uint32_t)0x00000000U)         /* !< No error was detected on the last
+                                                                                    operation. */
+#define I2C_MSR_ERR_SET                          ((uint32_t)0x00000002U)         /* !< An error occurred on the last
+                                                                                    operation. */
+/* I2C_MSR[ADRACK] Bits */
+#define I2C_MSR_ADRACK_OFS                       (2)                             /* !< ADRACK Offset */
+#define I2C_MSR_ADRACK_MASK                      ((uint32_t)0x00000004U)         /* !< Acknowledge Address */
+#define I2C_MSR_ADRACK_CLEARED                   ((uint32_t)0x00000000U)         /* !< The transmitted address was
+                                                                                    acknowledged */
+#define I2C_MSR_ADRACK_SET                       ((uint32_t)0x00000004U)         /* !< The transmitted address was not
+                                                                                    acknowledged. */
+/* I2C_MSR[DATACK] Bits */
+#define I2C_MSR_DATACK_OFS                       (3)                             /* !< DATACK Offset */
+#define I2C_MSR_DATACK_MASK                      ((uint32_t)0x00000008U)         /* !< Acknowledge Data */
+#define I2C_MSR_DATACK_CLEARED                   ((uint32_t)0x00000000U)         /* !< The transmitted data was
+                                                                                    acknowledged */
+#define I2C_MSR_DATACK_SET                       ((uint32_t)0x00000008U)         /* !< The transmitted data was not
+                                                                                    acknowledged. */
+/* I2C_MSR[ARBLST] Bits */
+#define I2C_MSR_ARBLST_OFS                       (4)                             /* !< ARBLST Offset */
+#define I2C_MSR_ARBLST_MASK                      ((uint32_t)0x00000010U)         /* !< Arbitration Lost */
+#define I2C_MSR_ARBLST_CLEARED                   ((uint32_t)0x00000000U)         /* !< The I2C controller won arbitration. */
+#define I2C_MSR_ARBLST_SET                       ((uint32_t)0x00000010U)         /* !< The I2C controller lost
+                                                                                    arbitration. */
+/* I2C_MSR[IDLE] Bits */
+#define I2C_MSR_IDLE_OFS                         (5)                             /* !< IDLE Offset */
+#define I2C_MSR_IDLE_MASK                        ((uint32_t)0x00000020U)         /* !< I2C Idle */
+#define I2C_MSR_IDLE_CLEARED                     ((uint32_t)0x00000000U)         /* !< The I2C controller is not idle. */
+#define I2C_MSR_IDLE_SET                         ((uint32_t)0x00000020U)         /* !< The I2C controller is idle. */
+/* I2C_MSR[BUSBSY] Bits */
+#define I2C_MSR_BUSBSY_OFS                       (6)                             /* !< BUSBSY Offset */
+#define I2C_MSR_BUSBSY_MASK                      ((uint32_t)0x00000040U)         /* !< I2C Bus is Busy Controller State
+                                                                                    Machine will wait until this bit is
+                                                                                    cleared before starting a
+                                                                                    transaction. When first enabling the
+                                                                                    Controller in multi Controller
+                                                                                    environments, FW should wait for one
+                                                                                    I2C clock period after setting ACTIVE
+                                                                                    high before writing to the MTCR
+                                                                                    register to start the transaction so
+                                                                                    that if SCL goes low it will trigger
+                                                                                    the BUSBSY. */
+#define I2C_MSR_BUSBSY_CLEARED                   ((uint32_t)0x00000000U)         /* !< The I2C bus is idle. */
+#define I2C_MSR_BUSBSY_SET                       ((uint32_t)0x00000040U)         /* !< 'This Status bit is set on a START
+                                                                                    or when SCL goes low. It is cleared
+                                                                                    on a STOP,  or when a SCL high bus
+                                                                                    busy timeout occurs and SCL and SDA
+                                                                                    are both high. This status is cleared
+                                                                                    when the ACTIVE bit is low.   Note
+                                                                                    that the Controller State Machine
+                                                                                    will wait until this bit is cleared
+                                                                                    before starting an I2C transaction.
+                                                                                    When first enabling the Controller in
+                                                                                    multi Controller environments, FW
+                                                                                    should wait for one I2C clock period
+                                                                                    after setting ACTIVE high before
+                                                                                    writing to the MTCR register to start
+                                                                                    the transaction so that if SCL goes
+                                                                                    low it will trigger the BUSBSY. */
+/* I2C_MSR[MBCNT] Bits */
+#define I2C_MSR_MBCNT_OFS                        (16)                            /* !< MBCNT Offset */
+#define I2C_MSR_MBCNT_MASK                       ((uint32_t)0x0FFF0000U)         /* !< I2C Controller Transaction Count
+                                                                                    This field contains the current
+                                                                                    count-down value of the transaction. */
+#define I2C_MSR_MBCNT_MINIMUM                    ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_MSR_MBCNT_MAXIMUM                    ((uint32_t)0x0FFF0000U)         /* !< Highest possible value */
+
+/* I2C_MRXDATA Bits */
+/* I2C_MRXDATA[VALUE] Bits */
+#define I2C_MRXDATA_VALUE_OFS                    (0)                             /* !< VALUE Offset */
+#define I2C_MRXDATA_VALUE_MASK                   ((uint32_t)0x000000FFU)         /* !< Received Data.  This field contains
+                                                                                    the last received data. */
+#define I2C_MRXDATA_VALUE_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_MRXDATA_VALUE_MAXIMUM                ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+
+/* I2C_MTXDATA Bits */
+/* I2C_MTXDATA[VALUE] Bits */
+#define I2C_MTXDATA_VALUE_OFS                    (0)                             /* !< VALUE Offset */
+#define I2C_MTXDATA_VALUE_MASK                   ((uint32_t)0x000000FFU)         /* !< Transmit Data This byte contains
+                                                                                    the data to be transferred during the
+                                                                                    next transaction. */
+#define I2C_MTXDATA_VALUE_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_MTXDATA_VALUE_MAXIMUM                ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+
+/* I2C_MTPR Bits */
+/* I2C_MTPR[TPR] Bits */
+#define I2C_MTPR_TPR_OFS                         (0)                             /* !< TPR Offset */
+#define I2C_MTPR_TPR_MASK                        ((uint32_t)0x0000007FU)         /* !< Timer Period  This field is used in
+                                                                                    the equation to configure SCL_PERIOD
+                                                                                    : SCL_PERIOD = (1 + TPR ) * (SCL_LP +
+                                                                                    SCL_HP ) * INT_CLK_PRD where:
+                                                                                    SCL_PRD is the SCL line period (I2C
+                                                                                    clock).   TPR is the Timer Period
+                                                                                    register value (range of 1 to 127).
+                                                                                    SCL_LP is the SCL Low period (fixed
+                                                                                    at 6).   SCL_HP is the SCL High
+                                                                                    period (fixed at 4).   CLK_PRD is the
+                                                                                    functional clock period in ns. */
+#define I2C_MTPR_TPR_MINIMUM                     ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_MTPR_TPR_MAXIMUM                     ((uint32_t)0x0000007FU)         /* !< Highest possible value */
+
+/* I2C_MCR Bits */
+/* I2C_MCR[LPBK] Bits */
+#define I2C_MCR_LPBK_OFS                         (8)                             /* !< LPBK Offset */
+#define I2C_MCR_LPBK_MASK                        ((uint32_t)0x00000100U)         /* !< I2C Loopback */
+#define I2C_MCR_LPBK_DISABLE                     ((uint32_t)0x00000000U)         /* !< Normal operation. */
+#define I2C_MCR_LPBK_ENABLE                      ((uint32_t)0x00000100U)         /* !< The controller in a test mode
+                                                                                    loopback configuration. */
+/* I2C_MCR[MMST] Bits */
+#define I2C_MCR_MMST_OFS                         (1)                             /* !< MMST Offset */
+#define I2C_MCR_MMST_MASK                        ((uint32_t)0x00000002U)         /* !< MultiController mode. In
+                                                                                    MultiController mode the SCL high
+                                                                                    time counts once the SCL line has
+                                                                                    been detected high. If this is not
+                                                                                    enabled the high time counts as soon
+                                                                                    as the SCL line has been set high by
+                                                                                    the I2C controller. */
+#define I2C_MCR_MMST_DISABLE                     ((uint32_t)0x00000000U)         /* !< Disable MultiController mode. */
+#define I2C_MCR_MMST_ENABLE                      ((uint32_t)0x00000002U)         /* !< Enable MultiController mode. */
+/* I2C_MCR[ACTIVE] Bits */
+#define I2C_MCR_ACTIVE_OFS                       (0)                             /* !< ACTIVE Offset */
+#define I2C_MCR_ACTIVE_MASK                      ((uint32_t)0x00000001U)         /* !< Device Active  After this bit has
+                                                                                    been set, it should not be set again
+                                                                                    unless it has been cleared by writing
+                                                                                    a 0 or by a reset, otherwise transfer
+                                                                                    failures may occur. */
+#define I2C_MCR_ACTIVE_DISABLE                   ((uint32_t)0x00000000U)         /* !< Disables the I2C Controller
+                                                                                    operation. */
+#define I2C_MCR_ACTIVE_ENABLE                    ((uint32_t)0x00000001U)         /* !< Enables the I2C Controller
+                                                                                    operation. */
+/* I2C_MCR[CLKSTRETCH] Bits */
+#define I2C_MCR_CLKSTRETCH_OFS                   (2)                             /* !< CLKSTRETCH Offset */
+#define I2C_MCR_CLKSTRETCH_MASK                  ((uint32_t)0x00000004U)         /* !< Clock Stretching. This bit controls
+                                                                                    the support for clock stretching of
+                                                                                    the I2C bus. */
+#define I2C_MCR_CLKSTRETCH_DISABLE               ((uint32_t)0x00000000U)         /* !< Disables the clock stretching
+                                                                                    detection. This can be disabled if no
+                                                                                    Target on the bus does support clock
+                                                                                    stretching, so that the maximum speed
+                                                                                    on the bus can be reached. */
+#define I2C_MCR_CLKSTRETCH_ENABLE                ((uint32_t)0x00000004U)         /* !< Enables the clock stretching
+                                                                                    detection. Enabling the clock
+                                                                                    stretching ensures compliance to the
+                                                                                    I2C standard but could limit the
+                                                                                    speed due the clock stretching. */
+
+/* I2C_MBMON Bits */
+/* I2C_MBMON[SCL] Bits */
+#define I2C_MBMON_SCL_OFS                        (0)                             /* !< SCL Offset */
+#define I2C_MBMON_SCL_MASK                       ((uint32_t)0x00000001U)         /* !< I2C SCL Status */
+#define I2C_MBMON_SCL_CLEARED                    ((uint32_t)0x00000000U)         /* !< The I2CSCL signal is low. */
+#define I2C_MBMON_SCL_SET                        ((uint32_t)0x00000001U)         /* !< The I2CSCL signal is high. Note:
+                                                                                    During and right after reset, the SCL
+                                                                                    pin is in GPIO input mode without the
+                                                                                    internal pull enabled. For proper I2C
+                                                                                    operation, the user should have the
+                                                                                    external pull-up resistor in place
+                                                                                    before starting any I2C operations. */
+/* I2C_MBMON[SDA] Bits */
+#define I2C_MBMON_SDA_OFS                        (1)                             /* !< SDA Offset */
+#define I2C_MBMON_SDA_MASK                       ((uint32_t)0x00000002U)         /* !< I2C SDA Status */
+#define I2C_MBMON_SDA_CLEARED                    ((uint32_t)0x00000000U)         /* !< The I2CSDA signal is low. */
+#define I2C_MBMON_SDA_SET                        ((uint32_t)0x00000002U)         /* !< The I2CSDA signal is high. Note:
+                                                                                    During and right after reset, the SDA
+                                                                                    pin is in GPIO input mode without the
+                                                                                    internal pull enabled. For proper I2C
+                                                                                    operation, the user should have the
+                                                                                    external pull-up resistor in place
+                                                                                    before starting any I2C operations. */
+
+/* I2C_MFIFOCTL Bits */
+/* I2C_MFIFOCTL[TXTRIG] Bits */
+#define I2C_MFIFOCTL_TXTRIG_OFS                  (0)                             /* !< TXTRIG Offset */
+#define I2C_MFIFOCTL_TXTRIG_MASK                 ((uint32_t)0x00000007U)         /* !< TX FIFO Trigger Indicates at what
+                                                                                    fill level in the TX FIFO a trigger
+                                                                                    will be generated. */
+#define I2C_MFIFOCTL_TXTRIG_EMPTY                ((uint32_t)0x00000000U)         /* !< Trigger when the TX FIFO is empty. */
+#define I2C_MFIFOCTL_TXTRIG_LEVEL_1              ((uint32_t)0x00000001U)         /* !< Trigger when TX FIFO contains  1
+                                                                                    byte */
+#define I2C_MFIFOCTL_TXTRIG_LEVEL_2              ((uint32_t)0x00000002U)         /* !< Trigger when TX FIFO contains  2
+                                                                                    byte */
+#define I2C_MFIFOCTL_TXTRIG_LEVEL_3              ((uint32_t)0x00000003U)         /* !< Trigger when TX FIFO contains  3
+                                                                                    byte */
+#define I2C_MFIFOCTL_TXTRIG_LEVEL_4              ((uint32_t)0x00000004U)         /* !< Trigger when TX FIFO contains  4
+                                                                                    byte */
+#define I2C_MFIFOCTL_TXTRIG_LEVEL_5              ((uint32_t)0x00000005U)         /* !< Trigger when TX FIFO contains  5
+                                                                                    byte */
+#define I2C_MFIFOCTL_TXTRIG_LEVEL_6              ((uint32_t)0x00000006U)         /* !< Trigger when TX FIFO contains  6
+                                                                                    byte */
+#define I2C_MFIFOCTL_TXTRIG_LEVEL_7              ((uint32_t)0x00000007U)         /* !< Trigger when TX FIFO contains  7
+                                                                                    byte */
+/* I2C_MFIFOCTL[TXFLUSH] Bits */
+#define I2C_MFIFOCTL_TXFLUSH_OFS                 (7)                             /* !< TXFLUSH Offset */
+#define I2C_MFIFOCTL_TXFLUSH_MASK                ((uint32_t)0x00000080U)         /* !< TX FIFO Flush Setting this bit will
+                                                                                    Flush the TX FIFO.  Before clearing
+                                                                                    this bit to stop Flush the TXFIFOCNT
+                                                                                    should be checked to be 8 and
+                                                                                    indicating that the Flush has
+                                                                                    completed. */
+#define I2C_MFIFOCTL_TXFLUSH_NOFLUSH             ((uint32_t)0x00000000U)         /* !< Do not Flush FIFO */
+#define I2C_MFIFOCTL_TXFLUSH_FLUSH               ((uint32_t)0x00000080U)         /* !< Flush FIFO */
+/* I2C_MFIFOCTL[RXTRIG] Bits */
+#define I2C_MFIFOCTL_RXTRIG_OFS                  (8)                             /* !< RXTRIG Offset */
+#define I2C_MFIFOCTL_RXTRIG_MASK                 ((uint32_t)0x00000700U)         /* !< RX FIFO Trigger Indicates at what
+                                                                                    fill level in the RX FIFO a trigger
+                                                                                    will be generated. Note: Programming
+                                                                                    RXTRIG to 0x0 has no effect since no
+                                                                                    data is present to transfer out of RX
+                                                                                    FIFO. */
+#define I2C_MFIFOCTL_RXTRIG_LEVEL_1              ((uint32_t)0x00000000U)         /* !< Trigger when RX FIFO contains >= 1
+                                                                                    byte */
+#define I2C_MFIFOCTL_RXTRIG_LEVEL_2              ((uint32_t)0x00000100U)         /* !< Trigger when RX FIFO contains >= 2
+                                                                                    byte */
+#define I2C_MFIFOCTL_RXTRIG_LEVEL_3              ((uint32_t)0x00000200U)         /* !< Trigger when RX FIFO contains >= 3
+                                                                                    byte */
+#define I2C_MFIFOCTL_RXTRIG_LEVEL_4              ((uint32_t)0x00000300U)         /* !< Trigger when RX FIFO contains >= 4
+                                                                                    byte */
+#define I2C_MFIFOCTL_RXTRIG_LEVEL_5              ((uint32_t)0x00000400U)         /* !< Trigger when RX FIFO contains >= 5
+                                                                                    byte */
+#define I2C_MFIFOCTL_RXTRIG_LEVEL_6              ((uint32_t)0x00000500U)         /* !< Trigger when RX FIFO contains >= 6
+                                                                                    byte */
+#define I2C_MFIFOCTL_RXTRIG_LEVEL_7              ((uint32_t)0x00000600U)         /* !< Trigger when RX FIFO contains >= 7
+                                                                                    byte */
+#define I2C_MFIFOCTL_RXTRIG_LEVEL_8              ((uint32_t)0x00000700U)         /* !< Trigger when RX FIFO contains >= 8
+                                                                                    byte */
+/* I2C_MFIFOCTL[RXFLUSH] Bits */
+#define I2C_MFIFOCTL_RXFLUSH_OFS                 (15)                            /* !< RXFLUSH Offset */
+#define I2C_MFIFOCTL_RXFLUSH_MASK                ((uint32_t)0x00008000U)         /* !< RX FIFO Flush Setting this bit will
+                                                                                    Flush the RX FIFO. Before clearing
+                                                                                    this bit to stop Flush the RXFIFOCNT
+                                                                                    should be checked to be 0 and
+                                                                                    indicating that the Flush has
+                                                                                    completed. */
+#define I2C_MFIFOCTL_RXFLUSH_NOFLUSH             ((uint32_t)0x00000000U)         /* !< Do not Flush FIFO */
+#define I2C_MFIFOCTL_RXFLUSH_FLUSH               ((uint32_t)0x00008000U)         /* !< Flush FIFO */
+
+/* I2C_MFIFOSR Bits */
+/* I2C_MFIFOSR[RXFIFOCNT] Bits */
+#define I2C_MFIFOSR_RXFIFOCNT_OFS                (0)                             /* !< RXFIFOCNT Offset */
+#define I2C_MFIFOSR_RXFIFOCNT_MASK               ((uint32_t)0x0000000FU)         /* !< Number of Bytes which could be read
+                                                                                    from the RX FIFO */
+#define I2C_MFIFOSR_RXFIFOCNT_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_MFIFOSR_RXFIFOCNT_MAXIMUM            ((uint32_t)0x00000008U)         /* !< Highest possible value */
+/* I2C_MFIFOSR[TXFIFOCNT] Bits */
+#define I2C_MFIFOSR_TXFIFOCNT_OFS                (8)                             /* !< TXFIFOCNT Offset */
+#define I2C_MFIFOSR_TXFIFOCNT_MASK               ((uint32_t)0x00000F00U)         /* !< Number of Bytes which could be put
+                                                                                    into the TX FIFO */
+#define I2C_MFIFOSR_TXFIFOCNT_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_MFIFOSR_TXFIFOCNT_MAXIMUM            ((uint32_t)0x00000800U)         /* !< Highest possible value */
+/* I2C_MFIFOSR[RXFLUSH] Bits */
+#define I2C_MFIFOSR_RXFLUSH_OFS                  (7)                             /* !< RXFLUSH Offset */
+#define I2C_MFIFOSR_RXFLUSH_MASK                 ((uint32_t)0x00000080U)         /* !< RX FIFO Flush When this bit is set
+                                                                                    a Flush operation for the RX FIFO is
+                                                                                    active. Clear the RXFLUSH bit in the
+                                                                                    control register to stop. */
+#define I2C_MFIFOSR_RXFLUSH_INACTIVE             ((uint32_t)0x00000000U)         /* !< FIFO Flush not active */
+#define I2C_MFIFOSR_RXFLUSH_ACTIVE               ((uint32_t)0x00000080U)         /* !< FIFO Flush active */
+/* I2C_MFIFOSR[TXFLUSH] Bits */
+#define I2C_MFIFOSR_TXFLUSH_OFS                  (15)                            /* !< TXFLUSH Offset */
+#define I2C_MFIFOSR_TXFLUSH_MASK                 ((uint32_t)0x00008000U)         /* !< TX FIFO Flush When this bit is set
+                                                                                    a Flush operation for the TX FIFO is
+                                                                                    active. Clear the TXFLUSH bit in the
+                                                                                    control register to stop. */
+#define I2C_MFIFOSR_TXFLUSH_INACTIVE             ((uint32_t)0x00000000U)         /* !< FIFO Flush not active */
+#define I2C_MFIFOSR_TXFLUSH_ACTIVE               ((uint32_t)0x00008000U)         /* !< FIFO Flush active */
+
+/* I2C_CONTROLLER_I2CPECCTL Bits */
+/* I2C_CONTROLLER_I2CPECCTL[PECCNT] Bits */
+#define I2C_CONTROLLER_I2CPECCTL_PECCNT_OFS      (0)                             /* !< PECCNT Offset */
+#define I2C_CONTROLLER_I2CPECCTL_PECCNT_MASK     ((uint32_t)0x000001FFU)         /* !< PEC Count When this field is non
+                                                                                    zero, the number of I2C bytes are
+                                                                                    counted (Note that although the PEC
+                                                                                    is calculated on the I2C address it
+                                                                                    is not counted at a byte). When the
+                                                                                    byte count = PECCNT and the state
+                                                                                    machine is transmitting, the contents
+                                                                                    of the LSFR is loaded into the shift
+                                                                                    register instead of the byte received
+                                                                                    from the Tx FIFO. When the state
+                                                                                    machine is receiving, after the last
+                                                                                    bit of this byte is received the LSFR
+                                                                                    is checked and if it is non-zero, a
+                                                                                    PEC RX Error interrupt is generated.
+                                                                                    The I2C packet must be padded to
+                                                                                    include the PEC byte for both
+                                                                                    transmit and receive. In transmit
+                                                                                    mode the FIFO must be loaded with a
+                                                                                    dummy PEC byte. In receive mode the
+                                                                                    PEC byte will be passed to the Rx
+                                                                                    FIFO.  In the normal Controller use
+                                                                                    case, FW would set PECEN=1 and
+                                                                                    PECCNT=SMB packet length (Not
+                                                                                    including Target Address byte, but
+                                                                                    including the PEC byte). FW would
+                                                                                    then configure DMA to allow the
+                                                                                    packet to complete unassisted and
+                                                                                    write MCTR to initiate the
+                                                                                    transaction.  Note that when the byte
+                                                                                    count = PEC CNT, the byte count is
+                                                                                    reset to 0 and multiple PEC
+                                                                                    calculation can automatically occur
+                                                                                    within a single I2C transaction.
+                                                                                    Note that any write to the
+                                                                                    Controller_I2CPECCTL Register will
+                                                                                    clear the current PEC Byte Count in
+                                                                                    the Controller State Machine. */
+#define I2C_CONTROLLER_I2CPECCTL_PECCNT_MINIMUM  ((uint32_t)0x00000000U)         /* !< Minimum Value */
+#define I2C_CONTROLLER_I2CPECCTL_PECCNT_MAXIMUM  ((uint32_t)0x000001FFU)         /* !< Maximum Value */
+/* I2C_CONTROLLER_I2CPECCTL[PECEN] Bits */
+#define I2C_CONTROLLER_I2CPECCTL_PECEN_OFS       (12)                            /* !< PECEN Offset */
+#define I2C_CONTROLLER_I2CPECCTL_PECEN_MASK      ((uint32_t)0x00001000U)         /* !< PEC Enable This bit enables the SMB
+                                                                                    Packet Error Checking (PEC). When
+                                                                                    enabled the PEC is calculated on all
+                                                                                    bits except the Start, Stop, Ack and
+                                                                                    Nack. The PEC LSFR and the Byte
+                                                                                    Counter is set to 0 when the State
+                                                                                    Machine is in the IDLE state, which
+                                                                                    occur following a Stop or when a
+                                                                                    timeout occurs. The Counter is also
+                                                                                    set to 0 after the PEC byte is sent
+                                                                                    or received. Note that the NACK is
+                                                                                    automatically send following a PEC
+                                                                                    byte that results in a PEC error. The
+                                                                                    PEC Polynomial is x^8 + x^2 + x^1 +
+                                                                                    1. */
+#define I2C_CONTROLLER_I2CPECCTL_PECEN_DISABLE   ((uint32_t)0x00000000U)         /* !< PEC is disabled in Controller mode */
+#define I2C_CONTROLLER_I2CPECCTL_PECEN_ENABLE    ((uint32_t)0x00001000U)         /* !< PEC is enabled in Controller mode */
+
+/* I2C_CONTROLLER_PECSR Bits */
+/* I2C_CONTROLLER_PECSR[PECBYTECNT] Bits */
+#define I2C_CONTROLLER_PECSR_PECBYTECNT_OFS      (0)                             /* !< PECBYTECNT Offset */
+#define I2C_CONTROLLER_PECSR_PECBYTECNT_MASK     ((uint32_t)0x000001FFU)         /* !< PEC Byte Count	 This is the current
+                                                                                    PEC Byte Count of the Controller
+                                                                                    State Machine. */
+#define I2C_CONTROLLER_PECSR_PECBYTECNT_MINIMUM  ((uint32_t)0x00000000U)         /* !< Minimum Value */
+#define I2C_CONTROLLER_PECSR_PECBYTECNT_MAXIMUM  ((uint32_t)0x000001FFU)         /* !< Maximum Value */
+/* I2C_CONTROLLER_PECSR[PECSTS_CHECK] Bits */
+#define I2C_CONTROLLER_PECSR_PECSTS_CHECK_OFS    (16)                            /* !< PECSTS_CHECK Offset */
+#define I2C_CONTROLLER_PECSR_PECSTS_CHECK_MASK   ((uint32_t)0x00010000U)         /* !< This status bit indicates if the
+                                                                                    PEC was checked in the transaction
+                                                                                    that occurred before the last Stop.
+                                                                                    Latched on Stop. */
+#define I2C_CONTROLLER_PECSR_PECSTS_CHECK_CLEARED ((uint32_t)0x00000000U)         /* !< Indicates PEC was not checked in
+                                                                                    the transaction that occurred before
+                                                                                    the last Stop */
+#define I2C_CONTROLLER_PECSR_PECSTS_CHECK_SET    ((uint32_t)0x00010000U)         /* !< Indicates if the PEC was checked in
+                                                                                    the transaction that occurred before
+                                                                                    the last Stop */
+/* I2C_CONTROLLER_PECSR[PECSTS_ERROR] Bits */
+#define I2C_CONTROLLER_PECSR_PECSTS_ERROR_OFS    (17)                            /* !< PECSTS_ERROR Offset */
+#define I2C_CONTROLLER_PECSR_PECSTS_ERROR_MASK   ((uint32_t)0x00020000U)         /* !< This status bit indicates if a PEC
+                                                                                    check error occurred in the
+                                                                                    transaction that occurred before the
+                                                                                    last Stop. Latched on Stop. */
+#define I2C_CONTROLLER_PECSR_PECSTS_ERROR_CLEARED ((uint32_t)0x00000000U)         /* !< Indicates PEC check error did not
+                                                                                    occurr in the transaction that
+                                                                                    occurred before the last Stop */
+#define I2C_CONTROLLER_PECSR_PECSTS_ERROR_SET    ((uint32_t)0x00020000U)         /* !< Indicates if a PEC check error
+                                                                                    occurred in the transaction that
+                                                                                    occurred before the last Stop */
+
+/* I2C_DMA_TRIG0_IIDX Bits */
+/* I2C_DMA_TRIG0_IIDX[STAT] Bits */
+#define I2C_DMA_TRIG0_IIDX_STAT_OFS              (0)                             /* !< STAT Offset */
+#define I2C_DMA_TRIG0_IIDX_STAT_MASK             ((uint32_t)0x000000FFU)         /* !< I2C Module Interrupt Vector Value.
+                                                                                    This register provides the highes
+                                                                                    priority interrupt index. A read
+                                                                                    clears the corresponding interrupt
+                                                                                    flag in RIS and MISC. 15h-1Fh =
+                                                                                    Reserved */
+#define I2C_DMA_TRIG0_IIDX_STAT_NO_INTR          ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define I2C_DMA_TRIG0_IIDX_STAT_MRXFIFOTRG       ((uint32_t)0x00000001U)         /* !< Controller receive FIFO Trigger
+                                                                                    Level */
+#define I2C_DMA_TRIG0_IIDX_STAT_MTXFIFOTRG       ((uint32_t)0x00000002U)         /* !< Controller transmit FIFO Trigger
+                                                                                    level */
+#define I2C_DMA_TRIG0_IIDX_STAT_SRXFIFOTRG       ((uint32_t)0x00000003U)         /* !< Target receive FIFO Trigger Level */
+#define I2C_DMA_TRIG0_IIDX_STAT_STXFIFOTRG       ((uint32_t)0x00000004U)         /* !< Target transmit FIFO Trigger level */
+
+/* I2C_DMA_TRIG0_IMASK Bits */
+/* I2C_DMA_TRIG0_IMASK[MRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_IMASK_MRXFIFOTRG_OFS       (0)                             /* !< MRXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_IMASK_MRXFIFOTRG_MASK      ((uint32_t)0x00000001U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_DMA_TRIG0_IMASK_MRXFIFOTRG_CLR       ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_IMASK_MRXFIFOTRG_SET       ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_IMASK[MTXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_IMASK_MTXFIFOTRG_OFS       (1)                             /* !< MTXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_IMASK_MTXFIFOTRG_MASK      ((uint32_t)0x00000002U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_DMA_TRIG0_IMASK_MTXFIFOTRG_CLR       ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_IMASK_MTXFIFOTRG_SET       ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_IMASK[SRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_IMASK_SRXFIFOTRG_OFS       (2)                             /* !< SRXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_IMASK_SRXFIFOTRG_MASK      ((uint32_t)0x00000004U)         /* !< Target Receive FIFO Trigger */
+#define I2C_DMA_TRIG0_IMASK_SRXFIFOTRG_CLR       ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_IMASK_SRXFIFOTRG_SET       ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_IMASK[STXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_IMASK_STXFIFOTRG_OFS       (3)                             /* !< STXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_IMASK_STXFIFOTRG_MASK      ((uint32_t)0x00000008U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_DMA_TRIG0_IMASK_STXFIFOTRG_CLR       ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_IMASK_STXFIFOTRG_SET       ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+
+/* I2C_DMA_TRIG0_RIS Bits */
+/* I2C_DMA_TRIG0_RIS[MRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_RIS_MRXFIFOTRG_OFS         (0)                             /* !< MRXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_RIS_MRXFIFOTRG_MASK        ((uint32_t)0x00000001U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_DMA_TRIG0_RIS_MRXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_RIS_MRXFIFOTRG_SET         ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_RIS[MTXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_RIS_MTXFIFOTRG_OFS         (1)                             /* !< MTXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_RIS_MTXFIFOTRG_MASK        ((uint32_t)0x00000002U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_DMA_TRIG0_RIS_MTXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_RIS_MTXFIFOTRG_SET         ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_RIS[SRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_RIS_SRXFIFOTRG_OFS         (2)                             /* !< SRXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_RIS_SRXFIFOTRG_MASK        ((uint32_t)0x00000004U)         /* !< Target Receive FIFO Trigger */
+#define I2C_DMA_TRIG0_RIS_SRXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_RIS_SRXFIFOTRG_SET         ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_RIS[STXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_RIS_STXFIFOTRG_OFS         (3)                             /* !< STXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_RIS_STXFIFOTRG_MASK        ((uint32_t)0x00000008U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_DMA_TRIG0_RIS_STXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_RIS_STXFIFOTRG_SET         ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+
+/* I2C_DMA_TRIG0_MIS Bits */
+/* I2C_DMA_TRIG0_MIS[MRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_MIS_MRXFIFOTRG_OFS         (0)                             /* !< MRXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_MIS_MRXFIFOTRG_MASK        ((uint32_t)0x00000001U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_DMA_TRIG0_MIS_MRXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_MIS_MRXFIFOTRG_SET         ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_MIS[MTXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_MIS_MTXFIFOTRG_OFS         (1)                             /* !< MTXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_MIS_MTXFIFOTRG_MASK        ((uint32_t)0x00000002U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_DMA_TRIG0_MIS_MTXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_MIS_MTXFIFOTRG_SET         ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_MIS[SRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_MIS_SRXFIFOTRG_OFS         (2)                             /* !< SRXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_MIS_SRXFIFOTRG_MASK        ((uint32_t)0x00000004U)         /* !< Target Receive FIFO Trigger */
+#define I2C_DMA_TRIG0_MIS_SRXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_MIS_SRXFIFOTRG_SET         ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_MIS[STXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_MIS_STXFIFOTRG_OFS         (3)                             /* !< STXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_MIS_STXFIFOTRG_MASK        ((uint32_t)0x00000008U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_DMA_TRIG0_MIS_STXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_MIS_STXFIFOTRG_SET         ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+
+/* I2C_DMA_TRIG0_ISET Bits */
+/* I2C_DMA_TRIG0_ISET[MRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_ISET_MRXFIFOTRG_OFS        (0)                             /* !< MRXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_ISET_MRXFIFOTRG_MASK       ((uint32_t)0x00000001U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_DMA_TRIG0_ISET_MRXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_ISET_MRXFIFOTRG_SET        ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_ISET[MTXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_ISET_MTXFIFOTRG_OFS        (1)                             /* !< MTXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_ISET_MTXFIFOTRG_MASK       ((uint32_t)0x00000002U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_DMA_TRIG0_ISET_MTXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_ISET_MTXFIFOTRG_SET        ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_ISET[SRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_ISET_SRXFIFOTRG_OFS        (2)                             /* !< SRXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_ISET_SRXFIFOTRG_MASK       ((uint32_t)0x00000004U)         /* !< Target Receive FIFO Trigger */
+#define I2C_DMA_TRIG0_ISET_SRXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_ISET_SRXFIFOTRG_SET        ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_ISET[STXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_ISET_STXFIFOTRG_OFS        (3)                             /* !< STXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_ISET_STXFIFOTRG_MASK       ((uint32_t)0x00000008U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_DMA_TRIG0_ISET_STXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_ISET_STXFIFOTRG_SET        ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+
+/* I2C_DMA_TRIG0_ICLR Bits */
+/* I2C_DMA_TRIG0_ICLR[MRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_ICLR_MRXFIFOTRG_OFS        (0)                             /* !< MRXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_ICLR_MRXFIFOTRG_MASK       ((uint32_t)0x00000001U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_DMA_TRIG0_ICLR_MRXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_ICLR_MRXFIFOTRG_CLR        ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_ICLR[MTXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_ICLR_MTXFIFOTRG_OFS        (1)                             /* !< MTXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_ICLR_MTXFIFOTRG_MASK       ((uint32_t)0x00000002U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_DMA_TRIG0_ICLR_MTXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_ICLR_MTXFIFOTRG_CLR        ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_ICLR[SRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_ICLR_SRXFIFOTRG_OFS        (2)                             /* !< SRXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_ICLR_SRXFIFOTRG_MASK       ((uint32_t)0x00000004U)         /* !< Target Receive FIFO Trigger */
+#define I2C_DMA_TRIG0_ICLR_SRXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_ICLR_SRXFIFOTRG_CLR        ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG0_ICLR[STXFIFOTRG] Bits */
+#define I2C_DMA_TRIG0_ICLR_STXFIFOTRG_OFS        (3)                             /* !< STXFIFOTRG Offset */
+#define I2C_DMA_TRIG0_ICLR_STXFIFOTRG_MASK       ((uint32_t)0x00000008U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_DMA_TRIG0_ICLR_STXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG0_ICLR_STXFIFOTRG_CLR        ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+
+/* I2C_DMA_TRIG1_IIDX Bits */
+/* I2C_DMA_TRIG1_IIDX[STAT] Bits */
+#define I2C_DMA_TRIG1_IIDX_STAT_OFS              (0)                             /* !< STAT Offset */
+#define I2C_DMA_TRIG1_IIDX_STAT_MASK             ((uint32_t)0x000000FFU)         /* !< I2C Module Interrupt Vector Value.
+                                                                                    This register provides the highes
+                                                                                    priority interrupt index. A read
+                                                                                    clears the corresponding interrupt
+                                                                                    flag in RIS and MISC. 15h-1Fh =
+                                                                                    Reserved */
+#define I2C_DMA_TRIG1_IIDX_STAT_NO_INTR          ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define I2C_DMA_TRIG1_IIDX_STAT_MRXFIFOTRG       ((uint32_t)0x00000001U)         /* !< Controller receive FIFO Trigger
+                                                                                    Level */
+#define I2C_DMA_TRIG1_IIDX_STAT_MTXFIFOTRG       ((uint32_t)0x00000002U)         /* !< Controller transmit FIFO Trigger
+                                                                                    level */
+#define I2C_DMA_TRIG1_IIDX_STAT_SRXFIFOTRG       ((uint32_t)0x00000003U)         /* !< Target receive FIFO Trigger Level */
+#define I2C_DMA_TRIG1_IIDX_STAT_STXFIFOTRG       ((uint32_t)0x00000004U)         /* !< Target transmit FIFO Trigger level */
+
+/* I2C_DMA_TRIG1_IMASK Bits */
+/* I2C_DMA_TRIG1_IMASK[MRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_IMASK_MRXFIFOTRG_OFS       (0)                             /* !< MRXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_IMASK_MRXFIFOTRG_MASK      ((uint32_t)0x00000001U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_DMA_TRIG1_IMASK_MRXFIFOTRG_CLR       ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_IMASK_MRXFIFOTRG_SET       ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_IMASK[MTXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_IMASK_MTXFIFOTRG_OFS       (1)                             /* !< MTXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_IMASK_MTXFIFOTRG_MASK      ((uint32_t)0x00000002U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_DMA_TRIG1_IMASK_MTXFIFOTRG_CLR       ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_IMASK_MTXFIFOTRG_SET       ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_IMASK[SRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_IMASK_SRXFIFOTRG_OFS       (2)                             /* !< SRXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_IMASK_SRXFIFOTRG_MASK      ((uint32_t)0x00000004U)         /* !< Target Receive FIFO Trigger */
+#define I2C_DMA_TRIG1_IMASK_SRXFIFOTRG_CLR       ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_IMASK_SRXFIFOTRG_SET       ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_IMASK[STXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_IMASK_STXFIFOTRG_OFS       (3)                             /* !< STXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_IMASK_STXFIFOTRG_MASK      ((uint32_t)0x00000008U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_DMA_TRIG1_IMASK_STXFIFOTRG_CLR       ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_IMASK_STXFIFOTRG_SET       ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+
+/* I2C_DMA_TRIG1_RIS Bits */
+/* I2C_DMA_TRIG1_RIS[MRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_RIS_MRXFIFOTRG_OFS         (0)                             /* !< MRXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_RIS_MRXFIFOTRG_MASK        ((uint32_t)0x00000001U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_DMA_TRIG1_RIS_MRXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_RIS_MRXFIFOTRG_SET         ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_RIS[MTXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_RIS_MTXFIFOTRG_OFS         (1)                             /* !< MTXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_RIS_MTXFIFOTRG_MASK        ((uint32_t)0x00000002U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_DMA_TRIG1_RIS_MTXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_RIS_MTXFIFOTRG_SET         ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_RIS[SRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_RIS_SRXFIFOTRG_OFS         (2)                             /* !< SRXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_RIS_SRXFIFOTRG_MASK        ((uint32_t)0x00000004U)         /* !< Target Receive FIFO Trigger */
+#define I2C_DMA_TRIG1_RIS_SRXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_RIS_SRXFIFOTRG_SET         ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_RIS[STXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_RIS_STXFIFOTRG_OFS         (3)                             /* !< STXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_RIS_STXFIFOTRG_MASK        ((uint32_t)0x00000008U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_DMA_TRIG1_RIS_STXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_RIS_STXFIFOTRG_SET         ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+
+/* I2C_DMA_TRIG1_MIS Bits */
+/* I2C_DMA_TRIG1_MIS[MRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_MIS_MRXFIFOTRG_OFS         (0)                             /* !< MRXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_MIS_MRXFIFOTRG_MASK        ((uint32_t)0x00000001U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_DMA_TRIG1_MIS_MRXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_MIS_MRXFIFOTRG_SET         ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_MIS[MTXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_MIS_MTXFIFOTRG_OFS         (1)                             /* !< MTXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_MIS_MTXFIFOTRG_MASK        ((uint32_t)0x00000002U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_DMA_TRIG1_MIS_MTXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_MIS_MTXFIFOTRG_SET         ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_MIS[SRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_MIS_SRXFIFOTRG_OFS         (2)                             /* !< SRXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_MIS_SRXFIFOTRG_MASK        ((uint32_t)0x00000004U)         /* !< Target Receive FIFO Trigger */
+#define I2C_DMA_TRIG1_MIS_SRXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_MIS_SRXFIFOTRG_SET         ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_MIS[STXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_MIS_STXFIFOTRG_OFS         (3)                             /* !< STXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_MIS_STXFIFOTRG_MASK        ((uint32_t)0x00000008U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_DMA_TRIG1_MIS_STXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_MIS_STXFIFOTRG_SET         ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+
+/* I2C_DMA_TRIG1_ISET Bits */
+/* I2C_DMA_TRIG1_ISET[MRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_ISET_MRXFIFOTRG_OFS        (0)                             /* !< MRXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_ISET_MRXFIFOTRG_MASK       ((uint32_t)0x00000001U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_DMA_TRIG1_ISET_MRXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_ISET_MRXFIFOTRG_SET        ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_ISET[MTXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_ISET_MTXFIFOTRG_OFS        (1)                             /* !< MTXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_ISET_MTXFIFOTRG_MASK       ((uint32_t)0x00000002U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_DMA_TRIG1_ISET_MTXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_ISET_MTXFIFOTRG_SET        ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_ISET[SRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_ISET_SRXFIFOTRG_OFS        (2)                             /* !< SRXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_ISET_SRXFIFOTRG_MASK       ((uint32_t)0x00000004U)         /* !< Target Receive FIFO Trigger */
+#define I2C_DMA_TRIG1_ISET_SRXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_ISET_SRXFIFOTRG_SET        ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_ISET[STXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_ISET_STXFIFOTRG_OFS        (3)                             /* !< STXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_ISET_STXFIFOTRG_MASK       ((uint32_t)0x00000008U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_DMA_TRIG1_ISET_STXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_ISET_STXFIFOTRG_SET        ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+
+/* I2C_DMA_TRIG1_ICLR Bits */
+/* I2C_DMA_TRIG1_ICLR[MRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_ICLR_MRXFIFOTRG_OFS        (0)                             /* !< MRXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_ICLR_MRXFIFOTRG_MASK       ((uint32_t)0x00000001U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_DMA_TRIG1_ICLR_MRXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_ICLR_MRXFIFOTRG_CLR        ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_ICLR[MTXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_ICLR_MTXFIFOTRG_OFS        (1)                             /* !< MTXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_ICLR_MTXFIFOTRG_MASK       ((uint32_t)0x00000002U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_DMA_TRIG1_ICLR_MTXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_ICLR_MTXFIFOTRG_CLR        ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_ICLR[SRXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_ICLR_SRXFIFOTRG_OFS        (2)                             /* !< SRXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_ICLR_SRXFIFOTRG_MASK       ((uint32_t)0x00000004U)         /* !< Target Receive FIFO Trigger */
+#define I2C_DMA_TRIG1_ICLR_SRXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_ICLR_SRXFIFOTRG_CLR        ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_DMA_TRIG1_ICLR[STXFIFOTRG] Bits */
+#define I2C_DMA_TRIG1_ICLR_STXFIFOTRG_OFS        (3)                             /* !< STXFIFOTRG Offset */
+#define I2C_DMA_TRIG1_ICLR_STXFIFOTRG_MASK       ((uint32_t)0x00000008U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_DMA_TRIG1_ICLR_STXFIFOTRG_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_DMA_TRIG1_ICLR_STXFIFOTRG_CLR        ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+
+/* I2C_CPU_INT_IIDX Bits */
+/* I2C_CPU_INT_IIDX[STAT] Bits */
+#define I2C_CPU_INT_IIDX_STAT_OFS                (0)                             /* !< STAT Offset */
+#define I2C_CPU_INT_IIDX_STAT_MASK               ((uint32_t)0x000000FFU)         /* !< I2C Module Interrupt Vector Value.
+                                                                                    This register provides the highes
+                                                                                    priority interrupt index. A read
+                                                                                    clears the corresponding interrupt
+                                                                                    flag in RIS and MISC. 15h-1Fh =
+                                                                                    Reserved */
+#define I2C_CPU_INT_IIDX_STAT_NO_INTR            ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define I2C_CPU_INT_IIDX_STAT_MRXDONEFG          ((uint32_t)0x00000001U)         /* !< Controller data received */
+#define I2C_CPU_INT_IIDX_STAT_MTXDONEFG          ((uint32_t)0x00000002U)         /* !< Controller data transmitted */
+#define I2C_CPU_INT_IIDX_STAT_MRXFIFOTRG         ((uint32_t)0x00000003U)         /* !< Controller receive FIFO Trigger
+                                                                                    Level */
+#define I2C_CPU_INT_IIDX_STAT_MTXFIFOTRG         ((uint32_t)0x00000004U)         /* !< Controller transmit FIFO Trigger
+                                                                                    level */
+#define I2C_CPU_INT_IIDX_STAT_MRXFIFOFULL        ((uint32_t)0x00000005U)         /* !< RX FIFO FULL Event/interrupt
+                                                                                    pending */
+#define I2C_CPU_INT_IIDX_STAT_MTX_EMPTY          ((uint32_t)0x00000006U)         /* !< Transmit FIFO/Buffer Empty
+                                                                                    Event/interrupt pending */
+#define I2C_CPU_INT_IIDX_STAT_MNACKFG            ((uint32_t)0x00000008U)         /* !< Address/Data NACK */
+#define I2C_CPU_INT_IIDX_STAT_MSTARTFG           ((uint32_t)0x00000009U)         /* !< Start Event */
+#define I2C_CPU_INT_IIDX_STAT_MSTOPFG            ((uint32_t)0x0000000AU)         /* !< Stop Event */
+#define I2C_CPU_INT_IIDX_STAT_MARBLOSTFG         ((uint32_t)0x0000000BU)         /* !< Arbitration Lost */
+#define I2C_CPU_INT_IIDX_STAT_MDMA_DONE_TX       ((uint32_t)0x0000000CU)         /* !< DMA DONE on Channel TX */
+#define I2C_CPU_INT_IIDX_STAT_MDMA_DONE_RX       ((uint32_t)0x0000000DU)         /* !< DMA DONE on Channel RX */
+#define I2C_CPU_INT_IIDX_STAT_MPEC_RX_ERR        ((uint32_t)0x0000000EU)         /* !< Controller PEC Receive Error Event */
+#define I2C_CPU_INT_IIDX_STAT_TIMEOUTA           ((uint32_t)0x0000000FU)         /* !< Timeout A Event */
+#define I2C_CPU_INT_IIDX_STAT_TIMEOUTB           ((uint32_t)0x00000010U)         /* !< Timeout B Event */
+#define I2C_CPU_INT_IIDX_STAT_SRXDONEFG          ((uint32_t)0x00000011U)         /* !< Target Data Event */
+#define I2C_CPU_INT_IIDX_STAT_STXDONEFG          ((uint32_t)0x00000012U)         /* !< Target Data Event */
+#define I2C_CPU_INT_IIDX_STAT_SRXFIFOTRG         ((uint32_t)0x00000013U)         /* !< Target receive FIFO Trigger Level */
+#define I2C_CPU_INT_IIDX_STAT_STXFIFOTRG         ((uint32_t)0x00000014U)         /* !< Target transmit FIFO Trigger level */
+#define I2C_CPU_INT_IIDX_STAT_SRXFIFOFULL        ((uint32_t)0x00000015U)         /* !< RX FIFO FULL Event/interrupt
+                                                                                    pending */
+#define I2C_CPU_INT_IIDX_STAT_STXEMPTY           ((uint32_t)0x00000016U)         /* !< Transmit FIFO/Buffer Empty
+                                                                                    Event/interrupt pending */
+#define I2C_CPU_INT_IIDX_STAT_SSTARTFG           ((uint32_t)0x00000017U)         /* !< Start Event */
+#define I2C_CPU_INT_IIDX_STAT_SSTOPFG            ((uint32_t)0x00000018U)         /* !< Stop Event */
+#define I2C_CPU_INT_IIDX_STAT_SGENCALL           ((uint32_t)0x00000019U)         /* !< General Call Event */
+#define I2C_CPU_INT_IIDX_STAT_SDMA_DONE_TX       ((uint32_t)0x0000001AU)         /* !< DMA DONE on Channel TX */
+#define I2C_CPU_INT_IIDX_STAT_SDMA_DONE_RX       ((uint32_t)0x0000001BU)         /* !< DMA DONE on Channel RX */
+#define I2C_CPU_INT_IIDX_STAT_SPEC_RX_ERR        ((uint32_t)0x0000001CU)         /* !< Target PEC receive error event */
+#define I2C_CPU_INT_IIDX_STAT_STX_UNFL           ((uint32_t)0x0000001DU)         /* !< Target TX FIFO underflow */
+#define I2C_CPU_INT_IIDX_STAT_SRX_OVFL           ((uint32_t)0x0000001EU)         /* !< Target RX FIFO overflow event */
+#define I2C_CPU_INT_IIDX_STAT_SARBLOST           ((uint32_t)0x0000001FU)         /* !< Target arbitration lost event */
+#define I2C_CPU_INT_IIDX_STAT_INTR_OVFL          ((uint32_t)0x00000020U)         /* !< Interrupt overflow event */
+
+/* I2C_CPU_INT_IMASK Bits */
+/* I2C_CPU_INT_IMASK[MRXDONE] Bits */
+#define I2C_CPU_INT_IMASK_MRXDONE_OFS            (0)                             /* !< MRXDONE Offset */
+#define I2C_CPU_INT_IMASK_MRXDONE_MASK           ((uint32_t)0x00000001U)         /* !< Controller Receive Transaction
+                                                                                    completed Interrupt */
+#define I2C_CPU_INT_IMASK_MRXDONE_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_MRXDONE_SET            ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[TIMEOUTA] Bits */
+#define I2C_CPU_INT_IMASK_TIMEOUTA_OFS           (14)                            /* !< TIMEOUTA Offset */
+#define I2C_CPU_INT_IMASK_TIMEOUTA_MASK          ((uint32_t)0x00004000U)         /* !< Timeout A Interrupt */
+#define I2C_CPU_INT_IMASK_TIMEOUTA_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_TIMEOUTA_SET           ((uint32_t)0x00004000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[MNACK] Bits */
+#define I2C_CPU_INT_IMASK_MNACK_OFS              (7)                             /* !< MNACK Offset */
+#define I2C_CPU_INT_IMASK_MNACK_MASK             ((uint32_t)0x00000080U)         /* !< Address/Data NACK Interrupt */
+#define I2C_CPU_INT_IMASK_MNACK_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_MNACK_SET              ((uint32_t)0x00000080U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[MSTART] Bits */
+#define I2C_CPU_INT_IMASK_MSTART_OFS             (8)                             /* !< MSTART Offset */
+#define I2C_CPU_INT_IMASK_MSTART_MASK            ((uint32_t)0x00000100U)         /* !< START Detection Interrupt */
+#define I2C_CPU_INT_IMASK_MSTART_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_MSTART_SET             ((uint32_t)0x00000100U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[MSTOP] Bits */
+#define I2C_CPU_INT_IMASK_MSTOP_OFS              (9)                             /* !< MSTOP Offset */
+#define I2C_CPU_INT_IMASK_MSTOP_MASK             ((uint32_t)0x00000200U)         /* !< STOP Detection Interrupt */
+#define I2C_CPU_INT_IMASK_MSTOP_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_MSTOP_SET              ((uint32_t)0x00000200U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[MARBLOST] Bits */
+#define I2C_CPU_INT_IMASK_MARBLOST_OFS           (10)                            /* !< MARBLOST Offset */
+#define I2C_CPU_INT_IMASK_MARBLOST_MASK          ((uint32_t)0x00000400U)         /* !< Arbitration Lost Interrupt */
+#define I2C_CPU_INT_IMASK_MARBLOST_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_MARBLOST_SET           ((uint32_t)0x00000400U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[MTXDONE] Bits */
+#define I2C_CPU_INT_IMASK_MTXDONE_OFS            (1)                             /* !< MTXDONE Offset */
+#define I2C_CPU_INT_IMASK_MTXDONE_MASK           ((uint32_t)0x00000002U)         /* !< Controller Transmit Transaction
+                                                                                    completed Interrupt */
+#define I2C_CPU_INT_IMASK_MTXDONE_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_MTXDONE_SET            ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[MRXFIFOFULL] Bits */
+#define I2C_CPU_INT_IMASK_MRXFIFOFULL_OFS        (4)                             /* !< MRXFIFOFULL Offset */
+#define I2C_CPU_INT_IMASK_MRXFIFOFULL_MASK       ((uint32_t)0x00000010U)         /* !< RXFIFO full event. This interrupt
+                                                                                    is set if an RX FIFO is full. */
+#define I2C_CPU_INT_IMASK_MRXFIFOFULL_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_MRXFIFOFULL_SET        ((uint32_t)0x00000010U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[MTXEMPTY] Bits */
+#define I2C_CPU_INT_IMASK_MTXEMPTY_OFS           (5)                             /* !< MTXEMPTY Offset */
+#define I2C_CPU_INT_IMASK_MTXEMPTY_MASK          ((uint32_t)0x00000020U)         /* !< Transmit FIFO Empty interrupt mask.
+                                                                                    This interrupt is set if all data in
+                                                                                    the Transmit FIFO have been shifted
+                                                                                    out and the transmit goes into idle
+                                                                                    mode. */
+#define I2C_CPU_INT_IMASK_MTXEMPTY_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_MTXEMPTY_SET           ((uint32_t)0x00000020U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[MRXFIFOTRG] Bits */
+#define I2C_CPU_INT_IMASK_MRXFIFOTRG_OFS         (2)                             /* !< MRXFIFOTRG Offset */
+#define I2C_CPU_INT_IMASK_MRXFIFOTRG_MASK        ((uint32_t)0x00000004U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_CPU_INT_IMASK_MRXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_MRXFIFOTRG_SET         ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[MTXFIFOTRG] Bits */
+#define I2C_CPU_INT_IMASK_MTXFIFOTRG_OFS         (3)                             /* !< MTXFIFOTRG Offset */
+#define I2C_CPU_INT_IMASK_MTXFIFOTRG_MASK        ((uint32_t)0x00000008U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_CPU_INT_IMASK_MTXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_MTXFIFOTRG_SET         ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[MDMA_DONE_TX] Bits */
+#define I2C_CPU_INT_IMASK_MDMA_DONE_TX_OFS       (11)                            /* !< MDMA_DONE_TX Offset */
+#define I2C_CPU_INT_IMASK_MDMA_DONE_TX_MASK      ((uint32_t)0x00000800U)         /* !< DMA Done on Event Channel TX */
+#define I2C_CPU_INT_IMASK_MDMA_DONE_TX_CLR       ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define I2C_CPU_INT_IMASK_MDMA_DONE_TX_SET       ((uint32_t)0x00000800U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[MDMA_DONE_RX] Bits */
+#define I2C_CPU_INT_IMASK_MDMA_DONE_RX_OFS       (12)                            /* !< MDMA_DONE_RX Offset */
+#define I2C_CPU_INT_IMASK_MDMA_DONE_RX_MASK      ((uint32_t)0x00001000U)         /* !< DMA Done on Event Channel RX */
+#define I2C_CPU_INT_IMASK_MDMA_DONE_RX_CLR       ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define I2C_CPU_INT_IMASK_MDMA_DONE_RX_SET       ((uint32_t)0x00001000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[SRXDONE] Bits */
+#define I2C_CPU_INT_IMASK_SRXDONE_OFS            (16)                            /* !< SRXDONE Offset */
+#define I2C_CPU_INT_IMASK_SRXDONE_MASK           ((uint32_t)0x00010000U)         /* !< Target Receive Data Interrupt
+                                                                                    Signals that a byte has been received */
+#define I2C_CPU_INT_IMASK_SRXDONE_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_SRXDONE_SET            ((uint32_t)0x00010000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[STXDONE] Bits */
+#define I2C_CPU_INT_IMASK_STXDONE_OFS            (17)                            /* !< STXDONE Offset */
+#define I2C_CPU_INT_IMASK_STXDONE_MASK           ((uint32_t)0x00020000U)         /* !< Target Transmit Transaction
+                                                                                    completed Interrupt */
+#define I2C_CPU_INT_IMASK_STXDONE_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_STXDONE_SET            ((uint32_t)0x00020000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[SGENCALL] Bits */
+#define I2C_CPU_INT_IMASK_SGENCALL_OFS           (24)                            /* !< SGENCALL Offset */
+#define I2C_CPU_INT_IMASK_SGENCALL_MASK          ((uint32_t)0x01000000U)         /* !< General Call Interrupt */
+#define I2C_CPU_INT_IMASK_SGENCALL_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_SGENCALL_SET           ((uint32_t)0x01000000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[STXEMPTY] Bits */
+#define I2C_CPU_INT_IMASK_STXEMPTY_OFS           (21)                            /* !< STXEMPTY Offset */
+#define I2C_CPU_INT_IMASK_STXEMPTY_MASK          ((uint32_t)0x00200000U)         /* !< Target Transmit FIFO Empty
+                                                                                    interrupt mask. This interrupt is set
+                                                                                    if all data in the Transmit FIFO have
+                                                                                    been shifted out and the transmit
+                                                                                    goes into idle mode. */
+#define I2C_CPU_INT_IMASK_STXEMPTY_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_STXEMPTY_SET           ((uint32_t)0x00200000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[SRXFIFOFULL] Bits */
+#define I2C_CPU_INT_IMASK_SRXFIFOFULL_OFS        (20)                            /* !< SRXFIFOFULL Offset */
+#define I2C_CPU_INT_IMASK_SRXFIFOFULL_MASK       ((uint32_t)0x00100000U)         /* !< RXFIFO full event. This interrupt
+                                                                                    is set if an Target RX FIFO is full. */
+#define I2C_CPU_INT_IMASK_SRXFIFOFULL_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_SRXFIFOFULL_SET        ((uint32_t)0x00100000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[SRXFIFOTRG] Bits */
+#define I2C_CPU_INT_IMASK_SRXFIFOTRG_OFS         (18)                            /* !< SRXFIFOTRG Offset */
+#define I2C_CPU_INT_IMASK_SRXFIFOTRG_MASK        ((uint32_t)0x00040000U)         /* !< Target Receive FIFO Trigger */
+#define I2C_CPU_INT_IMASK_SRXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_SRXFIFOTRG_SET         ((uint32_t)0x00040000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[STXFIFOTRG] Bits */
+#define I2C_CPU_INT_IMASK_STXFIFOTRG_OFS         (19)                            /* !< STXFIFOTRG Offset */
+#define I2C_CPU_INT_IMASK_STXFIFOTRG_MASK        ((uint32_t)0x00080000U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_CPU_INT_IMASK_STXFIFOTRG_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_STXFIFOTRG_SET         ((uint32_t)0x00080000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[SSTART] Bits */
+#define I2C_CPU_INT_IMASK_SSTART_OFS             (22)                            /* !< SSTART Offset */
+#define I2C_CPU_INT_IMASK_SSTART_MASK            ((uint32_t)0x00400000U)         /* !< Start Condition Interrupt */
+#define I2C_CPU_INT_IMASK_SSTART_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_SSTART_SET             ((uint32_t)0x00400000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[SSTOP] Bits */
+#define I2C_CPU_INT_IMASK_SSTOP_OFS              (23)                            /* !< SSTOP Offset */
+#define I2C_CPU_INT_IMASK_SSTOP_MASK             ((uint32_t)0x00800000U)         /* !< Stop Condition Interrupt */
+#define I2C_CPU_INT_IMASK_SSTOP_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_SSTOP_SET              ((uint32_t)0x00800000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[SDMA_DONE_TX] Bits */
+#define I2C_CPU_INT_IMASK_SDMA_DONE_TX_OFS       (25)                            /* !< SDMA_DONE_TX Offset */
+#define I2C_CPU_INT_IMASK_SDMA_DONE_TX_MASK      ((uint32_t)0x02000000U)         /* !< Target DMA Done on Event Channel TX */
+#define I2C_CPU_INT_IMASK_SDMA_DONE_TX_CLR       ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_SDMA_DONE_TX_SET       ((uint32_t)0x02000000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[SDMA_DONE_RX] Bits */
+#define I2C_CPU_INT_IMASK_SDMA_DONE_RX_OFS       (26)                            /* !< SDMA_DONE_RX Offset */
+#define I2C_CPU_INT_IMASK_SDMA_DONE_RX_MASK      ((uint32_t)0x04000000U)         /* !< Target DMA Done on Event Channel RX */
+#define I2C_CPU_INT_IMASK_SDMA_DONE_RX_CLR       ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_SDMA_DONE_RX_SET       ((uint32_t)0x04000000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[MPEC_RX_ERR] Bits */
+#define I2C_CPU_INT_IMASK_MPEC_RX_ERR_OFS        (13)                            /* !< MPEC_RX_ERR Offset */
+#define I2C_CPU_INT_IMASK_MPEC_RX_ERR_MASK       ((uint32_t)0x00002000U)         /* !< Controller RX Pec Error Interrupt */
+#define I2C_CPU_INT_IMASK_MPEC_RX_ERR_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_MPEC_RX_ERR_SET        ((uint32_t)0x00002000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[TIMEOUTB] Bits */
+#define I2C_CPU_INT_IMASK_TIMEOUTB_OFS           (15)                            /* !< TIMEOUTB Offset */
+#define I2C_CPU_INT_IMASK_TIMEOUTB_MASK          ((uint32_t)0x00008000U)         /* !< Timeout B Interrupt */
+#define I2C_CPU_INT_IMASK_TIMEOUTB_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_TIMEOUTB_SET           ((uint32_t)0x00008000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[SPEC_RX_ERR] Bits */
+#define I2C_CPU_INT_IMASK_SPEC_RX_ERR_OFS        (27)                            /* !< SPEC_RX_ERR Offset */
+#define I2C_CPU_INT_IMASK_SPEC_RX_ERR_MASK       ((uint32_t)0x08000000U)         /* !< Target RX Pec Error Interrupt */
+#define I2C_CPU_INT_IMASK_SPEC_RX_ERR_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_SPEC_RX_ERR_SET        ((uint32_t)0x08000000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[STX_UNFL] Bits */
+#define I2C_CPU_INT_IMASK_STX_UNFL_OFS           (28)                            /* !< STX_UNFL Offset */
+#define I2C_CPU_INT_IMASK_STX_UNFL_MASK          ((uint32_t)0x10000000U)         /* !< Target TX FIFO underflow */
+#define I2C_CPU_INT_IMASK_STX_UNFL_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_STX_UNFL_SET           ((uint32_t)0x10000000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[SRX_OVFL] Bits */
+#define I2C_CPU_INT_IMASK_SRX_OVFL_OFS           (29)                            /* !< SRX_OVFL Offset */
+#define I2C_CPU_INT_IMASK_SRX_OVFL_MASK          ((uint32_t)0x20000000U)         /* !< Target RX FIFO overflow */
+#define I2C_CPU_INT_IMASK_SRX_OVFL_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_SRX_OVFL_SET           ((uint32_t)0x20000000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[SARBLOST] Bits */
+#define I2C_CPU_INT_IMASK_SARBLOST_OFS           (30)                            /* !< SARBLOST Offset */
+#define I2C_CPU_INT_IMASK_SARBLOST_MASK          ((uint32_t)0x40000000U)         /* !< Target Arbitration Lost */
+#define I2C_CPU_INT_IMASK_SARBLOST_CLR           ((uint32_t)0x00000000U)         /* !< Clear Set Interrupt Mask */
+#define I2C_CPU_INT_IMASK_SARBLOST_SET           ((uint32_t)0x40000000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_IMASK[INTR_OVFL] Bits */
+#define I2C_CPU_INT_IMASK_INTR_OVFL_OFS          (31)                            /* !< INTR_OVFL Offset */
+#define I2C_CPU_INT_IMASK_INTR_OVFL_MASK         ((uint32_t)0x80000000U)         /* !< Interrupt Overflow Interrupt Mask */
+#define I2C_CPU_INT_IMASK_INTR_OVFL_CLR          ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_IMASK_INTR_OVFL_SET          ((uint32_t)0x80000000U)         /* !< Set Interrupt Mask */
+
+/* I2C_CPU_INT_RIS Bits */
+/* I2C_CPU_INT_RIS[MRXDONE] Bits */
+#define I2C_CPU_INT_RIS_MRXDONE_OFS              (0)                             /* !< MRXDONE Offset */
+#define I2C_CPU_INT_RIS_MRXDONE_MASK             ((uint32_t)0x00000001U)         /* !< Controller Receive Transaction
+                                                                                    completed Interrupt */
+#define I2C_CPU_INT_RIS_MRXDONE_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_MRXDONE_SET              ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[TIMEOUTA] Bits */
+#define I2C_CPU_INT_RIS_TIMEOUTA_OFS             (14)                            /* !< TIMEOUTA Offset */
+#define I2C_CPU_INT_RIS_TIMEOUTA_MASK            ((uint32_t)0x00004000U)         /* !< Timeout A Interrupt */
+#define I2C_CPU_INT_RIS_TIMEOUTA_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_TIMEOUTA_SET             ((uint32_t)0x00004000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[MNACK] Bits */
+#define I2C_CPU_INT_RIS_MNACK_OFS                (7)                             /* !< MNACK Offset */
+#define I2C_CPU_INT_RIS_MNACK_MASK               ((uint32_t)0x00000080U)         /* !< Address/Data NACK Interrupt */
+#define I2C_CPU_INT_RIS_MNACK_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_MNACK_SET                ((uint32_t)0x00000080U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[MSTART] Bits */
+#define I2C_CPU_INT_RIS_MSTART_OFS               (8)                             /* !< MSTART Offset */
+#define I2C_CPU_INT_RIS_MSTART_MASK              ((uint32_t)0x00000100U)         /* !< START Detection Interrupt */
+#define I2C_CPU_INT_RIS_MSTART_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_MSTART_SET               ((uint32_t)0x00000100U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[MSTOP] Bits */
+#define I2C_CPU_INT_RIS_MSTOP_OFS                (9)                             /* !< MSTOP Offset */
+#define I2C_CPU_INT_RIS_MSTOP_MASK               ((uint32_t)0x00000200U)         /* !< STOP Detection Interrupt */
+#define I2C_CPU_INT_RIS_MSTOP_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_MSTOP_SET                ((uint32_t)0x00000200U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[MARBLOST] Bits */
+#define I2C_CPU_INT_RIS_MARBLOST_OFS             (10)                            /* !< MARBLOST Offset */
+#define I2C_CPU_INT_RIS_MARBLOST_MASK            ((uint32_t)0x00000400U)         /* !< Arbitration Lost Interrupt */
+#define I2C_CPU_INT_RIS_MARBLOST_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_MARBLOST_SET             ((uint32_t)0x00000400U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[MTXDONE] Bits */
+#define I2C_CPU_INT_RIS_MTXDONE_OFS              (1)                             /* !< MTXDONE Offset */
+#define I2C_CPU_INT_RIS_MTXDONE_MASK             ((uint32_t)0x00000002U)         /* !< Controller Transmit Transaction
+                                                                                    completed Interrupt */
+#define I2C_CPU_INT_RIS_MTXDONE_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_MTXDONE_SET              ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[MRXFIFOFULL] Bits */
+#define I2C_CPU_INT_RIS_MRXFIFOFULL_OFS          (4)                             /* !< MRXFIFOFULL Offset */
+#define I2C_CPU_INT_RIS_MRXFIFOFULL_MASK         ((uint32_t)0x00000010U)         /* !< RXFIFO full event. This interrupt
+                                                                                    is set if an RX FIFO is full. */
+#define I2C_CPU_INT_RIS_MRXFIFOFULL_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_MRXFIFOFULL_SET          ((uint32_t)0x00000010U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[MTXEMPTY] Bits */
+#define I2C_CPU_INT_RIS_MTXEMPTY_OFS             (5)                             /* !< MTXEMPTY Offset */
+#define I2C_CPU_INT_RIS_MTXEMPTY_MASK            ((uint32_t)0x00000020U)         /* !< Transmit FIFO Empty interrupt mask.
+                                                                                    This interrupt is set if all data in
+                                                                                    the Transmit FIFO have been shifted
+                                                                                    out and the transmit goes into idle
+                                                                                    mode. */
+#define I2C_CPU_INT_RIS_MTXEMPTY_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_MTXEMPTY_SET             ((uint32_t)0x00000020U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[MRXFIFOTRG] Bits */
+#define I2C_CPU_INT_RIS_MRXFIFOTRG_OFS           (2)                             /* !< MRXFIFOTRG Offset */
+#define I2C_CPU_INT_RIS_MRXFIFOTRG_MASK          ((uint32_t)0x00000004U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_CPU_INT_RIS_MRXFIFOTRG_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_RIS_MRXFIFOTRG_SET           ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[MTXFIFOTRG] Bits */
+#define I2C_CPU_INT_RIS_MTXFIFOTRG_OFS           (3)                             /* !< MTXFIFOTRG Offset */
+#define I2C_CPU_INT_RIS_MTXFIFOTRG_MASK          ((uint32_t)0x00000008U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_CPU_INT_RIS_MTXFIFOTRG_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_RIS_MTXFIFOTRG_SET           ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[MDMA_DONE_TX] Bits */
+#define I2C_CPU_INT_RIS_MDMA_DONE_TX_OFS         (11)                            /* !< MDMA_DONE_TX Offset */
+#define I2C_CPU_INT_RIS_MDMA_DONE_TX_MASK        ((uint32_t)0x00000800U)         /* !< DMA Done on Event Channel TX */
+#define I2C_CPU_INT_RIS_MDMA_DONE_TX_CLR         ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define I2C_CPU_INT_RIS_MDMA_DONE_TX_SET         ((uint32_t)0x00000800U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[MDMA_DONE_RX] Bits */
+#define I2C_CPU_INT_RIS_MDMA_DONE_RX_OFS         (12)                            /* !< MDMA_DONE_RX Offset */
+#define I2C_CPU_INT_RIS_MDMA_DONE_RX_MASK        ((uint32_t)0x00001000U)         /* !< DMA Done on Event Channel RX */
+#define I2C_CPU_INT_RIS_MDMA_DONE_RX_CLR         ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define I2C_CPU_INT_RIS_MDMA_DONE_RX_SET         ((uint32_t)0x00001000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[SRXDONE] Bits */
+#define I2C_CPU_INT_RIS_SRXDONE_OFS              (16)                            /* !< SRXDONE Offset */
+#define I2C_CPU_INT_RIS_SRXDONE_MASK             ((uint32_t)0x00010000U)         /* !< Target Receive Data Interrupt
+                                                                                    Signals that a byte has been received */
+#define I2C_CPU_INT_RIS_SRXDONE_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_SRXDONE_SET              ((uint32_t)0x00010000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[STXDONE] Bits */
+#define I2C_CPU_INT_RIS_STXDONE_OFS              (17)                            /* !< STXDONE Offset */
+#define I2C_CPU_INT_RIS_STXDONE_MASK             ((uint32_t)0x00020000U)         /* !< Target Transmit Transaction
+                                                                                    completed Interrupt */
+#define I2C_CPU_INT_RIS_STXDONE_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_STXDONE_SET              ((uint32_t)0x00020000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[SGENCALL] Bits */
+#define I2C_CPU_INT_RIS_SGENCALL_OFS             (24)                            /* !< SGENCALL Offset */
+#define I2C_CPU_INT_RIS_SGENCALL_MASK            ((uint32_t)0x01000000U)         /* !< General Call Interrupt */
+#define I2C_CPU_INT_RIS_SGENCALL_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_RIS_SGENCALL_SET             ((uint32_t)0x01000000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[STXEMPTY] Bits */
+#define I2C_CPU_INT_RIS_STXEMPTY_OFS             (21)                            /* !< STXEMPTY Offset */
+#define I2C_CPU_INT_RIS_STXEMPTY_MASK            ((uint32_t)0x00200000U)         /* !< Transmit FIFO Empty interrupt mask.
+                                                                                    This interrupt is set if all data in
+                                                                                    the Transmit FIFO have been shifted
+                                                                                    out and the transmit goes into idle
+                                                                                    mode. */
+#define I2C_CPU_INT_RIS_STXEMPTY_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_STXEMPTY_SET             ((uint32_t)0x00200000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[SRXFIFOFULL] Bits */
+#define I2C_CPU_INT_RIS_SRXFIFOFULL_OFS          (20)                            /* !< SRXFIFOFULL Offset */
+#define I2C_CPU_INT_RIS_SRXFIFOFULL_MASK         ((uint32_t)0x00100000U)         /* !< RXFIFO full event. This interrupt
+                                                                                    is set if an RX FIFO is full. */
+#define I2C_CPU_INT_RIS_SRXFIFOFULL_CLR          ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_RIS_SRXFIFOFULL_SET          ((uint32_t)0x00100000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[SRXFIFOTRG] Bits */
+#define I2C_CPU_INT_RIS_SRXFIFOTRG_OFS           (18)                            /* !< SRXFIFOTRG Offset */
+#define I2C_CPU_INT_RIS_SRXFIFOTRG_MASK          ((uint32_t)0x00040000U)         /* !< Target Receive FIFO Trigger */
+#define I2C_CPU_INT_RIS_SRXFIFOTRG_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_RIS_SRXFIFOTRG_SET           ((uint32_t)0x00040000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[STXFIFOTRG] Bits */
+#define I2C_CPU_INT_RIS_STXFIFOTRG_OFS           (19)                            /* !< STXFIFOTRG Offset */
+#define I2C_CPU_INT_RIS_STXFIFOTRG_MASK          ((uint32_t)0x00080000U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_CPU_INT_RIS_STXFIFOTRG_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_RIS_STXFIFOTRG_SET           ((uint32_t)0x00080000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_RIS[SSTART] Bits */
+#define I2C_CPU_INT_RIS_SSTART_OFS               (22)                            /* !< SSTART Offset */
+#define I2C_CPU_INT_RIS_SSTART_MASK              ((uint32_t)0x00400000U)         /* !< Start Condition Interrupt */
+#define I2C_CPU_INT_RIS_SSTART_CLR               ((uint32_t)0x00000000U)         /* !< Clear interrupt */
+#define I2C_CPU_INT_RIS_SSTART_SET               ((uint32_t)0x00400000U)         /* !< Set Interrupt */
+/* I2C_CPU_INT_RIS[SSTOP] Bits */
+#define I2C_CPU_INT_RIS_SSTOP_OFS                (23)                            /* !< SSTOP Offset */
+#define I2C_CPU_INT_RIS_SSTOP_MASK               ((uint32_t)0x00800000U)         /* !< Stop Condition Interrupt */
+#define I2C_CPU_INT_RIS_SSTOP_CLR                ((uint32_t)0x00000000U)         /* !< Clear Interrupt */
+#define I2C_CPU_INT_RIS_SSTOP_SET                ((uint32_t)0x00800000U)         /* !< Set interrupt */
+/* I2C_CPU_INT_RIS[SDMA_DONE_TX] Bits */
+#define I2C_CPU_INT_RIS_SDMA_DONE_TX_OFS         (25)                            /* !< SDMA_DONE_TX Offset */
+#define I2C_CPU_INT_RIS_SDMA_DONE_TX_MASK        ((uint32_t)0x02000000U)         /* !< DMA Done on Event Channel TX */
+#define I2C_CPU_INT_RIS_SDMA_DONE_TX_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt */
+#define I2C_CPU_INT_RIS_SDMA_DONE_TX_SET         ((uint32_t)0x02000000U)         /* !< Set interrupt */
+/* I2C_CPU_INT_RIS[SDMA_DONE_RX] Bits */
+#define I2C_CPU_INT_RIS_SDMA_DONE_RX_OFS         (26)                            /* !< SDMA_DONE_RX Offset */
+#define I2C_CPU_INT_RIS_SDMA_DONE_RX_MASK        ((uint32_t)0x04000000U)         /* !< DMA Done on Event Channel RX */
+#define I2C_CPU_INT_RIS_SDMA_DONE_RX_CLR         ((uint32_t)0x00000000U)         /* !< Clear interrupt */
+#define I2C_CPU_INT_RIS_SDMA_DONE_RX_SET         ((uint32_t)0x04000000U)         /* !< Set interrupt */
+/* I2C_CPU_INT_RIS[MPEC_RX_ERR] Bits */
+#define I2C_CPU_INT_RIS_MPEC_RX_ERR_OFS          (13)                            /* !< MPEC_RX_ERR Offset */
+#define I2C_CPU_INT_RIS_MPEC_RX_ERR_MASK         ((uint32_t)0x00002000U)         /* !< Controller RX Pec Error Interrupt */
+#define I2C_CPU_INT_RIS_MPEC_RX_ERR_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_MPEC_RX_ERR_SET          ((uint32_t)0x00002000U)         /* !< Interrupt Occured */
+/* I2C_CPU_INT_RIS[TIMEOUTB] Bits */
+#define I2C_CPU_INT_RIS_TIMEOUTB_OFS             (15)                            /* !< TIMEOUTB Offset */
+#define I2C_CPU_INT_RIS_TIMEOUTB_MASK            ((uint32_t)0x00008000U)         /* !< Timeout B Interrupt */
+#define I2C_CPU_INT_RIS_TIMEOUTB_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_TIMEOUTB_SET             ((uint32_t)0x00008000U)         /* !< Interrupt occured */
+/* I2C_CPU_INT_RIS[SPEC_RX_ERR] Bits */
+#define I2C_CPU_INT_RIS_SPEC_RX_ERR_OFS          (27)                            /* !< SPEC_RX_ERR Offset */
+#define I2C_CPU_INT_RIS_SPEC_RX_ERR_MASK         ((uint32_t)0x08000000U)         /* !< Target RX Pec Error Interrupt */
+#define I2C_CPU_INT_RIS_SPEC_RX_ERR_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_SPEC_RX_ERR_SET          ((uint32_t)0x08000000U)         /* !< Interrupt ocuured */
+/* I2C_CPU_INT_RIS[STX_UNFL] Bits */
+#define I2C_CPU_INT_RIS_STX_UNFL_OFS             (28)                            /* !< STX_UNFL Offset */
+#define I2C_CPU_INT_RIS_STX_UNFL_MASK            ((uint32_t)0x10000000U)         /* !< Target TX FIFO underflow */
+#define I2C_CPU_INT_RIS_STX_UNFL_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_STX_UNFL_SET             ((uint32_t)0x10000000U)         /* !< Interrupt occured */
+/* I2C_CPU_INT_RIS[SRX_OVFL] Bits */
+#define I2C_CPU_INT_RIS_SRX_OVFL_OFS             (29)                            /* !< SRX_OVFL Offset */
+#define I2C_CPU_INT_RIS_SRX_OVFL_MASK            ((uint32_t)0x20000000U)         /* !< Target RX FIFO overflow */
+#define I2C_CPU_INT_RIS_SRX_OVFL_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_SRX_OVFL_SET             ((uint32_t)0x20000000U)         /* !< Interrupt Occured */
+/* I2C_CPU_INT_RIS[SARBLOST] Bits */
+#define I2C_CPU_INT_RIS_SARBLOST_OFS             (30)                            /* !< SARBLOST Offset */
+#define I2C_CPU_INT_RIS_SARBLOST_MASK            ((uint32_t)0x40000000U)         /* !< Target Arbitration Lost */
+#define I2C_CPU_INT_RIS_SARBLOST_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_SARBLOST_SET             ((uint32_t)0x40000000U)         /* !< Interrupt occured */
+/* I2C_CPU_INT_RIS[INTR_OVFL] Bits */
+#define I2C_CPU_INT_RIS_INTR_OVFL_OFS            (31)                            /* !< INTR_OVFL Offset */
+#define I2C_CPU_INT_RIS_INTR_OVFL_MASK           ((uint32_t)0x80000000U)         /* !< Interrupt overflow interrupt It is
+                                                                                    set when SSTART or SSTOP interrupts
+                                                                                    overflow i.e. occur twice without
+                                                                                    being serviced */
+#define I2C_CPU_INT_RIS_INTR_OVFL_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_RIS_INTR_OVFL_SET            ((uint32_t)0x80000000U)         /* !< Interrupt occured */
+
+/* I2C_CPU_INT_MIS Bits */
+/* I2C_CPU_INT_MIS[MRXDONE] Bits */
+#define I2C_CPU_INT_MIS_MRXDONE_OFS              (0)                             /* !< MRXDONE Offset */
+#define I2C_CPU_INT_MIS_MRXDONE_MASK             ((uint32_t)0x00000001U)         /* !< Controller Receive Data Interrupt */
+#define I2C_CPU_INT_MIS_MRXDONE_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_MRXDONE_SET              ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[TIMEOUTA] Bits */
+#define I2C_CPU_INT_MIS_TIMEOUTA_OFS             (14)                            /* !< TIMEOUTA Offset */
+#define I2C_CPU_INT_MIS_TIMEOUTA_MASK            ((uint32_t)0x00004000U)         /* !< Timeout A Interrupt */
+#define I2C_CPU_INT_MIS_TIMEOUTA_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_TIMEOUTA_SET             ((uint32_t)0x00004000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[MNACK] Bits */
+#define I2C_CPU_INT_MIS_MNACK_OFS                (7)                             /* !< MNACK Offset */
+#define I2C_CPU_INT_MIS_MNACK_MASK               ((uint32_t)0x00000080U)         /* !< Address/Data NACK Interrupt */
+#define I2C_CPU_INT_MIS_MNACK_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_MNACK_SET                ((uint32_t)0x00000080U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[MSTART] Bits */
+#define I2C_CPU_INT_MIS_MSTART_OFS               (8)                             /* !< MSTART Offset */
+#define I2C_CPU_INT_MIS_MSTART_MASK              ((uint32_t)0x00000100U)         /* !< START Detection Interrupt */
+#define I2C_CPU_INT_MIS_MSTART_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_MSTART_SET               ((uint32_t)0x00000100U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[MSTOP] Bits */
+#define I2C_CPU_INT_MIS_MSTOP_OFS                (9)                             /* !< MSTOP Offset */
+#define I2C_CPU_INT_MIS_MSTOP_MASK               ((uint32_t)0x00000200U)         /* !< STOP Detection Interrupt */
+#define I2C_CPU_INT_MIS_MSTOP_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_MSTOP_SET                ((uint32_t)0x00000200U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[MARBLOST] Bits */
+#define I2C_CPU_INT_MIS_MARBLOST_OFS             (10)                            /* !< MARBLOST Offset */
+#define I2C_CPU_INT_MIS_MARBLOST_MASK            ((uint32_t)0x00000400U)         /* !< Arbitration Lost Interrupt */
+#define I2C_CPU_INT_MIS_MARBLOST_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_MARBLOST_SET             ((uint32_t)0x00000400U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[MTXDONE] Bits */
+#define I2C_CPU_INT_MIS_MTXDONE_OFS              (1)                             /* !< MTXDONE Offset */
+#define I2C_CPU_INT_MIS_MTXDONE_MASK             ((uint32_t)0x00000002U)         /* !< Controller Transmit Transaction
+                                                                                    completed Interrupt */
+#define I2C_CPU_INT_MIS_MTXDONE_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_MTXDONE_SET              ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[MRXFIFOFULL] Bits */
+#define I2C_CPU_INT_MIS_MRXFIFOFULL_OFS          (4)                             /* !< MRXFIFOFULL Offset */
+#define I2C_CPU_INT_MIS_MRXFIFOFULL_MASK         ((uint32_t)0x00000010U)         /* !< RXFIFO full event. This interrupt
+                                                                                    is set if the RX FIFO is full. */
+#define I2C_CPU_INT_MIS_MRXFIFOFULL_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_MRXFIFOFULL_SET          ((uint32_t)0x00000010U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[MTXEMPTY] Bits */
+#define I2C_CPU_INT_MIS_MTXEMPTY_OFS             (5)                             /* !< MTXEMPTY Offset */
+#define I2C_CPU_INT_MIS_MTXEMPTY_MASK            ((uint32_t)0x00000020U)         /* !< Transmit FIFO Empty interrupt mask.
+                                                                                    This interrupt is set if all data in
+                                                                                    the Transmit FIFO have been shifted
+                                                                                    out and the transmit goes into idle
+                                                                                    mode. */
+#define I2C_CPU_INT_MIS_MTXEMPTY_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_MTXEMPTY_SET             ((uint32_t)0x00000020U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[MRXFIFOTRG] Bits */
+#define I2C_CPU_INT_MIS_MRXFIFOTRG_OFS           (2)                             /* !< MRXFIFOTRG Offset */
+#define I2C_CPU_INT_MIS_MRXFIFOTRG_MASK          ((uint32_t)0x00000004U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_CPU_INT_MIS_MRXFIFOTRG_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_MIS_MRXFIFOTRG_SET           ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[MTXFIFOTRG] Bits */
+#define I2C_CPU_INT_MIS_MTXFIFOTRG_OFS           (3)                             /* !< MTXFIFOTRG Offset */
+#define I2C_CPU_INT_MIS_MTXFIFOTRG_MASK          ((uint32_t)0x00000008U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_CPU_INT_MIS_MTXFIFOTRG_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_MIS_MTXFIFOTRG_SET           ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[MDMA_DONE_TX] Bits */
+#define I2C_CPU_INT_MIS_MDMA_DONE_TX_OFS         (11)                            /* !< MDMA_DONE_TX Offset */
+#define I2C_CPU_INT_MIS_MDMA_DONE_TX_MASK        ((uint32_t)0x00000800U)         /* !< DMA Done on Event Channel TX */
+#define I2C_CPU_INT_MIS_MDMA_DONE_TX_CLR         ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define I2C_CPU_INT_MIS_MDMA_DONE_TX_SET         ((uint32_t)0x00000800U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[MDMA_DONE_RX] Bits */
+#define I2C_CPU_INT_MIS_MDMA_DONE_RX_OFS         (12)                            /* !< MDMA_DONE_RX Offset */
+#define I2C_CPU_INT_MIS_MDMA_DONE_RX_MASK        ((uint32_t)0x00001000U)         /* !< DMA Done on Event Channel RX */
+#define I2C_CPU_INT_MIS_MDMA_DONE_RX_CLR         ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define I2C_CPU_INT_MIS_MDMA_DONE_RX_SET         ((uint32_t)0x00001000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[SRXDONE] Bits */
+#define I2C_CPU_INT_MIS_SRXDONE_OFS              (16)                            /* !< SRXDONE Offset */
+#define I2C_CPU_INT_MIS_SRXDONE_MASK             ((uint32_t)0x00010000U)         /* !< Target Receive Data Interrupt
+                                                                                    Signals that a byte has been received */
+#define I2C_CPU_INT_MIS_SRXDONE_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_SRXDONE_SET              ((uint32_t)0x00010000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[STXDONE] Bits */
+#define I2C_CPU_INT_MIS_STXDONE_OFS              (17)                            /* !< STXDONE Offset */
+#define I2C_CPU_INT_MIS_STXDONE_MASK             ((uint32_t)0x00020000U)         /* !< Target Transmit Transaction
+                                                                                    completed Interrupt */
+#define I2C_CPU_INT_MIS_STXDONE_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_STXDONE_SET              ((uint32_t)0x00020000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[SGENCALL] Bits */
+#define I2C_CPU_INT_MIS_SGENCALL_OFS             (24)                            /* !< SGENCALL Offset */
+#define I2C_CPU_INT_MIS_SGENCALL_MASK            ((uint32_t)0x01000000U)         /* !< General Call Interrupt */
+#define I2C_CPU_INT_MIS_SGENCALL_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_SGENCALL_SET             ((uint32_t)0x01000000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[STXEMPTY] Bits */
+#define I2C_CPU_INT_MIS_STXEMPTY_OFS             (21)                            /* !< STXEMPTY Offset */
+#define I2C_CPU_INT_MIS_STXEMPTY_MASK            ((uint32_t)0x00200000U)         /* !< Transmit FIFO Empty interrupt mask.
+                                                                                    This interrupt is set if all data in
+                                                                                    the Transmit FIFO have been shifted
+                                                                                    out and the transmit goes into idle
+                                                                                    mode. */
+#define I2C_CPU_INT_MIS_STXEMPTY_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_STXEMPTY_SET             ((uint32_t)0x00200000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[SRXFIFOFULL] Bits */
+#define I2C_CPU_INT_MIS_SRXFIFOFULL_OFS          (20)                            /* !< SRXFIFOFULL Offset */
+#define I2C_CPU_INT_MIS_SRXFIFOFULL_MASK         ((uint32_t)0x00100000U)         /* !< RXFIFO full event. This interrupt
+                                                                                    is set if an RX FIFO is full. */
+#define I2C_CPU_INT_MIS_SRXFIFOFULL_CLR          ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_MIS_SRXFIFOFULL_SET          ((uint32_t)0x00100000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[SRXFIFOTRG] Bits */
+#define I2C_CPU_INT_MIS_SRXFIFOTRG_OFS           (18)                            /* !< SRXFIFOTRG Offset */
+#define I2C_CPU_INT_MIS_SRXFIFOTRG_MASK          ((uint32_t)0x00040000U)         /* !< Target Receive FIFO Trigger */
+#define I2C_CPU_INT_MIS_SRXFIFOTRG_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_MIS_SRXFIFOTRG_SET           ((uint32_t)0x00040000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[STXFIFOTRG] Bits */
+#define I2C_CPU_INT_MIS_STXFIFOTRG_OFS           (19)                            /* !< STXFIFOTRG Offset */
+#define I2C_CPU_INT_MIS_STXFIFOTRG_MASK          ((uint32_t)0x00080000U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_CPU_INT_MIS_STXFIFOTRG_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_MIS_STXFIFOTRG_SET           ((uint32_t)0x00080000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_MIS[SSTART] Bits */
+#define I2C_CPU_INT_MIS_SSTART_OFS               (22)                            /* !< SSTART Offset */
+#define I2C_CPU_INT_MIS_SSTART_MASK              ((uint32_t)0x00400000U)         /* !< Target START Detection Interrupt */
+#define I2C_CPU_INT_MIS_SSTART_CLR               ((uint32_t)0x00000000U)         /* !< Clear MIS */
+#define I2C_CPU_INT_MIS_SSTART_SET               ((uint32_t)0x00400000U)         /* !< Set MIS */
+/* I2C_CPU_INT_MIS[SSTOP] Bits */
+#define I2C_CPU_INT_MIS_SSTOP_OFS                (23)                            /* !< SSTOP Offset */
+#define I2C_CPU_INT_MIS_SSTOP_MASK               ((uint32_t)0x00800000U)         /* !< Target STOP Detection Interrupt */
+#define I2C_CPU_INT_MIS_SSTOP_CLR                ((uint32_t)0x00000000U)         /* !< Clear MIS */
+#define I2C_CPU_INT_MIS_SSTOP_SET                ((uint32_t)0x00800000U)         /* !< Set MIS */
+/* I2C_CPU_INT_MIS[SDMA_DONE_TX] Bits */
+#define I2C_CPU_INT_MIS_SDMA_DONE_TX_OFS         (25)                            /* !< SDMA_DONE_TX Offset */
+#define I2C_CPU_INT_MIS_SDMA_DONE_TX_MASK        ((uint32_t)0x02000000U)         /* !< DMA Done on Event Channel TX */
+#define I2C_CPU_INT_MIS_SDMA_DONE_TX_CLR         ((uint32_t)0x00000000U)         /* !< Clear MIS */
+#define I2C_CPU_INT_MIS_SDMA_DONE_TX_SET         ((uint32_t)0x02000000U)         /* !< Set MIS */
+/* I2C_CPU_INT_MIS[SDMA_DONE_RX] Bits */
+#define I2C_CPU_INT_MIS_SDMA_DONE_RX_OFS         (26)                            /* !< SDMA_DONE_RX Offset */
+#define I2C_CPU_INT_MIS_SDMA_DONE_RX_MASK        ((uint32_t)0x04000000U)         /* !< DMA Done on Event Channel RX */
+#define I2C_CPU_INT_MIS_SDMA_DONE_RX_CLR         ((uint32_t)0x00000000U)         /* !< Clear MIS */
+#define I2C_CPU_INT_MIS_SDMA_DONE_RX_SET         ((uint32_t)0x04000000U)         /* !< Set MIS */
+/* I2C_CPU_INT_MIS[MPEC_RX_ERR] Bits */
+#define I2C_CPU_INT_MIS_MPEC_RX_ERR_OFS          (13)                            /* !< MPEC_RX_ERR Offset */
+#define I2C_CPU_INT_MIS_MPEC_RX_ERR_MASK         ((uint32_t)0x00002000U)         /* !< Controller RX Pec Error Interrupt */
+#define I2C_CPU_INT_MIS_MPEC_RX_ERR_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask */
+#define I2C_CPU_INT_MIS_MPEC_RX_ERR_SET          ((uint32_t)0x00002000U)         /* !< Set interrupt mask */
+/* I2C_CPU_INT_MIS[TIMEOUTB] Bits */
+#define I2C_CPU_INT_MIS_TIMEOUTB_OFS             (15)                            /* !< TIMEOUTB Offset */
+#define I2C_CPU_INT_MIS_TIMEOUTB_MASK            ((uint32_t)0x00008000U)         /* !< Timeout B Interrupt */
+#define I2C_CPU_INT_MIS_TIMEOUTB_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask */
+#define I2C_CPU_INT_MIS_TIMEOUTB_SET             ((uint32_t)0x00008000U)         /* !< Set interrupt mask */
+/* I2C_CPU_INT_MIS[SPEC_RX_ERR] Bits */
+#define I2C_CPU_INT_MIS_SPEC_RX_ERR_OFS          (27)                            /* !< SPEC_RX_ERR Offset */
+#define I2C_CPU_INT_MIS_SPEC_RX_ERR_MASK         ((uint32_t)0x08000000U)         /* !< Target RX Pec Error Interrupt */
+#define I2C_CPU_INT_MIS_SPEC_RX_ERR_CLR          ((uint32_t)0x00000000U)         /* !< Clear interrupt mask */
+#define I2C_CPU_INT_MIS_SPEC_RX_ERR_SET          ((uint32_t)0x08000000U)         /* !< Set interrupt mask */
+/* I2C_CPU_INT_MIS[STX_UNFL] Bits */
+#define I2C_CPU_INT_MIS_STX_UNFL_OFS             (28)                            /* !< STX_UNFL Offset */
+#define I2C_CPU_INT_MIS_STX_UNFL_MASK            ((uint32_t)0x10000000U)         /* !< Target TX FIFO underflow */
+#define I2C_CPU_INT_MIS_STX_UNFL_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask */
+#define I2C_CPU_INT_MIS_STX_UNFL_SET             ((uint32_t)0x10000000U)         /* !< Set interrupt mask */
+/* I2C_CPU_INT_MIS[SRX_OVFL] Bits */
+#define I2C_CPU_INT_MIS_SRX_OVFL_OFS             (29)                            /* !< SRX_OVFL Offset */
+#define I2C_CPU_INT_MIS_SRX_OVFL_MASK            ((uint32_t)0x20000000U)         /* !< Target RX FIFO overflow */
+#define I2C_CPU_INT_MIS_SRX_OVFL_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask */
+#define I2C_CPU_INT_MIS_SRX_OVFL_SET             ((uint32_t)0x20000000U)         /* !< Set interrupt mask */
+/* I2C_CPU_INT_MIS[SARBLOST] Bits */
+#define I2C_CPU_INT_MIS_SARBLOST_OFS             (30)                            /* !< SARBLOST Offset */
+#define I2C_CPU_INT_MIS_SARBLOST_MASK            ((uint32_t)0x40000000U)         /* !< Target Arbitration Lost */
+#define I2C_CPU_INT_MIS_SARBLOST_CLR             ((uint32_t)0x00000000U)         /* !< Clear interrupt mask */
+#define I2C_CPU_INT_MIS_SARBLOST_SET             ((uint32_t)0x40000000U)         /* !< Set interrupt mask */
+/* I2C_CPU_INT_MIS[INTR_OVFL] Bits */
+#define I2C_CPU_INT_MIS_INTR_OVFL_OFS            (31)                            /* !< INTR_OVFL Offset */
+#define I2C_CPU_INT_MIS_INTR_OVFL_MASK           ((uint32_t)0x80000000U)         /* !< Interrupt overflow */
+#define I2C_CPU_INT_MIS_INTR_OVFL_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define I2C_CPU_INT_MIS_INTR_OVFL_SET            ((uint32_t)0x80000000U)         /* !< Interrupt occured */
+
+/* I2C_CPU_INT_ISET Bits */
+/* I2C_CPU_INT_ISET[MRXDONE] Bits */
+#define I2C_CPU_INT_ISET_MRXDONE_OFS             (0)                             /* !< MRXDONE Offset */
+#define I2C_CPU_INT_ISET_MRXDONE_MASK            ((uint32_t)0x00000001U)         /* !< Controller Receive Data Interrupt
+                                                                                    Signals that a byte has been received */
+#define I2C_CPU_INT_ISET_MRXDONE_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_MRXDONE_SET             ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[TIMEOUTA] Bits */
+#define I2C_CPU_INT_ISET_TIMEOUTA_OFS            (14)                            /* !< TIMEOUTA Offset */
+#define I2C_CPU_INT_ISET_TIMEOUTA_MASK           ((uint32_t)0x00004000U)         /* !< Timeout A interrupt */
+#define I2C_CPU_INT_ISET_TIMEOUTA_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_TIMEOUTA_SET            ((uint32_t)0x00004000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[MNACK] Bits */
+#define I2C_CPU_INT_ISET_MNACK_OFS               (7)                             /* !< MNACK Offset */
+#define I2C_CPU_INT_ISET_MNACK_MASK              ((uint32_t)0x00000080U)         /* !< Address/Data NACK Interrupt */
+#define I2C_CPU_INT_ISET_MNACK_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_MNACK_SET               ((uint32_t)0x00000080U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[MSTART] Bits */
+#define I2C_CPU_INT_ISET_MSTART_OFS              (8)                             /* !< MSTART Offset */
+#define I2C_CPU_INT_ISET_MSTART_MASK             ((uint32_t)0x00000100U)         /* !< START Detection Interrupt */
+#define I2C_CPU_INT_ISET_MSTART_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_MSTART_SET              ((uint32_t)0x00000100U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[MSTOP] Bits */
+#define I2C_CPU_INT_ISET_MSTOP_OFS               (9)                             /* !< MSTOP Offset */
+#define I2C_CPU_INT_ISET_MSTOP_MASK              ((uint32_t)0x00000200U)         /* !< STOP Detection Interrupt */
+#define I2C_CPU_INT_ISET_MSTOP_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_MSTOP_SET               ((uint32_t)0x00000200U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[MARBLOST] Bits */
+#define I2C_CPU_INT_ISET_MARBLOST_OFS            (10)                            /* !< MARBLOST Offset */
+#define I2C_CPU_INT_ISET_MARBLOST_MASK           ((uint32_t)0x00000400U)         /* !< Arbitration Lost Interrupt */
+#define I2C_CPU_INT_ISET_MARBLOST_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_MARBLOST_SET            ((uint32_t)0x00000400U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[MTXDONE] Bits */
+#define I2C_CPU_INT_ISET_MTXDONE_OFS             (1)                             /* !< MTXDONE Offset */
+#define I2C_CPU_INT_ISET_MTXDONE_MASK            ((uint32_t)0x00000002U)         /* !< Controller Transmit Transaction
+                                                                                    completed Interrupt */
+#define I2C_CPU_INT_ISET_MTXDONE_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_MTXDONE_SET             ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[MRXFIFOFULL] Bits */
+#define I2C_CPU_INT_ISET_MRXFIFOFULL_OFS         (4)                             /* !< MRXFIFOFULL Offset */
+#define I2C_CPU_INT_ISET_MRXFIFOFULL_MASK        ((uint32_t)0x00000010U)         /* !< RXFIFO full event. */
+#define I2C_CPU_INT_ISET_MRXFIFOFULL_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_MRXFIFOFULL_SET         ((uint32_t)0x00000010U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[MTXEMPTY] Bits */
+#define I2C_CPU_INT_ISET_MTXEMPTY_OFS            (5)                             /* !< MTXEMPTY Offset */
+#define I2C_CPU_INT_ISET_MTXEMPTY_MASK           ((uint32_t)0x00000020U)         /* !< Transmit FIFO Empty interrupt mask.
+                                                                                    This interrupt is set if all data in
+                                                                                    the Transmit FIFO have been shifted
+                                                                                    out and the transmit goes into idle
+                                                                                    mode. */
+#define I2C_CPU_INT_ISET_MTXEMPTY_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_MTXEMPTY_SET            ((uint32_t)0x00000020U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[MRXFIFOTRG] Bits */
+#define I2C_CPU_INT_ISET_MRXFIFOTRG_OFS          (2)                             /* !< MRXFIFOTRG Offset */
+#define I2C_CPU_INT_ISET_MRXFIFOTRG_MASK         ((uint32_t)0x00000004U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_CPU_INT_ISET_MRXFIFOTRG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_ISET_MRXFIFOTRG_SET          ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[MTXFIFOTRG] Bits */
+#define I2C_CPU_INT_ISET_MTXFIFOTRG_OFS          (3)                             /* !< MTXFIFOTRG Offset */
+#define I2C_CPU_INT_ISET_MTXFIFOTRG_MASK         ((uint32_t)0x00000008U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_CPU_INT_ISET_MTXFIFOTRG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_ISET_MTXFIFOTRG_SET          ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[MDMA_DONE_TX] Bits */
+#define I2C_CPU_INT_ISET_MDMA_DONE_TX_OFS        (11)                            /* !< MDMA_DONE_TX Offset */
+#define I2C_CPU_INT_ISET_MDMA_DONE_TX_MASK       ((uint32_t)0x00000800U)         /* !< DMA Done on Event Channel TX */
+#define I2C_CPU_INT_ISET_MDMA_DONE_TX_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define I2C_CPU_INT_ISET_MDMA_DONE_TX_SET        ((uint32_t)0x00000800U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[MDMA_DONE_RX] Bits */
+#define I2C_CPU_INT_ISET_MDMA_DONE_RX_OFS        (12)                            /* !< MDMA_DONE_RX Offset */
+#define I2C_CPU_INT_ISET_MDMA_DONE_RX_MASK       ((uint32_t)0x00001000U)         /* !< DMA Done on Event Channel RX */
+#define I2C_CPU_INT_ISET_MDMA_DONE_RX_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define I2C_CPU_INT_ISET_MDMA_DONE_RX_SET        ((uint32_t)0x00001000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[SRXDONE] Bits */
+#define I2C_CPU_INT_ISET_SRXDONE_OFS             (16)                            /* !< SRXDONE Offset */
+#define I2C_CPU_INT_ISET_SRXDONE_MASK            ((uint32_t)0x00010000U)         /* !< Target Receive Data Interrupt
+                                                                                    Signals that a byte has been received */
+#define I2C_CPU_INT_ISET_SRXDONE_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_SRXDONE_SET             ((uint32_t)0x00010000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[STXDONE] Bits */
+#define I2C_CPU_INT_ISET_STXDONE_OFS             (17)                            /* !< STXDONE Offset */
+#define I2C_CPU_INT_ISET_STXDONE_MASK            ((uint32_t)0x00020000U)         /* !< Target Transmit Transaction
+                                                                                    completed Interrupt */
+#define I2C_CPU_INT_ISET_STXDONE_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_STXDONE_SET             ((uint32_t)0x00020000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[SGENCALL] Bits */
+#define I2C_CPU_INT_ISET_SGENCALL_OFS            (24)                            /* !< SGENCALL Offset */
+#define I2C_CPU_INT_ISET_SGENCALL_MASK           ((uint32_t)0x01000000U)         /* !< General Call Interrupt */
+#define I2C_CPU_INT_ISET_SGENCALL_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_SGENCALL_SET            ((uint32_t)0x01000000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[STXEMPTY] Bits */
+#define I2C_CPU_INT_ISET_STXEMPTY_OFS            (21)                            /* !< STXEMPTY Offset */
+#define I2C_CPU_INT_ISET_STXEMPTY_MASK           ((uint32_t)0x00200000U)         /* !< Transmit FIFO Empty interrupt mask.
+                                                                                    This interrupt is set if all data in
+                                                                                    the Transmit FIFO have been shifted
+                                                                                    out and the transmit goes into idle
+                                                                                    mode. */
+#define I2C_CPU_INT_ISET_STXEMPTY_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_STXEMPTY_SET            ((uint32_t)0x00200000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[SRXFIFOFULL] Bits */
+#define I2C_CPU_INT_ISET_SRXFIFOFULL_OFS         (20)                            /* !< SRXFIFOFULL Offset */
+#define I2C_CPU_INT_ISET_SRXFIFOFULL_MASK        ((uint32_t)0x00100000U)         /* !< RXFIFO full event. This interrupt
+                                                                                    is set if an RX FIFO is full. */
+#define I2C_CPU_INT_ISET_SRXFIFOFULL_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_ISET_SRXFIFOFULL_SET         ((uint32_t)0x00100000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[SRXFIFOTRG] Bits */
+#define I2C_CPU_INT_ISET_SRXFIFOTRG_OFS          (18)                            /* !< SRXFIFOTRG Offset */
+#define I2C_CPU_INT_ISET_SRXFIFOTRG_MASK         ((uint32_t)0x00040000U)         /* !< Target Receive FIFO Trigger */
+#define I2C_CPU_INT_ISET_SRXFIFOTRG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_ISET_SRXFIFOTRG_SET          ((uint32_t)0x00040000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[STXFIFOTRG] Bits */
+#define I2C_CPU_INT_ISET_STXFIFOTRG_OFS          (19)                            /* !< STXFIFOTRG Offset */
+#define I2C_CPU_INT_ISET_STXFIFOTRG_MASK         ((uint32_t)0x00080000U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_CPU_INT_ISET_STXFIFOTRG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_ISET_STXFIFOTRG_SET          ((uint32_t)0x00080000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ISET[SSTART] Bits */
+#define I2C_CPU_INT_ISET_SSTART_OFS              (22)                            /* !< SSTART Offset */
+#define I2C_CPU_INT_ISET_SSTART_MASK             ((uint32_t)0x00400000U)         /* !< Start Condition Interrupt */
+#define I2C_CPU_INT_ISET_SSTART_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_SSTART_SET              ((uint32_t)0x00400000U)         /* !< Set interrupt */
+/* I2C_CPU_INT_ISET[SSTOP] Bits */
+#define I2C_CPU_INT_ISET_SSTOP_OFS               (23)                            /* !< SSTOP Offset */
+#define I2C_CPU_INT_ISET_SSTOP_MASK              ((uint32_t)0x00800000U)         /* !< Stop Condition Interrupt */
+#define I2C_CPU_INT_ISET_SSTOP_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_SSTOP_SET               ((uint32_t)0x00800000U)         /* !< Set interrupt */
+/* I2C_CPU_INT_ISET[SDMA_DONE_TX] Bits */
+#define I2C_CPU_INT_ISET_SDMA_DONE_TX_OFS        (25)                            /* !< SDMA_DONE_TX Offset */
+#define I2C_CPU_INT_ISET_SDMA_DONE_TX_MASK       ((uint32_t)0x02000000U)         /* !< DMA Done on Event Channel TX */
+#define I2C_CPU_INT_ISET_SDMA_DONE_TX_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_SDMA_DONE_TX_SET        ((uint32_t)0x02000000U)         /* !< Set interrupt */
+/* I2C_CPU_INT_ISET[SDMA_DONE_RX] Bits */
+#define I2C_CPU_INT_ISET_SDMA_DONE_RX_OFS        (26)                            /* !< SDMA_DONE_RX Offset */
+#define I2C_CPU_INT_ISET_SDMA_DONE_RX_MASK       ((uint32_t)0x04000000U)         /* !< DMA Done on Event Channel RX */
+#define I2C_CPU_INT_ISET_SDMA_DONE_RX_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_SDMA_DONE_RX_SET        ((uint32_t)0x04000000U)         /* !< Set interrupt */
+/* I2C_CPU_INT_ISET[MPEC_RX_ERR] Bits */
+#define I2C_CPU_INT_ISET_MPEC_RX_ERR_OFS         (13)                            /* !< MPEC_RX_ERR Offset */
+#define I2C_CPU_INT_ISET_MPEC_RX_ERR_MASK        ((uint32_t)0x00002000U)         /* !< Controller RX Pec Error Interrupt */
+#define I2C_CPU_INT_ISET_MPEC_RX_ERR_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_MPEC_RX_ERR_SET         ((uint32_t)0x00002000U)         /* !< Set interrupt */
+/* I2C_CPU_INT_ISET[TIMEOUTB] Bits */
+#define I2C_CPU_INT_ISET_TIMEOUTB_OFS            (15)                            /* !< TIMEOUTB Offset */
+#define I2C_CPU_INT_ISET_TIMEOUTB_MASK           ((uint32_t)0x00008000U)         /* !< Timeout B Interrupt */
+#define I2C_CPU_INT_ISET_TIMEOUTB_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_TIMEOUTB_SET            ((uint32_t)0x00008000U)         /* !< Set interrupt */
+/* I2C_CPU_INT_ISET[SPEC_RX_ERR] Bits */
+#define I2C_CPU_INT_ISET_SPEC_RX_ERR_OFS         (27)                            /* !< SPEC_RX_ERR Offset */
+#define I2C_CPU_INT_ISET_SPEC_RX_ERR_MASK        ((uint32_t)0x08000000U)         /* !< Target RX Pec Error Interrupt */
+#define I2C_CPU_INT_ISET_SPEC_RX_ERR_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_SPEC_RX_ERR_SET         ((uint32_t)0x08000000U)         /* !< Set interrupt */
+/* I2C_CPU_INT_ISET[STX_UNFL] Bits */
+#define I2C_CPU_INT_ISET_STX_UNFL_OFS            (28)                            /* !< STX_UNFL Offset */
+#define I2C_CPU_INT_ISET_STX_UNFL_MASK           ((uint32_t)0x10000000U)         /* !< Target TX FIFO underflow */
+#define I2C_CPU_INT_ISET_STX_UNFL_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_STX_UNFL_SET            ((uint32_t)0x10000000U)         /* !< Set interrupt */
+/* I2C_CPU_INT_ISET[SRX_OVFL] Bits */
+#define I2C_CPU_INT_ISET_SRX_OVFL_OFS            (29)                            /* !< SRX_OVFL Offset */
+#define I2C_CPU_INT_ISET_SRX_OVFL_MASK           ((uint32_t)0x20000000U)         /* !< Target RX FIFO overflow */
+#define I2C_CPU_INT_ISET_SRX_OVFL_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_SRX_OVFL_SET            ((uint32_t)0x20000000U)         /* !< Set interrupt */
+/* I2C_CPU_INT_ISET[SARBLOST] Bits */
+#define I2C_CPU_INT_ISET_SARBLOST_OFS            (30)                            /* !< SARBLOST Offset */
+#define I2C_CPU_INT_ISET_SARBLOST_MASK           ((uint32_t)0x40000000U)         /* !< Target Arbitration Lost */
+#define I2C_CPU_INT_ISET_SARBLOST_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ISET_SARBLOST_SET            ((uint32_t)0x40000000U)         /* !< Set interrupt */
+/* I2C_CPU_INT_ISET[INTR_OVFL] Bits */
+#define I2C_CPU_INT_ISET_INTR_OVFL_OFS           (31)                            /* !< INTR_OVFL Offset */
+#define I2C_CPU_INT_ISET_INTR_OVFL_MASK          ((uint32_t)0x80000000U)         /* !< Interrupt overflow */
+#define I2C_CPU_INT_ISET_INTR_OVFL_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define I2C_CPU_INT_ISET_INTR_OVFL_SET           ((uint32_t)0x80000000U)         /* !< Set interrupt */
+
+/* I2C_CPU_INT_ICLR Bits */
+/* I2C_CPU_INT_ICLR[MRXDONE] Bits */
+#define I2C_CPU_INT_ICLR_MRXDONE_OFS             (0)                             /* !< MRXDONE Offset */
+#define I2C_CPU_INT_ICLR_MRXDONE_MASK            ((uint32_t)0x00000001U)         /* !< Controller Receive Data Interrupt
+                                                                                    Signals that a byte has been received */
+#define I2C_CPU_INT_ICLR_MRXDONE_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_MRXDONE_CLR             ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[TIMEOUTA] Bits */
+#define I2C_CPU_INT_ICLR_TIMEOUTA_OFS            (14)                            /* !< TIMEOUTA Offset */
+#define I2C_CPU_INT_ICLR_TIMEOUTA_MASK           ((uint32_t)0x00004000U)         /* !< Timeout A interrupt */
+#define I2C_CPU_INT_ICLR_TIMEOUTA_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_TIMEOUTA_CLR            ((uint32_t)0x00004000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[MNACK] Bits */
+#define I2C_CPU_INT_ICLR_MNACK_OFS               (7)                             /* !< MNACK Offset */
+#define I2C_CPU_INT_ICLR_MNACK_MASK              ((uint32_t)0x00000080U)         /* !< Address/Data NACK Interrupt */
+#define I2C_CPU_INT_ICLR_MNACK_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_MNACK_CLR               ((uint32_t)0x00000080U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[MSTART] Bits */
+#define I2C_CPU_INT_ICLR_MSTART_OFS              (8)                             /* !< MSTART Offset */
+#define I2C_CPU_INT_ICLR_MSTART_MASK             ((uint32_t)0x00000100U)         /* !< START Detection Interrupt */
+#define I2C_CPU_INT_ICLR_MSTART_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_MSTART_CLR              ((uint32_t)0x00000100U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[MSTOP] Bits */
+#define I2C_CPU_INT_ICLR_MSTOP_OFS               (9)                             /* !< MSTOP Offset */
+#define I2C_CPU_INT_ICLR_MSTOP_MASK              ((uint32_t)0x00000200U)         /* !< STOP Detection Interrupt */
+#define I2C_CPU_INT_ICLR_MSTOP_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_MSTOP_CLR               ((uint32_t)0x00000200U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[MARBLOST] Bits */
+#define I2C_CPU_INT_ICLR_MARBLOST_OFS            (10)                            /* !< MARBLOST Offset */
+#define I2C_CPU_INT_ICLR_MARBLOST_MASK           ((uint32_t)0x00000400U)         /* !< Arbitration Lost Interrupt */
+#define I2C_CPU_INT_ICLR_MARBLOST_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_MARBLOST_CLR            ((uint32_t)0x00000400U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[MTXDONE] Bits */
+#define I2C_CPU_INT_ICLR_MTXDONE_OFS             (1)                             /* !< MTXDONE Offset */
+#define I2C_CPU_INT_ICLR_MTXDONE_MASK            ((uint32_t)0x00000002U)         /* !< Controller Transmit Transaction
+                                                                                    completed Interrupt */
+#define I2C_CPU_INT_ICLR_MTXDONE_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_MTXDONE_CLR             ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[MRXFIFOFULL] Bits */
+#define I2C_CPU_INT_ICLR_MRXFIFOFULL_OFS         (4)                             /* !< MRXFIFOFULL Offset */
+#define I2C_CPU_INT_ICLR_MRXFIFOFULL_MASK        ((uint32_t)0x00000010U)         /* !< RXFIFO full event. */
+#define I2C_CPU_INT_ICLR_MRXFIFOFULL_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_MRXFIFOFULL_CLR         ((uint32_t)0x00000010U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[MTXEMPTY] Bits */
+#define I2C_CPU_INT_ICLR_MTXEMPTY_OFS            (5)                             /* !< MTXEMPTY Offset */
+#define I2C_CPU_INT_ICLR_MTXEMPTY_MASK           ((uint32_t)0x00000020U)         /* !< Transmit FIFO Empty interrupt mask.
+                                                                                    This interrupt is set if all data in
+                                                                                    the Transmit FIFO have been shifted
+                                                                                    out and the transmit goes into idle
+                                                                                    mode. */
+#define I2C_CPU_INT_ICLR_MTXEMPTY_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_MTXEMPTY_CLR            ((uint32_t)0x00000020U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[MRXFIFOTRG] Bits */
+#define I2C_CPU_INT_ICLR_MRXFIFOTRG_OFS          (2)                             /* !< MRXFIFOTRG Offset */
+#define I2C_CPU_INT_ICLR_MRXFIFOTRG_MASK         ((uint32_t)0x00000004U)         /* !< Controller Receive FIFO Trigger
+                                                                                    Trigger when RX FIFO contains >=
+                                                                                    defined bytes */
+#define I2C_CPU_INT_ICLR_MRXFIFOTRG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_ICLR_MRXFIFOTRG_CLR          ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[MTXFIFOTRG] Bits */
+#define I2C_CPU_INT_ICLR_MTXFIFOTRG_OFS          (3)                             /* !< MTXFIFOTRG Offset */
+#define I2C_CPU_INT_ICLR_MTXFIFOTRG_MASK         ((uint32_t)0x00000008U)         /* !< Controller Transmit FIFO Trigger
+                                                                                    Trigger when Transmit FIFO contains
+                                                                                    <= defined bytes */
+#define I2C_CPU_INT_ICLR_MTXFIFOTRG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_ICLR_MTXFIFOTRG_CLR          ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[MDMA_DONE_TX] Bits */
+#define I2C_CPU_INT_ICLR_MDMA_DONE_TX_OFS        (11)                            /* !< MDMA_DONE_TX Offset */
+#define I2C_CPU_INT_ICLR_MDMA_DONE_TX_MASK       ((uint32_t)0x00000800U)         /* !< DMA Done on Event Channel TX */
+#define I2C_CPU_INT_ICLR_MDMA_DONE_TX_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define I2C_CPU_INT_ICLR_MDMA_DONE_TX_CLR        ((uint32_t)0x00000800U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[MDMA_DONE_RX] Bits */
+#define I2C_CPU_INT_ICLR_MDMA_DONE_RX_OFS        (12)                            /* !< MDMA_DONE_RX Offset */
+#define I2C_CPU_INT_ICLR_MDMA_DONE_RX_MASK       ((uint32_t)0x00001000U)         /* !< DMA Done on Event Channel RX */
+#define I2C_CPU_INT_ICLR_MDMA_DONE_RX_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define I2C_CPU_INT_ICLR_MDMA_DONE_RX_CLR        ((uint32_t)0x00001000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[SRXDONE] Bits */
+#define I2C_CPU_INT_ICLR_SRXDONE_OFS             (16)                            /* !< SRXDONE Offset */
+#define I2C_CPU_INT_ICLR_SRXDONE_MASK            ((uint32_t)0x00010000U)         /* !< Target Receive Data Interrupt
+                                                                                    Signals that a byte has been received */
+#define I2C_CPU_INT_ICLR_SRXDONE_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_SRXDONE_CLR             ((uint32_t)0x00010000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[STXDONE] Bits */
+#define I2C_CPU_INT_ICLR_STXDONE_OFS             (17)                            /* !< STXDONE Offset */
+#define I2C_CPU_INT_ICLR_STXDONE_MASK            ((uint32_t)0x00020000U)         /* !< Target Transmit Transaction
+                                                                                    completed Interrupt */
+#define I2C_CPU_INT_ICLR_STXDONE_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_STXDONE_CLR             ((uint32_t)0x00020000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[SGENCALL] Bits */
+#define I2C_CPU_INT_ICLR_SGENCALL_OFS            (24)                            /* !< SGENCALL Offset */
+#define I2C_CPU_INT_ICLR_SGENCALL_MASK           ((uint32_t)0x01000000U)         /* !< General Call Interrupt */
+#define I2C_CPU_INT_ICLR_SGENCALL_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_SGENCALL_CLR            ((uint32_t)0x01000000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[STXEMPTY] Bits */
+#define I2C_CPU_INT_ICLR_STXEMPTY_OFS            (21)                            /* !< STXEMPTY Offset */
+#define I2C_CPU_INT_ICLR_STXEMPTY_MASK           ((uint32_t)0x00200000U)         /* !< Transmit FIFO Empty interrupt mask.
+                                                                                    This interrupt is set if all data in
+                                                                                    the Transmit FIFO have been shifted
+                                                                                    out and the transmit goes into idle
+                                                                                    mode. */
+#define I2C_CPU_INT_ICLR_STXEMPTY_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_STXEMPTY_CLR            ((uint32_t)0x00200000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[SRXFIFOFULL] Bits */
+#define I2C_CPU_INT_ICLR_SRXFIFOFULL_OFS         (20)                            /* !< SRXFIFOFULL Offset */
+#define I2C_CPU_INT_ICLR_SRXFIFOFULL_MASK        ((uint32_t)0x00100000U)         /* !< RXFIFO full event. This interrupt
+                                                                                    is set if an RX FIFO is full. */
+#define I2C_CPU_INT_ICLR_SRXFIFOFULL_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_ICLR_SRXFIFOFULL_CLR         ((uint32_t)0x00100000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[SRXFIFOTRG] Bits */
+#define I2C_CPU_INT_ICLR_SRXFIFOTRG_OFS          (18)                            /* !< SRXFIFOTRG Offset */
+#define I2C_CPU_INT_ICLR_SRXFIFOTRG_MASK         ((uint32_t)0x00040000U)         /* !< Target Receive FIFO Trigger */
+#define I2C_CPU_INT_ICLR_SRXFIFOTRG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_ICLR_SRXFIFOTRG_CLR          ((uint32_t)0x00040000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[STXFIFOTRG] Bits */
+#define I2C_CPU_INT_ICLR_STXFIFOTRG_OFS          (19)                            /* !< STXFIFOTRG Offset */
+#define I2C_CPU_INT_ICLR_STXFIFOTRG_MASK         ((uint32_t)0x00080000U)         /* !< Target Transmit FIFO Trigger */
+#define I2C_CPU_INT_ICLR_STXFIFOTRG_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define I2C_CPU_INT_ICLR_STXFIFOTRG_CLR          ((uint32_t)0x00080000U)         /* !< Set Interrupt Mask */
+/* I2C_CPU_INT_ICLR[SSTART] Bits */
+#define I2C_CPU_INT_ICLR_SSTART_OFS              (22)                            /* !< SSTART Offset */
+#define I2C_CPU_INT_ICLR_SSTART_MASK             ((uint32_t)0x00400000U)         /* !< Target START Detection Interrupt */
+#define I2C_CPU_INT_ICLR_SSTART_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_SSTART_CLR              ((uint32_t)0x00400000U)         /* !< Clear interrupt */
+/* I2C_CPU_INT_ICLR[SSTOP] Bits */
+#define I2C_CPU_INT_ICLR_SSTOP_OFS               (23)                            /* !< SSTOP Offset */
+#define I2C_CPU_INT_ICLR_SSTOP_MASK              ((uint32_t)0x00800000U)         /* !< Target STOP Detection Interrupt */
+#define I2C_CPU_INT_ICLR_SSTOP_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_SSTOP_CLR               ((uint32_t)0x00800000U)         /* !< Clear interrupt */
+/* I2C_CPU_INT_ICLR[SDMA_DONE_TX] Bits */
+#define I2C_CPU_INT_ICLR_SDMA_DONE_TX_OFS        (25)                            /* !< SDMA_DONE_TX Offset */
+#define I2C_CPU_INT_ICLR_SDMA_DONE_TX_MASK       ((uint32_t)0x02000000U)         /* !< DMA Done on Event Channel TX */
+#define I2C_CPU_INT_ICLR_SDMA_DONE_TX_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_SDMA_DONE_TX_CLR        ((uint32_t)0x02000000U)         /* !< Clear interrupt */
+/* I2C_CPU_INT_ICLR[SDMA_DONE_RX] Bits */
+#define I2C_CPU_INT_ICLR_SDMA_DONE_RX_OFS        (26)                            /* !< SDMA_DONE_RX Offset */
+#define I2C_CPU_INT_ICLR_SDMA_DONE_RX_MASK       ((uint32_t)0x04000000U)         /* !< DMA Done on Event Channel RX */
+#define I2C_CPU_INT_ICLR_SDMA_DONE_RX_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_SDMA_DONE_RX_CLR        ((uint32_t)0x04000000U)         /* !< Clear interrupt */
+/* I2C_CPU_INT_ICLR[MPEC_RX_ERR] Bits */
+#define I2C_CPU_INT_ICLR_MPEC_RX_ERR_OFS         (13)                            /* !< MPEC_RX_ERR Offset */
+#define I2C_CPU_INT_ICLR_MPEC_RX_ERR_MASK        ((uint32_t)0x00002000U)         /* !< Controller RX Pec Error Interrupt */
+#define I2C_CPU_INT_ICLR_MPEC_RX_ERR_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_MPEC_RX_ERR_CLR         ((uint32_t)0x00002000U)         /* !< Clear Interrupt */
+/* I2C_CPU_INT_ICLR[TIMEOUTB] Bits */
+#define I2C_CPU_INT_ICLR_TIMEOUTB_OFS            (15)                            /* !< TIMEOUTB Offset */
+#define I2C_CPU_INT_ICLR_TIMEOUTB_MASK           ((uint32_t)0x00008000U)         /* !< Timeout B Interrupt */
+#define I2C_CPU_INT_ICLR_TIMEOUTB_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_TIMEOUTB_CLR            ((uint32_t)0x00008000U)         /* !< Clear Interrupt */
+/* I2C_CPU_INT_ICLR[SPEC_RX_ERR] Bits */
+#define I2C_CPU_INT_ICLR_SPEC_RX_ERR_OFS         (27)                            /* !< SPEC_RX_ERR Offset */
+#define I2C_CPU_INT_ICLR_SPEC_RX_ERR_MASK        ((uint32_t)0x08000000U)         /* !< Target RX Pec Error Interrupt */
+#define I2C_CPU_INT_ICLR_SPEC_RX_ERR_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_SPEC_RX_ERR_CLR         ((uint32_t)0x08000000U)         /* !< Clear Interrupt */
+/* I2C_CPU_INT_ICLR[STX_UNFL] Bits */
+#define I2C_CPU_INT_ICLR_STX_UNFL_OFS            (28)                            /* !< STX_UNFL Offset */
+#define I2C_CPU_INT_ICLR_STX_UNFL_MASK           ((uint32_t)0x10000000U)         /* !< Target TX FIFO underflow */
+#define I2C_CPU_INT_ICLR_STX_UNFL_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_STX_UNFL_CLR            ((uint32_t)0x10000000U)         /* !< Clear Interrupt */
+/* I2C_CPU_INT_ICLR[SRX_OVFL] Bits */
+#define I2C_CPU_INT_ICLR_SRX_OVFL_OFS            (29)                            /* !< SRX_OVFL Offset */
+#define I2C_CPU_INT_ICLR_SRX_OVFL_MASK           ((uint32_t)0x20000000U)         /* !< Target RX FIFO overflow */
+#define I2C_CPU_INT_ICLR_SRX_OVFL_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_SRX_OVFL_CLR            ((uint32_t)0x20000000U)         /* !< Clear Interrupt */
+/* I2C_CPU_INT_ICLR[SARBLOST] Bits */
+#define I2C_CPU_INT_ICLR_SARBLOST_OFS            (30)                            /* !< SARBLOST Offset */
+#define I2C_CPU_INT_ICLR_SARBLOST_MASK           ((uint32_t)0x40000000U)         /* !< Target Arbitration Lost */
+#define I2C_CPU_INT_ICLR_SARBLOST_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_CPU_INT_ICLR_SARBLOST_CLR            ((uint32_t)0x40000000U)         /* !< Clear Interrupt */
+/* I2C_CPU_INT_ICLR[INTR_OVFL] Bits */
+#define I2C_CPU_INT_ICLR_INTR_OVFL_OFS           (31)                            /* !< INTR_OVFL Offset */
+#define I2C_CPU_INT_ICLR_INTR_OVFL_MASK          ((uint32_t)0x80000000U)         /* !< Interrupt overflow */
+#define I2C_CPU_INT_ICLR_INTR_OVFL_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< No effect */
+#define I2C_CPU_INT_ICLR_INTR_OVFL_CLR           ((uint32_t)0x80000000U)         /* !< Clear interrupt */
+
+/* I2C_PWREN Bits */
+/* I2C_PWREN[ENABLE] Bits */
+#define I2C_PWREN_ENABLE_OFS                     (0)                             /* !< ENABLE Offset */
+#define I2C_PWREN_ENABLE_MASK                    ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define I2C_PWREN_ENABLE_DISABLE                 ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define I2C_PWREN_ENABLE_ENABLE                  ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* I2C_PWREN[KEY] Bits */
+#define I2C_PWREN_KEY_OFS                        (24)                            /* !< KEY Offset */
+#define I2C_PWREN_KEY_MASK                       ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define I2C_PWREN_KEY_UNLOCK_W                   ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* I2C_RSTCTL Bits */
+/* I2C_RSTCTL[RESETSTKYCLR] Bits */
+#define I2C_RSTCTL_RESETSTKYCLR_OFS              (1)                             /* !< RESETSTKYCLR Offset */
+#define I2C_RSTCTL_RESETSTKYCLR_MASK             ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define I2C_RSTCTL_RESETSTKYCLR_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_RSTCTL_RESETSTKYCLR_CLR              ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* I2C_RSTCTL[RESETASSERT] Bits */
+#define I2C_RSTCTL_RESETASSERT_OFS               (0)                             /* !< RESETASSERT Offset */
+#define I2C_RSTCTL_RESETASSERT_MASK              ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define I2C_RSTCTL_RESETASSERT_NOP               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define I2C_RSTCTL_RESETASSERT_ASSERT            ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* I2C_RSTCTL[KEY] Bits */
+#define I2C_RSTCTL_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define I2C_RSTCTL_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define I2C_RSTCTL_KEY_UNLOCK_W                  ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* I2C_CLKCFG Bits */
+/* I2C_CLKCFG[KEY] Bits */
+#define I2C_CLKCFG_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define I2C_CLKCFG_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define I2C_CLKCFG_KEY_UNLOCK                    ((uint32_t)0xA9000000U)         /* !< key value to allow change field of
+                                                                                    GPRCM */
+/* I2C_CLKCFG[BLOCKASYNC] Bits */
+#define I2C_CLKCFG_BLOCKASYNC_OFS                (8)                             /* !< BLOCKASYNC Offset */
+#define I2C_CLKCFG_BLOCKASYNC_MASK               ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define I2C_CLKCFG_BLOCKASYNC_DISABLE            ((uint32_t)0x00000000U)         /* !< Not block async clock request */
+#define I2C_CLKCFG_BLOCKASYNC_ENABLE             ((uint32_t)0x00000100U)         /* !< Block async clock request */
+
+/* I2C_STAT Bits */
+/* I2C_STAT[RESETSTKY] Bits */
+#define I2C_STAT_RESETSTKY_OFS                   (16)                            /* !< RESETSTKY Offset */
+#define I2C_STAT_RESETSTKY_MASK                  ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define I2C_STAT_RESETSTKY_NORES                 ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define I2C_STAT_RESETSTKY_RESET                 ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* I2C_CLKDIV Bits */
+/* I2C_CLKDIV[RATIO] Bits */
+#define I2C_CLKDIV_RATIO_OFS                     (0)                             /* !< RATIO Offset */
+#define I2C_CLKDIV_RATIO_MASK                    ((uint32_t)0x00000007U)         /* !< Selects divide ratio of module
+                                                                                    clock */
+#define I2C_CLKDIV_RATIO_DIV_BY_1                ((uint32_t)0x00000000U)         /* !< Do not divide clock source */
+#define I2C_CLKDIV_RATIO_DIV_BY_2                ((uint32_t)0x00000001U)         /* !< Divide clock source by 2 */
+#define I2C_CLKDIV_RATIO_DIV_BY_3                ((uint32_t)0x00000002U)         /* !< Divide clock source by 3 */
+#define I2C_CLKDIV_RATIO_DIV_BY_4                ((uint32_t)0x00000003U)         /* !< Divide clock source by 4 */
+#define I2C_CLKDIV_RATIO_DIV_BY_5                ((uint32_t)0x00000004U)         /* !< Divide clock source by 5 */
+#define I2C_CLKDIV_RATIO_DIV_BY_6                ((uint32_t)0x00000005U)         /* !< Divide clock source by 6 */
+#define I2C_CLKDIV_RATIO_DIV_BY_7                ((uint32_t)0x00000006U)         /* !< Divide clock source by 7 */
+#define I2C_CLKDIV_RATIO_DIV_BY_8                ((uint32_t)0x00000007U)         /* !< Divide clock source by 8 */
+
+/* I2C_CLKSEL Bits */
+/* I2C_CLKSEL[MFCLK_SEL] Bits */
+#define I2C_CLKSEL_MFCLK_SEL_OFS                 (2)                             /* !< MFCLK_SEL Offset */
+#define I2C_CLKSEL_MFCLK_SEL_MASK                ((uint32_t)0x00000004U)         /* !< Selects MFCLK as clock source if
+                                                                                    enabled */
+#define I2C_CLKSEL_MFCLK_SEL_DISABLE             ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define I2C_CLKSEL_MFCLK_SEL_ENABLE              ((uint32_t)0x00000004U)         /* !< Select this clock as a source */
+/* I2C_CLKSEL[BUSCLK_SEL] Bits */
+#define I2C_CLKSEL_BUSCLK_SEL_OFS                (3)                             /* !< BUSCLK_SEL Offset */
+#define I2C_CLKSEL_BUSCLK_SEL_MASK               ((uint32_t)0x00000008U)         /* !< Selects BUSCLK as clock source if
+                                                                                    enabled */
+#define I2C_CLKSEL_BUSCLK_SEL_DISABLE            ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define I2C_CLKSEL_BUSCLK_SEL_ENABLE             ((uint32_t)0x00000008U)         /* !< Select this clock as a source */
+
+/* I2C_PDBGCTL Bits */
+/* I2C_PDBGCTL[FREE] Bits */
+#define I2C_PDBGCTL_FREE_OFS                     (0)                             /* !< FREE Offset */
+#define I2C_PDBGCTL_FREE_MASK                    ((uint32_t)0x00000001U)         /* !< Free run control */
+#define I2C_PDBGCTL_FREE_STOP                    ((uint32_t)0x00000000U)         /* !< The peripheral freezes
+                                                                                    functionality while the Core Halted
+                                                                                    input is asserted and resumes when it
+                                                                                    is deasserted. */
+#define I2C_PDBGCTL_FREE_RUN                     ((uint32_t)0x00000001U)         /* !< The peripheral ignores the state of
+                                                                                    the Core Halted input */
+/* I2C_PDBGCTL[SOFT] Bits */
+#define I2C_PDBGCTL_SOFT_OFS                     (1)                             /* !< SOFT Offset */
+#define I2C_PDBGCTL_SOFT_MASK                    ((uint32_t)0x00000002U)         /* !< Soft halt boundary control. This
+                                                                                    function is only available, if [FREE]
+                                                                                    is set to 'STOP' */
+#define I2C_PDBGCTL_SOFT_IMMEDIATE               ((uint32_t)0x00000000U)         /* !< The peripheral will halt
+                                                                                    immediately, even if the resultant
+                                                                                    state will result in corruption if
+                                                                                    the system is restarted */
+#define I2C_PDBGCTL_SOFT_DELAYED                 ((uint32_t)0x00000002U)         /* !< The peripheral blocks the debug
+                                                                                    freeze until it has reached a
+                                                                                    boundary where it can resume without
+                                                                                    corruption */
+
+/* I2C_EVT_MODE Bits */
+/* I2C_EVT_MODE[INT0_CFG] Bits */
+#define I2C_EVT_MODE_INT0_CFG_OFS                (0)                             /* !< INT0_CFG Offset */
+#define I2C_EVT_MODE_INT0_CFG_MASK               ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT0] */
+#define I2C_EVT_MODE_INT0_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define I2C_EVT_MODE_INT0_CFG_SOFTWARE           ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define I2C_EVT_MODE_INT0_CFG_HARDWARE           ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* I2C_EVT_MODE[INT1_CFG] Bits */
+#define I2C_EVT_MODE_INT1_CFG_OFS                (2)                             /* !< INT1_CFG Offset */
+#define I2C_EVT_MODE_INT1_CFG_MASK               ((uint32_t)0x0000000CU)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT1] */
+#define I2C_EVT_MODE_INT1_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define I2C_EVT_MODE_INT1_CFG_SOFTWARE           ((uint32_t)0x00000004U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define I2C_EVT_MODE_INT1_CFG_HARDWARE           ((uint32_t)0x00000008U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* I2C_EVT_MODE[EVT2_CFG] Bits */
+#define I2C_EVT_MODE_EVT2_CFG_OFS                (4)                             /* !< EVT2_CFG Offset */
+#define I2C_EVT_MODE_EVT2_CFG_MASK               ((uint32_t)0x00000030U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT2] */
+#define I2C_EVT_MODE_EVT2_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define I2C_EVT_MODE_EVT2_CFG_SOFTWARE           ((uint32_t)0x00000010U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define I2C_EVT_MODE_EVT2_CFG_HARDWARE           ((uint32_t)0x00000020U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* I2C_INTCTL Bits */
+/* I2C_INTCTL[INTEVAL] Bits */
+#define I2C_INTCTL_INTEVAL_OFS                   (0)                             /* !< INTEVAL Offset */
+#define I2C_INTCTL_INTEVAL_MASK                  ((uint32_t)0x00000001U)         /* !< Writing a 1 to this field
+                                                                                    re-evaluates the interrupt sources. */
+#define I2C_INTCTL_INTEVAL_DISABLE               ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define I2C_INTCTL_INTEVAL_EVAL                  ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+
+/* I2C_DESC Bits */
+/* I2C_DESC[MINREV] Bits */
+#define I2C_DESC_MINREV_OFS                      (0)                             /* !< MINREV Offset */
+#define I2C_DESC_MINREV_MASK                     ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+#define I2C_DESC_MINREV_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_DESC_MINREV_MAXIMUM                  ((uint32_t)0x0000000FU)         /* !< Highest possible value */
+/* I2C_DESC[MAJREV] Bits */
+#define I2C_DESC_MAJREV_OFS                      (4)                             /* !< MAJREV Offset */
+#define I2C_DESC_MAJREV_MASK                     ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+#define I2C_DESC_MAJREV_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_DESC_MAJREV_MAXIMUM                  ((uint32_t)0x000000F0U)         /* !< Highest possible value */
+/* I2C_DESC[INSTNUM] Bits */
+#define I2C_DESC_INSTNUM_OFS                     (8)                             /* !< INSTNUM Offset */
+#define I2C_DESC_INSTNUM_MASK                    ((uint32_t)0x00000F00U)         /* !< Instance Number within the device.
+                                                                                    This will be a parameter to the RTL
+                                                                                    for modules that can have multiple
+                                                                                    instances */
+#define I2C_DESC_INSTNUM_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_DESC_INSTNUM_MAXIMUM                 ((uint32_t)0x00000F00U)         /* !< Highest possible value */
+/* I2C_DESC[FEATUREVER] Bits */
+#define I2C_DESC_FEATUREVER_OFS                  (12)                            /* !< FEATUREVER Offset */
+#define I2C_DESC_FEATUREVER_MASK                 ((uint32_t)0x0000F000U)         /* !< Feature Set for the module
+                                                                                    *instance* */
+#define I2C_DESC_FEATUREVER_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_DESC_FEATUREVER_MAXIMUM              ((uint32_t)0x0000F000U)         /* !< Highest possible value */
+/* I2C_DESC[MODULEID] Bits */
+#define I2C_DESC_MODULEID_OFS                    (16)                            /* !< MODULEID Offset */
+#define I2C_DESC_MODULEID_MASK                   ((uint32_t)0xFFFF0000U)         /* !< Module identification contains a
+                                                                                    unique peripheral identification
+                                                                                    number. The assignments are
+                                                                                    maintained in a central database for
+                                                                                    all of the platform modules to ensure
+                                                                                    uniqueness. */
+#define I2C_DESC_MODULEID_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define I2C_DESC_MODULEID_MAXIMUM                ((uint32_t)0xFFFF0000U)         /* !< Highest possible value */
+
+/* I2C_GFCTL Bits */
+/* I2C_GFCTL[AGFSEL] Bits */
+#define I2C_GFCTL_AGFSEL_OFS                     (9)                             /* !< AGFSEL Offset */
+#define I2C_GFCTL_AGFSEL_MASK                    ((uint32_t)0x00000600U)         /* !< Analog Glitch Suppression Pulse
+                                                                                    Width This field controls the pulse
+                                                                                    width select for the analog glitch
+                                                                                    suppression on SCL and SDA lines.
+                                                                                    See device datasheet for exact
+                                                                                    values. (ULP I2C only) */
+#define I2C_GFCTL_AGFSEL_AGLIT_5                 ((uint32_t)0x00000000U)         /* !< Pulses shorter then 5ns length are
+                                                                                    filtered. */
+#define I2C_GFCTL_AGFSEL_AGLIT_10                ((uint32_t)0x00000200U)         /* !< Pulses shorter then 10ns length are
+                                                                                    filtered. */
+#define I2C_GFCTL_AGFSEL_AGLIT_25                ((uint32_t)0x00000400U)         /* !< Pulses shorter then 25ns length are
+                                                                                    filtered. */
+#define I2C_GFCTL_AGFSEL_AGLIT_50                ((uint32_t)0x00000600U)         /* !< Pulses shorter then 50ns length are
+                                                                                    filtered. */
+/* I2C_GFCTL[DGFSEL] Bits */
+#define I2C_GFCTL_DGFSEL_OFS                     (0)                             /* !< DGFSEL Offset */
+#define I2C_GFCTL_DGFSEL_MASK                    ((uint32_t)0x00000007U)         /* !< Glitch Suppression Pulse Width
+                                                                                    This field controls the pulse width
+                                                                                    select for glitch suppression on the
+                                                                                    SCL and SDA lines. The following
+                                                                                    values are the glitch suppression
+                                                                                    values in terms of functional clocks.
+                                                                                    (Core Domain only) */
+#define I2C_GFCTL_DGFSEL_DISABLED                ((uint32_t)0x00000000U)         /* !< Bypass */
+#define I2C_GFCTL_DGFSEL_CLK_1                   ((uint32_t)0x00000001U)         /* !< 1 clock */
+#define I2C_GFCTL_DGFSEL_CLK_2                   ((uint32_t)0x00000002U)         /* !< 2 clocks */
+#define I2C_GFCTL_DGFSEL_CLK_3                   ((uint32_t)0x00000003U)         /* !< 3 clocks */
+#define I2C_GFCTL_DGFSEL_CLK_4                   ((uint32_t)0x00000004U)         /* !< 4 clocks */
+#define I2C_GFCTL_DGFSEL_CLK_8                   ((uint32_t)0x00000005U)         /* !< 8 clocks */
+#define I2C_GFCTL_DGFSEL_CLK_16                  ((uint32_t)0x00000006U)         /* !< 16 clocks */
+#define I2C_GFCTL_DGFSEL_CLK_31                  ((uint32_t)0x00000007U)         /* !< 31 clocks */
+/* I2C_GFCTL[AGFEN] Bits */
+#define I2C_GFCTL_AGFEN_OFS                      (8)                             /* !< AGFEN Offset */
+#define I2C_GFCTL_AGFEN_MASK                     ((uint32_t)0x00000100U)         /* !< Analog Glitch Suppression Enable */
+#define I2C_GFCTL_AGFEN_DISABLE                  ((uint32_t)0x00000000U)         /* !< Analog Glitch Filter disable */
+#define I2C_GFCTL_AGFEN_ENABLE                   ((uint32_t)0x00000100U)         /* !< Analog Glitch Filter enable */
+/* I2C_GFCTL[CHAIN] Bits */
+#define I2C_GFCTL_CHAIN_OFS                      (11)                            /* !< CHAIN Offset */
+#define I2C_GFCTL_CHAIN_MASK                     ((uint32_t)0x00000800U)         /* !< Analog and digital noise filters
+                                                                                    chaining enable. */
+#define I2C_GFCTL_CHAIN_DISABLE                  ((uint32_t)0x00000000U)         /* !< When 0, chaining is disabled and
+                                                                                    only digital filter output is
+                                                                                    available to IP logic for
+                                                                                    oversampling */
+#define I2C_GFCTL_CHAIN_ENABLE                   ((uint32_t)0x00000800U)         /* !< When 1, analog and digital glitch
+                                                                                    filters are chained and the output of
+                                                                                    the combination is made available to
+                                                                                    IP logic for oversampling */
+
+/* I2C_TIMEOUT_CTL Bits */
+/* I2C_TIMEOUT_CTL[TCNTLA] Bits */
+#define I2C_TIMEOUT_CTL_TCNTLA_OFS               (0)                             /* !< TCNTLA Offset */
+#define I2C_TIMEOUT_CTL_TCNTLA_MASK              ((uint32_t)0x000000FFU)         /* !< Timeout counter A load value
+                                                                                    Counter A is used for SCL low
+                                                                                    detection. This field contains the
+                                                                                    upper 8 bits of a 12-bit pre-load
+                                                                                    value for the Timeout A count. NOTE:
+                                                                                    The value of CNTLA must be greater
+                                                                                    than 1h.   Each count is equal to 520
+                                                                                    times the timeout period of
+                                                                                    functional clock. For example, with
+                                                                                    8MHz functional clock and a 100KHz
+                                                                                    operating I2C clock, one timeout
+                                                                                    period will be equal to (1 / 8MHz) *
+                                                                                    520 or 65 us. */
+#define I2C_TIMEOUT_CTL_TCNTLA_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest Value */
+#define I2C_TIMEOUT_CTL_TCNTLA_MAXIMUM           ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+/* I2C_TIMEOUT_CTL[TCNTAEN] Bits */
+#define I2C_TIMEOUT_CTL_TCNTAEN_OFS              (15)                            /* !< TCNTAEN Offset */
+#define I2C_TIMEOUT_CTL_TCNTAEN_MASK             ((uint32_t)0x00008000U)         /* !< Timeout Counter A Enable */
+#define I2C_TIMEOUT_CTL_TCNTAEN_DISABLE          ((uint32_t)0x00000000U)         /* !< Disable Timeout Counter B */
+#define I2C_TIMEOUT_CTL_TCNTAEN_ENABLE           ((uint32_t)0x00008000U)         /* !< Enable Timeout Counter B */
+/* I2C_TIMEOUT_CTL[TCNTLB] Bits */
+#define I2C_TIMEOUT_CTL_TCNTLB_OFS               (16)                            /* !< TCNTLB Offset */
+#define I2C_TIMEOUT_CTL_TCNTLB_MASK              ((uint32_t)0x00FF0000U)         /* !< Timeout Count B Load: Counter B is
+                                                                                    used for SCL High Detection. This
+                                                                                    field contains the upper 8 bits of a
+                                                                                    12-bit pre-load value for the Timeout
+                                                                                    B count. NOTE: The value of CNTLB
+                                                                                    must be greater than 1h.   Each count
+                                                                                    is equal to 1* clock period. For
+                                                                                    example, with 10MHz functional clock
+                                                                                    one timeout period will be equal
+                                                                                    to1*100ns. */
+#define I2C_TIMEOUT_CTL_TCNTLB_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest possible value */
+#define I2C_TIMEOUT_CTL_TCNTLB_MAXIMUM           ((uint32_t)0x00FF0000U)         /* !< Highest possible value */
+/* I2C_TIMEOUT_CTL[TCNTBEN] Bits */
+#define I2C_TIMEOUT_CTL_TCNTBEN_OFS              (31)                            /* !< TCNTBEN Offset */
+#define I2C_TIMEOUT_CTL_TCNTBEN_MASK             ((uint32_t)0x80000000U)         /* !< Timeout Counter B Enable */
+#define I2C_TIMEOUT_CTL_TCNTBEN_DISABLE          ((uint32_t)0x00000000U)         /* !< Disable Timeout Counter B */
+#define I2C_TIMEOUT_CTL_TCNTBEN_ENABLE           ((uint32_t)0x80000000U)         /* !< Enable Timeout Counter B */
+
+/* I2C_TIMEOUT_CNT Bits */
+/* I2C_TIMEOUT_CNT[TCNTA] Bits */
+#define I2C_TIMEOUT_CNT_TCNTA_OFS                (0)                             /* !< TCNTA Offset */
+#define I2C_TIMEOUT_CNT_TCNTA_MASK               ((uint32_t)0x000000FFU)         /* !< Timeout Count A Current Count: This
+                                                                                    field contains the upper 8 bits of a
+                                                                                    12-bit current counter for timeout
+                                                                                    counter A */
+#define I2C_TIMEOUT_CNT_TCNTA_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest Value */
+#define I2C_TIMEOUT_CNT_TCNTA_MAXIMUM            ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+/* I2C_TIMEOUT_CNT[TCNTB] Bits */
+#define I2C_TIMEOUT_CNT_TCNTB_OFS                (16)                            /* !< TCNTB Offset */
+#define I2C_TIMEOUT_CNT_TCNTB_MASK               ((uint32_t)0x00FF0000U)         /* !< Timeout Count B Current Count: This
+                                                                                    field contains the upper 8 bits of a
+                                                                                    12-bit current counter for timeout
+                                                                                    counter B */
+#define I2C_TIMEOUT_CNT_TCNTB_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest Value */
+#define I2C_TIMEOUT_CNT_TCNTB_MAXIMUM            ((uint32_t)0x00FF0000U)         /* !< Highest possible value */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_i2c__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_iomux.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_iomux.h
@@ -1,0 +1,180 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_iomux__include
+#define ti_devices_msp_peripherals_hw_iomux__include
+
+/* Filename: hw_iomux.h */
+/* Revised: 2023-05-10 21:32:43 */
+/* Revision: ccc8d5592eceba00f0e63b10bdaec9c7cd64733b */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* IOMUX Registers
+******************************************************************************/
+#define IOMUX_SECCFG_OFS                         ((uint32_t)0x00000000U)
+
+
+/** @addtogroup IOMUX_SECCFG
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0;
+  __IO uint32_t PINCM[251];                        /* !< (@ 0x00000004) Pin Control Management Register in SECCFG region */
+} IOMUX_SECCFG_Regs;
+
+/*@}*/ /* end of group IOMUX_SECCFG */
+
+/** @addtogroup IOMUX
+  @{
+*/
+
+typedef struct {
+  IOMUX_SECCFG_Regs  SECCFG;                            /* !< (@ 0x00000000) SECCFG register region */
+} IOMUX_Regs;
+
+/*@}*/ /* end of group IOMUX */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* IOMUX Register Control Bits
+******************************************************************************/
+
+/* IOMUX_PINCM Bits */
+/* IOMUX_PINCM[PF] Bits */
+#define IOMUX_PINCM_PF_OFS                       (0)                             /* !< PF Offset */
+#define IOMUX_PINCM_PF_MASK                      ((uint32_t)0x0000003FU)         /* !< Peripheral Function selection bits */
+#define IOMUX_PINCM_PF_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Reserved as unconnected */
+#define IOMUX_PINCM_PF_MAXIMUM                   ((uint32_t)0x0000003FU)         /* !< An encoding per function that can
+                                                                                    be connected to this pin. */
+/* IOMUX_PINCM[PC] Bits */
+#define IOMUX_PINCM_PC_OFS                       (7)                             /* !< PC Offset */
+#define IOMUX_PINCM_PC_MASK                      ((uint32_t)0x00000080U)         /* !< Peripheral is Connected */
+#define IOMUX_PINCM_PC_UNCONNECTED               ((uint32_t)0x00000000U)         /* !< The output of the peripheral (and
+                                                                                    its output enable) will not propagate
+                                                                                    to the IOCELL */
+#define IOMUX_PINCM_PC_CONNECTED                 ((uint32_t)0x00000080U)         /* !< The output latch of the dataflow
+                                                                                    will be transparent */
+/* IOMUX_PINCM[WAKESTAT] Bits */
+#define IOMUX_PINCM_WAKESTAT_OFS                 (13)                            /* !< WAKESTAT Offset */
+#define IOMUX_PINCM_WAKESTAT_MASK                ((uint32_t)0x00002000U)         /* !< This has the IOPAD WAKEUP signal as
+                                                                                    status bit. */
+#define IOMUX_PINCM_WAKESTAT_DISABLE             ((uint32_t)0x00000000U)         /* !< wakeup source is NOT from this
+                                                                                    IOCELL */
+#define IOMUX_PINCM_WAKESTAT_ENABLE              ((uint32_t)0x00002000U)         /* !< wakeup source is from this IOCELL */
+/* IOMUX_PINCM[PIPD] Bits */
+#define IOMUX_PINCM_PIPD_OFS                     (16)                            /* !< PIPD Offset */
+#define IOMUX_PINCM_PIPD_MASK                    ((uint32_t)0x00010000U)         /* !< Pull Down control selection */
+#define IOMUX_PINCM_PIPD_DISABLE                 ((uint32_t)0x00000000U)         /* !< Pull down is disabled. */
+#define IOMUX_PINCM_PIPD_ENABLE                  ((uint32_t)0x00010000U)         /* !< Pull down is enabled */
+/* IOMUX_PINCM[PIPU] Bits */
+#define IOMUX_PINCM_PIPU_OFS                     (17)                            /* !< PIPU Offset */
+#define IOMUX_PINCM_PIPU_MASK                    ((uint32_t)0x00020000U)         /* !< Pull Up control selection */
+#define IOMUX_PINCM_PIPU_DISABLE                 ((uint32_t)0x00000000U)         /* !< Pull up is disabled. */
+#define IOMUX_PINCM_PIPU_ENABLE                  ((uint32_t)0x00020000U)         /* !< Pull up is enabled */
+/* IOMUX_PINCM[INENA] Bits */
+#define IOMUX_PINCM_INENA_OFS                    (18)                            /* !< INENA Offset */
+#define IOMUX_PINCM_INENA_MASK                   ((uint32_t)0x00040000U)         /* !< Input Enable Control Selection */
+#define IOMUX_PINCM_INENA_DISABLE                ((uint32_t)0x00000000U)         /* !< Input enable is disabled. */
+#define IOMUX_PINCM_INENA_ENABLE                 ((uint32_t)0x00040000U)         /* !< Input enable is enabled. */
+/* IOMUX_PINCM[HYSTEN] Bits */
+#define IOMUX_PINCM_HYSTEN_OFS                   (19)                            /* !< HYSTEN Offset */
+#define IOMUX_PINCM_HYSTEN_MASK                  ((uint32_t)0x00080000U)         /* !< Hysteresis Enable Control Selection */
+#define IOMUX_PINCM_HYSTEN_DISABLE               ((uint32_t)0x00000000U)         /* !< hysteresis is disabled. */
+#define IOMUX_PINCM_HYSTEN_ENABLE                ((uint32_t)0x00080000U)         /* !< hysteresis is enabled */
+/* IOMUX_PINCM[DRV] Bits */
+#define IOMUX_PINCM_DRV_OFS                      (20)                            /* !< DRV Offset */
+#define IOMUX_PINCM_DRV_MASK                     ((uint32_t)0x00100000U)         /* !< Drive strength control selection,
+                                                                                    for HS IOCELL only */
+#define IOMUX_PINCM_DRV_DRVVAL0                  ((uint32_t)0x00000000U)         /* !< Drive setting of 0 selected */
+#define IOMUX_PINCM_DRV_DRVVAL1                  ((uint32_t)0x00100000U)         /* !< Drive setting of 1 selected */
+/* IOMUX_PINCM[HIZ1] Bits */
+#define IOMUX_PINCM_HIZ1_OFS                     (25)                            /* !< HIZ1 Offset */
+#define IOMUX_PINCM_HIZ1_MASK                    ((uint32_t)0x02000000U)         /* !< High output value will tri-state
+                                                                                    the output when this bit is enabled */
+#define IOMUX_PINCM_HIZ1_DISABLE                 ((uint32_t)0x00000000U)         /* !< open-drain is disabled. */
+#define IOMUX_PINCM_HIZ1_ENABLE                  ((uint32_t)0x02000000U)         /* !< open-drain is enabled. */
+/* IOMUX_PINCM[WUEN] Bits */
+#define IOMUX_PINCM_WUEN_OFS                     (27)                            /* !< WUEN Offset */
+#define IOMUX_PINCM_WUEN_MASK                    ((uint32_t)0x08000000U)         /* !< Wakeup Enable bit */
+#define IOMUX_PINCM_WUEN_DISABLE                 ((uint32_t)0x00000000U)         /* !< wakeup is disabled. */
+#define IOMUX_PINCM_WUEN_ENABLE                  ((uint32_t)0x08000000U)         /* !< wakeup is enabled */
+/* IOMUX_PINCM[WCOMP] Bits */
+#define IOMUX_PINCM_WCOMP_OFS                    (28)                            /* !< WCOMP Offset */
+#define IOMUX_PINCM_WCOMP_MASK                   ((uint32_t)0x10000000U)         /* !< Wakeup Compare Value bit */
+#define IOMUX_PINCM_WCOMP_MATCH0                 ((uint32_t)0x00000000U)         /* !< Wakeup on a match of 0 */
+#define IOMUX_PINCM_WCOMP_MATCH1                 ((uint32_t)0x10000000U)         /* !< Wakeup on a match of 1 */
+/* IOMUX_PINCM[INV] Bits */
+#define IOMUX_PINCM_INV_OFS                      (26)                            /* !< INV Offset */
+#define IOMUX_PINCM_INV_MASK                     ((uint32_t)0x04000000U)         /* !< Data inversion selection */
+#define IOMUX_PINCM_INV_DISABLE                  ((uint32_t)0x00000000U)         /* !< Data inversion is disabled. */
+#define IOMUX_PINCM_INV_ENABLE                   ((uint32_t)0x04000000U)         /* !< Data inversion is enabled */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_iomux__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_keystorectl.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_keystorectl.h
@@ -1,0 +1,203 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_keystorectl__include
+#define ti_devices_msp_peripherals_hw_keystorectl__include
+
+/* This preliminary header file does not have a version number */
+/* MMR repo: https://bitbucket.itg.ti.com/projects/cmcu_msp65ip/repos/f65mspkeystorectl */
+/* MMR revision: da65027d31f78c7139cd945e99c27064d5e09c65 */
+/* Generator revision: c98c4ac511e2bd0d918c5d427bd46b7a359dacf1
+   (MInT: ec7ec7482a60c6871be32db8b378ec27aa4771f6) */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* KEYSTORECTL Registers
+******************************************************************************/
+
+
+/** @addtogroup KEYSTORECTL
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[1088];
+  __IO uint32_t CFG;                               /* !< (@ 0x00001100) Keystore configuration */
+  __IO uint32_t KEYWR;                             /* !< (@ 0x00001104) Key write configuration */
+  __IO uint32_t KEYRD;                             /* !< (@ 0x00001108) Key read configuration */
+  __I  uint32_t STATUS;                            /* !< (@ 0x0000110C) Status */
+  __O  uint32_t KEYIN;                             /* !< (@ 0x00001110) Input key */
+} KEYSTORECTL_Regs;
+
+/*@}*/ /* end of group KEYSTORECTL */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* KEYSTORECTL Register Control Bits
+******************************************************************************/
+
+/* KEYSTORECTL_CFG Bits */
+/* KEYSTORECTL_CFG[NK256] Bits */
+#define KEYSTORECTL_CFG_NK256_OFS                (0)                             /* !< NK256 Offset */
+#define KEYSTORECTL_CFG_NK256_MASK               ((uint32_t)0x0000000FU)         /* !< Number of 256 bit keys to be held
+                                                                                    in the key-store. Can not exceed the
+                                                                                    total number of slots present in the
+                                                                                    hardware / 2. For eg: if SYS_N_SLOTS
+                                                                                    = 4, then atmost 2 256-bit keys can
+                                                                                    be held in the key-store. Incorrect
+                                                                                    setting of this field will be
+                                                                                    reported via STATUS register */
+#define KEYSTORECTL_CFG_NK256_ZERO               ((uint32_t)0x00000000U)         /* !< No 256-bit keys */
+#define KEYSTORECTL_CFG_NK256_ONE                ((uint32_t)0x00000001U)         /* !< One 256-bit key */
+#define KEYSTORECTL_CFG_NK256_TWO                ((uint32_t)0x00000002U)         /* !< Two 256-bit keys */
+#define KEYSTORECTL_CFG_NK256_THREE              ((uint32_t)0x00000003U)         /* !< Three 256-bit keys */
+#define KEYSTORECTL_CFG_NK256_FOUR               ((uint32_t)0x00000004U)         /* !< Four 256-bit keys */
+
+/* KEYSTORECTL_KEYWR Bits */
+/* KEYSTORECTL_KEYWR[KEYSZSEL] Bits */
+#define KEYSTORECTL_KEYWR_KEYSZSEL_OFS           (0)                             /* !< KEYSZSEL Offset */
+#define KEYSTORECTL_KEYWR_KEYSZSEL_MASK          ((uint32_t)0x00000007U)         /* !< Key size selection. Selection of
+                                                                                    128 or 256 bit keys */
+#define KEYSTORECTL_KEYWR_KEYSZSEL_K256          ((uint32_t)0x00000000U)         /* !< 256 bit key */
+#define KEYSTORECTL_KEYWR_KEYSZSEL_K128          ((uint32_t)0x00000001U)         /* !< 128 bit key */
+/* KEYSTORECTL_KEYWR[KEYSLOTSEL] Bits */
+#define KEYSTORECTL_KEYWR_KEYSLOTSEL_OFS         (4)                             /* !< KEYSLOTSEL Offset */
+#define KEYSTORECTL_KEYWR_KEYSLOTSEL_MASK        ((uint32_t)0x000000F0U)         /* !< Select the key slot to write the
+                                                                                    key into. NOTE: SW needs to ensure
+                                                                                    that it is writing to the correct
+                                                                                    slots. The slot numbering is from 0
+                                                                                    through SYS_N_SLOTS-1. Each slot is a
+                                                                                    128-bit slot. Therefore, when writing
+                                                                                    a 256-bit key, two slots will need to
+                                                                                    budgeted. */
+#define KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT0       ((uint32_t)0x00000000U)         /* !< Slot 0 */
+#define KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT1       ((uint32_t)0x00000010U)         /* !< Slot 1 */
+#define KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT2       ((uint32_t)0x00000020U)         /* !< Slot 2 */
+#define KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT3       ((uint32_t)0x00000030U)         /* !< Slot 3 */
+#define KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT4       ((uint32_t)0x00000040U)         /* !< Slot 4 */
+#define KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT5       ((uint32_t)0x00000050U)         /* !< Slot 5 */
+#define KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT6       ((uint32_t)0x00000060U)         /* !< Slot 6 */
+#define KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT7       ((uint32_t)0x00000070U)         /* !< Slot 7 */
+
+/* KEYSTORECTL_KEYRD Bits */
+/* KEYSTORECTL_KEYRD[KEYSZSEL] Bits */
+#define KEYSTORECTL_KEYRD_KEYSZSEL_OFS           (0)                             /* !< KEYSZSEL Offset */
+#define KEYSTORECTL_KEYRD_KEYSZSEL_MASK          ((uint32_t)0x00000007U)         /* !< Key size selection. Selection of
+                                                                                    128 or 256 bit keys */
+#define KEYSTORECTL_KEYRD_KEYSZSEL_K256          ((uint32_t)0x00000000U)         /* !< 256 bit key */
+#define KEYSTORECTL_KEYRD_KEYSZSEL_K128          ((uint32_t)0x00000001U)         /* !< 128 bit key */
+/* KEYSTORECTL_KEYRD[KEYSLOTSEL] Bits */
+#define KEYSTORECTL_KEYRD_KEYSLOTSEL_OFS         (4)                             /* !< KEYSLOTSEL Offset */
+#define KEYSTORECTL_KEYRD_KEYSLOTSEL_MASK        ((uint32_t)0x000000F0U)         /* !< Select the key slot to read the key
+                                                                                    from. NOTE: SW needs to ensure that
+                                                                                    it is reading from the correct slots.
+                                                                                    The slot numbering is from 0 through
+                                                                                    SYS_N_SLOTS-1. Each slot is a 128-bit
+                                                                                    slot. Therefore, when reading a
+                                                                                    256-bit key, two adjacent slots will
+                                                                                    be read. */
+/* KEYSTORECTL_KEYRD[CRYPTOSEL] Bits */
+#define KEYSTORECTL_KEYRD_CRYPTOSEL_OFS          (8)                             /* !< CRYPTOSEL Offset */
+#define KEYSTORECTL_KEYRD_CRYPTOSEL_MASK         ((uint32_t)0x00000300U)         /* !< Crypto engine selector */
+#define KEYSTORECTL_KEYRD_CRYPTOSEL_AES          ((uint32_t)0x00000000U)         /* !< Transfer key to AES */
+
+/* KEYSTORECTL_STATUS Bits */
+/* KEYSTORECTL_STATUS[STAT] Bits */
+#define KEYSTORECTL_STATUS_STAT_OFS              (0)                             /* !< STAT Offset */
+#define KEYSTORECTL_STATUS_STAT_MASK             ((uint32_t)0x0000000FU)         /* !< Status information */
+#define KEYSTORECTL_STATUS_STAT_VALID            ((uint32_t)0x00000000U)         /* !< Valid configuration */
+#define KEYSTORECTL_STATUS_STAT_NO_CFG           ((uint32_t)0x00000001U)         /* !< Key-store has not been configured.
+                                                                                    NK256 has not been set. */
+#define KEYSTORECTL_STATUS_STAT_INVALID_NK256    ((uint32_t)0x00000002U)         /* !< Invalid value for NK256 field in
+                                                                                    CFG. */
+#define KEYSTORECTL_STATUS_STAT_BUSY_RECEIVE     ((uint32_t)0x00000003U)         /* !< Busy receiving a key deposit */
+#define KEYSTORECTL_STATUS_STAT_BUSY_TRANSMIT    ((uint32_t)0x00000004U)         /* !< Busy transmitting a key to a crypto
+                                                                                    engine */
+#define KEYSTORECTL_STATUS_STAT_INVALID_KEYSLOTSELW ((uint32_t)0x00000005U)         /* !< Invalid keyslot selection for
+                                                                                    writing */
+#define KEYSTORECTL_STATUS_STAT_INVALID_KEYSLOTSELR ((uint32_t)0x00000006U)         /* !< Invalid keyslot selection for
+                                                                                    reading */
+/* KEYSTORECTL_STATUS[VALID] Bits */
+#define KEYSTORECTL_STATUS_VALID_OFS             (4)                             /* !< VALID Offset */
+#define KEYSTORECTL_STATUS_VALID_MASK            ((uint32_t)0x00000FF0U)         /* !< Bitvector of valid bits to indicate
+                                                                                    which slots have been configured */
+/* KEYSTORECTL_STATUS[NKEYSLOTS] Bits */
+#define KEYSTORECTL_STATUS_NKEYSLOTS_OFS         (16)                            /* !< NKEYSLOTS Offset */
+#define KEYSTORECTL_STATUS_NKEYSLOTS_MASK        ((uint32_t)0x00030000U)         /* !< Size of keystorage: Number of
+                                                                                    128-bit key slots */
+#define KEYSTORECTL_STATUS_NKEYSLOTS_TWO         ((uint32_t)0x00000000U)         /* !< Two slots */
+#define KEYSTORECTL_STATUS_NKEYSLOTS_THREE       ((uint32_t)0x00010000U)         /* !< Three slots */
+#define KEYSTORECTL_STATUS_NKEYSLOTS_FOUR        ((uint32_t)0x00020000U)         /* !< Four slots */
+
+/* KEYSTORECTL_KEYIN Bits */
+/* KEYSTORECTL_KEYIN[DATA] Bits */
+#define KEYSTORECTL_KEYIN_DATA_OFS               (0)                             /* !< DATA Offset */
+#define KEYSTORECTL_KEYIN_DATA_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< 32-bit key data */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_keystorectl__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_lcd.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_lcd.h
@@ -1,0 +1,2157 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_lcd__include
+#define ti_devices_msp_peripherals_hw_lcd__include
+
+/* This preliminary header file does not have a version number */
+/* MMR repo: https://bitbucket.itg.ti.com/projects/cmcu_msp65ip/repos/f65msplcd */
+/* MMR revision: f30da4e0c2d59567e167092fa6005fd6fe36bbf6 */
+/* Generator revision: c98c4ac511e2bd0d918c5d427bd46b7a359dacf1
+   (MInT: ec7ec7482a60c6871be32db8b378ec27aa4771f6) */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* LCD Registers
+******************************************************************************/
+#define LCD_INT_EVENT0_OFS                       ((uint32_t)0x00001020U)
+
+
+/** @addtogroup LCD_INT_EVENT0
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} LCD_INT_EVENT0_Regs;
+
+/*@}*/ /* end of group LCD_INT_EVENT0 */
+
+/** @addtogroup LCD
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+       uint32_t RESERVED1[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+       uint32_t RESERVED2[514];
+  LCD_INT_EVENT0_Regs  INT_EVENT0;                        /* !< (@ 0x00001020) */
+       uint32_t RESERVED3[37];
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED4[7];
+  __IO uint32_t LCDCTL0;                           /* !< (@ 0x00001100) LCD control register 0 */
+       uint32_t RESERVED5;
+  __IO uint32_t LCDBLKCTL;                         /* !< (@ 0x00001108) LCD blicking control register */
+  __IO uint32_t LCDMEMCTL;                         /* !< (@ 0x0000110C) LCD memory control LCD memory control register */
+  __IO uint32_t LCDVCTL;                           /* !< (@ 0x00001110) LCD voltage control register */
+  __IO uint32_t LCDPCTL0;                          /* !< (@ 0x00001114) LCD port control register 0 */
+  __IO uint32_t LCDPCTL1;                          /* !< (@ 0x00001118) LCD port control register 1 */
+  __IO uint32_t LCDPCTL2;                          /* !< (@ 0x0000111C) LCD port control register 2 */
+  __IO uint32_t LCDPCTL3;                          /* !< (@ 0x00001120) LCD port control  register 3 */
+       uint32_t RESERVED6;
+  __IO uint32_t LCDCSSEL0;                         /* !< (@ 0x00001128) LCD common segment select register 0 */
+  __IO uint32_t LCDCSSEL1;                         /* !< (@ 0x0000112C) LCD common segment select register 1 */
+  __IO uint32_t LCDCSSEL2;                         /* !< (@ 0x00001130) LCD common segment select register 2 */
+  __IO uint32_t LCDCSSEL3;                         /* !< (@ 0x00001134) LCD common segment select register 3 */
+       uint32_t RESERVED7[2];
+  __IO uint8_t LCDM[64];                          /* !< (@ 0x00001140) LCD memory index register */
+  __IO uint8_t LCDBM[32];                         /* !< (@ 0x00001180) LCD blinking memory index register */
+       uint32_t RESERVED8[791];
+  __IO uint32_t LCDVREFCFG;                        /* !< (@ 0x00001DFC) LCD VREF config register */
+} LCD_Regs;
+
+/*@}*/ /* end of group LCD */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* LCD Register Control Bits
+******************************************************************************/
+
+/* LCD_IIDX Bits */
+/* LCD_IIDX[STAT] Bits */
+#define LCD_IIDX_STAT_OFS                        (0)                             /* !< STAT Offset */
+#define LCD_IIDX_STAT_MASK                       ((uint32_t)0x000000FFU)         /* !< LCD Module Interrupt Vector Value.
+                                                                                    This register provides the highes
+                                                                                    priority interrupt index. A read
+                                                                                    clears the corresponding interrupt
+                                                                                    flag in RIS and MISC. 15h-1Fh =
+                                                                                    Reserved */
+#define LCD_IIDX_STAT_NO_INTR                    ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define LCD_IIDX_STAT_FRAME_START                ((uint32_t)0x00000001U)         /* !< Start of new frame interrupt */
+#define LCD_IIDX_STAT_BLK_OFF                    ((uint32_t)0x00000002U)         /* !< Blinking segments off interrupt */
+#define LCD_IIDX_STAT_BLK_ON                     ((uint32_t)0x00000003U)         /* !< Blinking segments on interrupt */
+
+/* LCD_IMASK Bits */
+/* LCD_IMASK[FRMSTART] Bits */
+#define LCD_IMASK_FRMSTART_OFS                   (0)                             /* !< FRMSTART Offset */
+#define LCD_IMASK_FRMSTART_MASK                  ((uint32_t)0x00000001U)         /* !< Start of new LCD frame. */
+#define LCD_IMASK_FRMSTART_CLR                   ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LCD_IMASK_FRMSTART_SET                   ((uint32_t)0x00000001U)         /* !< Set Interrrupt Mask */
+/* LCD_IMASK[BLKOFF] Bits */
+#define LCD_IMASK_BLKOFF_OFS                     (1)                             /* !< BLKOFF Offset */
+#define LCD_IMASK_BLKOFF_MASK                    ((uint32_t)0x00000002U)         /* !< Blinking segments off. */
+#define LCD_IMASK_BLKOFF_CLR                     ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LCD_IMASK_BLKOFF_SET                     ((uint32_t)0x00000002U)         /* !< Set Interrrupt Mask */
+/* LCD_IMASK[BLKON] Bits */
+#define LCD_IMASK_BLKON_OFS                      (2)                             /* !< BLKON Offset */
+#define LCD_IMASK_BLKON_MASK                     ((uint32_t)0x00000004U)         /* !< Blinkking segments on. */
+#define LCD_IMASK_BLKON_CLR                      ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LCD_IMASK_BLKON_SET                      ((uint32_t)0x00000004U)         /* !< Set Interrrupt Mask */
+
+/* LCD_RIS Bits */
+/* LCD_RIS[FRMSTART] Bits */
+#define LCD_RIS_FRMSTART_OFS                     (0)                             /* !< FRMSTART Offset */
+#define LCD_RIS_FRMSTART_MASK                    ((uint32_t)0x00000001U)         /* !< Set in start of a new frame. */
+#define LCD_RIS_FRMSTART_CLR                     ((uint32_t)0x00000000U)         /* !< Interrupt flag cleared */
+#define LCD_RIS_FRMSTART_SET                     ((uint32_t)0x00000001U)         /* !< Interrupt flag set */
+/* LCD_RIS[BLKOFF] Bits */
+#define LCD_RIS_BLKOFF_OFS                       (1)                             /* !< BLKOFF Offset */
+#define LCD_RIS_BLKOFF_MASK                      ((uint32_t)0x00000002U)         /* !< Blinking segments turned off
+                                                                                    interrupt flag. */
+#define LCD_RIS_BLKOFF_CLR                       ((uint32_t)0x00000000U)         /* !< Interrupt flag cleared */
+#define LCD_RIS_BLKOFF_SET                       ((uint32_t)0x00000002U)         /* !< Interrupt flag set */
+/* LCD_RIS[BLKON] Bits */
+#define LCD_RIS_BLKON_OFS                        (2)                             /* !< BLKON Offset */
+#define LCD_RIS_BLKON_MASK                       ((uint32_t)0x00000004U)         /* !< Blinking segments turned on. */
+#define LCD_RIS_BLKON_CLR                        ((uint32_t)0x00000000U)         /* !< Interrupt flag cleared */
+#define LCD_RIS_BLKON_SET                        ((uint32_t)0x00000004U)         /* !< Interrupt flag set */
+
+/* LCD_MIS Bits */
+/* LCD_MIS[FRMSTART] Bits */
+#define LCD_MIS_FRMSTART_OFS                     (0)                             /* !< FRMSTART Offset */
+#define LCD_MIS_FRMSTART_MASK                    ((uint32_t)0x00000001U)         /* !< Master FRMSTART interrupt flag */
+#define LCD_MIS_FRMSTART_CLR                     ((uint32_t)0x00000000U)         /* !< Interrupt flag cleared */
+#define LCD_MIS_FRMSTART_SET                     ((uint32_t)0x00000001U)         /* !< Interrupt flag set */
+/* LCD_MIS[BLKOFF] Bits */
+#define LCD_MIS_BLKOFF_OFS                       (1)                             /* !< BLKOFF Offset */
+#define LCD_MIS_BLKOFF_MASK                      ((uint32_t)0x00000002U)         /* !< Masked BLKOFF interrupt flag */
+#define LCD_MIS_BLKOFF_CLR                       ((uint32_t)0x00000000U)         /* !< Masked interrupt flag cleared */
+#define LCD_MIS_BLKOFF_SET                       ((uint32_t)0x00000002U)         /* !< Masked interrupt flag set */
+/* LCD_MIS[BLKON] Bits */
+#define LCD_MIS_BLKON_OFS                        (2)                             /* !< BLKON Offset */
+#define LCD_MIS_BLKON_MASK                       ((uint32_t)0x00000004U)         /* !< Masked BLKON interrupt flag */
+#define LCD_MIS_BLKON_CLR                        ((uint32_t)0x00000000U)         /* !< Masked interrupt flag cleared */
+#define LCD_MIS_BLKON_SET                        ((uint32_t)0x00000004U)         /* !< Masked interrupt flag set */
+
+/* LCD_ISET Bits */
+/* LCD_ISET[FRMSTART] Bits */
+#define LCD_ISET_FRMSTART_OFS                    (0)                             /* !< FRMSTART Offset */
+#define LCD_ISET_FRMSTART_MASK                   ((uint32_t)0x00000001U)         /* !< Set FRMSTART RIS flag. */
+#define LCD_ISET_FRMSTART_NO_EFFECT              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LCD_ISET_FRMSTART_SET                    ((uint32_t)0x00000001U)         /* !< Set corresponding RIS flag */
+/* LCD_ISET[BLKOFF] Bits */
+#define LCD_ISET_BLKOFF_OFS                      (1)                             /* !< BLKOFF Offset */
+#define LCD_ISET_BLKOFF_MASK                     ((uint32_t)0x00000002U)         /* !< Set BLKOFF RIS flag */
+#define LCD_ISET_BLKOFF_NO_EFFECT                ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LCD_ISET_BLKOFF_SET                      ((uint32_t)0x00000002U)         /* !< Set corresponding RIS flag */
+/* LCD_ISET[BLKON] Bits */
+#define LCD_ISET_BLKON_OFS                       (2)                             /* !< BLKON Offset */
+#define LCD_ISET_BLKON_MASK                      ((uint32_t)0x00000004U)         /* !< Set BLKON RIS flag */
+#define LCD_ISET_BLKON_NO_EFFECT                 ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LCD_ISET_BLKON_SET                       ((uint32_t)0x00000004U)         /* !< Set corresponding RIS flag */
+
+/* LCD_ICLR Bits */
+/* LCD_ICLR[FRMSTART] Bits */
+#define LCD_ICLR_FRMSTART_OFS                    (0)                             /* !< FRMSTART Offset */
+#define LCD_ICLR_FRMSTART_MASK                   ((uint32_t)0x00000001U)         /* !< Clear FRMSTART RIS flag */
+#define LCD_ICLR_FRMSTART_NO_EFFECT              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LCD_ICLR_FRMSTART_CLR                    ((uint32_t)0x00000001U)         /* !< Clear corresponding RIS flag */
+/* LCD_ICLR[BLKOFF] Bits */
+#define LCD_ICLR_BLKOFF_OFS                      (1)                             /* !< BLKOFF Offset */
+#define LCD_ICLR_BLKOFF_MASK                     ((uint32_t)0x00000002U)         /* !< Clear BLKOFF RIS flag */
+#define LCD_ICLR_BLKOFF_NO_EFFECT                ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LCD_ICLR_BLKOFF_CLR                      ((uint32_t)0x00000002U)         /* !< Clear corresponding RIS flag */
+/* LCD_ICLR[BLKON] Bits */
+#define LCD_ICLR_BLKON_OFS                       (2)                             /* !< BLKON Offset */
+#define LCD_ICLR_BLKON_MASK                      ((uint32_t)0x00000004U)         /* !< Clear BLKON RIS flag */
+#define LCD_ICLR_BLKON_NO_EFFECT                 ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LCD_ICLR_BLKON_CLR                       ((uint32_t)0x00000004U)         /* !< Clear corresponding RIS flag */
+
+/* LCD_PWREN Bits */
+/* LCD_PWREN[ENABLE] Bits */
+#define LCD_PWREN_ENABLE_OFS                     (0)                             /* !< ENABLE Offset */
+#define LCD_PWREN_ENABLE_MASK                    ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define LCD_PWREN_ENABLE_DISABLE                 ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define LCD_PWREN_ENABLE_ENABLE                  ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* LCD_PWREN[KEY] Bits */
+#define LCD_PWREN_KEY_OFS                        (24)                            /* !< KEY Offset */
+#define LCD_PWREN_KEY_MASK                       ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define LCD_PWREN_KEY_UNLOCK_W                   ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* LCD_RSTCTL Bits */
+/* LCD_RSTCTL[RESETSTKYCLR] Bits */
+#define LCD_RSTCTL_RESETSTKYCLR_OFS              (1)                             /* !< RESETSTKYCLR Offset */
+#define LCD_RSTCTL_RESETSTKYCLR_MASK             ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define LCD_RSTCTL_RESETSTKYCLR_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LCD_RSTCTL_RESETSTKYCLR_CLR              ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* LCD_RSTCTL[RESETASSERT] Bits */
+#define LCD_RSTCTL_RESETASSERT_OFS               (0)                             /* !< RESETASSERT Offset */
+#define LCD_RSTCTL_RESETASSERT_MASK              ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define LCD_RSTCTL_RESETASSERT_NOP               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LCD_RSTCTL_RESETASSERT_ASSERT            ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* LCD_RSTCTL[KEY] Bits */
+#define LCD_RSTCTL_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define LCD_RSTCTL_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define LCD_RSTCTL_KEY_UNLOCK_W                  ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* LCD_STAT Bits */
+/* LCD_STAT[RESETSTKY] Bits */
+#define LCD_STAT_RESETSTKY_OFS                   (16)                            /* !< RESETSTKY Offset */
+#define LCD_STAT_RESETSTKY_MASK                  ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define LCD_STAT_RESETSTKY_NORES                 ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define LCD_STAT_RESETSTKY_RESET                 ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* LCD_EVT_MODE Bits */
+/* LCD_EVT_MODE[INT0_CFG] Bits */
+#define LCD_EVT_MODE_INT0_CFG_OFS                (0)                             /* !< INT0_CFG Offset */
+#define LCD_EVT_MODE_INT0_CFG_MASK               ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT0] */
+#define LCD_EVT_MODE_INT0_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define LCD_EVT_MODE_INT0_CFG_SOFTWARE           ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define LCD_EVT_MODE_INT0_CFG_HARDWARE           ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* LCD_LCDCTL0 Bits */
+/* LCD_LCDCTL0[LCDDIVX] Bits */
+#define LCD_LCDCTL0_LCDDIVX_OFS                  (11)                            /* !< LCDDIVX Offset */
+#define LCD_LCDCTL0_LCDDIVX_MASK                 ((uint32_t)0x0000F800U)         /* !< LCD frequency divider. Together
+                                                                                    with LCDMXx, the LCD frequency fLCD
+                                                                                    is calculated as fLCD = fSOURCE /
+                                                                                    ((LCDDIVx + 1) * Value[LCDMXx]).
+                                                                                    Change only while LCDON = 0.  00000b
+                                                                                    = Divide by 1 00001b = Divide by 2 .
+                                                                                    11110b = Divide by 31 11111b = Divide
+                                                                                    by 32 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_1             ((uint32_t)0x00000000U)         /* !< Divide by 1 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_2             ((uint32_t)0x00000800U)         /* !< Divide by 2 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_3             ((uint32_t)0x00001000U)         /* !< Divide by 3 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_4             ((uint32_t)0x00001800U)         /* !< Divide by 4 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_5             ((uint32_t)0x00002000U)         /* !< Divide by 5 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_6             ((uint32_t)0x00002800U)         /* !< Divide by 6 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_7             ((uint32_t)0x00003000U)         /* !< Divide by 7 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_8             ((uint32_t)0x00003800U)         /* !< Divide by 8 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_9             ((uint32_t)0x00004000U)         /* !< Divide by 9 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_10            ((uint32_t)0x00004800U)         /* !< Divide by 10 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_11            ((uint32_t)0x00005000U)         /* !< Divide by 11 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_12            ((uint32_t)0x00005800U)         /* !< Divide by 12 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_13            ((uint32_t)0x00006000U)         /* !< Divide by 13 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_14            ((uint32_t)0x00006800U)         /* !< Divide by 14 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_15            ((uint32_t)0x00007000U)         /* !< Divide by 15 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_16            ((uint32_t)0x00007800U)         /* !< Divide by 16 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_17            ((uint32_t)0x00008000U)         /* !< Divide by 17 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_18            ((uint32_t)0x00008800U)         /* !< Divide by 18 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_19            ((uint32_t)0x00009000U)         /* !< Divide by 19 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_20            ((uint32_t)0x00009800U)         /* !< Divide by 20 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_21            ((uint32_t)0x0000A000U)         /* !< Divide by 21 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_22            ((uint32_t)0x0000A800U)         /* !< Divide by 22 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_23            ((uint32_t)0x0000B000U)         /* !< Divide by 23 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_24            ((uint32_t)0x0000B800U)         /* !< Divide by 24 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_25            ((uint32_t)0x0000C000U)         /* !< Divide by 25 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_26            ((uint32_t)0x0000C800U)         /* !< Divide by 26 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_27            ((uint32_t)0x0000D000U)         /* !< Divide by 27 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_28            ((uint32_t)0x0000D800U)         /* !< Divide by 28 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_29            ((uint32_t)0x0000E000U)         /* !< Divide by 29 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_30            ((uint32_t)0x0000E800U)         /* !< Divide by 30 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_31            ((uint32_t)0x0000F000U)         /* !< Divide by 31 */
+#define LCD_LCDCTL0_LCDDIVX_DIV_BY_32            ((uint32_t)0x0000F800U)         /* !< Divide by 32 */
+/* LCD_LCDCTL0[LCDLP] Bits */
+#define LCD_LCDCTL0_LCDLP_OFS                    (1)                             /* !< LCDLP Offset */
+#define LCD_LCDCTL0_LCDLP_MASK                   ((uint32_t)0x00000002U)         /* !< LCD low-power waveform. This bit is
+                                                                                    only applicable for 1/3 bias mode,
+                                                                                    that is, for LCDBIASSEL = 0.  0b =
+                                                                                    Standard LCD waveforms on segment and
+                                                                                    common lines selected.  1b =
+                                                                                    Low-power LCD waveforms on segment
+                                                                                    and common lines selected. */
+#define LCD_LCDCTL0_LCDLP_STD_LCD                ((uint32_t)0x00000000U)         /* !< Standard LCD waveforms */
+#define LCD_LCDCTL0_LCDLP_LP_LCD                 ((uint32_t)0x00000002U)         /* !< Low power LCD waveforms */
+/* LCD_LCDCTL0[LCDMXX] Bits */
+#define LCD_LCDCTL0_LCDMXX_OFS                   (3)                             /* !< LCDMXX Offset */
+#define LCD_LCDCTL0_LCDMXX_MASK                  ((uint32_t)0x00000038U)         /* !< LCD mux rate. These bits select the
+                                                                                    LCD mode. Change only while LCDON =
+                                                                                    0.  000b = Static 001b = 2-mux 010b =
+                                                                                    3-mux 011b = 4-mux 100b = 5-mux 101b
+                                                                                    = 6-mux 110b = 7-mux 111b = 8-mux */
+#define LCD_LCDCTL0_LCDMXX_MX_STATIC             ((uint32_t)0x00000000U)         /* !< Static */
+#define LCD_LCDCTL0_LCDMXX_MX_2                  ((uint32_t)0x00000008U)         /* !< 2-mux */
+#define LCD_LCDCTL0_LCDMXX_MX_3                  ((uint32_t)0x00000010U)         /* !< 3-mux */
+#define LCD_LCDCTL0_LCDMXX_MX_4                  ((uint32_t)0x00000018U)         /* !< 4-mux */
+#define LCD_LCDCTL0_LCDMXX_MX_5                  ((uint32_t)0x00000020U)         /* !< 5-mux */
+#define LCD_LCDCTL0_LCDMXX_MX_6                  ((uint32_t)0x00000028U)         /* !< 6-mux */
+#define LCD_LCDCTL0_LCDMXX_MX_7                  ((uint32_t)0x00000030U)         /* !< 7-mux */
+#define LCD_LCDCTL0_LCDMXX_MX_8                  ((uint32_t)0x00000038U)         /* !< 8-mux */
+/* LCD_LCDCTL0[LCDON] Bits */
+#define LCD_LCDCTL0_LCDON_OFS                    (0)                             /* !< LCDON Offset */
+#define LCD_LCDCTL0_LCDON_MASK                   ((uint32_t)0x00000001U)         /* !< LCD on. This bit turns the LCD
+                                                                                    module on or off.  0b = LCD module
+                                                                                    off 1b = LCD module on */
+#define LCD_LCDCTL0_LCDON_LCD_MOD_DISABLE        ((uint32_t)0x00000000U)         /* !< LCD module off */
+#define LCD_LCDCTL0_LCDON_LCD_MOD_ENABLE         ((uint32_t)0x00000001U)         /* !< LCD module on */
+/* LCD_LCDCTL0[LCDSON] Bits */
+#define LCD_LCDCTL0_LCDSON_OFS                   (2)                             /* !< LCDSON Offset */
+#define LCD_LCDCTL0_LCDSON_MASK                  ((uint32_t)0x00000004U)         /* !< LCD segments on. This bit supports
+                                                                                    flashing LCD applications by turning
+                                                                                    off all segment lines, while leaving
+                                                                                    the LCD timing generator and R33
+                                                                                    enabled.  0b = All LCD segments are
+                                                                                    off.  1b = All LCD segments are
+                                                                                    enabled and on or off according to
+                                                                                    their corresponding memory location. */
+#define LCD_LCDCTL0_LCDSON_LCD_SEG_OFF           ((uint32_t)0x00000000U)         /* !< All LCD segments are off. */
+#define LCD_LCDCTL0_LCDSON_LCD_SEG_ON            ((uint32_t)0x00000004U)         /* !< All LCD segments are enabled and on
+                                                                                    or off according to their
+                                                                                    corresponding memory location. */
+/* LCD_LCDCTL0[LCDSYNCEXT] Bits */
+#define LCD_LCDCTL0_LCDSYNCEXT_OFS               (24)                            /* !< LCDSYNCEXT Offset */
+#define LCD_LCDCTL0_LCDSYNCEXT_MASK              ((uint32_t)0x01000000U)
+#define LCD_LCDCTL0_LCDSYNCEXT_LCD_EXT_SYNC_OFF  ((uint32_t)0x00000000U)         /* !< External eynchronization off. */
+#define LCD_LCDCTL0_LCDSYNCEXT_LCD_EXT_SYNC_ON   ((uint32_t)0x01000000U)         /* !< External synchronization on. */
+
+/* LCD_LCDBLKCTL Bits */
+/* LCD_LCDBLKCTL[LCDBLKMODX] Bits */
+#define LCD_LCDBLKCTL_LCDBLKMODX_OFS             (0)                             /* !< LCDBLKMODX Offset */
+#define LCD_LCDBLKCTL_LCDBLKMODX_MASK            ((uint32_t)0x00000003U)         /* !< Blinking mode 00b = Blinking
+                                                                                    disabled.  01b = Blinking of
+                                                                                    individual segments as enabled in
+                                                                                    blinking memory register LCDBMx. In
+                                                                                    mux mode >5 blinking is disabled.
+                                                                                    10b = Blinking of all segments 11b =
+                                                                                    Switching between display contents as
+                                                                                    stored in LCDMx and LCDBMx memory
+                                                                                    registers. In mux mode >5 blinking is
+                                                                                    disabled. */
+#define LCD_LCDBLKCTL_LCDBLKMODX_BLINK_DISABLE   ((uint32_t)0x00000000U)         /* !< Blinking disabled. */
+#define LCD_LCDBLKCTL_LCDBLKMODX_BLINK_SELECED   ((uint32_t)0x00000001U)         /* !< Blinking of individual segments as
+                                                                                    enabled in blinking memory register
+                                                                                    LCDBMx. In mux mode >5 blinking is
+                                                                                    disabled. */
+#define LCD_LCDBLKCTL_LCDBLKMODX_BLINK_ALL       ((uint32_t)0x00000002U)         /* !< Blinking of all segments */
+#define LCD_LCDBLKCTL_LCDBLKMODX_BKINK_TOGGLE    ((uint32_t)0x00000003U)         /* !< Switching between display contents
+                                                                                    as stored in LCDMx and LCDBMx memory
+                                                                                    registers. In mux mode >5 blinking is
+                                                                                    disabled. */
+/* LCD_LCDBLKCTL[LCDBLKPREX] Bits */
+#define LCD_LCDBLKCTL_LCDBLKPREX_OFS             (2)                             /* !< LCDBLKPREX Offset */
+#define LCD_LCDBLKCTL_LCDBLKPREX_MASK            ((uint32_t)0x0000001CU)         /* !< Clock prescaler for blinking
+                                                                                    frequency. */
+#define LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_2        ((uint32_t)0x00000000U)         /* !< Divide by 2 */
+#define LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_4        ((uint32_t)0x00000004U)         /* !< Divide by 4 */
+#define LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_8        ((uint32_t)0x00000008U)         /* !< Divide by 8 */
+#define LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_16       ((uint32_t)0x0000000CU)         /* !< Divide by 16 */
+#define LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_32       ((uint32_t)0x00000010U)         /* !< Divide by 32 */
+#define LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_64       ((uint32_t)0x00000014U)         /* !< Divide by 64 */
+#define LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_128      ((uint32_t)0x00000018U)         /* !< Divide by 128 */
+#define LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_256      ((uint32_t)0x0000001CU)         /* !< Divide by 256 */
+
+/* LCD_LCDMEMCTL Bits */
+/* LCD_LCDMEMCTL[LCDCLRBM] Bits */
+#define LCD_LCDMEMCTL_LCDCLRBM_OFS               (2)                             /* !< LCDCLRBM Offset */
+#define LCD_LCDMEMCTL_LCDCLRBM_MASK              ((uint32_t)0x00000004U)         /* !< Clear LCD blinking memory Clears
+                                                                                    all blinking memory registers LCDBMx.
+                                                                                    The bit is automatically reset when
+                                                                                    the blinking memory is cleared.
+                                                                                    Setting this bit in 5-mux mode and
+                                                                                    above has no effect. It is
+                                                                                    immediately reset again.  0b =
+                                                                                    Contents of blinking memory registers
+                                                                                    LCDBMx remain unchanged 1b = Clear
+                                                                                    content of all blinking memory
+                                                                                    registers LCDBMx */
+#define LCD_LCDMEMCTL_LCDCLRBM_NO_CLR_BLNK_MEM_REGS ((uint32_t)0x00000000U)         /* !< Contents of blinking memory
+                                                                                    registers LCDBMx remain unchanged */
+#define LCD_LCDMEMCTL_LCDCLRBM_CLR_BLNK_MEM_REGS ((uint32_t)0x00000004U)         /* !< Clear content of all blinking
+                                                                                    memory registers LCDBMx */
+/* LCD_LCDMEMCTL[LCDCLRM] Bits */
+#define LCD_LCDMEMCTL_LCDCLRM_OFS                (1)                             /* !< LCDCLRM Offset */
+#define LCD_LCDMEMCTL_LCDCLRM_MASK               ((uint32_t)0x00000002U)         /* !< Clear LCD memory Clears all LCD
+                                                                                    memory registers LCDMx. The bit is
+                                                                                    automatically reset when the LCD
+                                                                                    memory is cleared.  0b = Contents of
+                                                                                    LCD memory registers LCDMx remain
+                                                                                    unchanged 1b = Clear content of all
+                                                                                    LCD memory registers LCDMx */
+#define LCD_LCDMEMCTL_LCDCLRM_NO_CLR_LCD_MEM_REGS ((uint32_t)0x00000000U)         /* !< Contents of LCD memory registers
+                                                                                    LCDMx remain unchanged */
+#define LCD_LCDMEMCTL_LCDCLRM_CLR_LCD_MEM_REGS   ((uint32_t)0x00000002U)         /* !< Clear content of all LCD memory
+                                                                                    registers LCDMx */
+/* LCD_LCDMEMCTL[LCDDISP] Bits */
+#define LCD_LCDMEMCTL_LCDDISP_OFS                (0)                             /* !< LCDDISP Offset */
+#define LCD_LCDMEMCTL_LCDDISP_MASK               ((uint32_t)0x00000001U)         /* !< Select LCD memory registers for
+                                                                                    display When LCDBLKMODx = 00, LCDDISP
+                                                                                    can be set by software.  The bit is
+                                                                                    cleared in LCDBLKMODx = 01 and
+                                                                                    LCDBLKMODx = 10 or if a mux mode =5
+                                                                                    is selected and cannot be changed by
+                                                                                    software.  When LCDBLKMODx = 11, this
+                                                                                    bit reflects the currently displayed
+                                                                                    memory but cannot be changed by
+                                                                                    software. When returning to
+                                                                                    LCDBLKMODx = 00 the bit is cleared.
+                                                                                    0b = Display content of LCD memory
+                                                                                    registers LCDMx 1b = Display content
+                                                                                    of LCD blinking memory registers
+                                                                                    LCDBMx */
+#define LCD_LCDMEMCTL_LCDDISP_SEL_LCD_MEM_REGS   ((uint32_t)0x00000000U)         /* !< Display content of LCD memory
+                                                                                    registers LCDMx */
+#define LCD_LCDMEMCTL_LCDDISP_SEL_BLNK_MEM_REGS  ((uint32_t)0x00000001U)         /* !< Display content of LCD blinking
+                                                                                    memory registers LCDBMx */
+
+/* LCD_LCDVCTL Bits */
+/* LCD_LCDVCTL[LCDBIASSEL] Bits */
+#define LCD_LCDVCTL_LCDBIASSEL_OFS               (1)                             /* !< LCDBIASSEL Offset */
+#define LCD_LCDVCTL_LCDBIASSEL_MASK              ((uint32_t)0x00000002U)         /* !< Bias select.  LCDBIASSEL is ignored
+                                                                                    in static mode as well as for 2-mux,
+                                                                                    3-mux and 4-mux LCD modes.  For 5-mux
+                                                                                    to 8-mux modes: 0b = 1/3 bias 1b =
+                                                                                    1/4 bias */
+#define LCD_LCDVCTL_LCDBIASSEL_ONE_BY_3_BIAS     ((uint32_t)0x00000000U)         /* !< 1/3 bias */
+#define LCD_LCDVCTL_LCDBIASSEL_ONE_BY_4_BIAS     ((uint32_t)0x00000002U)         /* !< 1/4 bias */
+/* LCD_LCDVCTL[LCDCPEN] Bits */
+#define LCD_LCDVCTL_LCDCPEN_OFS                  (7)                             /* !< LCDCPEN Offset */
+#define LCD_LCDVCTL_LCDCPEN_MASK                 ((uint32_t)0x00000080U)         /* !< Charge pump enable 0b = Charge pump
+                                                                                    disabled(1) 1b = Charge pump enabled
+                                                                                    when VLCD is generated internally
+                                                                                    (VLCDEXT = 0) and VLCDx > 0 or
+                                                                                    VLCDREFx > 0. */
+#define LCD_LCDVCTL_LCDCPEN_CP_DISABLE           ((uint32_t)0x00000000U)         /* !< Charge pump disabled(1) */
+#define LCD_LCDVCTL_LCDCPEN_CP_ENABLE            ((uint32_t)0x00000080U)         /* !< Charge pump enabled when VLCD is
+                                                                                    generated internally (VLCDEXT = 0)
+                                                                                    and VLCDx > 0 or VLCDREFx > 0. */
+/* LCD_LCDVCTL[LCDCPFSELX] Bits */
+#define LCD_LCDVCTL_LCDCPFSELX_OFS               (12)                            /* !< LCDCPFSELX Offset */
+#define LCD_LCDVCTL_LCDCPFSELX_MASK              ((uint32_t)0x0000F000U)         /* !< Charge pump frequency selection.
+                                                                                    0000b = 32.768 kHz / 1 / 8 = 4.096
+                                                                                    kHz 0001b = 32.768 kHz / 2 / 8 =
+                                                                                    2.048 kHz 0010b = 32.768 kHz / 3 / 8
+                                                                                    = 1.365 kHz 0011b = 32.768 kHz / 4 /
+                                                                                    8 = 1.024 kHz 0100b = 32.768 kHz / 5
+                                                                                    / 8 = 819 Hz 0101b = 32.768 kHz / 6 /
+                                                                                    8 = 682 Hz 0110b = 32.768 kHz / 7 / 8
+                                                                                    = 585 Hz 0111b = 32.768 kHz / 8 / 8 =
+                                                                                    512 Hz 1000b = 32.768 kHz / 9 / 8 =
+                                                                                    455 Hz 1001b = 32.768 kHz / 10 / 8 =
+                                                                                    409 Hz 1010b = 32.768 kHz / 11 / 8 =
+                                                                                    372 Hz 1011b = 32.768 kHz / 12 / 8 =
+                                                                                    341 Hz 1100b = 32.768 kHz / 13 / 8 =
+                                                                                    315 Hz 1101b = 32.768 kHz / 14 / 8 =
+                                                                                    292 Hz 1110b = 32.768 kHz / 15 / 8 =
+                                                                                    273 Hz 1111b = 32.768 kHz / 16 / 8 =
+                                                                                    256 Hz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_1_BY_8     ((uint32_t)0x00000000U)         /* !< 32.768 kHz / 1 / 8 = 4.096 kHz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_2_BY_8     ((uint32_t)0x00001000U)         /* !< 32.768 kHz / 2 / 8 = 2.048 kHz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_3_BY_8     ((uint32_t)0x00002000U)         /* !< 32.768 kHz / 3 / 8 = 1.365 kHz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_4_BY_8     ((uint32_t)0x00003000U)         /* !< 32.768 kHz / 4 / 8 = 1.024 kHz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_5_BY_8     ((uint32_t)0x00004000U)         /* !< 32.768 kHz / 5 / 8 = 819 Hz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_6_BY_8     ((uint32_t)0x00005000U)         /* !< 32.768 kHz / 6 / 8 = 682 Hz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_7_BY_8     ((uint32_t)0x00006000U)         /* !< 32.768 kHz / 7 / 8 = 585 Hz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_8_BY_8     ((uint32_t)0x00007000U)         /* !< 32.768 kHz / 8 / 8 = 512 Hz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_9_BY_8     ((uint32_t)0x00008000U)         /* !< 32.768 kHz / 9 / 8 = 455 Hz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_10_BY_8    ((uint32_t)0x00009000U)         /* !< 32.768 kHz / 10 / 8 = 409 Hz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_11_BY_8    ((uint32_t)0x0000A000U)         /* !< 32.768 kHz / 11 / 8 = 372 Hz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_12_BY_8    ((uint32_t)0x0000B000U)         /* !< 32.768 kHz / 12 / 8 = 341 Hz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_13_BY_8    ((uint32_t)0x0000C000U)         /* !< 32.768 kHz / 13 / 8 = 315 Hz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_14_BY_8    ((uint32_t)0x0000D000U)         /* !< 32.768 kHz / 14 / 8 = 292 Hz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_15_BY_8    ((uint32_t)0x0000E000U)         /* !< 32.768 kHz / 15 / 8 = 273 Hz */
+#define LCD_LCDVCTL_LCDCPFSELX_DIV_BY_16_BY_8    ((uint32_t)0x0000F000U)         /* !< 32.768 kHz / 16 / 8 = 256 Hz */
+/* LCD_LCDVCTL[LCDINTBIASEN] Bits */
+#define LCD_LCDVCTL_LCDINTBIASEN_OFS             (2)                             /* !< LCDINTBIASEN Offset */
+#define LCD_LCDVCTL_LCDINTBIASEN_MASK            ((uint32_t)0x00000004U)         /* !< Enables the internal bias voltage
+                                                                                    resistor divider.  The actual voltage
+                                                                                    source used for the resistor divider
+                                                                                    is selected by the VLCDSEL_VDD_R33
+                                                                                    bit configuration.  0b = Internal
+                                                                                    bias voltage resistor divider is
+                                                                                    disabled 1b = Internal bias voltage
+                                                                                    resistor divider is enabledDD */
+#define LCD_LCDVCTL_LCDINTBIASEN_INT_BIAS_DISABLE ((uint32_t)0x00000000U)         /* !< Internal bias voltage resistor
+                                                                                    divider is disabled */
+#define LCD_LCDVCTL_LCDINTBIASEN_INT_BIAS_ENABLE ((uint32_t)0x00000004U)         /* !< Internal bias voltage resistor
+                                                                                    divider is enabled */
+/* LCD_LCDVCTL[LCDREFEN] Bits */
+#define LCD_LCDVCTL_LCDREFEN_OFS                 (6)                             /* !< LCDREFEN Offset */
+#define LCD_LCDVCTL_LCDREFEN_MASK                ((uint32_t)0x00000040U)         /* !< Internal reference voltage enable
+                                                                                    on R13 0b = Internal reference
+                                                                                    voltage disabled 1b = Internal
+                                                                                    reference voltage enabled */
+#define LCD_LCDVCTL_LCDREFEN_INT_REF_DISABLE     ((uint32_t)0x00000000U)         /* !< Internal reference voltage disabled */
+#define LCD_LCDVCTL_LCDREFEN_INT_REF_ENABLE      ((uint32_t)0x00000040U)         /* !< Internal reference voltage enabled */
+/* LCD_LCDVCTL[LCDREFMODE] Bits */
+#define LCD_LCDVCTL_LCDREFMODE_OFS               (0)                             /* !< LCDREFMODE Offset */
+#define LCD_LCDVCTL_LCDREFMODE_MASK              ((uint32_t)0x00000001U)         /* !< Selects whether R13 voltage is
+                                                                                    switched or in static mode 0b =
+                                                                                    Static mode 1b = Switched mode */
+#define LCD_LCDVCTL_LCDREFMODE_STATIC_MODE       ((uint32_t)0x00000000U)         /* !< Static mode */
+#define LCD_LCDVCTL_LCDREFMODE_SWITCHED_MODE     ((uint32_t)0x00000001U)         /* !< Switched mode */
+/* LCD_LCDVCTL[LCDSELVDD] Bits */
+#define LCD_LCDVCTL_LCDSELVDD_OFS                (5)                             /* !< LCDSELVDD Offset */
+#define LCD_LCDVCTL_LCDSELVDD_MASK               ((uint32_t)0x00000020U)         /* !< Selects if R33 is supplied either
+                                                                                    from AVDD internally or from charge
+                                                                                    pump 0b = R33 connected to external
+                                                                                    supply 1b = R33 internally connected
+                                                                                    to AVDD */
+#define LCD_LCDVCTL_LCDSELVDD_SEL_EXT_SUPPLY     ((uint32_t)0x00000000U)         /* !< R33 connected to external supply */
+#define LCD_LCDVCTL_LCDSELVDD_SEL_AVDD           ((uint32_t)0x00000020U)         /* !< R33 internally connected to AVDD */
+/* LCD_LCDVCTL[LCD_HP_LP] Bits */
+#define LCD_LCDVCTL_LCD_HP_LP_OFS                (4)                             /* !< LCD_HP_LP Offset */
+#define LCD_LCDVCTL_LCD_HP_LP_MASK               ((uint32_t)0x00000010U)         /* !< High-power or Low-power LCD.  This
+                                                                                    bit is only effective when the
+                                                                                    internal bias voltage resistor
+                                                                                    divider is used, that is, when
+                                                                                    LCDINTBIASEN = 1. It selects the
+                                                                                    resistor ladder that is used to
+                                                                                    generate the bias voltages for the
+                                                                                    LCD.  0b = Low-power LCD is used 1b =
+                                                                                    Higher-power LCD is used */
+#define LCD_LCDVCTL_LCD_HP_LP_LP_MODE            ((uint32_t)0x00000000U)         /* !< Low-power LCD is used */
+#define LCD_LCDVCTL_LCD_HP_LP_HP_MODE            ((uint32_t)0x00000010U)         /* !< Higher-power LCD is used */
+/* LCD_LCDVCTL[VLCDSEL_VDD_R33] Bits */
+#define LCD_LCDVCTL_VLCDSEL_VDD_R33_OFS          (3)                             /* !< VLCDSEL_VDD_R33 Offset */
+#define LCD_LCDVCTL_VLCDSEL_VDD_R33_MASK         ((uint32_t)0x00000008U)         /* !< Selects if the LCD bias voltage V1
+                                                                                    is sourced from the R33 pin or from
+                                                                                    the internal supply voltage AVDD This
+                                                                                    bit is only effective when the
+                                                                                    internal bias voltage resistor
+                                                                                    divider is used, that is, when
+                                                                                    LCDINTBIASEN = 1 0b = V1 is sourced
+                                                                                    from R33 1b = V1 is sourced
+                                                                                    internally from AVDD */
+#define LCD_LCDVCTL_VLCDSEL_VDD_R33_SEL_R33      ((uint32_t)0x00000000U)         /* !< V1 is sourced from R33 */
+#define LCD_LCDVCTL_VLCDSEL_VDD_R33_SEL_AVDD     ((uint32_t)0x00000008U)         /* !< V1 is sourced internally from AVDD */
+/* LCD_LCDVCTL[VLCDX] Bits */
+#define LCD_LCDVCTL_VLCDX_OFS                    (8)                             /* !< VLCDX Offset */
+#define LCD_LCDVCTL_VLCDX_MASK                   ((uint32_t)0x00000F00U)         /* !< Internal reference voltage select
+                                                                                    on R13. */
+#define LCD_LCDVCTL_VLCDX_SEL_2P60V              ((uint32_t)0x00000000U)         /* !< 2.60 V */
+#define LCD_LCDVCTL_VLCDX_SEL_2P66V              ((uint32_t)0x00000100U)         /* !< 2.66 V */
+#define LCD_LCDVCTL_VLCDX_SEL_2P72V              ((uint32_t)0x00000200U)         /* !< 2.72 V */
+#define LCD_LCDVCTL_VLCDX_SEL_2P78V              ((uint32_t)0x00000300U)         /* !< 2.78 V */
+#define LCD_LCDVCTL_VLCDX_SEL_2P84V              ((uint32_t)0x00000400U)         /* !< 2.84 V */
+#define LCD_LCDVCTL_VLCDX_SEL_2P90V              ((uint32_t)0x00000500U)         /* !< 2.90 V */
+#define LCD_LCDVCTL_VLCDX_SEL_2P96V              ((uint32_t)0x00000600U)         /* !< 2.96 V */
+#define LCD_LCDVCTL_VLCDX_SEL_3P02V              ((uint32_t)0x00000700U)         /* !< 3.02 V */
+#define LCD_LCDVCTL_VLCDX_SEL_3P08V              ((uint32_t)0x00000800U)         /* !< 3.08 V */
+#define LCD_LCDVCTL_VLCDX_SEL_3P14V              ((uint32_t)0x00000900U)         /* !< 3.14 V */
+#define LCD_LCDVCTL_VLCDX_SEL_3P20V              ((uint32_t)0x00000A00U)         /* !< 3.20 V */
+#define LCD_LCDVCTL_VLCDX_SEL_3P26V              ((uint32_t)0x00000B00U)         /* !< 3.26 V */
+#define LCD_LCDVCTL_VLCDX_SEL_3P32V              ((uint32_t)0x00000C00U)         /* !< 3.32 V */
+#define LCD_LCDVCTL_VLCDX_SEL_3P38V              ((uint32_t)0x00000D00U)         /* !< 3.38 V */
+#define LCD_LCDVCTL_VLCDX_SEL_3P44V              ((uint32_t)0x00000E00U)         /* !< 3.44 V */
+#define LCD_LCDVCTL_VLCDX_SEL_3P50V              ((uint32_t)0x00000F00U)         /* !< 3.50 V */
+/* LCD_LCDVCTL[LCDVBSTEN] Bits */
+#define LCD_LCDVCTL_LCDVBSTEN_OFS                (24)                            /* !< LCDVBSTEN Offset */
+#define LCD_LCDVCTL_LCDVBSTEN_MASK               ((uint32_t)0x01000000U)         /* !< Enables the voltage boost circuitry
+                                                                                    which provides a boosted VDDA
+                                                                                    voltage. This boosted voltage is to
+                                                                                    be used in the switch controls, when
+                                                                                    the VDDA supply is less than 1.6V. */
+#define LCD_LCDVCTL_LCDVBSTEN_DISABLE            ((uint32_t)0x00000000U)         /* !< Disable. */
+#define LCD_LCDVCTL_LCDVBSTEN_ENABLE             ((uint32_t)0x01000000U)         /* !< Enable. */
+
+/* LCD_LCDPCTL0 Bits */
+/* LCD_LCDPCTL0[LCDS0] Bits */
+#define LCD_LCDPCTL0_LCDS0_OFS                   (0)                             /* !< LCDS0 Offset */
+#define LCD_LCDPCTL0_LCDS0_MASK                  ((uint32_t)0x00000001U)         /* !< LCD pin 0 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS0_SEL_PORT              ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS0_SEL_LCD               ((uint32_t)0x00000001U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS1] Bits */
+#define LCD_LCDPCTL0_LCDS1_OFS                   (1)                             /* !< LCDS1 Offset */
+#define LCD_LCDPCTL0_LCDS1_MASK                  ((uint32_t)0x00000002U)         /* !< LCD pin 1 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS1_SEL_PORT              ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS1_SEL_LCD               ((uint32_t)0x00000002U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS10] Bits */
+#define LCD_LCDPCTL0_LCDS10_OFS                  (10)                            /* !< LCDS10 Offset */
+#define LCD_LCDPCTL0_LCDS10_MASK                 ((uint32_t)0x00000400U)         /* !< LCD pin 10 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS10_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS10_SEL_LCD              ((uint32_t)0x00000400U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS11] Bits */
+#define LCD_LCDPCTL0_LCDS11_OFS                  (11)                            /* !< LCDS11 Offset */
+#define LCD_LCDPCTL0_LCDS11_MASK                 ((uint32_t)0x00000800U)         /* !< LCD pin 11 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS11_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS11_SEL_LCD              ((uint32_t)0x00000800U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS12] Bits */
+#define LCD_LCDPCTL0_LCDS12_OFS                  (12)                            /* !< LCDS12 Offset */
+#define LCD_LCDPCTL0_LCDS12_MASK                 ((uint32_t)0x00001000U)         /* !< LCD pin 12 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS12_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS12_SEL_LCD              ((uint32_t)0x00001000U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS13] Bits */
+#define LCD_LCDPCTL0_LCDS13_OFS                  (13)                            /* !< LCDS13 Offset */
+#define LCD_LCDPCTL0_LCDS13_MASK                 ((uint32_t)0x00002000U)         /* !< LCD pin 13 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS13_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS13_SEL_LCD              ((uint32_t)0x00002000U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS14] Bits */
+#define LCD_LCDPCTL0_LCDS14_OFS                  (14)                            /* !< LCDS14 Offset */
+#define LCD_LCDPCTL0_LCDS14_MASK                 ((uint32_t)0x00004000U)         /* !< LCD pin 14 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS14_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS14_SEL_LCD              ((uint32_t)0x00004000U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS15] Bits */
+#define LCD_LCDPCTL0_LCDS15_OFS                  (15)                            /* !< LCDS15 Offset */
+#define LCD_LCDPCTL0_LCDS15_MASK                 ((uint32_t)0x00008000U)         /* !< LCD pin 15 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS15_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS15_SEL_LCD              ((uint32_t)0x00008000U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS2] Bits */
+#define LCD_LCDPCTL0_LCDS2_OFS                   (2)                             /* !< LCDS2 Offset */
+#define LCD_LCDPCTL0_LCDS2_MASK                  ((uint32_t)0x00000004U)         /* !< LCD pin 2 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS2_SEL_PORT              ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS2_SEL_LCD               ((uint32_t)0x00000004U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS3] Bits */
+#define LCD_LCDPCTL0_LCDS3_OFS                   (3)                             /* !< LCDS3 Offset */
+#define LCD_LCDPCTL0_LCDS3_MASK                  ((uint32_t)0x00000008U)         /* !< LCD pin 3 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS3_SEL_PORT              ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS3_SEL_LCD               ((uint32_t)0x00000008U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS4] Bits */
+#define LCD_LCDPCTL0_LCDS4_OFS                   (4)                             /* !< LCDS4 Offset */
+#define LCD_LCDPCTL0_LCDS4_MASK                  ((uint32_t)0x00000010U)         /* !< LCD pin 4 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS4_SEL_PORT              ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS4_SEL_LCD               ((uint32_t)0x00000010U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS5] Bits */
+#define LCD_LCDPCTL0_LCDS5_OFS                   (5)                             /* !< LCDS5 Offset */
+#define LCD_LCDPCTL0_LCDS5_MASK                  ((uint32_t)0x00000020U)         /* !< LCD pin 5 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS5_SEL_PORT              ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS5_SEL_LCD               ((uint32_t)0x00000020U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS6] Bits */
+#define LCD_LCDPCTL0_LCDS6_OFS                   (6)                             /* !< LCDS6 Offset */
+#define LCD_LCDPCTL0_LCDS6_MASK                  ((uint32_t)0x00000040U)         /* !< LCD pin 6 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS6_SEL_PORT              ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS6_SEL_LCD               ((uint32_t)0x00000040U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS7] Bits */
+#define LCD_LCDPCTL0_LCDS7_OFS                   (7)                             /* !< LCDS7 Offset */
+#define LCD_LCDPCTL0_LCDS7_MASK                  ((uint32_t)0x00000080U)         /* !< LCD pin 7 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS7_SEL_PORT              ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS7_SEL_LCD               ((uint32_t)0x00000080U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS8] Bits */
+#define LCD_LCDPCTL0_LCDS8_OFS                   (8)                             /* !< LCDS8 Offset */
+#define LCD_LCDPCTL0_LCDS8_MASK                  ((uint32_t)0x00000100U)         /* !< LCD pin 8 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS8_SEL_PORT              ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS8_SEL_LCD               ((uint32_t)0x00000100U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL0[LCDS9] Bits */
+#define LCD_LCDPCTL0_LCDS9_OFS                   (9)                             /* !< LCDS9 Offset */
+#define LCD_LCDPCTL0_LCDS9_MASK                  ((uint32_t)0x00000200U)         /* !< LCD pin 9 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS9_SEL_PORT              ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL0_LCDS9_SEL_LCD               ((uint32_t)0x00000200U)         /* !< Pins are LCD functions. */
+
+/* LCD_LCDPCTL1 Bits */
+/* LCD_LCDPCTL1[LCDS16] Bits */
+#define LCD_LCDPCTL1_LCDS16_OFS                  (0)                             /* !< LCDS16 Offset */
+#define LCD_LCDPCTL1_LCDS16_MASK                 ((uint32_t)0x00000001U)         /* !< LCD segment line 16 enable. This
+                                                                                    bit affects only pins with
+                                                                                    multiplexed functions.  Dedicated LCD
+                                                                                    pins are always LCD function.  0b =
+                                                                                    Multiplexed pins are port functions.
+                                                                                    1b = Pins are LCD functions. */
+#define LCD_LCDPCTL1_LCDS16_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS16_SEL_LCD              ((uint32_t)0x00000001U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS17] Bits */
+#define LCD_LCDPCTL1_LCDS17_OFS                  (1)                             /* !< LCDS17 Offset */
+#define LCD_LCDPCTL1_LCDS17_MASK                 ((uint32_t)0x00000002U)         /* !< LCD segment line 17 enable. This
+                                                                                    bit affects only pins with
+                                                                                    multiplexed functions.  Dedicated LCD
+                                                                                    pins are always LCD function.  0b =
+                                                                                    Multiplexed pins are port functions.
+                                                                                    1b = Pins are LCD functions. */
+#define LCD_LCDPCTL1_LCDS17_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS17_SEL_LCD              ((uint32_t)0x00000002U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS18] Bits */
+#define LCD_LCDPCTL1_LCDS18_OFS                  (2)                             /* !< LCDS18 Offset */
+#define LCD_LCDPCTL1_LCDS18_MASK                 ((uint32_t)0x00000004U)         /* !< LCD segment line 18 enable. This
+                                                                                    bit affects only pins with
+                                                                                    multiplexed functions.  Dedicated LCD
+                                                                                    pins are always LCD function.  0b =
+                                                                                    Multiplexed pins are port functions.
+                                                                                    1b = Pins are LCD functions. */
+#define LCD_LCDPCTL1_LCDS18_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS18_SEL_LCD              ((uint32_t)0x00000004U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS19] Bits */
+#define LCD_LCDPCTL1_LCDS19_OFS                  (3)                             /* !< LCDS19 Offset */
+#define LCD_LCDPCTL1_LCDS19_MASK                 ((uint32_t)0x00000008U)         /* !< LCD segment line 19 enable. This
+                                                                                    bit affects only pins with
+                                                                                    multiplexed functions.  Dedicated LCD
+                                                                                    pins are always LCD function.  0b =
+                                                                                    Multiplexed pins are port functions.
+                                                                                    1b = Pins are LCD functions. */
+#define LCD_LCDPCTL1_LCDS19_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS19_SEL_LCD              ((uint32_t)0x00000008U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS20] Bits */
+#define LCD_LCDPCTL1_LCDS20_OFS                  (4)                             /* !< LCDS20 Offset */
+#define LCD_LCDPCTL1_LCDS20_MASK                 ((uint32_t)0x00000010U)         /* !< LCD segment line 20 enable. This
+                                                                                    bit affects only pins with
+                                                                                    multiplexed functions.  Dedicated LCD
+                                                                                    pins are always LCD function.  0b =
+                                                                                    Multiplexed pins are port functions.
+                                                                                    1b = Pins are LCD functions. */
+#define LCD_LCDPCTL1_LCDS20_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS20_SEL_LCD              ((uint32_t)0x00000010U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS21] Bits */
+#define LCD_LCDPCTL1_LCDS21_OFS                  (5)                             /* !< LCDS21 Offset */
+#define LCD_LCDPCTL1_LCDS21_MASK                 ((uint32_t)0x00000020U)         /* !< LCD segment line 21 enable. This
+                                                                                    bit affects only pins with
+                                                                                    multiplexed functions.  Dedicated LCD
+                                                                                    pins are always LCD function.  0b =
+                                                                                    Multiplexed pins are port functions.
+                                                                                    1b = Pins are LCD functions. */
+#define LCD_LCDPCTL1_LCDS21_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS21_SEL_LCD              ((uint32_t)0x00000020U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS22] Bits */
+#define LCD_LCDPCTL1_LCDS22_OFS                  (6)                             /* !< LCDS22 Offset */
+#define LCD_LCDPCTL1_LCDS22_MASK                 ((uint32_t)0x00000040U)         /* !< LCD segment line 22 enable. This
+                                                                                    bit affects only pins with
+                                                                                    multiplexed functions.  Dedicated LCD
+                                                                                    pins are always LCD function.  0b =
+                                                                                    Multiplexed pins are port functions.
+                                                                                    1b = Pins are LCD functions. */
+#define LCD_LCDPCTL1_LCDS22_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS22_SEL_LCD              ((uint32_t)0x00000040U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS23] Bits */
+#define LCD_LCDPCTL1_LCDS23_OFS                  (7)                             /* !< LCDS23 Offset */
+#define LCD_LCDPCTL1_LCDS23_MASK                 ((uint32_t)0x00000080U)         /* !< LCD segment line 23 enable. This
+                                                                                    bit affects only pins with
+                                                                                    multiplexed functions.  Dedicated LCD
+                                                                                    pins are always LCD function.  0b =
+                                                                                    Multiplexed pins are port functions.
+                                                                                    1b = Pins are LCD functions. */
+#define LCD_LCDPCTL1_LCDS23_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS23_SEL_LCD              ((uint32_t)0x00000080U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS24] Bits */
+#define LCD_LCDPCTL1_LCDS24_OFS                  (8)                             /* !< LCDS24 Offset */
+#define LCD_LCDPCTL1_LCDS24_MASK                 ((uint32_t)0x00000100U)         /* !< LCD pin 24 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS24_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS24_SEL_LCD              ((uint32_t)0x00000100U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS25] Bits */
+#define LCD_LCDPCTL1_LCDS25_OFS                  (9)                             /* !< LCDS25 Offset */
+#define LCD_LCDPCTL1_LCDS25_MASK                 ((uint32_t)0x00000200U)         /* !< LCD pin 25 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS25_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS25_SEL_LCD              ((uint32_t)0x00000200U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS26] Bits */
+#define LCD_LCDPCTL1_LCDS26_OFS                  (10)                            /* !< LCDS26 Offset */
+#define LCD_LCDPCTL1_LCDS26_MASK                 ((uint32_t)0x00000400U)         /* !< LCD pin 26 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS26_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS26_SEL_LCD              ((uint32_t)0x00000400U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS27] Bits */
+#define LCD_LCDPCTL1_LCDS27_OFS                  (11)                            /* !< LCDS27 Offset */
+#define LCD_LCDPCTL1_LCDS27_MASK                 ((uint32_t)0x00000800U)         /* !< LCD pin 27 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS27_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS27_SEL_LCD              ((uint32_t)0x00000800U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS28] Bits */
+#define LCD_LCDPCTL1_LCDS28_OFS                  (12)                            /* !< LCDS28 Offset */
+#define LCD_LCDPCTL1_LCDS28_MASK                 ((uint32_t)0x00001000U)         /* !< LCD pin 28 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS28_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS28_SEL_LCD              ((uint32_t)0x00001000U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS29] Bits */
+#define LCD_LCDPCTL1_LCDS29_OFS                  (13)                            /* !< LCDS29 Offset */
+#define LCD_LCDPCTL1_LCDS29_MASK                 ((uint32_t)0x00002000U)         /* !< LCD pin 29 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS29_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS29_SEL_LCD              ((uint32_t)0x00002000U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS30] Bits */
+#define LCD_LCDPCTL1_LCDS30_OFS                  (14)                            /* !< LCDS30 Offset */
+#define LCD_LCDPCTL1_LCDS30_MASK                 ((uint32_t)0x00004000U)         /* !< LCD pin 30 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS30_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS30_SEL_LCD              ((uint32_t)0x00004000U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL1[LCDS31] Bits */
+#define LCD_LCDPCTL1_LCDS31_OFS                  (15)                            /* !< LCDS31 Offset */
+#define LCD_LCDPCTL1_LCDS31_MASK                 ((uint32_t)0x00008000U)         /* !< LCD pin 31 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS31_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL1_LCDS31_SEL_LCD              ((uint32_t)0x00008000U)         /* !< Pins are LCD functions. */
+
+/* LCD_LCDPCTL2 Bits */
+/* LCD_LCDPCTL2[LCDS32] Bits */
+#define LCD_LCDPCTL2_LCDS32_OFS                  (0)                             /* !< LCDS32 Offset */
+#define LCD_LCDPCTL2_LCDS32_MASK                 ((uint32_t)0x00000001U)         /* !< LCD pin 32 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS32_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS32_SEL_LCD              ((uint32_t)0x00000001U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS33] Bits */
+#define LCD_LCDPCTL2_LCDS33_OFS                  (1)                             /* !< LCDS33 Offset */
+#define LCD_LCDPCTL2_LCDS33_MASK                 ((uint32_t)0x00000002U)         /* !< LCD pin 33 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS33_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS33_SEL_LCD              ((uint32_t)0x00000002U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS34] Bits */
+#define LCD_LCDPCTL2_LCDS34_OFS                  (2)                             /* !< LCDS34 Offset */
+#define LCD_LCDPCTL2_LCDS34_MASK                 ((uint32_t)0x00000004U)         /* !< LCD pin 34 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS34_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS34_SEL_LCD              ((uint32_t)0x00000004U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS35] Bits */
+#define LCD_LCDPCTL2_LCDS35_OFS                  (3)                             /* !< LCDS35 Offset */
+#define LCD_LCDPCTL2_LCDS35_MASK                 ((uint32_t)0x00000008U)         /* !< LCD pin 35 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS35_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS35_SEL_LCD              ((uint32_t)0x00000008U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS36] Bits */
+#define LCD_LCDPCTL2_LCDS36_OFS                  (4)                             /* !< LCDS36 Offset */
+#define LCD_LCDPCTL2_LCDS36_MASK                 ((uint32_t)0x00000010U)         /* !< LCD pin 36 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS36_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS36_SEL_LCD              ((uint32_t)0x00000010U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS37] Bits */
+#define LCD_LCDPCTL2_LCDS37_OFS                  (5)                             /* !< LCDS37 Offset */
+#define LCD_LCDPCTL2_LCDS37_MASK                 ((uint32_t)0x00000020U)         /* !< LCD pin 37 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS37_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS37_SEL_LCD              ((uint32_t)0x00000020U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS38] Bits */
+#define LCD_LCDPCTL2_LCDS38_OFS                  (6)                             /* !< LCDS38 Offset */
+#define LCD_LCDPCTL2_LCDS38_MASK                 ((uint32_t)0x00000040U)         /* !< LCD pin 38 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS38_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS38_SEL_LCD              ((uint32_t)0x00000040U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS39] Bits */
+#define LCD_LCDPCTL2_LCDS39_OFS                  (7)                             /* !< LCDS39 Offset */
+#define LCD_LCDPCTL2_LCDS39_MASK                 ((uint32_t)0x00000080U)         /* !< LCD pin 39 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS39_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS39_SEL_LCD              ((uint32_t)0x00000080U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS40] Bits */
+#define LCD_LCDPCTL2_LCDS40_OFS                  (8)                             /* !< LCDS40 Offset */
+#define LCD_LCDPCTL2_LCDS40_MASK                 ((uint32_t)0x00000100U)         /* !< LCD pin 40 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS40_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS40_SEL_LCD              ((uint32_t)0x00000100U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS41] Bits */
+#define LCD_LCDPCTL2_LCDS41_OFS                  (9)                             /* !< LCDS41 Offset */
+#define LCD_LCDPCTL2_LCDS41_MASK                 ((uint32_t)0x00000200U)         /* !< LCD pin 41 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS41_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS41_SEL_LCD              ((uint32_t)0x00000200U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS42] Bits */
+#define LCD_LCDPCTL2_LCDS42_OFS                  (10)                            /* !< LCDS42 Offset */
+#define LCD_LCDPCTL2_LCDS42_MASK                 ((uint32_t)0x00000400U)         /* !< LCD pin 42 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS42_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS42_SEL_LCD              ((uint32_t)0x00000400U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS43] Bits */
+#define LCD_LCDPCTL2_LCDS43_OFS                  (11)                            /* !< LCDS43 Offset */
+#define LCD_LCDPCTL2_LCDS43_MASK                 ((uint32_t)0x00000800U)         /* !< LCD pin 43 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS43_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS43_SEL_LCD              ((uint32_t)0x00000800U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS44] Bits */
+#define LCD_LCDPCTL2_LCDS44_OFS                  (12)                            /* !< LCDS44 Offset */
+#define LCD_LCDPCTL2_LCDS44_MASK                 ((uint32_t)0x00001000U)         /* !< LCD pin 44 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS44_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS44_SEL_LCD              ((uint32_t)0x00001000U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS45] Bits */
+#define LCD_LCDPCTL2_LCDS45_OFS                  (13)                            /* !< LCDS45 Offset */
+#define LCD_LCDPCTL2_LCDS45_MASK                 ((uint32_t)0x00002000U)         /* !< LCD pin 45 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS45_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS45_SEL_LCD              ((uint32_t)0x00002000U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS46] Bits */
+#define LCD_LCDPCTL2_LCDS46_OFS                  (14)                            /* !< LCDS46 Offset */
+#define LCD_LCDPCTL2_LCDS46_MASK                 ((uint32_t)0x00004000U)         /* !< LCD pin 46 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS46_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS46_SEL_LCD              ((uint32_t)0x00004000U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL2[LCDS47] Bits */
+#define LCD_LCDPCTL2_LCDS47_OFS                  (15)                            /* !< LCDS47 Offset */
+#define LCD_LCDPCTL2_LCDS47_MASK                 ((uint32_t)0x00008000U)         /* !< LCD pin 47 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS47_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL2_LCDS47_SEL_LCD              ((uint32_t)0x00008000U)         /* !< Pins are LCD functions. */
+
+/* LCD_LCDPCTL3 Bits */
+/* LCD_LCDPCTL3[LCDS48] Bits */
+#define LCD_LCDPCTL3_LCDS48_OFS                  (0)                             /* !< LCDS48 Offset */
+#define LCD_LCDPCTL3_LCDS48_MASK                 ((uint32_t)0x00000001U)         /* !< LCD pin 48 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS48_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS48_SEL_LCD              ((uint32_t)0x00000001U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS49] Bits */
+#define LCD_LCDPCTL3_LCDS49_OFS                  (1)                             /* !< LCDS49 Offset */
+#define LCD_LCDPCTL3_LCDS49_MASK                 ((uint32_t)0x00000002U)         /* !< LCD pin 49 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS49_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS49_SEL_LCD              ((uint32_t)0x00000002U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS50] Bits */
+#define LCD_LCDPCTL3_LCDS50_OFS                  (2)                             /* !< LCDS50 Offset */
+#define LCD_LCDPCTL3_LCDS50_MASK                 ((uint32_t)0x00000004U)         /* !< LCD pin 50 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS50_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS50_SEL_LCD              ((uint32_t)0x00000004U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS51] Bits */
+#define LCD_LCDPCTL3_LCDS51_OFS                  (3)                             /* !< LCDS51 Offset */
+#define LCD_LCDPCTL3_LCDS51_MASK                 ((uint32_t)0x00000008U)         /* !< LCD pin 51 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS51_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS51_SEL_LCD              ((uint32_t)0x00000008U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS52] Bits */
+#define LCD_LCDPCTL3_LCDS52_OFS                  (4)                             /* !< LCDS52 Offset */
+#define LCD_LCDPCTL3_LCDS52_MASK                 ((uint32_t)0x00000010U)         /* !< LCD pin 52 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS52_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS52_SEL_LCD              ((uint32_t)0x00000010U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS53] Bits */
+#define LCD_LCDPCTL3_LCDS53_OFS                  (5)                             /* !< LCDS53 Offset */
+#define LCD_LCDPCTL3_LCDS53_MASK                 ((uint32_t)0x00000020U)         /* !< LCD pin 53 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS53_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS53_SEL_LCD              ((uint32_t)0x00000020U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS54] Bits */
+#define LCD_LCDPCTL3_LCDS54_OFS                  (6)                             /* !< LCDS54 Offset */
+#define LCD_LCDPCTL3_LCDS54_MASK                 ((uint32_t)0x00000040U)         /* !< LCD pin 54 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS54_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS54_SEL_LCD              ((uint32_t)0x00000040U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS55] Bits */
+#define LCD_LCDPCTL3_LCDS55_OFS                  (7)                             /* !< LCDS55 Offset */
+#define LCD_LCDPCTL3_LCDS55_MASK                 ((uint32_t)0x00000080U)         /* !< LCD pin 55 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS55_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS55_SEL_LCD              ((uint32_t)0x00000080U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS56] Bits */
+#define LCD_LCDPCTL3_LCDS56_OFS                  (8)                             /* !< LCDS56 Offset */
+#define LCD_LCDPCTL3_LCDS56_MASK                 ((uint32_t)0x00000100U)         /* !< LCD pin 56 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS56_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS56_SEL_LCD              ((uint32_t)0x00000100U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS57] Bits */
+#define LCD_LCDPCTL3_LCDS57_OFS                  (9)                             /* !< LCDS57 Offset */
+#define LCD_LCDPCTL3_LCDS57_MASK                 ((uint32_t)0x00000200U)         /* !< LCD pin 57 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS57_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS57_SEL_LCD              ((uint32_t)0x00000200U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS58] Bits */
+#define LCD_LCDPCTL3_LCDS58_OFS                  (10)                            /* !< LCDS58 Offset */
+#define LCD_LCDPCTL3_LCDS58_MASK                 ((uint32_t)0x00000400U)         /* !< LCD pin 58 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS58_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS58_SEL_LCD              ((uint32_t)0x00000400U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS59] Bits */
+#define LCD_LCDPCTL3_LCDS59_OFS                  (11)                            /* !< LCDS59 Offset */
+#define LCD_LCDPCTL3_LCDS59_MASK                 ((uint32_t)0x00000800U)         /* !< LCD pin 59 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS59_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS59_SEL_LCD              ((uint32_t)0x00000800U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS60] Bits */
+#define LCD_LCDPCTL3_LCDS60_OFS                  (12)                            /* !< LCDS60 Offset */
+#define LCD_LCDPCTL3_LCDS60_MASK                 ((uint32_t)0x00001000U)         /* !< LCD pin 60 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS60_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS60_SEL_LCD              ((uint32_t)0x00001000U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS61] Bits */
+#define LCD_LCDPCTL3_LCDS61_OFS                  (13)                            /* !< LCDS61 Offset */
+#define LCD_LCDPCTL3_LCDS61_MASK                 ((uint32_t)0x00002000U)         /* !< LCD pin 61 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS61_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS61_SEL_LCD              ((uint32_t)0x00002000U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS62] Bits */
+#define LCD_LCDPCTL3_LCDS62_OFS                  (14)                            /* !< LCDS62 Offset */
+#define LCD_LCDPCTL3_LCDS62_MASK                 ((uint32_t)0x00004000U)         /* !< LCD pin 62 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS62_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS62_SEL_LCD              ((uint32_t)0x00004000U)         /* !< Pins are LCD functions. */
+/* LCD_LCDPCTL3[LCDS63] Bits */
+#define LCD_LCDPCTL3_LCDS63_OFS                  (15)                            /* !< LCDS63 Offset */
+#define LCD_LCDPCTL3_LCDS63_MASK                 ((uint32_t)0x00008000U)         /* !< LCD pin 63 enable. This bit affects
+                                                                                    only pins with multiplexed functions.
+                                                                                    Dedicated LCD pins are always LCD
+                                                                                    function.  0b = Multiplexed pins are
+                                                                                    port functions.  1b = Pins are LCD
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS63_SEL_PORT             ((uint32_t)0x00000000U)         /* !< Multiplexed pins are port
+                                                                                    functions. */
+#define LCD_LCDPCTL3_LCDS63_SEL_LCD              ((uint32_t)0x00008000U)         /* !< Pins are LCD functions. */
+
+/* LCD_LCDCSSEL0 Bits */
+/* LCD_LCDCSSEL0[LCDCSS0] Bits */
+#define LCD_LCDCSSEL0_LCDCSS0_OFS                (0)                             /* !< LCDCSS0 Offset */
+#define LCD_LCDCSSEL0_LCDCSS0_MASK               ((uint32_t)0x00000001U)         /* !< Selects pin L0 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS0_SEL_SEG            ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS0_SEL_COM            ((uint32_t)0x00000001U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS1] Bits */
+#define LCD_LCDCSSEL0_LCDCSS1_OFS                (1)                             /* !< LCDCSS1 Offset */
+#define LCD_LCDCSSEL0_LCDCSS1_MASK               ((uint32_t)0x00000002U)         /* !< Selects pin L1 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS1_SEL_SEG            ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS1_SEL_COM            ((uint32_t)0x00000002U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS10] Bits */
+#define LCD_LCDCSSEL0_LCDCSS10_OFS               (10)                            /* !< LCDCSS10 Offset */
+#define LCD_LCDCSSEL0_LCDCSS10_MASK              ((uint32_t)0x00000400U)         /* !< Selects pin L10 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS10_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS10_SEL_COM           ((uint32_t)0x00000400U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS11] Bits */
+#define LCD_LCDCSSEL0_LCDCSS11_OFS               (11)                            /* !< LCDCSS11 Offset */
+#define LCD_LCDCSSEL0_LCDCSS11_MASK              ((uint32_t)0x00000800U)         /* !< Selects pin L11 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS11_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS11_SEL_COM           ((uint32_t)0x00000800U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS12] Bits */
+#define LCD_LCDCSSEL0_LCDCSS12_OFS               (12)                            /* !< LCDCSS12 Offset */
+#define LCD_LCDCSSEL0_LCDCSS12_MASK              ((uint32_t)0x00001000U)         /* !< Selects pin L12 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS12_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS12_SEL_COM           ((uint32_t)0x00001000U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS13] Bits */
+#define LCD_LCDCSSEL0_LCDCSS13_OFS               (13)                            /* !< LCDCSS13 Offset */
+#define LCD_LCDCSSEL0_LCDCSS13_MASK              ((uint32_t)0x00002000U)         /* !< Selects pin L13 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS13_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS13_SEL_COM           ((uint32_t)0x00002000U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS14] Bits */
+#define LCD_LCDCSSEL0_LCDCSS14_OFS               (14)                            /* !< LCDCSS14 Offset */
+#define LCD_LCDCSSEL0_LCDCSS14_MASK              ((uint32_t)0x00004000U)         /* !< Selects pin L14 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS14_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS14_SEL_COM           ((uint32_t)0x00004000U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS15] Bits */
+#define LCD_LCDCSSEL0_LCDCSS15_OFS               (15)                            /* !< LCDCSS15 Offset */
+#define LCD_LCDCSSEL0_LCDCSS15_MASK              ((uint32_t)0x00008000U)         /* !< Selects pin L15 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS15_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS15_SEL_COM           ((uint32_t)0x00008000U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS2] Bits */
+#define LCD_LCDCSSEL0_LCDCSS2_OFS                (2)                             /* !< LCDCSS2 Offset */
+#define LCD_LCDCSSEL0_LCDCSS2_MASK               ((uint32_t)0x00000004U)         /* !< Selects pin L2 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS2_SEL_SEG            ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS2_SEL_COM            ((uint32_t)0x00000004U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS3] Bits */
+#define LCD_LCDCSSEL0_LCDCSS3_OFS                (3)                             /* !< LCDCSS3 Offset */
+#define LCD_LCDCSSEL0_LCDCSS3_MASK               ((uint32_t)0x00000008U)         /* !< Selects pin L3 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS3_SEL_SEG            ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS3_SEL_COM            ((uint32_t)0x00000008U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS4] Bits */
+#define LCD_LCDCSSEL0_LCDCSS4_OFS                (4)                             /* !< LCDCSS4 Offset */
+#define LCD_LCDCSSEL0_LCDCSS4_MASK               ((uint32_t)0x00000010U)         /* !< Selects pin L4 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS4_SEL_SEG            ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS4_SEL_COM            ((uint32_t)0x00000010U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS5] Bits */
+#define LCD_LCDCSSEL0_LCDCSS5_OFS                (5)                             /* !< LCDCSS5 Offset */
+#define LCD_LCDCSSEL0_LCDCSS5_MASK               ((uint32_t)0x00000020U)         /* !< Selects pin L5 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS5_SEL_SEG            ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS5_SEL_COM            ((uint32_t)0x00000020U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS6] Bits */
+#define LCD_LCDCSSEL0_LCDCSS6_OFS                (6)                             /* !< LCDCSS6 Offset */
+#define LCD_LCDCSSEL0_LCDCSS6_MASK               ((uint32_t)0x00000040U)         /* !< Selects pin L6 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS6_SEL_SEG            ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS6_SEL_COM            ((uint32_t)0x00000040U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS7] Bits */
+#define LCD_LCDCSSEL0_LCDCSS7_OFS                (7)                             /* !< LCDCSS7 Offset */
+#define LCD_LCDCSSEL0_LCDCSS7_MASK               ((uint32_t)0x00000080U)         /* !< Selects pin L7 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS7_SEL_SEG            ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS7_SEL_COM            ((uint32_t)0x00000080U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS8] Bits */
+#define LCD_LCDCSSEL0_LCDCSS8_OFS                (8)                             /* !< LCDCSS8 Offset */
+#define LCD_LCDCSSEL0_LCDCSS8_MASK               ((uint32_t)0x00000100U)         /* !< Selects pin L8 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS8_SEL_SEG            ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS8_SEL_COM            ((uint32_t)0x00000100U)         /* !< Common line */
+/* LCD_LCDCSSEL0[LCDCSS9] Bits */
+#define LCD_LCDCSSEL0_LCDCSS9_OFS                (9)                             /* !< LCDCSS9 Offset */
+#define LCD_LCDCSSEL0_LCDCSS9_MASK               ((uint32_t)0x00000200U)         /* !< Selects pin L9 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL0_LCDCSS9_SEL_SEG            ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL0_LCDCSS9_SEL_COM            ((uint32_t)0x00000200U)         /* !< Common line */
+
+/* LCD_LCDCSSEL1 Bits */
+/* LCD_LCDCSSEL1[LCDCSS16] Bits */
+#define LCD_LCDCSSEL1_LCDCSS16_OFS               (0)                             /* !< LCDCSS16 Offset */
+#define LCD_LCDCSSEL1_LCDCSS16_MASK              ((uint32_t)0x00000001U)         /* !< Selects pin L16 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS16_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS16_SEL_COM           ((uint32_t)0x00000001U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS17] Bits */
+#define LCD_LCDCSSEL1_LCDCSS17_OFS               (1)                             /* !< LCDCSS17 Offset */
+#define LCD_LCDCSSEL1_LCDCSS17_MASK              ((uint32_t)0x00000002U)         /* !< Selects pin L17 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS17_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS17_SEL_COM           ((uint32_t)0x00000002U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS18] Bits */
+#define LCD_LCDCSSEL1_LCDCSS18_OFS               (2)                             /* !< LCDCSS18 Offset */
+#define LCD_LCDCSSEL1_LCDCSS18_MASK              ((uint32_t)0x00000004U)         /* !< Selects pin L18 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS18_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS18_SEL_COM           ((uint32_t)0x00000004U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS19] Bits */
+#define LCD_LCDCSSEL1_LCDCSS19_OFS               (3)                             /* !< LCDCSS19 Offset */
+#define LCD_LCDCSSEL1_LCDCSS19_MASK              ((uint32_t)0x00000008U)         /* !< Selects pin L19 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS19_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS19_SEL_COM           ((uint32_t)0x00000008U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS20] Bits */
+#define LCD_LCDCSSEL1_LCDCSS20_OFS               (4)                             /* !< LCDCSS20 Offset */
+#define LCD_LCDCSSEL1_LCDCSS20_MASK              ((uint32_t)0x00000010U)         /* !< Selects pin L20 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS20_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS20_SEL_COM           ((uint32_t)0x00000010U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS21] Bits */
+#define LCD_LCDCSSEL1_LCDCSS21_OFS               (5)                             /* !< LCDCSS21 Offset */
+#define LCD_LCDCSSEL1_LCDCSS21_MASK              ((uint32_t)0x00000020U)         /* !< Selects pin L21 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS21_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS21_SEL_COM           ((uint32_t)0x00000020U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS22] Bits */
+#define LCD_LCDCSSEL1_LCDCSS22_OFS               (6)                             /* !< LCDCSS22 Offset */
+#define LCD_LCDCSSEL1_LCDCSS22_MASK              ((uint32_t)0x00000040U)         /* !< Selects pin L22 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS22_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS22_SEL_COM           ((uint32_t)0x00000040U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS23] Bits */
+#define LCD_LCDCSSEL1_LCDCSS23_OFS               (7)                             /* !< LCDCSS23 Offset */
+#define LCD_LCDCSSEL1_LCDCSS23_MASK              ((uint32_t)0x00000080U)         /* !< Selects pin L23 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS23_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS23_SEL_COM           ((uint32_t)0x00000080U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS24] Bits */
+#define LCD_LCDCSSEL1_LCDCSS24_OFS               (8)                             /* !< LCDCSS24 Offset */
+#define LCD_LCDCSSEL1_LCDCSS24_MASK              ((uint32_t)0x00000100U)         /* !< Selects pin L24 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS24_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS24_SEL_COM           ((uint32_t)0x00000100U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS25] Bits */
+#define LCD_LCDCSSEL1_LCDCSS25_OFS               (9)                             /* !< LCDCSS25 Offset */
+#define LCD_LCDCSSEL1_LCDCSS25_MASK              ((uint32_t)0x00000200U)         /* !< Selects pin L25 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS25_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS25_SEL_COM           ((uint32_t)0x00000200U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS26] Bits */
+#define LCD_LCDCSSEL1_LCDCSS26_OFS               (10)                            /* !< LCDCSS26 Offset */
+#define LCD_LCDCSSEL1_LCDCSS26_MASK              ((uint32_t)0x00000400U)         /* !< Selects pin L26 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS26_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS26_SEL_COM           ((uint32_t)0x00000400U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS27] Bits */
+#define LCD_LCDCSSEL1_LCDCSS27_OFS               (11)                            /* !< LCDCSS27 Offset */
+#define LCD_LCDCSSEL1_LCDCSS27_MASK              ((uint32_t)0x00000800U)         /* !< Selects pin L27 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS27_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS27_SEL_COM           ((uint32_t)0x00000800U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS28] Bits */
+#define LCD_LCDCSSEL1_LCDCSS28_OFS               (12)                            /* !< LCDCSS28 Offset */
+#define LCD_LCDCSSEL1_LCDCSS28_MASK              ((uint32_t)0x00001000U)         /* !< Selects pin L28 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS28_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS28_SEL_COM           ((uint32_t)0x00001000U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS29] Bits */
+#define LCD_LCDCSSEL1_LCDCSS29_OFS               (13)                            /* !< LCDCSS29 Offset */
+#define LCD_LCDCSSEL1_LCDCSS29_MASK              ((uint32_t)0x00002000U)         /* !< Selects pin L29 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS29_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS29_SEL_COM           ((uint32_t)0x00002000U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS30] Bits */
+#define LCD_LCDCSSEL1_LCDCSS30_OFS               (14)                            /* !< LCDCSS30 Offset */
+#define LCD_LCDCSSEL1_LCDCSS30_MASK              ((uint32_t)0x00004000U)         /* !< Selects pin L30 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS30_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS30_SEL_COM           ((uint32_t)0x00004000U)         /* !< Common line */
+/* LCD_LCDCSSEL1[LCDCSS31] Bits */
+#define LCD_LCDCSSEL1_LCDCSS31_OFS               (15)                            /* !< LCDCSS31 Offset */
+#define LCD_LCDCSSEL1_LCDCSS31_MASK              ((uint32_t)0x00008000U)         /* !< Selects pin L31 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL1_LCDCSS31_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL1_LCDCSS31_SEL_COM           ((uint32_t)0x00008000U)         /* !< Common line */
+
+/* LCD_LCDCSSEL2 Bits */
+/* LCD_LCDCSSEL2[LCDCSS32] Bits */
+#define LCD_LCDCSSEL2_LCDCSS32_OFS               (0)                             /* !< LCDCSS32 Offset */
+#define LCD_LCDCSSEL2_LCDCSS32_MASK              ((uint32_t)0x00000001U)         /* !< Selects pin L32 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS32_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS32_SEL_COM           ((uint32_t)0x00000001U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS33] Bits */
+#define LCD_LCDCSSEL2_LCDCSS33_OFS               (1)                             /* !< LCDCSS33 Offset */
+#define LCD_LCDCSSEL2_LCDCSS33_MASK              ((uint32_t)0x00000002U)         /* !< Selects pin L33 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS33_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS33_SEL_COM           ((uint32_t)0x00000002U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS34] Bits */
+#define LCD_LCDCSSEL2_LCDCSS34_OFS               (2)                             /* !< LCDCSS34 Offset */
+#define LCD_LCDCSSEL2_LCDCSS34_MASK              ((uint32_t)0x00000004U)         /* !< Selects pin L34 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS34_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS34_SEL_COM           ((uint32_t)0x00000004U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS35] Bits */
+#define LCD_LCDCSSEL2_LCDCSS35_OFS               (3)                             /* !< LCDCSS35 Offset */
+#define LCD_LCDCSSEL2_LCDCSS35_MASK              ((uint32_t)0x00000008U)         /* !< Selects pin L35 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS35_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS35_SEL_COM           ((uint32_t)0x00000008U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS36] Bits */
+#define LCD_LCDCSSEL2_LCDCSS36_OFS               (4)                             /* !< LCDCSS36 Offset */
+#define LCD_LCDCSSEL2_LCDCSS36_MASK              ((uint32_t)0x00000010U)         /* !< Selects pin L36 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS36_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS36_SEL_COM           ((uint32_t)0x00000010U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS37] Bits */
+#define LCD_LCDCSSEL2_LCDCSS37_OFS               (5)                             /* !< LCDCSS37 Offset */
+#define LCD_LCDCSSEL2_LCDCSS37_MASK              ((uint32_t)0x00000020U)         /* !< Selects pin L37 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS37_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS37_SEL_COM           ((uint32_t)0x00000020U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS38] Bits */
+#define LCD_LCDCSSEL2_LCDCSS38_OFS               (6)                             /* !< LCDCSS38 Offset */
+#define LCD_LCDCSSEL2_LCDCSS38_MASK              ((uint32_t)0x00000040U)         /* !< Selects pin L38 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS38_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS38_SEL_COM           ((uint32_t)0x00000040U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS39] Bits */
+#define LCD_LCDCSSEL2_LCDCSS39_OFS               (7)                             /* !< LCDCSS39 Offset */
+#define LCD_LCDCSSEL2_LCDCSS39_MASK              ((uint32_t)0x00000080U)         /* !< Selects pin L39 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS39_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS39_SEL_COM           ((uint32_t)0x00000080U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS40] Bits */
+#define LCD_LCDCSSEL2_LCDCSS40_OFS               (8)                             /* !< LCDCSS40 Offset */
+#define LCD_LCDCSSEL2_LCDCSS40_MASK              ((uint32_t)0x00000100U)         /* !< Selects pin L40 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS40_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS40_SEL_COM           ((uint32_t)0x00000100U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS41] Bits */
+#define LCD_LCDCSSEL2_LCDCSS41_OFS               (9)                             /* !< LCDCSS41 Offset */
+#define LCD_LCDCSSEL2_LCDCSS41_MASK              ((uint32_t)0x00000200U)         /* !< Selects pin L41 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS41_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS41_SEL_COM           ((uint32_t)0x00000200U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS42] Bits */
+#define LCD_LCDCSSEL2_LCDCSS42_OFS               (10)                            /* !< LCDCSS42 Offset */
+#define LCD_LCDCSSEL2_LCDCSS42_MASK              ((uint32_t)0x00000400U)         /* !< Selects pin L42 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS42_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS42_SEL_COM           ((uint32_t)0x00000400U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS43] Bits */
+#define LCD_LCDCSSEL2_LCDCSS43_OFS               (11)                            /* !< LCDCSS43 Offset */
+#define LCD_LCDCSSEL2_LCDCSS43_MASK              ((uint32_t)0x00000800U)         /* !< Selects pin L43 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS43_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS43_SEL_COM           ((uint32_t)0x00000800U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS44] Bits */
+#define LCD_LCDCSSEL2_LCDCSS44_OFS               (12)                            /* !< LCDCSS44 Offset */
+#define LCD_LCDCSSEL2_LCDCSS44_MASK              ((uint32_t)0x00001000U)         /* !< Selects pin L44 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS44_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS44_SEL_COM           ((uint32_t)0x00001000U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS45] Bits */
+#define LCD_LCDCSSEL2_LCDCSS45_OFS               (13)                            /* !< LCDCSS45 Offset */
+#define LCD_LCDCSSEL2_LCDCSS45_MASK              ((uint32_t)0x00002000U)         /* !< Selects pin L45 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS45_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS45_SEL_COM           ((uint32_t)0x00002000U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS46] Bits */
+#define LCD_LCDCSSEL2_LCDCSS46_OFS               (14)                            /* !< LCDCSS46 Offset */
+#define LCD_LCDCSSEL2_LCDCSS46_MASK              ((uint32_t)0x00004000U)         /* !< Selects pin L46 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS46_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS46_SEL_COM           ((uint32_t)0x00004000U)         /* !< Common line */
+/* LCD_LCDCSSEL2[LCDCSS47] Bits */
+#define LCD_LCDCSSEL2_LCDCSS47_OFS               (15)                            /* !< LCDCSS47 Offset */
+#define LCD_LCDCSSEL2_LCDCSS47_MASK              ((uint32_t)0x00008000U)         /* !< Selects pin L47 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL2_LCDCSS47_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL2_LCDCSS47_SEL_COM           ((uint32_t)0x00008000U)         /* !< Common line */
+
+/* LCD_LCDCSSEL3 Bits */
+/* LCD_LCDCSSEL3[LCDCSS48] Bits */
+#define LCD_LCDCSSEL3_LCDCSS48_OFS               (0)                             /* !< LCDCSS48 Offset */
+#define LCD_LCDCSSEL3_LCDCSS48_MASK              ((uint32_t)0x00000001U)         /* !< Selects pin L48 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS48_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS48_SEL_COM           ((uint32_t)0x00000001U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS49] Bits */
+#define LCD_LCDCSSEL3_LCDCSS49_OFS               (1)                             /* !< LCDCSS49 Offset */
+#define LCD_LCDCSSEL3_LCDCSS49_MASK              ((uint32_t)0x00000002U)         /* !< Selects pin L49 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS49_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS49_SEL_COM           ((uint32_t)0x00000002U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS50] Bits */
+#define LCD_LCDCSSEL3_LCDCSS50_OFS               (2)                             /* !< LCDCSS50 Offset */
+#define LCD_LCDCSSEL3_LCDCSS50_MASK              ((uint32_t)0x00000004U)         /* !< Selects pin L50 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS50_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS50_SEL_COM           ((uint32_t)0x00000004U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS51] Bits */
+#define LCD_LCDCSSEL3_LCDCSS51_OFS               (3)                             /* !< LCDCSS51 Offset */
+#define LCD_LCDCSSEL3_LCDCSS51_MASK              ((uint32_t)0x00000008U)         /* !< Selects pin L51 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS51_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS51_SEL_COM           ((uint32_t)0x00000008U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS52] Bits */
+#define LCD_LCDCSSEL3_LCDCSS52_OFS               (4)                             /* !< LCDCSS52 Offset */
+#define LCD_LCDCSSEL3_LCDCSS52_MASK              ((uint32_t)0x00000010U)         /* !< Selects pin L52 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS52_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS52_SEL_COM           ((uint32_t)0x00000010U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS53] Bits */
+#define LCD_LCDCSSEL3_LCDCSS53_OFS               (5)                             /* !< LCDCSS53 Offset */
+#define LCD_LCDCSSEL3_LCDCSS53_MASK              ((uint32_t)0x00000020U)         /* !< Selects pin L53 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS53_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS53_SEL_COM           ((uint32_t)0x00000020U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS54] Bits */
+#define LCD_LCDCSSEL3_LCDCSS54_OFS               (6)                             /* !< LCDCSS54 Offset */
+#define LCD_LCDCSSEL3_LCDCSS54_MASK              ((uint32_t)0x00000040U)         /* !< Selects pin L54 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS54_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS54_SEL_COM           ((uint32_t)0x00000040U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS55] Bits */
+#define LCD_LCDCSSEL3_LCDCSS55_OFS               (7)                             /* !< LCDCSS55 Offset */
+#define LCD_LCDCSSEL3_LCDCSS55_MASK              ((uint32_t)0x00000080U)         /* !< Selects pin L55 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS55_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS55_SEL_COM           ((uint32_t)0x00000080U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS56] Bits */
+#define LCD_LCDCSSEL3_LCDCSS56_OFS               (8)                             /* !< LCDCSS56 Offset */
+#define LCD_LCDCSSEL3_LCDCSS56_MASK              ((uint32_t)0x00000100U)         /* !< Selects pin L56 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS56_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS56_SEL_COM           ((uint32_t)0x00000100U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS57] Bits */
+#define LCD_LCDCSSEL3_LCDCSS57_OFS               (9)                             /* !< LCDCSS57 Offset */
+#define LCD_LCDCSSEL3_LCDCSS57_MASK              ((uint32_t)0x00000200U)         /* !< Selects pin L57 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS57_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS57_SEL_COM           ((uint32_t)0x00000200U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS58] Bits */
+#define LCD_LCDCSSEL3_LCDCSS58_OFS               (10)                            /* !< LCDCSS58 Offset */
+#define LCD_LCDCSSEL3_LCDCSS58_MASK              ((uint32_t)0x00000400U)         /* !< Selects pin L58 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS58_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS58_SEL_COM           ((uint32_t)0x00000400U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS59] Bits */
+#define LCD_LCDCSSEL3_LCDCSS59_OFS               (11)                            /* !< LCDCSS59 Offset */
+#define LCD_LCDCSSEL3_LCDCSS59_MASK              ((uint32_t)0x00000800U)         /* !< Selects pin L59 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS59_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS59_SEL_COM           ((uint32_t)0x00000800U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS60] Bits */
+#define LCD_LCDCSSEL3_LCDCSS60_OFS               (12)                            /* !< LCDCSS60 Offset */
+#define LCD_LCDCSSEL3_LCDCSS60_MASK              ((uint32_t)0x00001000U)         /* !< Selects pin L60 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS60_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS60_SEL_COM           ((uint32_t)0x00001000U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS61] Bits */
+#define LCD_LCDCSSEL3_LCDCSS61_OFS               (13)                            /* !< LCDCSS61 Offset */
+#define LCD_LCDCSSEL3_LCDCSS61_MASK              ((uint32_t)0x00002000U)         /* !< Selects pin L61 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS61_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS61_SEL_COM           ((uint32_t)0x00002000U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS62] Bits */
+#define LCD_LCDCSSEL3_LCDCSS62_OFS               (14)                            /* !< LCDCSS62 Offset */
+#define LCD_LCDCSSEL3_LCDCSS62_MASK              ((uint32_t)0x00004000U)         /* !< Selects pin L62 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS62_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS62_SEL_COM           ((uint32_t)0x00004000U)         /* !< Common line */
+/* LCD_LCDCSSEL3[LCDCSS63] Bits */
+#define LCD_LCDCSSEL3_LCDCSS63_OFS               (15)                            /* !< LCDCSS63 Offset */
+#define LCD_LCDCSSEL3_LCDCSS63_MASK              ((uint32_t)0x00008000U)         /* !< Selects pin L63 as either common or
+                                                                                    segment line.  0b = Segment line 1b =
+                                                                                    Common line */
+#define LCD_LCDCSSEL3_LCDCSS63_SEL_SEG           ((uint32_t)0x00000000U)         /* !< Segment line */
+#define LCD_LCDCSSEL3_LCDCSS63_SEL_COM           ((uint32_t)0x00008000U)         /* !< Common line */
+
+/* LCD_LCDM Bits */
+/* LCD_LCDM[MBIT0] Bits */
+#define LCD_LCDM_MBIT0_OFS                       (0)                             /* !< MBIT0 Offset */
+#define LCD_LCDM_MBIT0_MASK                      ((uint8_t)0x00000001U)          /* !< If LCD L[2*index] is selected as
+                                                                                    segment line (LCDCSS[2*index] = 0b)
+                                                                                    and LCD mux rate is static, 2-, 3- or
+                                                                                    4-mux (000b <= LCDMXx <= 011b) 0b =
+                                                                                    LCD segment off 1b = LCD segment on
+                                                                                    If LCD pin L[2*index] is selected as
+                                                                                    common line (LCDCSS[2*index] = 1b):
+                                                                                    0b = Pin L[2*index] not used as COM0
+                                                                                    1b = Pin L[2*index] is used as COM0
+                                                                                    If LCD pin L(index) is selected as
+                                                                                    segment line (LCDCSS(index) = 0b) and
+                                                                                    LCD mux rate is 5-, 6-, 7- or 8-mux
+                                                                                    (LCDMXx >= 100b): 0b = LCD segment
+                                                                                    off 1b = LCD segment on If LCD pin
+                                                                                    L(index) is selected as common line
+                                                                                    (LCDCSS(index) = 1b): 0b = Pin
+                                                                                    L(index) not used as COM0 1b = Pin
+                                                                                    L(index) is used as COM0 */
+#define LCD_LCDM_MBIT0_OFF                       ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDM_MBIT0_ON                        ((uint8_t)0x00000001U)          /* !< LCD segment/common on */
+/* LCD_LCDM[MBIT1] Bits */
+#define LCD_LCDM_MBIT1_OFS                       (1)                             /* !< MBIT1 Offset */
+#define LCD_LCDM_MBIT1_MASK                      ((uint8_t)0x00000002U)          /* !< If LCD pin L[2*index] is selected
+                                                                                    as segment line (LCDCSS[2*index] =
+                                                                                    0b) and LCD mux rate is 2-, 3- or
+                                                                                    4-mux (001b <= LCDMXx <= 011b): 0b =
+                                                                                    LCD segment off 1b = LCD segment on
+                                                                                    If LCD pin L[2*index] is selected as
+                                                                                    common line (LCDCSS[2*index] = 1b):
+                                                                                    0b = Pin L[2*index] not used as COM1
+                                                                                    1b = Pin L[2*index] is used as COM1
+                                                                                    If LCD pin L(index) is selected as
+                                                                                    segment line (LCDCSS(index) = 0b) and
+                                                                                    LCD mux rate is 5-, 6-, 7- or 8-mux
+                                                                                    (LCDMXx >= 100b): 0b = LCD segment
+                                                                                    off 1b = LCD segment on If LCD pin
+                                                                                    L(index) is selected as common line
+                                                                                    (LCDCSS(index) = 1b): 0b = Pin
+                                                                                    L(index) not used as COM1 1b = Pin
+                                                                                    L(index) is used as COM1 */
+#define LCD_LCDM_MBIT1_OFF                       ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDM_MBIT1_ON                        ((uint8_t)0x00000002U)          /* !< LCD segment/common on */
+/* LCD_LCDM[MBIT2] Bits */
+#define LCD_LCDM_MBIT2_OFS                       (2)                             /* !< MBIT2 Offset */
+#define LCD_LCDM_MBIT2_MASK                      ((uint8_t)0x00000004U)          /* !< If LCD pin L[2*index] is selected
+                                                                                    as segment line (LCDCSS[2*index] =
+                                                                                    0b) and LCD mux rate is 3- or 4-mux
+                                                                                    (010b <= LCDMXx <= 011b): 0b = LCD
+                                                                                    segment off 1b = LCD segment on If
+                                                                                    LCD pin L[2*index] is selected as
+                                                                                    common line (LCDCSS[2*index] = 1b):
+                                                                                    0b = Pin L[2*index] not used as COM2
+                                                                                    1b = Pin L[2*index] is used as COM2
+                                                                                    If LCD pin L(index) is selected as
+                                                                                    segment line (LCDCSS(index) = 0b) and
+                                                                                    LCD mux rate is 5-, 6-, 7- or 8-mux
+                                                                                    (LCDMXx >= 100b): 0b = LCD segment
+                                                                                    off 1b = LCD segment on If LCD pin
+                                                                                    L(index) is selected as common line
+                                                                                    (LCDCSS(index) = 1b): 0b = Pin
+                                                                                    L[index-1] not used as COM2 1b = Pin
+                                                                                    L[index-1] is used as COM2 */
+#define LCD_LCDM_MBIT2_OFF                       ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDM_MBIT2_ON                        ((uint8_t)0x00000004U)          /* !< LCD segment/common on */
+/* LCD_LCDM[MBIT3] Bits */
+#define LCD_LCDM_MBIT3_OFS                       (3)                             /* !< MBIT3 Offset */
+#define LCD_LCDM_MBIT3_MASK                      ((uint8_t)0x00000008U)          /* !< If LCD pin L(index) is selected as
+                                                                                    segment line (LCDCSS(index) = 0b) and
+                                                                                    LCD mux rate is 4-mux (LCDMXx=011b):
+                                                                                    0b = LCD segment off 1b = LCD segment
+                                                                                    on If LCD pin L[2*index] is selected
+                                                                                    as common line (LCDCSS[2*index] =
+                                                                                    1b): 0b = Pin L[2*index] not used as
+                                                                                    COM3 1b = Pin L[2*index] is used as
+                                                                                    COM3 If LCD pin L(index) is selected
+                                                                                    as segment line (LCDCSS(index) = 0b)
+                                                                                    and LCD mux rate is 5-, 6-, 7- or
+                                                                                    8-mux (LCDMXx >= 100b): 0b = LCD
+                                                                                    segment off 1b = LCD segment on If
+                                                                                    LCD pin L(index) is selected as
+                                                                                    common line (LCDCSS(index) = 1b): 0b
+                                                                                    = Pin L(index) not used as COM3 1b =
+                                                                                    Pin L(index) is used as COM3 */
+#define LCD_LCDM_MBIT3_OFF                       ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDM_MBIT3_ON                        ((uint8_t)0x00000008U)          /* !< LCD segment/common on */
+/* LCD_LCDM[MBIT4] Bits */
+#define LCD_LCDM_MBIT4_OFS                       (4)                             /* !< MBIT4 Offset */
+#define LCD_LCDM_MBIT4_MASK                      ((uint8_t)0x00000010U)          /* !< If LCD pin L[2*index+1] is selected
+                                                                                    as segment line (LCDCSS[2*index+1] =
+                                                                                    0b) and LCD mux rate is static, 2-,
+                                                                                    3- or 4-mux (000 <= LCDMXx <= 011b)
+                                                                                    0b = LCD segment off 1b = LCD segment
+                                                                                    on If LCD pin L[2*index+1] is
+                                                                                    selected as common line
+                                                                                    (LCDCSS[2*index+1] = 1b): 0b = Pin
+                                                                                    L[2*ndex+1] not used as COM0 1b = Pin
+                                                                                    L[2*ndex+1] is used as COM0 */
+#define LCD_LCDM_MBIT4_OFF                       ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDM_MBIT4_ON                        ((uint8_t)0x00000010U)          /* !< LCD segment/common on */
+/* LCD_LCDM[MBIT5] Bits */
+#define LCD_LCDM_MBIT5_OFS                       (5)                             /* !< MBIT5 Offset */
+#define LCD_LCDM_MBIT5_MASK                      ((uint8_t)0x00000020U)          /* !< If LCD pin L[2*index+1] is selected
+                                                                                    as segment line (LCDCSS[2*index+1] =
+                                                                                    0b) and LCD mux rate is 2-, 3- or
+                                                                                    4-mux (001b <= LCDMXx <= 011b): 0b =
+                                                                                    LCD segment off 1b = LCD segment on
+                                                                                    If LCD pin L[2*index+1] is selected
+                                                                                    as common line (LCDCSS[2*index+1] =
+                                                                                    1b): 0b = Pin L[2*index+1] not used
+                                                                                    as COM1 1b = Pin L[2*index+1] is used
+                                                                                    as COM1 If LCD pin L(index) is
+                                                                                    selected as segment line
+                                                                                    (LCDCSS(index) = 0b) and LCD mux rate
+                                                                                    is 6-, 7- or 8-mux (LCDMXx >= 101b):
+                                                                                    0b = LCD segment off 1b = LCD segment
+                                                                                    on If LCD pin L(index) is selected as
+                                                                                    common line (LCDCSS(index) = 1b): 0b
+                                                                                    = Pin L(index) not used as COM5 1b =
+                                                                                    Pin L(index) is used as COM5 */
+#define LCD_LCDM_MBIT5_OFF                       ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDM_MBIT5_ON                        ((uint8_t)0x00000020U)          /* !< LCD segment/common on */
+/* LCD_LCDM[MBIT6] Bits */
+#define LCD_LCDM_MBIT6_OFS                       (6)                             /* !< MBIT6 Offset */
+#define LCD_LCDM_MBIT6_MASK                      ((uint8_t)0x00000040U)          /* !< If LCD pin L[2*index+1] is selected
+                                                                                    as segment line (LCDCSS[2*index+1] =
+                                                                                    0b) and LCD mux rate is 3- or 4-mux
+                                                                                    (010b <= LCDMXx <= 011b): 0b = LCD
+                                                                                    segment off 1b = LCD segment on If
+                                                                                    LCD pin L[2*index+1] is selected as
+                                                                                    common line (LCDCSS[2*index+1] = 1b):
+                                                                                    0b = Pin L[2*index+1] not used as
+                                                                                    COM2 1b = Pin L[2*index+1] is used as
+                                                                                    COM2 If LCD pin L(index) is selected
+                                                                                    as segment line (LCDCSS(index) = 0b)
+                                                                                    and LCD mux rate is 7- or 8-mux
+                                                                                    (LCDMXx >= 110b): 0b = LCD segment
+                                                                                    off 1b = LCD segment on If LCD pin
+                                                                                    L(index) is selected as common line
+                                                                                    (LCDCSS(index) = 1b): 0b = Pin
+                                                                                    L(index) not used as COM6 1b = Pin
+                                                                                    L(index) is used as COM6 */
+/* LCD_LCDM[MBIT7] Bits */
+#define LCD_LCDM_MBIT7_OFS                       (7)                             /* !< MBIT7 Offset */
+#define LCD_LCDM_MBIT7_MASK                      ((uint8_t)0x00000080U)          /* !< If LCD pin L[2*index+1] is selected
+                                                                                    as segment line (LCDCSS[2*index+1] =
+                                                                                    0b) and LCD mux rate is 4-mux
+                                                                                    (LCDMXx=011b): 0b = LCD segment off
+                                                                                    1b = LCD segment on If LCD pin
+                                                                                    L[2*index+1] is selected as common
+                                                                                    line (LCDCSS[2*index+1] = 1b): 0b =
+                                                                                    Pin L[2*index+1] not used as COM3 1b
+                                                                                    = Pin L[2*index+1] is used as COM3 If
+                                                                                    LCD pin L(index) is selected as
+                                                                                    segment line (LCDCSS(index) = 0b) and
+                                                                                    LCD mux rate is 8-mux (LCDMXx =
+                                                                                    111b): 0b = LCD segment off 1b = LCD
+                                                                                    segment on If LCD pin L(index) is
+                                                                                    selected as common line
+                                                                                    (LCDCSS(index) = 1b): 0b = Pin
+                                                                                    L(index) not used as COM7 1b = Pin
+                                                                                    L(index) is used as COM7 */
+#define LCD_LCDM_MBIT7_OFF                       ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDM_MBIT7_ON                        ((uint8_t)0x00000080U)          /* !< LCD segment/common on */
+
+/* LCD_LCDBM Bits */
+/* LCD_LCDBM[MBIT0] Bits */
+#define LCD_LCDBM_MBIT0_OFS                      (0)                             /* !< MBIT0 Offset */
+#define LCD_LCDBM_MBIT0_MASK                     ((uint8_t)0x00000001U)          /* !< If LCD L[2*index] is selected as
+                                                                                    segment line (LCDCSS[2*index] = 0b)
+                                                                                    and LCD mux rate is static, 2-, 3- or
+                                                                                    4-mux (000b <= LCDMXx <= 011b) 0b =
+                                                                                    LCD segment off 1b = LCD segment on
+                                                                                    If LCD pin L[2*index] is selected as
+                                                                                    common line (LCDCSS[2*index] = 1b):
+                                                                                    0b = Pin L[2*index] not used as COM0
+                                                                                    1b = Pin L[2*index] is used as COM0
+                                                                                    If LCD pin L(index) is selected as
+                                                                                    segment line (LCDCSS(index) = 0b) and
+                                                                                    LCD mux rate is 5-, 6-, 7- or 8-mux
+                                                                                    (LCDMXx >= 100b): 0b = LCD segment
+                                                                                    off 1b = LCD segment on If LCD pin
+                                                                                    L(index) is selected as common line
+                                                                                    (LCDCSS(index) = 1b): 0b = Pin
+                                                                                    L(index) not used as COM0 1b = Pin
+                                                                                    L(index) is used as COM0 */
+#define LCD_LCDBM_MBIT0_OFF                      ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDBM_MBIT0_ON                       ((uint8_t)0x00000001U)          /* !< LCD segment/common on */
+/* LCD_LCDBM[MBIT1] Bits */
+#define LCD_LCDBM_MBIT1_OFS                      (1)                             /* !< MBIT1 Offset */
+#define LCD_LCDBM_MBIT1_MASK                     ((uint8_t)0x00000002U)          /* !< If LCD pin L[2*index] is selected
+                                                                                    as segment line (LCDCSS[2*index] =
+                                                                                    0b) and LCD mux rate is 2-, 3- or
+                                                                                    4-mux (001b <= LCDMXx <= 011b): 0b =
+                                                                                    LCD segment off 1b = LCD segment on
+                                                                                    If LCD pin L[2*index] is selected as
+                                                                                    common line (LCDCSS[2*index] = 1b):
+                                                                                    0b = Pin L[2*index] not used as COM1
+                                                                                    1b = Pin L[2*index] is used as COM1
+                                                                                    If LCD pin L(index) is selected as
+                                                                                    segment line (LCDCSS(index) = 0b) and
+                                                                                    LCD mux rate is 5-, 6-, 7- or 8-mux
+                                                                                    (LCDMXx >= 100b): 0b = LCD segment
+                                                                                    off 1b = LCD segment on If LCD pin
+                                                                                    L(index) is selected as common line
+                                                                                    (LCDCSS(index) = 1b): 0b = Pin
+                                                                                    L(index) not used as COM1 1b = Pin
+                                                                                    L(index) is used as COM1 */
+#define LCD_LCDBM_MBIT1_OFF                      ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDBM_MBIT1_ON                       ((uint8_t)0x00000002U)          /* !< LCD segment/common on */
+/* LCD_LCDBM[MBIT2] Bits */
+#define LCD_LCDBM_MBIT2_OFS                      (2)                             /* !< MBIT2 Offset */
+#define LCD_LCDBM_MBIT2_MASK                     ((uint8_t)0x00000004U)          /* !< If LCD pin L[2*index] is selected
+                                                                                    as segment line (LCDCSS[2*index] =
+                                                                                    0b) and LCD mux rate is 3- or 4-mux
+                                                                                    (010b <= LCDMXx <= 011b): 0b = LCD
+                                                                                    segment off 1b = LCD segment on If
+                                                                                    LCD pin L[2*index] is selected as
+                                                                                    common line (LCDCSS[2*index] = 1b):
+                                                                                    0b = Pin L[2*index] not used as COM2
+                                                                                    1b = Pin L[2*index] is used as COM2
+                                                                                    If LCD pin L(index) is selected as
+                                                                                    segment line (LCDCSS(index) = 0b) and
+                                                                                    LCD mux rate is 5-, 6-, 7- or 8-mux
+                                                                                    (LCDMXx >= 100b): 0b = LCD segment
+                                                                                    off 1b = LCD segment on If LCD pin
+                                                                                    L(index) is selected as common line
+                                                                                    (LCDCSS(index) = 1b): 0b = Pin
+                                                                                    L[index-1] not used as COM2 1b = Pin
+                                                                                    L[index-1] is used as COM2 */
+#define LCD_LCDBM_MBIT2_OFF                      ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDBM_MBIT2_ON                       ((uint8_t)0x00000004U)          /* !< LCD segment/common on */
+/* LCD_LCDBM[MBIT3] Bits */
+#define LCD_LCDBM_MBIT3_OFS                      (3)                             /* !< MBIT3 Offset */
+#define LCD_LCDBM_MBIT3_MASK                     ((uint8_t)0x00000008U)          /* !< If LCD pin L(index) is selected as
+                                                                                    segment line (LCDCSS(index) = 0b) and
+                                                                                    LCD mux rate is 4-mux (LCDMXx=011b):
+                                                                                    0b = LCD segment off 1b = LCD segment
+                                                                                    on If LCD pin L[2*index] is selected
+                                                                                    as common line (LCDCSS[2*index] =
+                                                                                    1b): 0b = Pin L[2*index] not used as
+                                                                                    COM3 1b = Pin L[2*index] is used as
+                                                                                    COM3 If LCD pin L(index) is selected
+                                                                                    as segment line (LCDCSS(index) = 0b)
+                                                                                    and LCD mux rate is 5-, 6-, 7- or
+                                                                                    8-mux (LCDMXx >= 100b): 0b = LCD
+                                                                                    segment off 1b = LCD segment on If
+                                                                                    LCD pin L(index) is selected as
+                                                                                    common line (LCDCSS(index) = 1b): 0b
+                                                                                    = Pin L(index) not used as COM3 1b =
+                                                                                    Pin L(index) is used as COM3 */
+#define LCD_LCDBM_MBIT3_OFF                      ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDBM_MBIT3_ON                       ((uint8_t)0x00000008U)          /* !< LCD segment/common on */
+/* LCD_LCDBM[MBIT4] Bits */
+#define LCD_LCDBM_MBIT4_OFS                      (4)                             /* !< MBIT4 Offset */
+#define LCD_LCDBM_MBIT4_MASK                     ((uint8_t)0x00000010U)          /* !< If LCD pin L[2*index+1] is selected
+                                                                                    as segment line (LCDCSS[2*index+1] =
+                                                                                    0b) and LCD mux rate is static, 2-,
+                                                                                    3- or 4-mux (000b <= LCDMXx <= 011b)
+                                                                                    0b = LCD segment off 1b = LCD segment
+                                                                                    on If LCD pin L[2*index+1] is
+                                                                                    selected as common line
+                                                                                    (LCDCSS[2*index+1] = 1b): 0b = Pin
+                                                                                    L[2*ndex+1] not used as COM0 1b = Pin
+                                                                                    L[2*ndex+1] is used as COM0 */
+#define LCD_LCDBM_MBIT4_OFF                      ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDBM_MBIT4_ON                       ((uint8_t)0x00000010U)          /* !< LCD segment/common on */
+/* LCD_LCDBM[MBIT5] Bits */
+#define LCD_LCDBM_MBIT5_OFS                      (5)                             /* !< MBIT5 Offset */
+#define LCD_LCDBM_MBIT5_MASK                     ((uint8_t)0x00000020U)          /* !< If LCD pin L[2*index+1] is selected
+                                                                                    as segment line (LCDCSS[2*index+1] =
+                                                                                    0b) and LCD mux rate is 2-, 3- or
+                                                                                    4-mux (001b <= LCDMXx <= 011b): 0b =
+                                                                                    LCD segment off 1b = LCD segment on
+                                                                                    If LCD pin L[2*index+1] is selected
+                                                                                    as common line (LCDCSS[2*index+1] =
+                                                                                    1b): 0b = Pin L[2*index+1] not used
+                                                                                    as COM1 1b = Pin L[2*index+1] is used
+                                                                                    as COM1 If LCD pin L(index) is
+                                                                                    selected as segment line
+                                                                                    (LCDCSS(index) = 0b) and LCD mux rate
+                                                                                    is 6-, 7- or 8-mux (LCDMXx >= 101b):
+                                                                                    0b = LCD segment off 1b = LCD segment
+                                                                                    on If LCD pin L(index) is selected as
+                                                                                    common line (LCDCSS(index) = 1b): 0b
+                                                                                    = Pin L(index) not used as COM5 1b =
+                                                                                    Pin L(index) is used as COM5 */
+#define LCD_LCDBM_MBIT5_OFF                      ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDBM_MBIT5_ON                       ((uint8_t)0x00000020U)          /* !< LCD segment/common on */
+/* LCD_LCDBM[MBIT6] Bits */
+#define LCD_LCDBM_MBIT6_OFS                      (6)                             /* !< MBIT6 Offset */
+#define LCD_LCDBM_MBIT6_MASK                     ((uint8_t)0x00000040U)          /* !< If LCD pin L[2*index+1] is selected
+                                                                                    as segment line (LCDCSS[2*index+1] =
+                                                                                    0b) and LCD mux rate is 3- or 4-mux
+                                                                                    (010b <= LCDMXx <= 011b): 0b = LCD
+                                                                                    segment off 1b = LCD segment on If
+                                                                                    LCD pin L[2*index+1] is selected as
+                                                                                    common line (LCDCSS[2*index+1] = 1b):
+                                                                                    0b = Pin L[2*index+1] not used as
+                                                                                    COM2 1b = Pin L[2*index+1] is used as
+                                                                                    COM2 If LCD pin L(index) is selected
+                                                                                    as segment line (LCDCSS(index) = 0b)
+                                                                                    and LCD mux rate is 7- or 8-mux
+                                                                                    (LCDMXx >= 110b): 0b = LCD segment
+                                                                                    off 1b = LCD segment on If LCD pin
+                                                                                    L(index) is selected as common line
+                                                                                    (LCDCSS(index) = 1b): 0b = Pin
+                                                                                    L(index) not used as COM6 1b = Pin
+                                                                                    L(index) is used as COM6 */
+#define LCD_LCDBM_MBIT6_OFF                      ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDBM_MBIT6_ON                       ((uint8_t)0x00000040U)          /* !< LCD segment/common on */
+/* LCD_LCDBM[MBIT7] Bits */
+#define LCD_LCDBM_MBIT7_OFS                      (7)                             /* !< MBIT7 Offset */
+#define LCD_LCDBM_MBIT7_MASK                     ((uint8_t)0x00000080U)          /* !< If LCD pin L[2*index+1] is selected
+                                                                                    as segment line (LCDCSS[2*index+1] =
+                                                                                    0b) and LCD mux rate is 4-mux
+                                                                                    (LCDMXx=011b): 0b = LCD segment off
+                                                                                    1b = LCD segment on If LCD pin
+                                                                                    L[2*index+1] is selected as common
+                                                                                    line (LCDCSS[2*index+1] = 1b): 0b =
+                                                                                    Pin L[2*index+1] not used as COM3 1b
+                                                                                    = Pin L[2*index+1] is used as COM3 If
+                                                                                    LCD pin L(index) is selected as
+                                                                                    segment line (LCDCSS(index) = 0b) and
+                                                                                    LCD mux rate is 8-mux (LCDMXx =
+                                                                                    111b): 0b = LCD segment off 1b = LCD
+                                                                                    segment on If LCD pin L(index) is
+                                                                                    selected as common line
+                                                                                    (LCDCSS(index) = 1b): 0b = Pin
+                                                                                    L(index) not used as COM7 1b = Pin
+                                                                                    L(index) is used as COM7 */
+#define LCD_LCDBM_MBIT7_OFF                      ((uint8_t)0x00000000U)          /* !< LCD segment/common off */
+#define LCD_LCDBM_MBIT7_ON                       ((uint8_t)0x00000080U)          /* !< LCD segment/common on */
+
+/* LCD_LCDVREFCFG Bits */
+/* LCD_LCDVREFCFG[ONTIME] Bits */
+#define LCD_LCDVREFCFG_ONTIME_OFS                (0)                             /* !< ONTIME Offset */
+#define LCD_LCDVREFCFG_ONTIME_MASK               ((uint32_t)0x00000003U)         /* !< Configures the ontime of the VREF. */
+#define LCD_LCDVREFCFG_ONTIME_ONTIME16           ((uint32_t)0x00000000U)         /* !< 16 CLKCP cycles of ontime */
+#define LCD_LCDVREFCFG_ONTIME_ONTIME32           ((uint32_t)0x00000001U)         /* !< 32 CLKCP cycles of ontime */
+#define LCD_LCDVREFCFG_ONTIME_ONTIME128          ((uint32_t)0x00000002U)         /* !< 128 CLKCP cycles of ontime */
+#define LCD_LCDVREFCFG_ONTIME_ONTIME256          ((uint32_t)0x00000003U)         /* !< 256 CLKCP cycles of ontime */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_lcd__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_lfss.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_lfss.h
@@ -1,0 +1,5008 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_lfss__include
+#define ti_devices_msp_peripherals_hw_lfss__include
+
+/* Filename: hw_lfss.h */
+/* Revised: 2023-09-04 05:06:06 */
+/* Revision: 031875008c19c251e8c3a56bbee9e382e723e74e */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* LFSS Registers
+******************************************************************************/
+#define LFSS_IPSPECIFIC_MEM_OFS                  ((uint32_t)0x00001400U)
+#define LFSS_IPSPECIFIC_WDT_OFS                  ((uint32_t)0x00001300U)
+#define LFSS_IPSPECIFIC_TIO_OFS                  ((uint32_t)0x00001200U)
+#define LFSS_IPSPECIFIC_RTC_OFS                  ((uint32_t)0x00001100U)
+#define LFSS_GEN_EVENT_OFS                       ((uint32_t)0x00001050U)
+#define LFSS_CPU_INT_OFS                         ((uint32_t)0x00001020U)
+
+
+/** @addtogroup LFSS_IPSPECIFIC_MEM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t SPMEM[32];                         /* !< (@ 0x00001400) Scratch Pad Memory Data Register */
+       uint32_t RESERVED0[32];
+  __IO uint32_t SPMWPROT0;                         /* !< (@ 0x00001500) Scratch Pad Memory Write Protect Register 0 */
+  __IO uint32_t SPMWPROT1;                         /* !< (@ 0x00001504) Scratch Pad Memory Write Protect Register 1 */
+  __IO uint32_t SPMWPROT2;                         /* !< (@ 0x00001508) Scratch Pad Memory Write Protect Register 2 */
+  __IO uint32_t SPMWPROT3;                         /* !< (@ 0x0000150C) Scratch Pad Memory Write Protect Register 3 */
+  __IO uint32_t SPMWPROT4;                         /* !< (@ 0x00001510) Scratch Pad Memory Write Protect Register 4 */
+  __IO uint32_t SPMWPROT5;                         /* !< (@ 0x00001514) Scratch Pad Memory Write Protect Register 5 */
+  __IO uint32_t SPMWPROT6;                         /* !< (@ 0x00001518) Scratch Pad Memory Write Protect Register 6 */
+  __IO uint32_t SPMWPROT7;                         /* !< (@ 0x0000151C) Scratch Pad Memory Write Protect Register 7 */
+       uint32_t RESERVED1[8];
+  __IO uint32_t SPMTERASE0;                        /* !< (@ 0x00001540) Scratch Pad Memory Tamper Erase Register 0 */
+  __IO uint32_t SPMTERASE1;                        /* !< (@ 0x00001544) Scratch Pad Memory Tamper Erase Register 1 */
+  __IO uint32_t SPMTERASE2;                        /* !< (@ 0x00001548) Scratch Pad Memory Tamper Erase Register 2 */
+  __IO uint32_t SPMTERASE3;                        /* !< (@ 0x0000154C) Scratch Pad Memory Tamper Erase Register 3 */
+  __IO uint32_t SPMTERASE4;                        /* !< (@ 0x00001550) Scratch Pad Memory Tamper Erase Register 4 */
+  __IO uint32_t SPMTERASE5;                        /* !< (@ 0x00001554) Scratch Pad Memory Tamper Erase Register 5 */
+  __IO uint32_t SPMTERASE6;                        /* !< (@ 0x00001558) Scratch Pad Memory Tamper Erase Register 6 */
+  __IO uint32_t SPMTERASE7;                        /* !< (@ 0x0000155C) Scratch Pad Memory Tamper Erase Register 7 */
+} LFSS_IPSPECIFIC_MEM_Regs;
+
+/*@}*/ /* end of group LFSS_IPSPECIFIC_MEM */
+
+/** @addtogroup LFSS_IPSPECIFIC_WDT
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t WDTEN;                             /* !< (@ 0x00001300) Watchdog Timer Enable Register */
+  __IO uint32_t WDTDBGCTL;                         /* !< (@ 0x00001304) Watchdog Timer Debug Control Register */
+  __IO uint32_t WDTCTL;                            /* !< (@ 0x00001308) Watchdog Timer Control Register */
+  __O  uint32_t WDTCNTRST;                         /* !< (@ 0x0000130C) Watchdog Timer Counter Reset Register */
+  __I  uint32_t WDTSTAT;                           /* !< (@ 0x00001310) Watchdog Timer Status Register */
+       uint32_t RESERVED0[58];
+  __IO uint32_t WDTLOCK;                           /* !< (@ 0x000013FC) Watchdog timer lock register */
+} LFSS_IPSPECIFIC_WDT_Regs;
+
+/*@}*/ /* end of group LFSS_IPSPECIFIC_WDT */
+
+/** @addtogroup LFSS_IPSPECIFIC_TIO
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t TIOCTL[16];                        /* !< (@ 0x00001200) Tamper I/O Control Register */
+       uint32_t RESERVED0[16];
+  __IO uint32_t TOUT3_0;                           /* !< (@ 0x00001280) Tamper Output 3 to 0 */
+  __IO uint32_t TOUT7_4;                           /* !< (@ 0x00001284) Tamper Output 7 to 4 */
+  __IO uint32_t TOUT11_8;                          /* !< (@ 0x00001288) Tamper Output 11 to 8 */
+  __IO uint32_t TOUT15_12;                         /* !< (@ 0x0000128C) Tamper Output 15 to 12 */
+  __IO uint32_t TOE3_0;                            /* !< (@ 0x00001290) Tamper Output Enable 3 to 0 */
+  __IO uint32_t TOE7_4;                            /* !< (@ 0x00001294) Tamper Output Enable 7 to 4 */
+  __IO uint32_t TOE11_8;                           /* !< (@ 0x00001298) Tamper Output Enable 7 to 4 */
+  __IO uint32_t TOE15_12;                          /* !< (@ 0x0000129C) Tamper Output Enable 7 to 4 */
+  __I  uint32_t TIN3_0;                            /* !< (@ 0x000012A0) Tamper Input Register */
+  __I  uint32_t TIN7_4;                            /* !< (@ 0x000012A4) Tamper Input Register */
+  __I  uint32_t TIN11_8;                           /* !< (@ 0x000012A8) Tamper Input Register */
+  __I  uint32_t TIN15_12;                          /* !< (@ 0x000012AC) Tamper Input Register */
+       uint32_t RESERVED1[4];
+  __IO uint32_t HEARTBEAT;                         /* !< (@ 0x000012C0) Heartbeat Register */
+       uint32_t RESERVED2[14];
+  __IO uint32_t TIOLOCK;                           /* !< (@ 0x000012FC) Tamper I/O lock register */
+} LFSS_IPSPECIFIC_TIO_Regs;
+
+/*@}*/ /* end of group LFSS_IPSPECIFIC_TIO */
+
+/** @addtogroup LFSS_IPSPECIFIC_RTC
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t CLKCTL;                            /* !< (@ 0x00001100) RTC Clock Control Register */
+  __IO uint32_t DBGCTL;                            /* !< (@ 0x00001104) RTC Module Debug Control Register */
+  __IO uint32_t CTL;                               /* !< (@ 0x00001108) RTC Control Register */
+  __I  uint32_t STA;                               /* !< (@ 0x0000110C) RTC Status Register */
+  __IO uint32_t CAL;                               /* !< (@ 0x00001110) RTC Clock Offset Calibration Register */
+  __IO uint32_t TCMP;                              /* !< (@ 0x00001114) RTC Temperature Compensation Register */
+  __IO uint32_t SEC;                               /* !< (@ 0x00001118) RTC Seconds Register - Calendar Mode With Binary /
+                                                      BCD Format */
+  __IO uint32_t MIN;                               /* !< (@ 0x0000111C) RTC Minutes Register - Calendar Mode With Binary /
+                                                      BCD Format */
+  __IO uint32_t HOUR;                              /* !< (@ 0x00001120) RTC Hours Register - Calendar Mode With Binary /
+                                                      BCD Format */
+  __IO uint32_t DAY;                               /* !< (@ 0x00001124) RTC Day Of Week / Month Register - Calendar Mode
+                                                      With Binary / BCD Format */
+  __IO uint32_t MON;                               /* !< (@ 0x00001128) RTC Month Register - Calendar Mode With Binary /
+                                                      BCD Format */
+  __IO uint32_t YEAR;                              /* !< (@ 0x0000112C) RTC Year Register - Calendar Mode With Binary /
+                                                      BCD Format */
+  __IO uint32_t A1MIN;                             /* !< (@ 0x00001130) RTC Minute Alarm Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __IO uint32_t A1HOUR;                            /* !< (@ 0x00001134) RTC Hours Alarm Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __IO uint32_t A1DAY;                             /* !< (@ 0x00001138) RTC Alarm Day Of Week / Month Register - Calendar
+                                                      Mode With Binary / BCD Format */
+  __IO uint32_t A2MIN;                             /* !< (@ 0x0000113C) RTC Minute Alarm Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __IO uint32_t A2HOUR;                            /* !< (@ 0x00001140) RTC Hours Alarm Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __IO uint32_t A2DAY;                             /* !< (@ 0x00001144) RTC Alarm Day Of Week / Month Register - Calendar
+                                                      Mode With Binary / BCD Format */
+  __IO uint32_t PSCTL;                             /* !< (@ 0x00001148) RTC Prescale Timer 0/1 Control Register */
+  __IO uint32_t EXTPSCTL;                          /* !< (@ 0x0000114C) RTC Prescale Timer 2 Control Register */
+  __I  uint32_t TSSEC;                             /* !< (@ 0x00001150) Time Stamp Seconds Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __I  uint32_t TSMIN;                             /* !< (@ 0x00001154) Time Stamp Minutes Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __I  uint32_t TSHOUR;                            /* !< (@ 0x00001158) Time Stamp Hours Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __I  uint32_t TSDAY;                             /* !< (@ 0x0000115C) Time Stamp Day Of Week / MonthRegister - Calendar
+                                                      Mode With Binary / BCD Format */
+  __I  uint32_t TSMON;                             /* !< (@ 0x00001160) Time Stamp Month Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __I  uint32_t TSYEAR;                            /* !< (@ 0x00001164) Time Stamp Years Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __I  uint32_t TSSTAT;                            /* !< (@ 0x00001168) Time Stamp Status Register */
+  __IO uint32_t TSCTL;                             /* !< (@ 0x0000116C) Time Stamp Control Register */
+  __O  uint32_t TSCLR;                             /* !< (@ 0x00001170) Time Stamp Clear Register */
+       uint32_t RESERVED0[31];
+  __IO uint32_t LFSSRST;                           /* !< (@ 0x000011F0) Low frequency sub-system reset request */
+       uint32_t RESERVED1[2];
+  __IO uint32_t RTCLOCK;                           /* !< (@ 0x000011FC) Real time clock lock register */
+} LFSS_IPSPECIFIC_RTC_Regs;
+
+/*@}*/ /* end of group LFSS_IPSPECIFIC_RTC */
+
+/** @addtogroup LFSS_GEN_EVENT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001050) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001058) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001060) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001068) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001070) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001078) Interrupt clear */
+} LFSS_GEN_EVENT_Regs;
+
+/*@}*/ /* end of group LFSS_GEN_EVENT */
+
+/** @addtogroup LFSS_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} LFSS_CPU_INT_Regs;
+
+/*@}*/ /* end of group LFSS_CPU_INT */
+
+/** @addtogroup LFSS
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[256];
+  __IO uint32_t FSUB_0;                            /* !< (@ 0x00000400) Subsciber Port 0 */
+       uint32_t RESERVED1[16];
+  __IO uint32_t FPUB_0;                            /* !< (@ 0x00000444) Publisher Port 0 */
+       uint32_t RESERVED2[751];
+  __I  uint32_t CLKSEL;                            /* !< (@ 0x00001004) Clock Select for Ultra Low Power peripherals */
+       uint32_t RESERVED3[6];
+  LFSS_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED4;
+  LFSS_GEN_EVENT_Regs  GEN_EVENT;                         /* !< (@ 0x00001050) */
+       uint32_t RESERVED5[25];
+  __I  uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED6[6];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) LFSS Descriptor Register */
+  LFSS_IPSPECIFIC_RTC_Regs  IPSPECIFIC_RTC;                    /* !< (@ 0x00001100) */
+  LFSS_IPSPECIFIC_TIO_Regs  IPSPECIFIC_TIO;                    /* !< (@ 0x00001200) */
+  LFSS_IPSPECIFIC_WDT_Regs  IPSPECIFIC_WDT;                    /* !< (@ 0x00001300) */
+  LFSS_IPSPECIFIC_MEM_Regs  IPSPECIFIC_MEM;                    /* !< (@ 0x00001400) */
+} LFSS_Regs;
+
+/*@}*/ /* end of group LFSS */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* LFSS Register Control Bits
+******************************************************************************/
+
+/* LFSS_SPMEM Bits */
+/* LFSS_SPMEM[DATA3] Bits */
+#define LFSS_SPMEM_DATA3_OFS                     (24)                            /* !< DATA3 Offset */
+#define LFSS_SPMEM_DATA3_MASK                    ((uint32_t)0xFF000000U)         /* !< memory data byte 3 */
+#define LFSS_SPMEM_DATA3_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_SPMEM_DATA3_MAXIMUM                 ((uint32_t)0xFF000000U)         /* !< Highest possible value */
+/* LFSS_SPMEM[DATA2] Bits */
+#define LFSS_SPMEM_DATA2_OFS                     (16)                            /* !< DATA2 Offset */
+#define LFSS_SPMEM_DATA2_MASK                    ((uint32_t)0x00FF0000U)         /* !< memory data byte 2 */
+#define LFSS_SPMEM_DATA2_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_SPMEM_DATA2_MAXIMUM                 ((uint32_t)0x00FF0000U)         /* !< Highest possible value */
+/* LFSS_SPMEM[DATA1] Bits */
+#define LFSS_SPMEM_DATA1_OFS                     (8)                             /* !< DATA1 Offset */
+#define LFSS_SPMEM_DATA1_MASK                    ((uint32_t)0x0000FF00U)         /* !< memory data byte 1 */
+#define LFSS_SPMEM_DATA1_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_SPMEM_DATA1_MAXIMUM                 ((uint32_t)0x0000FF00U)         /* !< Highest possible value */
+/* LFSS_SPMEM[DATA0] Bits */
+#define LFSS_SPMEM_DATA0_OFS                     (0)                             /* !< DATA0 Offset */
+#define LFSS_SPMEM_DATA0_MASK                    ((uint32_t)0x000000FFU)         /* !< memory data byte 0 */
+#define LFSS_SPMEM_DATA0_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_SPMEM_DATA0_MAXIMUM                 ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+
+/* LFSS_SPMWPROT0 Bits */
+/* LFSS_SPMWPROT0[KEY] Bits */
+#define LFSS_SPMWPROT0_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define LFSS_SPMWPROT0_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xE8) to update
+                                                                                    this register */
+#define LFSS_SPMWPROT0_KEY_UNLOCK_W              ((uint32_t)0xE8000000U)         /* !< This field must be written with
+                                                                                    0xE8 to be update the write protect
+                                                                                    bits. */
+/* LFSS_SPMWPROT0[WP_3_3] Bits */
+#define LFSS_SPMWPROT0_WP_3_3_OFS                (15)                            /* !< WP_3_3 Offset */
+#define LFSS_SPMWPROT0_WP_3_3_MASK               ((uint32_t)0x00008000U)         /* !< write protect SPMEM3 - DATA3 */
+#define LFSS_SPMWPROT0_WP_3_3_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_3_3_READONLY           ((uint32_t)0x00008000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_3_2] Bits */
+#define LFSS_SPMWPROT0_WP_3_2_OFS                (14)                            /* !< WP_3_2 Offset */
+#define LFSS_SPMWPROT0_WP_3_2_MASK               ((uint32_t)0x00004000U)         /* !< write protect SPMEM3 - DATA2 */
+#define LFSS_SPMWPROT0_WP_3_2_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_3_2_READONLY           ((uint32_t)0x00004000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_3_1] Bits */
+#define LFSS_SPMWPROT0_WP_3_1_OFS                (13)                            /* !< WP_3_1 Offset */
+#define LFSS_SPMWPROT0_WP_3_1_MASK               ((uint32_t)0x00002000U)         /* !< write protect SPMEM3 - DATA1 */
+#define LFSS_SPMWPROT0_WP_3_1_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_3_1_READONLY           ((uint32_t)0x00002000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_3_0] Bits */
+#define LFSS_SPMWPROT0_WP_3_0_OFS                (12)                            /* !< WP_3_0 Offset */
+#define LFSS_SPMWPROT0_WP_3_0_MASK               ((uint32_t)0x00001000U)         /* !< write protect SPMEM3 - DATA0 */
+#define LFSS_SPMWPROT0_WP_3_0_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_3_0_READONLY           ((uint32_t)0x00001000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_2_3] Bits */
+#define LFSS_SPMWPROT0_WP_2_3_OFS                (11)                            /* !< WP_2_3 Offset */
+#define LFSS_SPMWPROT0_WP_2_3_MASK               ((uint32_t)0x00000800U)         /* !< write protect SPMEM2 - DATA3 */
+#define LFSS_SPMWPROT0_WP_2_3_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_2_3_READONLY           ((uint32_t)0x00000800U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_2_2] Bits */
+#define LFSS_SPMWPROT0_WP_2_2_OFS                (10)                            /* !< WP_2_2 Offset */
+#define LFSS_SPMWPROT0_WP_2_2_MASK               ((uint32_t)0x00000400U)         /* !< write protect SPMEM2 - DATA2 */
+#define LFSS_SPMWPROT0_WP_2_2_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_2_2_READONLY           ((uint32_t)0x00000400U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_2_1] Bits */
+#define LFSS_SPMWPROT0_WP_2_1_OFS                (9)                             /* !< WP_2_1 Offset */
+#define LFSS_SPMWPROT0_WP_2_1_MASK               ((uint32_t)0x00000200U)         /* !< write protect SPMEM2 - DATA1 */
+#define LFSS_SPMWPROT0_WP_2_1_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_2_1_READONLY           ((uint32_t)0x00000200U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_2_0] Bits */
+#define LFSS_SPMWPROT0_WP_2_0_OFS                (8)                             /* !< WP_2_0 Offset */
+#define LFSS_SPMWPROT0_WP_2_0_MASK               ((uint32_t)0x00000100U)         /* !< write protect SPMEM2 - DATA0 */
+#define LFSS_SPMWPROT0_WP_2_0_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_2_0_READONLY           ((uint32_t)0x00000100U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_1_3] Bits */
+#define LFSS_SPMWPROT0_WP_1_3_OFS                (7)                             /* !< WP_1_3 Offset */
+#define LFSS_SPMWPROT0_WP_1_3_MASK               ((uint32_t)0x00000080U)         /* !< write protect SPMEM1 - DATA3 */
+#define LFSS_SPMWPROT0_WP_1_3_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_1_3_READONLY           ((uint32_t)0x00000080U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_1_2] Bits */
+#define LFSS_SPMWPROT0_WP_1_2_OFS                (6)                             /* !< WP_1_2 Offset */
+#define LFSS_SPMWPROT0_WP_1_2_MASK               ((uint32_t)0x00000040U)         /* !< write protect SPMEM1 - DATA2 */
+#define LFSS_SPMWPROT0_WP_1_2_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_1_2_READONLY           ((uint32_t)0x00000040U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_1_1] Bits */
+#define LFSS_SPMWPROT0_WP_1_1_OFS                (5)                             /* !< WP_1_1 Offset */
+#define LFSS_SPMWPROT0_WP_1_1_MASK               ((uint32_t)0x00000020U)         /* !< write protect SPMEM1 - DATA1 */
+#define LFSS_SPMWPROT0_WP_1_1_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_1_1_READONLY           ((uint32_t)0x00000020U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_1_0] Bits */
+#define LFSS_SPMWPROT0_WP_1_0_OFS                (4)                             /* !< WP_1_0 Offset */
+#define LFSS_SPMWPROT0_WP_1_0_MASK               ((uint32_t)0x00000010U)         /* !< write protect SPMEM1 - DATA0 */
+#define LFSS_SPMWPROT0_WP_1_0_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_1_0_READONLY           ((uint32_t)0x00000010U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_0_3] Bits */
+#define LFSS_SPMWPROT0_WP_0_3_OFS                (3)                             /* !< WP_0_3 Offset */
+#define LFSS_SPMWPROT0_WP_0_3_MASK               ((uint32_t)0x00000008U)         /* !< write protect SPMEM0 - DATA3 */
+#define LFSS_SPMWPROT0_WP_0_3_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_0_3_READONLY           ((uint32_t)0x00000008U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_0_2] Bits */
+#define LFSS_SPMWPROT0_WP_0_2_OFS                (2)                             /* !< WP_0_2 Offset */
+#define LFSS_SPMWPROT0_WP_0_2_MASK               ((uint32_t)0x00000004U)         /* !< write protect SPMEM0 - DATA2 */
+#define LFSS_SPMWPROT0_WP_0_2_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_0_2_READONLY           ((uint32_t)0x00000004U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_0_1] Bits */
+#define LFSS_SPMWPROT0_WP_0_1_OFS                (1)                             /* !< WP_0_1 Offset */
+#define LFSS_SPMWPROT0_WP_0_1_MASK               ((uint32_t)0x00000002U)         /* !< write protect SPMEM0 - DATA1 */
+#define LFSS_SPMWPROT0_WP_0_1_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_0_1_READONLY           ((uint32_t)0x00000002U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT0[WP_0_0] Bits */
+#define LFSS_SPMWPROT0_WP_0_0_OFS                (0)                             /* !< WP_0_0 Offset */
+#define LFSS_SPMWPROT0_WP_0_0_MASK               ((uint32_t)0x00000001U)         /* !< write protect SPMEM0 - DATA0 */
+#define LFSS_SPMWPROT0_WP_0_0_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT0_WP_0_0_READONLY           ((uint32_t)0x00000001U)         /* !< SPMEM is read only access */
+
+/* LFSS_SPMWPROT1 Bits */
+/* LFSS_SPMWPROT1[KEY] Bits */
+#define LFSS_SPMWPROT1_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define LFSS_SPMWPROT1_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xE8) to update
+                                                                                    this register */
+#define LFSS_SPMWPROT1_KEY_UNLOCK_W              ((uint32_t)0xE8000000U)         /* !< This field must be written with
+                                                                                    0xE8 to be update the write protect
+                                                                                    bits. */
+/* LFSS_SPMWPROT1[WP_7_3] Bits */
+#define LFSS_SPMWPROT1_WP_7_3_OFS                (15)                            /* !< WP_7_3 Offset */
+#define LFSS_SPMWPROT1_WP_7_3_MASK               ((uint32_t)0x00008000U)         /* !< write protect SPMEM7 - DATA3 */
+#define LFSS_SPMWPROT1_WP_7_3_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_7_3_READONLY           ((uint32_t)0x00008000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_7_2] Bits */
+#define LFSS_SPMWPROT1_WP_7_2_OFS                (14)                            /* !< WP_7_2 Offset */
+#define LFSS_SPMWPROT1_WP_7_2_MASK               ((uint32_t)0x00004000U)         /* !< write protect SPMEM7 - DATA2 */
+#define LFSS_SPMWPROT1_WP_7_2_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_7_2_READONLY           ((uint32_t)0x00004000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_7_1] Bits */
+#define LFSS_SPMWPROT1_WP_7_1_OFS                (13)                            /* !< WP_7_1 Offset */
+#define LFSS_SPMWPROT1_WP_7_1_MASK               ((uint32_t)0x00002000U)         /* !< write protect SPMEM7 - DATA1 */
+#define LFSS_SPMWPROT1_WP_7_1_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_7_1_READONLY           ((uint32_t)0x00002000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_7_0] Bits */
+#define LFSS_SPMWPROT1_WP_7_0_OFS                (12)                            /* !< WP_7_0 Offset */
+#define LFSS_SPMWPROT1_WP_7_0_MASK               ((uint32_t)0x00001000U)         /* !< write protect SPMEM7 - DATA0 */
+#define LFSS_SPMWPROT1_WP_7_0_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_7_0_READONLY           ((uint32_t)0x00001000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_6_3] Bits */
+#define LFSS_SPMWPROT1_WP_6_3_OFS                (11)                            /* !< WP_6_3 Offset */
+#define LFSS_SPMWPROT1_WP_6_3_MASK               ((uint32_t)0x00000800U)         /* !< write protect SPMEM6 - DATA3 */
+#define LFSS_SPMWPROT1_WP_6_3_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_6_3_READONLY           ((uint32_t)0x00000800U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_6_2] Bits */
+#define LFSS_SPMWPROT1_WP_6_2_OFS                (10)                            /* !< WP_6_2 Offset */
+#define LFSS_SPMWPROT1_WP_6_2_MASK               ((uint32_t)0x00000400U)         /* !< write protect SPMEM6 - DATA2 */
+#define LFSS_SPMWPROT1_WP_6_2_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_6_2_READONLY           ((uint32_t)0x00000400U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_6_1] Bits */
+#define LFSS_SPMWPROT1_WP_6_1_OFS                (9)                             /* !< WP_6_1 Offset */
+#define LFSS_SPMWPROT1_WP_6_1_MASK               ((uint32_t)0x00000200U)         /* !< write protect SPMEM6 - DATA1 */
+#define LFSS_SPMWPROT1_WP_6_1_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_6_1_READONLY           ((uint32_t)0x00000200U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_6_0] Bits */
+#define LFSS_SPMWPROT1_WP_6_0_OFS                (8)                             /* !< WP_6_0 Offset */
+#define LFSS_SPMWPROT1_WP_6_0_MASK               ((uint32_t)0x00000100U)         /* !< write protect SPMEM6 - DATA0 */
+#define LFSS_SPMWPROT1_WP_6_0_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_6_0_READONLY           ((uint32_t)0x00000100U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_5_3] Bits */
+#define LFSS_SPMWPROT1_WP_5_3_OFS                (7)                             /* !< WP_5_3 Offset */
+#define LFSS_SPMWPROT1_WP_5_3_MASK               ((uint32_t)0x00000080U)         /* !< write protect SPMEM5 - DATA3 */
+#define LFSS_SPMWPROT1_WP_5_3_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_5_3_READONLY           ((uint32_t)0x00000080U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_5_2] Bits */
+#define LFSS_SPMWPROT1_WP_5_2_OFS                (6)                             /* !< WP_5_2 Offset */
+#define LFSS_SPMWPROT1_WP_5_2_MASK               ((uint32_t)0x00000040U)         /* !< write protect SPMEM5 - DATA2 */
+#define LFSS_SPMWPROT1_WP_5_2_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_5_2_READONLY           ((uint32_t)0x00000040U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_5_1] Bits */
+#define LFSS_SPMWPROT1_WP_5_1_OFS                (5)                             /* !< WP_5_1 Offset */
+#define LFSS_SPMWPROT1_WP_5_1_MASK               ((uint32_t)0x00000020U)         /* !< write protect SPMEM5 - DATA1 */
+#define LFSS_SPMWPROT1_WP_5_1_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_5_1_READONLY           ((uint32_t)0x00000020U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_5_0] Bits */
+#define LFSS_SPMWPROT1_WP_5_0_OFS                (4)                             /* !< WP_5_0 Offset */
+#define LFSS_SPMWPROT1_WP_5_0_MASK               ((uint32_t)0x00000010U)         /* !< write protect SPMEM5 - DATA0 */
+#define LFSS_SPMWPROT1_WP_5_0_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_5_0_READONLY           ((uint32_t)0x00000010U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_4_3] Bits */
+#define LFSS_SPMWPROT1_WP_4_3_OFS                (3)                             /* !< WP_4_3 Offset */
+#define LFSS_SPMWPROT1_WP_4_3_MASK               ((uint32_t)0x00000008U)         /* !< write protect SPMEM4 - DATA3 */
+#define LFSS_SPMWPROT1_WP_4_3_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_4_3_READONLY           ((uint32_t)0x00000008U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_4_2] Bits */
+#define LFSS_SPMWPROT1_WP_4_2_OFS                (2)                             /* !< WP_4_2 Offset */
+#define LFSS_SPMWPROT1_WP_4_2_MASK               ((uint32_t)0x00000004U)         /* !< write protect SPMEM4 - DATA2 */
+#define LFSS_SPMWPROT1_WP_4_2_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_4_2_READONLY           ((uint32_t)0x00000004U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_4_1] Bits */
+#define LFSS_SPMWPROT1_WP_4_1_OFS                (1)                             /* !< WP_4_1 Offset */
+#define LFSS_SPMWPROT1_WP_4_1_MASK               ((uint32_t)0x00000002U)         /* !< write protect SPMEM4 - DATA1 */
+#define LFSS_SPMWPROT1_WP_4_1_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_4_1_READONLY           ((uint32_t)0x00000002U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT1[WP_4_0] Bits */
+#define LFSS_SPMWPROT1_WP_4_0_OFS                (0)                             /* !< WP_4_0 Offset */
+#define LFSS_SPMWPROT1_WP_4_0_MASK               ((uint32_t)0x00000001U)         /* !< write protect SPMEM4 - DATA0 */
+#define LFSS_SPMWPROT1_WP_4_0_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT1_WP_4_0_READONLY           ((uint32_t)0x00000001U)         /* !< SPMEM is read only access */
+
+/* LFSS_SPMWPROT2 Bits */
+/* LFSS_SPMWPROT2[KEY] Bits */
+#define LFSS_SPMWPROT2_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define LFSS_SPMWPROT2_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xE8) to update
+                                                                                    this register */
+#define LFSS_SPMWPROT2_KEY_UNLOCK_W              ((uint32_t)0xE8000000U)         /* !< This field must be written with
+                                                                                    0xE8 to be update the write protect
+                                                                                    bits. */
+/* LFSS_SPMWPROT2[WP_11_3] Bits */
+#define LFSS_SPMWPROT2_WP_11_3_OFS               (15)                            /* !< WP_11_3 Offset */
+#define LFSS_SPMWPROT2_WP_11_3_MASK              ((uint32_t)0x00008000U)         /* !< write protect SPMEM11 - DATA3 */
+#define LFSS_SPMWPROT2_WP_11_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_11_3_READONLY          ((uint32_t)0x00008000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_11_2] Bits */
+#define LFSS_SPMWPROT2_WP_11_2_OFS               (14)                            /* !< WP_11_2 Offset */
+#define LFSS_SPMWPROT2_WP_11_2_MASK              ((uint32_t)0x00004000U)         /* !< write protect SPMEM11 - DATA2 */
+#define LFSS_SPMWPROT2_WP_11_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_11_2_READONLY          ((uint32_t)0x00004000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_11_1] Bits */
+#define LFSS_SPMWPROT2_WP_11_1_OFS               (13)                            /* !< WP_11_1 Offset */
+#define LFSS_SPMWPROT2_WP_11_1_MASK              ((uint32_t)0x00002000U)         /* !< write protect SPMEM11 - DATA1 */
+#define LFSS_SPMWPROT2_WP_11_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_11_1_READONLY          ((uint32_t)0x00002000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_11_0] Bits */
+#define LFSS_SPMWPROT2_WP_11_0_OFS               (12)                            /* !< WP_11_0 Offset */
+#define LFSS_SPMWPROT2_WP_11_0_MASK              ((uint32_t)0x00001000U)         /* !< write protect SPMEM11 - DATA0 */
+#define LFSS_SPMWPROT2_WP_11_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_11_0_READONLY          ((uint32_t)0x00001000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_10_3] Bits */
+#define LFSS_SPMWPROT2_WP_10_3_OFS               (11)                            /* !< WP_10_3 Offset */
+#define LFSS_SPMWPROT2_WP_10_3_MASK              ((uint32_t)0x00000800U)         /* !< write protect SPMEM10 - DATA3 */
+#define LFSS_SPMWPROT2_WP_10_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_10_3_READONLY          ((uint32_t)0x00000800U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_10_2] Bits */
+#define LFSS_SPMWPROT2_WP_10_2_OFS               (10)                            /* !< WP_10_2 Offset */
+#define LFSS_SPMWPROT2_WP_10_2_MASK              ((uint32_t)0x00000400U)         /* !< write protect SPMEM610- DATA2 */
+#define LFSS_SPMWPROT2_WP_10_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_10_2_READONLY          ((uint32_t)0x00000400U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_10_1] Bits */
+#define LFSS_SPMWPROT2_WP_10_1_OFS               (9)                             /* !< WP_10_1 Offset */
+#define LFSS_SPMWPROT2_WP_10_1_MASK              ((uint32_t)0x00000200U)         /* !< write protect SPMEM10 - DATA1 */
+#define LFSS_SPMWPROT2_WP_10_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_10_1_READONLY          ((uint32_t)0x00000200U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_10_0] Bits */
+#define LFSS_SPMWPROT2_WP_10_0_OFS               (8)                             /* !< WP_10_0 Offset */
+#define LFSS_SPMWPROT2_WP_10_0_MASK              ((uint32_t)0x00000100U)         /* !< write protect SPMEM10 - DATA0 */
+#define LFSS_SPMWPROT2_WP_10_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_10_0_READONLY          ((uint32_t)0x00000100U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_9_3] Bits */
+#define LFSS_SPMWPROT2_WP_9_3_OFS                (7)                             /* !< WP_9_3 Offset */
+#define LFSS_SPMWPROT2_WP_9_3_MASK               ((uint32_t)0x00000080U)         /* !< write protect SPMEM9 - DATA3 */
+#define LFSS_SPMWPROT2_WP_9_3_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_9_3_READONLY           ((uint32_t)0x00000080U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_9_2] Bits */
+#define LFSS_SPMWPROT2_WP_9_2_OFS                (6)                             /* !< WP_9_2 Offset */
+#define LFSS_SPMWPROT2_WP_9_2_MASK               ((uint32_t)0x00000040U)         /* !< write protect SPMEM9 - DATA2 */
+#define LFSS_SPMWPROT2_WP_9_2_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_9_2_READONLY           ((uint32_t)0x00000040U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_9_1] Bits */
+#define LFSS_SPMWPROT2_WP_9_1_OFS                (5)                             /* !< WP_9_1 Offset */
+#define LFSS_SPMWPROT2_WP_9_1_MASK               ((uint32_t)0x00000020U)         /* !< write protect SPMEM9 - DATA1 */
+#define LFSS_SPMWPROT2_WP_9_1_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_9_1_READONLY           ((uint32_t)0x00000020U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_9_0] Bits */
+#define LFSS_SPMWPROT2_WP_9_0_OFS                (4)                             /* !< WP_9_0 Offset */
+#define LFSS_SPMWPROT2_WP_9_0_MASK               ((uint32_t)0x00000010U)         /* !< write protect SPMEM9 - DATA0 */
+#define LFSS_SPMWPROT2_WP_9_0_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_9_0_READONLY           ((uint32_t)0x00000010U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_8_3] Bits */
+#define LFSS_SPMWPROT2_WP_8_3_OFS                (3)                             /* !< WP_8_3 Offset */
+#define LFSS_SPMWPROT2_WP_8_3_MASK               ((uint32_t)0x00000008U)         /* !< write protect SPMEM8 - DATA3 */
+#define LFSS_SPMWPROT2_WP_8_3_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_8_3_READONLY           ((uint32_t)0x00000008U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_8_2] Bits */
+#define LFSS_SPMWPROT2_WP_8_2_OFS                (2)                             /* !< WP_8_2 Offset */
+#define LFSS_SPMWPROT2_WP_8_2_MASK               ((uint32_t)0x00000004U)         /* !< write protect SPMEM8 - DATA2 */
+#define LFSS_SPMWPROT2_WP_8_2_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_8_2_READONLY           ((uint32_t)0x00000004U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_8_1] Bits */
+#define LFSS_SPMWPROT2_WP_8_1_OFS                (1)                             /* !< WP_8_1 Offset */
+#define LFSS_SPMWPROT2_WP_8_1_MASK               ((uint32_t)0x00000002U)         /* !< write protect SPMEM8 - DATA1 */
+#define LFSS_SPMWPROT2_WP_8_1_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_8_1_READONLY           ((uint32_t)0x00000002U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT2[WP_8_0] Bits */
+#define LFSS_SPMWPROT2_WP_8_0_OFS                (0)                             /* !< WP_8_0 Offset */
+#define LFSS_SPMWPROT2_WP_8_0_MASK               ((uint32_t)0x00000001U)         /* !< write protect SPMEM8 - DATA0 */
+#define LFSS_SPMWPROT2_WP_8_0_READWRITE          ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT2_WP_8_0_READONLY           ((uint32_t)0x00000001U)         /* !< SPMEM is read only access */
+
+/* LFSS_SPMWPROT3 Bits */
+/* LFSS_SPMWPROT3[KEY] Bits */
+#define LFSS_SPMWPROT3_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define LFSS_SPMWPROT3_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xE8) to update
+                                                                                    this register */
+#define LFSS_SPMWPROT3_KEY_UNLOCK_W              ((uint32_t)0xE8000000U)         /* !< This field must be written with
+                                                                                    0xE8 to be update the write protect
+                                                                                    bits. */
+/* LFSS_SPMWPROT3[WP_15_3] Bits */
+#define LFSS_SPMWPROT3_WP_15_3_OFS               (15)                            /* !< WP_15_3 Offset */
+#define LFSS_SPMWPROT3_WP_15_3_MASK              ((uint32_t)0x00008000U)         /* !< write protect SPMEM15 - DATA3 */
+#define LFSS_SPMWPROT3_WP_15_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_15_3_READONLY          ((uint32_t)0x00008000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_15_2] Bits */
+#define LFSS_SPMWPROT3_WP_15_2_OFS               (14)                            /* !< WP_15_2 Offset */
+#define LFSS_SPMWPROT3_WP_15_2_MASK              ((uint32_t)0x00004000U)         /* !< write protect SPMEM15 - DATA2 */
+#define LFSS_SPMWPROT3_WP_15_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_15_2_READONLY          ((uint32_t)0x00004000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_15_1] Bits */
+#define LFSS_SPMWPROT3_WP_15_1_OFS               (13)                            /* !< WP_15_1 Offset */
+#define LFSS_SPMWPROT3_WP_15_1_MASK              ((uint32_t)0x00002000U)         /* !< write protect SPMEM15 - DATA1 */
+#define LFSS_SPMWPROT3_WP_15_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_15_1_READONLY          ((uint32_t)0x00002000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_15_0] Bits */
+#define LFSS_SPMWPROT3_WP_15_0_OFS               (12)                            /* !< WP_15_0 Offset */
+#define LFSS_SPMWPROT3_WP_15_0_MASK              ((uint32_t)0x00001000U)         /* !< write protect SPMEM15 - DATA0 */
+#define LFSS_SPMWPROT3_WP_15_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_15_0_READONLY          ((uint32_t)0x00001000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_14_3] Bits */
+#define LFSS_SPMWPROT3_WP_14_3_OFS               (11)                            /* !< WP_14_3 Offset */
+#define LFSS_SPMWPROT3_WP_14_3_MASK              ((uint32_t)0x00000800U)         /* !< write protect SPMEM14 - DATA3 */
+#define LFSS_SPMWPROT3_WP_14_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_14_3_READONLY          ((uint32_t)0x00000800U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_14_2] Bits */
+#define LFSS_SPMWPROT3_WP_14_2_OFS               (10)                            /* !< WP_14_2 Offset */
+#define LFSS_SPMWPROT3_WP_14_2_MASK              ((uint32_t)0x00000400U)         /* !< write protect SPMEM14- DATA2 */
+#define LFSS_SPMWPROT3_WP_14_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_14_2_READONLY          ((uint32_t)0x00000400U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_14_1] Bits */
+#define LFSS_SPMWPROT3_WP_14_1_OFS               (9)                             /* !< WP_14_1 Offset */
+#define LFSS_SPMWPROT3_WP_14_1_MASK              ((uint32_t)0x00000200U)         /* !< write protect SPMEM14 - DATA1 */
+#define LFSS_SPMWPROT3_WP_14_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_14_1_READONLY          ((uint32_t)0x00000200U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_14_0] Bits */
+#define LFSS_SPMWPROT3_WP_14_0_OFS               (8)                             /* !< WP_14_0 Offset */
+#define LFSS_SPMWPROT3_WP_14_0_MASK              ((uint32_t)0x00000100U)         /* !< write protect SPMEM14 - DATA0 */
+#define LFSS_SPMWPROT3_WP_14_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_14_0_READONLY          ((uint32_t)0x00000100U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_13_3] Bits */
+#define LFSS_SPMWPROT3_WP_13_3_OFS               (7)                             /* !< WP_13_3 Offset */
+#define LFSS_SPMWPROT3_WP_13_3_MASK              ((uint32_t)0x00000080U)         /* !< write protect SPMEM13 - DATA3 */
+#define LFSS_SPMWPROT3_WP_13_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_13_3_READONLY          ((uint32_t)0x00000080U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_13_2] Bits */
+#define LFSS_SPMWPROT3_WP_13_2_OFS               (6)                             /* !< WP_13_2 Offset */
+#define LFSS_SPMWPROT3_WP_13_2_MASK              ((uint32_t)0x00000040U)         /* !< write protect SPMEM13 - DATA2 */
+#define LFSS_SPMWPROT3_WP_13_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_13_2_READONLY          ((uint32_t)0x00000040U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_13_1] Bits */
+#define LFSS_SPMWPROT3_WP_13_1_OFS               (5)                             /* !< WP_13_1 Offset */
+#define LFSS_SPMWPROT3_WP_13_1_MASK              ((uint32_t)0x00000020U)         /* !< write protect SPMEM13 - DATA1 */
+#define LFSS_SPMWPROT3_WP_13_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_13_1_READONLY          ((uint32_t)0x00000020U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_13_0] Bits */
+#define LFSS_SPMWPROT3_WP_13_0_OFS               (4)                             /* !< WP_13_0 Offset */
+#define LFSS_SPMWPROT3_WP_13_0_MASK              ((uint32_t)0x00000010U)         /* !< write protect SPMEM13 - DATA0 */
+#define LFSS_SPMWPROT3_WP_13_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_13_0_READONLY          ((uint32_t)0x00000010U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_12_3] Bits */
+#define LFSS_SPMWPROT3_WP_12_3_OFS               (3)                             /* !< WP_12_3 Offset */
+#define LFSS_SPMWPROT3_WP_12_3_MASK              ((uint32_t)0x00000008U)         /* !< write protect SPMEM12 - DATA3 */
+#define LFSS_SPMWPROT3_WP_12_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_12_3_READONLY          ((uint32_t)0x00000008U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_12_2] Bits */
+#define LFSS_SPMWPROT3_WP_12_2_OFS               (2)                             /* !< WP_12_2 Offset */
+#define LFSS_SPMWPROT3_WP_12_2_MASK              ((uint32_t)0x00000004U)         /* !< write protect SPMEM12 - DATA2 */
+#define LFSS_SPMWPROT3_WP_12_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_12_2_READONLY          ((uint32_t)0x00000004U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_12_1] Bits */
+#define LFSS_SPMWPROT3_WP_12_1_OFS               (1)                             /* !< WP_12_1 Offset */
+#define LFSS_SPMWPROT3_WP_12_1_MASK              ((uint32_t)0x00000002U)         /* !< write protect SPMEM12 - DATA1 */
+#define LFSS_SPMWPROT3_WP_12_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_12_1_READONLY          ((uint32_t)0x00000002U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT3[WP_12_0] Bits */
+#define LFSS_SPMWPROT3_WP_12_0_OFS               (0)                             /* !< WP_12_0 Offset */
+#define LFSS_SPMWPROT3_WP_12_0_MASK              ((uint32_t)0x00000001U)         /* !< write protect SPMEM12 - DATA0 */
+#define LFSS_SPMWPROT3_WP_12_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT3_WP_12_0_READONLY          ((uint32_t)0x00000001U)         /* !< SPMEM is read only access */
+
+/* LFSS_SPMWPROT4 Bits */
+/* LFSS_SPMWPROT4[KEY] Bits */
+#define LFSS_SPMWPROT4_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define LFSS_SPMWPROT4_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xE8) to update
+                                                                                    this register */
+#define LFSS_SPMWPROT4_KEY_UNLOCK_W              ((uint32_t)0xE8000000U)         /* !< This field must be written with
+                                                                                    0xE8 to be update the write protect
+                                                                                    bits. */
+/* LFSS_SPMWPROT4[WP_19_3] Bits */
+#define LFSS_SPMWPROT4_WP_19_3_OFS               (15)                            /* !< WP_19_3 Offset */
+#define LFSS_SPMWPROT4_WP_19_3_MASK              ((uint32_t)0x00008000U)         /* !< write protect SPMEM19 - DATA3 */
+#define LFSS_SPMWPROT4_WP_19_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_19_3_READONLY          ((uint32_t)0x00008000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_19_2] Bits */
+#define LFSS_SPMWPROT4_WP_19_2_OFS               (14)                            /* !< WP_19_2 Offset */
+#define LFSS_SPMWPROT4_WP_19_2_MASK              ((uint32_t)0x00004000U)         /* !< write protect SPMEM19 - DATA2 */
+#define LFSS_SPMWPROT4_WP_19_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_19_2_READONLY          ((uint32_t)0x00004000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_19_1] Bits */
+#define LFSS_SPMWPROT4_WP_19_1_OFS               (13)                            /* !< WP_19_1 Offset */
+#define LFSS_SPMWPROT4_WP_19_1_MASK              ((uint32_t)0x00002000U)         /* !< write protect SPMEM19 - DATA1 */
+#define LFSS_SPMWPROT4_WP_19_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_19_1_READONLY          ((uint32_t)0x00002000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_19_0] Bits */
+#define LFSS_SPMWPROT4_WP_19_0_OFS               (12)                            /* !< WP_19_0 Offset */
+#define LFSS_SPMWPROT4_WP_19_0_MASK              ((uint32_t)0x00001000U)         /* !< write protect SPMEM19 - DATA0 */
+#define LFSS_SPMWPROT4_WP_19_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_19_0_READONLY          ((uint32_t)0x00001000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_18_3] Bits */
+#define LFSS_SPMWPROT4_WP_18_3_OFS               (11)                            /* !< WP_18_3 Offset */
+#define LFSS_SPMWPROT4_WP_18_3_MASK              ((uint32_t)0x00000800U)         /* !< write protect SPMEM18 - DATA3 */
+#define LFSS_SPMWPROT4_WP_18_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_18_3_READONLY          ((uint32_t)0x00000800U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_18_2] Bits */
+#define LFSS_SPMWPROT4_WP_18_2_OFS               (10)                            /* !< WP_18_2 Offset */
+#define LFSS_SPMWPROT4_WP_18_2_MASK              ((uint32_t)0x00000400U)         /* !< write protect SPMEM18- DATA2 */
+#define LFSS_SPMWPROT4_WP_18_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_18_2_READONLY          ((uint32_t)0x00000400U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_18_1] Bits */
+#define LFSS_SPMWPROT4_WP_18_1_OFS               (9)                             /* !< WP_18_1 Offset */
+#define LFSS_SPMWPROT4_WP_18_1_MASK              ((uint32_t)0x00000200U)         /* !< write protect SPMEM18 - DATA1 */
+#define LFSS_SPMWPROT4_WP_18_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_18_1_READONLY          ((uint32_t)0x00000200U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_18_0] Bits */
+#define LFSS_SPMWPROT4_WP_18_0_OFS               (8)                             /* !< WP_18_0 Offset */
+#define LFSS_SPMWPROT4_WP_18_0_MASK              ((uint32_t)0x00000100U)         /* !< write protect SPMEM18 - DATA0 */
+#define LFSS_SPMWPROT4_WP_18_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_18_0_READONLY          ((uint32_t)0x00000100U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_17_3] Bits */
+#define LFSS_SPMWPROT4_WP_17_3_OFS               (7)                             /* !< WP_17_3 Offset */
+#define LFSS_SPMWPROT4_WP_17_3_MASK              ((uint32_t)0x00000080U)         /* !< write protect SPMEM17 - DATA3 */
+#define LFSS_SPMWPROT4_WP_17_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_17_3_READONLY          ((uint32_t)0x00000080U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_17_2] Bits */
+#define LFSS_SPMWPROT4_WP_17_2_OFS               (6)                             /* !< WP_17_2 Offset */
+#define LFSS_SPMWPROT4_WP_17_2_MASK              ((uint32_t)0x00000040U)         /* !< write protect SPMEM17 - DATA2 */
+#define LFSS_SPMWPROT4_WP_17_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_17_2_READONLY          ((uint32_t)0x00000040U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_17_1] Bits */
+#define LFSS_SPMWPROT4_WP_17_1_OFS               (5)                             /* !< WP_17_1 Offset */
+#define LFSS_SPMWPROT4_WP_17_1_MASK              ((uint32_t)0x00000020U)         /* !< write protect SPMEM17 - DATA1 */
+#define LFSS_SPMWPROT4_WP_17_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_17_1_READONLY          ((uint32_t)0x00000020U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_17_0] Bits */
+#define LFSS_SPMWPROT4_WP_17_0_OFS               (4)                             /* !< WP_17_0 Offset */
+#define LFSS_SPMWPROT4_WP_17_0_MASK              ((uint32_t)0x00000010U)         /* !< write protect SPMEM17 - DATA0 */
+#define LFSS_SPMWPROT4_WP_17_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_17_0_READONLY          ((uint32_t)0x00000010U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_16_3] Bits */
+#define LFSS_SPMWPROT4_WP_16_3_OFS               (3)                             /* !< WP_16_3 Offset */
+#define LFSS_SPMWPROT4_WP_16_3_MASK              ((uint32_t)0x00000008U)         /* !< write protect SPMEM16 - DATA3 */
+#define LFSS_SPMWPROT4_WP_16_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_16_3_READONLY          ((uint32_t)0x00000008U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_16_2] Bits */
+#define LFSS_SPMWPROT4_WP_16_2_OFS               (2)                             /* !< WP_16_2 Offset */
+#define LFSS_SPMWPROT4_WP_16_2_MASK              ((uint32_t)0x00000004U)         /* !< write protect SPMEM16 - DATA2 */
+#define LFSS_SPMWPROT4_WP_16_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_16_2_READONLY          ((uint32_t)0x00000004U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_16_1] Bits */
+#define LFSS_SPMWPROT4_WP_16_1_OFS               (1)                             /* !< WP_16_1 Offset */
+#define LFSS_SPMWPROT4_WP_16_1_MASK              ((uint32_t)0x00000002U)         /* !< write protect SPMEM16 - DATA1 */
+#define LFSS_SPMWPROT4_WP_16_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_16_1_READONLY          ((uint32_t)0x00000002U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT4[WP_16_0] Bits */
+#define LFSS_SPMWPROT4_WP_16_0_OFS               (0)                             /* !< WP_16_0 Offset */
+#define LFSS_SPMWPROT4_WP_16_0_MASK              ((uint32_t)0x00000001U)         /* !< write protect SPMEM16 - DATA0 */
+#define LFSS_SPMWPROT4_WP_16_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT4_WP_16_0_READONLY          ((uint32_t)0x00000001U)         /* !< SPMEM is read only access */
+
+/* LFSS_SPMWPROT5 Bits */
+/* LFSS_SPMWPROT5[KEY] Bits */
+#define LFSS_SPMWPROT5_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define LFSS_SPMWPROT5_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xE8) to update
+                                                                                    this register */
+#define LFSS_SPMWPROT5_KEY_UNLOCK_W              ((uint32_t)0xE8000000U)         /* !< This field must be written with
+                                                                                    0xE8 to be update the write protect
+                                                                                    bits. */
+/* LFSS_SPMWPROT5[WP_23_3] Bits */
+#define LFSS_SPMWPROT5_WP_23_3_OFS               (15)                            /* !< WP_23_3 Offset */
+#define LFSS_SPMWPROT5_WP_23_3_MASK              ((uint32_t)0x00008000U)         /* !< write protect SPMEM23 - DATA3 */
+#define LFSS_SPMWPROT5_WP_23_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_23_3_READONLY          ((uint32_t)0x00008000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_23_2] Bits */
+#define LFSS_SPMWPROT5_WP_23_2_OFS               (14)                            /* !< WP_23_2 Offset */
+#define LFSS_SPMWPROT5_WP_23_2_MASK              ((uint32_t)0x00004000U)         /* !< write protect SPMEM23 - DATA2 */
+#define LFSS_SPMWPROT5_WP_23_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_23_2_READONLY          ((uint32_t)0x00004000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_23_1] Bits */
+#define LFSS_SPMWPROT5_WP_23_1_OFS               (13)                            /* !< WP_23_1 Offset */
+#define LFSS_SPMWPROT5_WP_23_1_MASK              ((uint32_t)0x00002000U)         /* !< write protect SPMEM23 - DATA1 */
+#define LFSS_SPMWPROT5_WP_23_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_23_1_READONLY          ((uint32_t)0x00002000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_23_0] Bits */
+#define LFSS_SPMWPROT5_WP_23_0_OFS               (12)                            /* !< WP_23_0 Offset */
+#define LFSS_SPMWPROT5_WP_23_0_MASK              ((uint32_t)0x00001000U)         /* !< write protect SPMEM23 - DATA0 */
+#define LFSS_SPMWPROT5_WP_23_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_23_0_READONLY          ((uint32_t)0x00001000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_22_3] Bits */
+#define LFSS_SPMWPROT5_WP_22_3_OFS               (11)                            /* !< WP_22_3 Offset */
+#define LFSS_SPMWPROT5_WP_22_3_MASK              ((uint32_t)0x00000800U)         /* !< write protect SPMEM22 - DATA3 */
+#define LFSS_SPMWPROT5_WP_22_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_22_3_READONLY          ((uint32_t)0x00000800U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_22_2] Bits */
+#define LFSS_SPMWPROT5_WP_22_2_OFS               (10)                            /* !< WP_22_2 Offset */
+#define LFSS_SPMWPROT5_WP_22_2_MASK              ((uint32_t)0x00000400U)         /* !< write protect SPMEM22- DATA2 */
+#define LFSS_SPMWPROT5_WP_22_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_22_2_READONLY          ((uint32_t)0x00000400U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_22_1] Bits */
+#define LFSS_SPMWPROT5_WP_22_1_OFS               (9)                             /* !< WP_22_1 Offset */
+#define LFSS_SPMWPROT5_WP_22_1_MASK              ((uint32_t)0x00000200U)         /* !< write protect SPMEM22 - DATA1 */
+#define LFSS_SPMWPROT5_WP_22_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_22_1_READONLY          ((uint32_t)0x00000200U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_22_0] Bits */
+#define LFSS_SPMWPROT5_WP_22_0_OFS               (8)                             /* !< WP_22_0 Offset */
+#define LFSS_SPMWPROT5_WP_22_0_MASK              ((uint32_t)0x00000100U)         /* !< write protect SPMEM22 - DATA0 */
+#define LFSS_SPMWPROT5_WP_22_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_22_0_READONLY          ((uint32_t)0x00000100U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_21_3] Bits */
+#define LFSS_SPMWPROT5_WP_21_3_OFS               (7)                             /* !< WP_21_3 Offset */
+#define LFSS_SPMWPROT5_WP_21_3_MASK              ((uint32_t)0x00000080U)         /* !< write protect SPMEM21 - DATA3 */
+#define LFSS_SPMWPROT5_WP_21_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_21_3_READONLY          ((uint32_t)0x00000080U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_21_2] Bits */
+#define LFSS_SPMWPROT5_WP_21_2_OFS               (6)                             /* !< WP_21_2 Offset */
+#define LFSS_SPMWPROT5_WP_21_2_MASK              ((uint32_t)0x00000040U)         /* !< write protect SPMEM21 - DATA2 */
+#define LFSS_SPMWPROT5_WP_21_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_21_2_READONLY          ((uint32_t)0x00000040U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_21_1] Bits */
+#define LFSS_SPMWPROT5_WP_21_1_OFS               (5)                             /* !< WP_21_1 Offset */
+#define LFSS_SPMWPROT5_WP_21_1_MASK              ((uint32_t)0x00000020U)         /* !< write protect SPMEM21 - DATA1 */
+#define LFSS_SPMWPROT5_WP_21_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_21_1_READONLY          ((uint32_t)0x00000020U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_21_0] Bits */
+#define LFSS_SPMWPROT5_WP_21_0_OFS               (4)                             /* !< WP_21_0 Offset */
+#define LFSS_SPMWPROT5_WP_21_0_MASK              ((uint32_t)0x00000010U)         /* !< write protect SPMEM21 - DATA0 */
+#define LFSS_SPMWPROT5_WP_21_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_21_0_READONLY          ((uint32_t)0x00000010U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_20_3] Bits */
+#define LFSS_SPMWPROT5_WP_20_3_OFS               (3)                             /* !< WP_20_3 Offset */
+#define LFSS_SPMWPROT5_WP_20_3_MASK              ((uint32_t)0x00000008U)         /* !< write protect SPMEM20 - DATA3 */
+#define LFSS_SPMWPROT5_WP_20_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_20_3_READONLY          ((uint32_t)0x00000008U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_20_2] Bits */
+#define LFSS_SPMWPROT5_WP_20_2_OFS               (2)                             /* !< WP_20_2 Offset */
+#define LFSS_SPMWPROT5_WP_20_2_MASK              ((uint32_t)0x00000004U)         /* !< write protect SPMEM20 - DATA2 */
+#define LFSS_SPMWPROT5_WP_20_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_20_2_READONLY          ((uint32_t)0x00000004U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_20_1] Bits */
+#define LFSS_SPMWPROT5_WP_20_1_OFS               (1)                             /* !< WP_20_1 Offset */
+#define LFSS_SPMWPROT5_WP_20_1_MASK              ((uint32_t)0x00000002U)         /* !< write protect SPMEM20 - DATA1 */
+#define LFSS_SPMWPROT5_WP_20_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_20_1_READONLY          ((uint32_t)0x00000002U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT5[WP_20_0] Bits */
+#define LFSS_SPMWPROT5_WP_20_0_OFS               (0)                             /* !< WP_20_0 Offset */
+#define LFSS_SPMWPROT5_WP_20_0_MASK              ((uint32_t)0x00000001U)         /* !< write protect SPMEM20 - DATA0 */
+#define LFSS_SPMWPROT5_WP_20_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT5_WP_20_0_READONLY          ((uint32_t)0x00000001U)         /* !< SPMEM is read only access */
+
+/* LFSS_SPMWPROT6 Bits */
+/* LFSS_SPMWPROT6[KEY] Bits */
+#define LFSS_SPMWPROT6_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define LFSS_SPMWPROT6_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xE8) to update
+                                                                                    this register */
+#define LFSS_SPMWPROT6_KEY_UNLOCK_W              ((uint32_t)0xE8000000U)         /* !< This field must be written with
+                                                                                    0xE8 to be update the write protect
+                                                                                    bits. */
+/* LFSS_SPMWPROT6[WP_27_3] Bits */
+#define LFSS_SPMWPROT6_WP_27_3_OFS               (15)                            /* !< WP_27_3 Offset */
+#define LFSS_SPMWPROT6_WP_27_3_MASK              ((uint32_t)0x00008000U)         /* !< write protect SPMEM27 - DATA3 */
+#define LFSS_SPMWPROT6_WP_27_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_27_3_READONLY          ((uint32_t)0x00008000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_27_2] Bits */
+#define LFSS_SPMWPROT6_WP_27_2_OFS               (14)                            /* !< WP_27_2 Offset */
+#define LFSS_SPMWPROT6_WP_27_2_MASK              ((uint32_t)0x00004000U)         /* !< write protect SPMEM27 - DATA2 */
+#define LFSS_SPMWPROT6_WP_27_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_27_2_READONLY          ((uint32_t)0x00004000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_27_1] Bits */
+#define LFSS_SPMWPROT6_WP_27_1_OFS               (13)                            /* !< WP_27_1 Offset */
+#define LFSS_SPMWPROT6_WP_27_1_MASK              ((uint32_t)0x00002000U)         /* !< write protect SPMEM27 - DATA1 */
+#define LFSS_SPMWPROT6_WP_27_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_27_1_READONLY          ((uint32_t)0x00002000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_27_0] Bits */
+#define LFSS_SPMWPROT6_WP_27_0_OFS               (12)                            /* !< WP_27_0 Offset */
+#define LFSS_SPMWPROT6_WP_27_0_MASK              ((uint32_t)0x00001000U)         /* !< write protect SPMEM27 - DATA0 */
+#define LFSS_SPMWPROT6_WP_27_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_27_0_READONLY          ((uint32_t)0x00001000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_26_3] Bits */
+#define LFSS_SPMWPROT6_WP_26_3_OFS               (11)                            /* !< WP_26_3 Offset */
+#define LFSS_SPMWPROT6_WP_26_3_MASK              ((uint32_t)0x00000800U)         /* !< write protect SPMEM26 - DATA3 */
+#define LFSS_SPMWPROT6_WP_26_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_26_3_READONLY          ((uint32_t)0x00000800U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_26_2] Bits */
+#define LFSS_SPMWPROT6_WP_26_2_OFS               (10)                            /* !< WP_26_2 Offset */
+#define LFSS_SPMWPROT6_WP_26_2_MASK              ((uint32_t)0x00000400U)         /* !< write protect SPMEM26- DATA2 */
+#define LFSS_SPMWPROT6_WP_26_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_26_2_READONLY          ((uint32_t)0x00000400U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_26_1] Bits */
+#define LFSS_SPMWPROT6_WP_26_1_OFS               (9)                             /* !< WP_26_1 Offset */
+#define LFSS_SPMWPROT6_WP_26_1_MASK              ((uint32_t)0x00000200U)         /* !< write protect SPMEM26 - DATA1 */
+#define LFSS_SPMWPROT6_WP_26_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_26_1_READONLY          ((uint32_t)0x00000200U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_26_0] Bits */
+#define LFSS_SPMWPROT6_WP_26_0_OFS               (8)                             /* !< WP_26_0 Offset */
+#define LFSS_SPMWPROT6_WP_26_0_MASK              ((uint32_t)0x00000100U)         /* !< write protect SPMEM26 - DATA0 */
+#define LFSS_SPMWPROT6_WP_26_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_26_0_READONLY          ((uint32_t)0x00000100U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_25_3] Bits */
+#define LFSS_SPMWPROT6_WP_25_3_OFS               (7)                             /* !< WP_25_3 Offset */
+#define LFSS_SPMWPROT6_WP_25_3_MASK              ((uint32_t)0x00000080U)         /* !< write protect SPMEM25 - DATA3 */
+#define LFSS_SPMWPROT6_WP_25_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_25_3_READONLY          ((uint32_t)0x00000080U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_25_2] Bits */
+#define LFSS_SPMWPROT6_WP_25_2_OFS               (6)                             /* !< WP_25_2 Offset */
+#define LFSS_SPMWPROT6_WP_25_2_MASK              ((uint32_t)0x00000040U)         /* !< write protect SPMEM25 - DATA2 */
+#define LFSS_SPMWPROT6_WP_25_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_25_2_READONLY          ((uint32_t)0x00000040U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_25_1] Bits */
+#define LFSS_SPMWPROT6_WP_25_1_OFS               (5)                             /* !< WP_25_1 Offset */
+#define LFSS_SPMWPROT6_WP_25_1_MASK              ((uint32_t)0x00000020U)         /* !< write protect SPMEM25 - DATA1 */
+#define LFSS_SPMWPROT6_WP_25_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_25_1_READONLY          ((uint32_t)0x00000020U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_25_0] Bits */
+#define LFSS_SPMWPROT6_WP_25_0_OFS               (4)                             /* !< WP_25_0 Offset */
+#define LFSS_SPMWPROT6_WP_25_0_MASK              ((uint32_t)0x00000010U)         /* !< write protect SPMEM25 - DATA0 */
+#define LFSS_SPMWPROT6_WP_25_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_25_0_READONLY          ((uint32_t)0x00000010U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_24_3] Bits */
+#define LFSS_SPMWPROT6_WP_24_3_OFS               (3)                             /* !< WP_24_3 Offset */
+#define LFSS_SPMWPROT6_WP_24_3_MASK              ((uint32_t)0x00000008U)         /* !< write protect SPMEM24 - DATA3 */
+#define LFSS_SPMWPROT6_WP_24_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_24_3_READONLY          ((uint32_t)0x00000008U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_24_2] Bits */
+#define LFSS_SPMWPROT6_WP_24_2_OFS               (2)                             /* !< WP_24_2 Offset */
+#define LFSS_SPMWPROT6_WP_24_2_MASK              ((uint32_t)0x00000004U)         /* !< write protect SPMEM24 - DATA2 */
+#define LFSS_SPMWPROT6_WP_24_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_24_2_READONLY          ((uint32_t)0x00000004U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_24_1] Bits */
+#define LFSS_SPMWPROT6_WP_24_1_OFS               (1)                             /* !< WP_24_1 Offset */
+#define LFSS_SPMWPROT6_WP_24_1_MASK              ((uint32_t)0x00000002U)         /* !< write protect SPMEM24 - DATA1 */
+#define LFSS_SPMWPROT6_WP_24_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_24_1_READONLY          ((uint32_t)0x00000002U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT6[WP_24_0] Bits */
+#define LFSS_SPMWPROT6_WP_24_0_OFS               (0)                             /* !< WP_24_0 Offset */
+#define LFSS_SPMWPROT6_WP_24_0_MASK              ((uint32_t)0x00000001U)         /* !< write protect SPMEM24 - DATA0 */
+#define LFSS_SPMWPROT6_WP_24_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT6_WP_24_0_READONLY          ((uint32_t)0x00000001U)         /* !< SPMEM is read only access */
+
+/* LFSS_SPMWPROT7 Bits */
+/* LFSS_SPMWPROT7[KEY] Bits */
+#define LFSS_SPMWPROT7_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define LFSS_SPMWPROT7_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xE8) to update
+                                                                                    this register */
+#define LFSS_SPMWPROT7_KEY_UNLOCK_W              ((uint32_t)0xE8000000U)         /* !< This field must be written with
+                                                                                    0xE8 to be update the write protect
+                                                                                    bits. */
+/* LFSS_SPMWPROT7[WP_31_3] Bits */
+#define LFSS_SPMWPROT7_WP_31_3_OFS               (15)                            /* !< WP_31_3 Offset */
+#define LFSS_SPMWPROT7_WP_31_3_MASK              ((uint32_t)0x00008000U)         /* !< write protect SPMEM31 - DATA3 */
+#define LFSS_SPMWPROT7_WP_31_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_31_3_READONLY          ((uint32_t)0x00008000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_31_2] Bits */
+#define LFSS_SPMWPROT7_WP_31_2_OFS               (14)                            /* !< WP_31_2 Offset */
+#define LFSS_SPMWPROT7_WP_31_2_MASK              ((uint32_t)0x00004000U)         /* !< write protect SPMEM31 - DATA2 */
+#define LFSS_SPMWPROT7_WP_31_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_31_2_READONLY          ((uint32_t)0x00004000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_31_1] Bits */
+#define LFSS_SPMWPROT7_WP_31_1_OFS               (13)                            /* !< WP_31_1 Offset */
+#define LFSS_SPMWPROT7_WP_31_1_MASK              ((uint32_t)0x00002000U)         /* !< write protect SPMEM31 - DATA1 */
+#define LFSS_SPMWPROT7_WP_31_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_31_1_READONLY          ((uint32_t)0x00002000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_31_0] Bits */
+#define LFSS_SPMWPROT7_WP_31_0_OFS               (12)                            /* !< WP_31_0 Offset */
+#define LFSS_SPMWPROT7_WP_31_0_MASK              ((uint32_t)0x00001000U)         /* !< write protect SPMEM31 - DATA0 */
+#define LFSS_SPMWPROT7_WP_31_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_31_0_READONLY          ((uint32_t)0x00001000U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_30_3] Bits */
+#define LFSS_SPMWPROT7_WP_30_3_OFS               (11)                            /* !< WP_30_3 Offset */
+#define LFSS_SPMWPROT7_WP_30_3_MASK              ((uint32_t)0x00000800U)         /* !< write protect SPMEM30 - DATA3 */
+#define LFSS_SPMWPROT7_WP_30_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_30_3_READONLY          ((uint32_t)0x00000800U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_30_2] Bits */
+#define LFSS_SPMWPROT7_WP_30_2_OFS               (10)                            /* !< WP_30_2 Offset */
+#define LFSS_SPMWPROT7_WP_30_2_MASK              ((uint32_t)0x00000400U)         /* !< write protect SPMEM30- DATA2 */
+#define LFSS_SPMWPROT7_WP_30_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_30_2_READONLY          ((uint32_t)0x00000400U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_30_1] Bits */
+#define LFSS_SPMWPROT7_WP_30_1_OFS               (9)                             /* !< WP_30_1 Offset */
+#define LFSS_SPMWPROT7_WP_30_1_MASK              ((uint32_t)0x00000200U)         /* !< write protect SPMEM30 - DATA1 */
+#define LFSS_SPMWPROT7_WP_30_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_30_1_READONLY          ((uint32_t)0x00000200U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_30_0] Bits */
+#define LFSS_SPMWPROT7_WP_30_0_OFS               (8)                             /* !< WP_30_0 Offset */
+#define LFSS_SPMWPROT7_WP_30_0_MASK              ((uint32_t)0x00000100U)         /* !< write protect SPMEM30 - DATA0 */
+#define LFSS_SPMWPROT7_WP_30_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_30_0_READONLY          ((uint32_t)0x00000100U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_29_3] Bits */
+#define LFSS_SPMWPROT7_WP_29_3_OFS               (7)                             /* !< WP_29_3 Offset */
+#define LFSS_SPMWPROT7_WP_29_3_MASK              ((uint32_t)0x00000080U)         /* !< write protect SPMEM29 - DATA3 */
+#define LFSS_SPMWPROT7_WP_29_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_29_3_READONLY          ((uint32_t)0x00000080U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_29_2] Bits */
+#define LFSS_SPMWPROT7_WP_29_2_OFS               (6)                             /* !< WP_29_2 Offset */
+#define LFSS_SPMWPROT7_WP_29_2_MASK              ((uint32_t)0x00000040U)         /* !< write protect SPMEM29 - DATA2 */
+#define LFSS_SPMWPROT7_WP_29_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_29_2_READONLY          ((uint32_t)0x00000040U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_29_1] Bits */
+#define LFSS_SPMWPROT7_WP_29_1_OFS               (5)                             /* !< WP_29_1 Offset */
+#define LFSS_SPMWPROT7_WP_29_1_MASK              ((uint32_t)0x00000020U)         /* !< write protect SPMEM29 - DATA1 */
+#define LFSS_SPMWPROT7_WP_29_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_29_1_READONLY          ((uint32_t)0x00000020U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_29_0] Bits */
+#define LFSS_SPMWPROT7_WP_29_0_OFS               (4)                             /* !< WP_29_0 Offset */
+#define LFSS_SPMWPROT7_WP_29_0_MASK              ((uint32_t)0x00000010U)         /* !< write protect SPMEM29 - DATA0 */
+#define LFSS_SPMWPROT7_WP_29_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_29_0_READONLY          ((uint32_t)0x00000010U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_28_3] Bits */
+#define LFSS_SPMWPROT7_WP_28_3_OFS               (3)                             /* !< WP_28_3 Offset */
+#define LFSS_SPMWPROT7_WP_28_3_MASK              ((uint32_t)0x00000008U)         /* !< write protect SPMEM28 - DATA3 */
+#define LFSS_SPMWPROT7_WP_28_3_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_28_3_READONLY          ((uint32_t)0x00000008U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_28_2] Bits */
+#define LFSS_SPMWPROT7_WP_28_2_OFS               (2)                             /* !< WP_28_2 Offset */
+#define LFSS_SPMWPROT7_WP_28_2_MASK              ((uint32_t)0x00000004U)         /* !< write protect SPMEM28 - DATA2 */
+#define LFSS_SPMWPROT7_WP_28_2_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_28_2_READONLY          ((uint32_t)0x00000004U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_28_1] Bits */
+#define LFSS_SPMWPROT7_WP_28_1_OFS               (1)                             /* !< WP_28_1 Offset */
+#define LFSS_SPMWPROT7_WP_28_1_MASK              ((uint32_t)0x00000002U)         /* !< write protect SPMEM28 - DATA1 */
+#define LFSS_SPMWPROT7_WP_28_1_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_28_1_READONLY          ((uint32_t)0x00000002U)         /* !< SPMEM is read only access */
+/* LFSS_SPMWPROT7[WP_28_0] Bits */
+#define LFSS_SPMWPROT7_WP_28_0_OFS               (0)                             /* !< WP_28_0 Offset */
+#define LFSS_SPMWPROT7_WP_28_0_MASK              ((uint32_t)0x00000001U)         /* !< write protect SPMEM28 - DATA0 */
+#define LFSS_SPMWPROT7_WP_28_0_READWRITE         ((uint32_t)0x00000000U)         /* !< SPMEM is read and write access */
+#define LFSS_SPMWPROT7_WP_28_0_READONLY          ((uint32_t)0x00000001U)         /* !< SPMEM is read only access */
+
+/* LFSS_SPMTERASE0 Bits */
+/* LFSS_SPMTERASE0[KEY] Bits */
+#define LFSS_SPMTERASE0_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define LFSS_SPMTERASE0_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xA3) to update
+                                                                                    this register */
+#define LFSS_SPMTERASE0_KEY_UNLOCK_W             ((uint32_t)0xA3000000U)         /* !< This field must be written with
+                                                                                    0xA3 to be update the tamper erase
+                                                                                    enable bit. */
+/* LFSS_SPMTERASE0[TE_3_3] Bits */
+#define LFSS_SPMTERASE0_TE_3_3_OFS               (15)                            /* !< TE_3_3 Offset */
+#define LFSS_SPMTERASE0_TE_3_3_MASK              ((uint32_t)0x00008000U)         /* !< tamper erase enable SPMEM3 - DATA3 */
+#define LFSS_SPMTERASE0_TE_3_3_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_3_3_ENABLE            ((uint32_t)0x00008000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_3_2] Bits */
+#define LFSS_SPMTERASE0_TE_3_2_OFS               (14)                            /* !< TE_3_2 Offset */
+#define LFSS_SPMTERASE0_TE_3_2_MASK              ((uint32_t)0x00004000U)         /* !< tamper erase enable SPMEM3 - DATA2 */
+#define LFSS_SPMTERASE0_TE_3_2_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_3_2_ENABLE            ((uint32_t)0x00004000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_3_1] Bits */
+#define LFSS_SPMTERASE0_TE_3_1_OFS               (13)                            /* !< TE_3_1 Offset */
+#define LFSS_SPMTERASE0_TE_3_1_MASK              ((uint32_t)0x00002000U)         /* !< tamper erase enable SPMEM3 - DATA1 */
+#define LFSS_SPMTERASE0_TE_3_1_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_3_1_ENABLE            ((uint32_t)0x00002000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_3_0] Bits */
+#define LFSS_SPMTERASE0_TE_3_0_OFS               (12)                            /* !< TE_3_0 Offset */
+#define LFSS_SPMTERASE0_TE_3_0_MASK              ((uint32_t)0x00001000U)         /* !< tamper erase enable SPMEM3 - DATA0 */
+#define LFSS_SPMTERASE0_TE_3_0_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_3_0_ENABLE            ((uint32_t)0x00001000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_2_3] Bits */
+#define LFSS_SPMTERASE0_TE_2_3_OFS               (11)                            /* !< TE_2_3 Offset */
+#define LFSS_SPMTERASE0_TE_2_3_MASK              ((uint32_t)0x00000800U)         /* !< tamper erase enable SPMEM2 - DATA3 */
+#define LFSS_SPMTERASE0_TE_2_3_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_2_3_ENABLE            ((uint32_t)0x00000800U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_2_2] Bits */
+#define LFSS_SPMTERASE0_TE_2_2_OFS               (10)                            /* !< TE_2_2 Offset */
+#define LFSS_SPMTERASE0_TE_2_2_MASK              ((uint32_t)0x00000400U)         /* !< tamper erase enable SPMEM2 - DATA2 */
+#define LFSS_SPMTERASE0_TE_2_2_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_2_2_ENABLE            ((uint32_t)0x00000400U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_2_1] Bits */
+#define LFSS_SPMTERASE0_TE_2_1_OFS               (9)                             /* !< TE_2_1 Offset */
+#define LFSS_SPMTERASE0_TE_2_1_MASK              ((uint32_t)0x00000200U)         /* !< tamper erase enable SPMEM2 - DATA1 */
+#define LFSS_SPMTERASE0_TE_2_1_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_2_1_ENABLE            ((uint32_t)0x00000200U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_2_0] Bits */
+#define LFSS_SPMTERASE0_TE_2_0_OFS               (8)                             /* !< TE_2_0 Offset */
+#define LFSS_SPMTERASE0_TE_2_0_MASK              ((uint32_t)0x00000100U)         /* !< tamper erase enable SPMEM2 - DATA0 */
+#define LFSS_SPMTERASE0_TE_2_0_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_2_0_ENABLE            ((uint32_t)0x00000100U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_1_3] Bits */
+#define LFSS_SPMTERASE0_TE_1_3_OFS               (7)                             /* !< TE_1_3 Offset */
+#define LFSS_SPMTERASE0_TE_1_3_MASK              ((uint32_t)0x00000080U)         /* !< tamper erase enable SPMEM1 - DATA3 */
+#define LFSS_SPMTERASE0_TE_1_3_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_1_3_ENABLE            ((uint32_t)0x00000080U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_1_2] Bits */
+#define LFSS_SPMTERASE0_TE_1_2_OFS               (6)                             /* !< TE_1_2 Offset */
+#define LFSS_SPMTERASE0_TE_1_2_MASK              ((uint32_t)0x00000040U)         /* !< tamper erase enable SPMEM1 - DATA2 */
+#define LFSS_SPMTERASE0_TE_1_2_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_1_2_ENABLE            ((uint32_t)0x00000040U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_1_1] Bits */
+#define LFSS_SPMTERASE0_TE_1_1_OFS               (5)                             /* !< TE_1_1 Offset */
+#define LFSS_SPMTERASE0_TE_1_1_MASK              ((uint32_t)0x00000020U)         /* !< tamper erase enable SPMEM1 - DATA1 */
+#define LFSS_SPMTERASE0_TE_1_1_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_1_1_ENABLE            ((uint32_t)0x00000020U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_1_0] Bits */
+#define LFSS_SPMTERASE0_TE_1_0_OFS               (4)                             /* !< TE_1_0 Offset */
+#define LFSS_SPMTERASE0_TE_1_0_MASK              ((uint32_t)0x00000010U)         /* !< tamper erase enable SPMEM1 - DATA0 */
+#define LFSS_SPMTERASE0_TE_1_0_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_1_0_ENABLE            ((uint32_t)0x00000010U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_0_3] Bits */
+#define LFSS_SPMTERASE0_TE_0_3_OFS               (3)                             /* !< TE_0_3 Offset */
+#define LFSS_SPMTERASE0_TE_0_3_MASK              ((uint32_t)0x00000008U)         /* !< tamper erase enable SPMEM0 - DATA3 */
+#define LFSS_SPMTERASE0_TE_0_3_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_0_3_ENABLE            ((uint32_t)0x00000008U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_0_2] Bits */
+#define LFSS_SPMTERASE0_TE_0_2_OFS               (2)                             /* !< TE_0_2 Offset */
+#define LFSS_SPMTERASE0_TE_0_2_MASK              ((uint32_t)0x00000004U)         /* !< tamper erase enable SPMEM0 - DATA2 */
+#define LFSS_SPMTERASE0_TE_0_2_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_0_2_ENABLE            ((uint32_t)0x00000004U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_0_1] Bits */
+#define LFSS_SPMTERASE0_TE_0_1_OFS               (1)                             /* !< TE_0_1 Offset */
+#define LFSS_SPMTERASE0_TE_0_1_MASK              ((uint32_t)0x00000002U)         /* !< tamper erase enable SPMEM0 - DATA1 */
+#define LFSS_SPMTERASE0_TE_0_1_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_0_1_ENABLE            ((uint32_t)0x00000002U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE0[TE_0_0] Bits */
+#define LFSS_SPMTERASE0_TE_0_0_OFS               (0)                             /* !< TE_0_0 Offset */
+#define LFSS_SPMTERASE0_TE_0_0_MASK              ((uint32_t)0x00000001U)         /* !< tamper erase enable SPMEM0 - DATA0 */
+#define LFSS_SPMTERASE0_TE_0_0_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE0_TE_0_0_ENABLE            ((uint32_t)0x00000001U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+
+/* LFSS_SPMTERASE1 Bits */
+/* LFSS_SPMTERASE1[KEY] Bits */
+#define LFSS_SPMTERASE1_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define LFSS_SPMTERASE1_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xA3) to update
+                                                                                    this register */
+#define LFSS_SPMTERASE1_KEY_UNLOCK_W             ((uint32_t)0xA3000000U)         /* !< This field must be written with
+                                                                                    0xA3 to be update the tamper erase
+                                                                                    enable bit. */
+/* LFSS_SPMTERASE1[TE_7_3] Bits */
+#define LFSS_SPMTERASE1_TE_7_3_OFS               (15)                            /* !< TE_7_3 Offset */
+#define LFSS_SPMTERASE1_TE_7_3_MASK              ((uint32_t)0x00008000U)         /* !< tamper erase enable SPMEM7 - DATA3 */
+#define LFSS_SPMTERASE1_TE_7_3_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_7_3_ENABLE            ((uint32_t)0x00008000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_7_2] Bits */
+#define LFSS_SPMTERASE1_TE_7_2_OFS               (14)                            /* !< TE_7_2 Offset */
+#define LFSS_SPMTERASE1_TE_7_2_MASK              ((uint32_t)0x00004000U)         /* !< tamper erase enable SPMEM7 - DATA2 */
+#define LFSS_SPMTERASE1_TE_7_2_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_7_2_ENABLE            ((uint32_t)0x00004000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_7_1] Bits */
+#define LFSS_SPMTERASE1_TE_7_1_OFS               (13)                            /* !< TE_7_1 Offset */
+#define LFSS_SPMTERASE1_TE_7_1_MASK              ((uint32_t)0x00002000U)         /* !< tamper erase enable SPMEM7 - DATA1 */
+#define LFSS_SPMTERASE1_TE_7_1_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_7_1_ENABLE            ((uint32_t)0x00002000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_7_0] Bits */
+#define LFSS_SPMTERASE1_TE_7_0_OFS               (12)                            /* !< TE_7_0 Offset */
+#define LFSS_SPMTERASE1_TE_7_0_MASK              ((uint32_t)0x00001000U)         /* !< tamper erase enable SPMEM7 - DATA0 */
+#define LFSS_SPMTERASE1_TE_7_0_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_7_0_ENABLE            ((uint32_t)0x00001000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_6_3] Bits */
+#define LFSS_SPMTERASE1_TE_6_3_OFS               (11)                            /* !< TE_6_3 Offset */
+#define LFSS_SPMTERASE1_TE_6_3_MASK              ((uint32_t)0x00000800U)         /* !< tamper erase enable SPMEM6 - DATA3 */
+#define LFSS_SPMTERASE1_TE_6_3_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_6_3_ENABLE            ((uint32_t)0x00000800U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_6_2] Bits */
+#define LFSS_SPMTERASE1_TE_6_2_OFS               (10)                            /* !< TE_6_2 Offset */
+#define LFSS_SPMTERASE1_TE_6_2_MASK              ((uint32_t)0x00000400U)         /* !< tamper erase enable SPMEM6 - DATA2 */
+#define LFSS_SPMTERASE1_TE_6_2_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_6_2_ENABLE            ((uint32_t)0x00000400U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_6_1] Bits */
+#define LFSS_SPMTERASE1_TE_6_1_OFS               (9)                             /* !< TE_6_1 Offset */
+#define LFSS_SPMTERASE1_TE_6_1_MASK              ((uint32_t)0x00000200U)         /* !< tamper erase enable SPMEM6 - DATA1 */
+#define LFSS_SPMTERASE1_TE_6_1_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_6_1_ENABLE            ((uint32_t)0x00000200U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_6_0] Bits */
+#define LFSS_SPMTERASE1_TE_6_0_OFS               (8)                             /* !< TE_6_0 Offset */
+#define LFSS_SPMTERASE1_TE_6_0_MASK              ((uint32_t)0x00000100U)         /* !< tamper erase enable SPMEM6 - DATA0 */
+#define LFSS_SPMTERASE1_TE_6_0_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_6_0_ENABLE            ((uint32_t)0x00000100U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_5_3] Bits */
+#define LFSS_SPMTERASE1_TE_5_3_OFS               (7)                             /* !< TE_5_3 Offset */
+#define LFSS_SPMTERASE1_TE_5_3_MASK              ((uint32_t)0x00000080U)         /* !< tamper erase enable SPMEM5 - DATA3 */
+#define LFSS_SPMTERASE1_TE_5_3_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_5_3_ENABLE            ((uint32_t)0x00000080U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_5_2] Bits */
+#define LFSS_SPMTERASE1_TE_5_2_OFS               (6)                             /* !< TE_5_2 Offset */
+#define LFSS_SPMTERASE1_TE_5_2_MASK              ((uint32_t)0x00000040U)         /* !< tamper erase enable SPMEM5 - DATA2 */
+#define LFSS_SPMTERASE1_TE_5_2_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_5_2_ENABLE            ((uint32_t)0x00000040U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_5_1] Bits */
+#define LFSS_SPMTERASE1_TE_5_1_OFS               (5)                             /* !< TE_5_1 Offset */
+#define LFSS_SPMTERASE1_TE_5_1_MASK              ((uint32_t)0x00000020U)         /* !< tamper erase enable SPMEM5 - DATA1 */
+#define LFSS_SPMTERASE1_TE_5_1_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_5_1_ENABLE            ((uint32_t)0x00000020U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_5_0] Bits */
+#define LFSS_SPMTERASE1_TE_5_0_OFS               (4)                             /* !< TE_5_0 Offset */
+#define LFSS_SPMTERASE1_TE_5_0_MASK              ((uint32_t)0x00000010U)         /* !< tamper erase enable SPMEM5 - DATA0 */
+#define LFSS_SPMTERASE1_TE_5_0_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_5_0_ENABLE            ((uint32_t)0x00000010U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_4_3] Bits */
+#define LFSS_SPMTERASE1_TE_4_3_OFS               (3)                             /* !< TE_4_3 Offset */
+#define LFSS_SPMTERASE1_TE_4_3_MASK              ((uint32_t)0x00000008U)         /* !< tamper erase enable SPMEM4 - DATA3 */
+#define LFSS_SPMTERASE1_TE_4_3_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_4_3_ENABLE            ((uint32_t)0x00000008U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_4_2] Bits */
+#define LFSS_SPMTERASE1_TE_4_2_OFS               (2)                             /* !< TE_4_2 Offset */
+#define LFSS_SPMTERASE1_TE_4_2_MASK              ((uint32_t)0x00000004U)         /* !< tamper erase enable SPMEM4 - DATA2 */
+#define LFSS_SPMTERASE1_TE_4_2_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_4_2_ENABLE            ((uint32_t)0x00000004U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_4_1] Bits */
+#define LFSS_SPMTERASE1_TE_4_1_OFS               (1)                             /* !< TE_4_1 Offset */
+#define LFSS_SPMTERASE1_TE_4_1_MASK              ((uint32_t)0x00000002U)         /* !< tamper erase enable SPMEM4 - DATA1 */
+#define LFSS_SPMTERASE1_TE_4_1_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_4_1_ENABLE            ((uint32_t)0x00000002U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE1[TE_4_0] Bits */
+#define LFSS_SPMTERASE1_TE_4_0_OFS               (0)                             /* !< TE_4_0 Offset */
+#define LFSS_SPMTERASE1_TE_4_0_MASK              ((uint32_t)0x00000001U)         /* !< tamper erase enable SPMEM4 - DATA0 */
+#define LFSS_SPMTERASE1_TE_4_0_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE1_TE_4_0_ENABLE            ((uint32_t)0x00000001U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+
+/* LFSS_SPMTERASE2 Bits */
+/* LFSS_SPMTERASE2[KEY] Bits */
+#define LFSS_SPMTERASE2_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define LFSS_SPMTERASE2_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xA3) to update
+                                                                                    this register */
+#define LFSS_SPMTERASE2_KEY_UNLOCK_W             ((uint32_t)0xA3000000U)         /* !< This field must be written with
+                                                                                    0xA3 to be update the tamper erase
+                                                                                    enable bit. */
+/* LFSS_SPMTERASE2[TE_11_3] Bits */
+#define LFSS_SPMTERASE2_TE_11_3_OFS              (15)                            /* !< TE_11_3 Offset */
+#define LFSS_SPMTERASE2_TE_11_3_MASK             ((uint32_t)0x00008000U)         /* !< tamper erase enable SPMEM11 - DATA3 */
+#define LFSS_SPMTERASE2_TE_11_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_11_3_ENABLE           ((uint32_t)0x00008000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_11_2] Bits */
+#define LFSS_SPMTERASE2_TE_11_2_OFS              (14)                            /* !< TE_11_2 Offset */
+#define LFSS_SPMTERASE2_TE_11_2_MASK             ((uint32_t)0x00004000U)         /* !< tamper erase enable SPMEM11 - DATA2 */
+#define LFSS_SPMTERASE2_TE_11_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_11_2_ENABLE           ((uint32_t)0x00004000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_11_1] Bits */
+#define LFSS_SPMTERASE2_TE_11_1_OFS              (13)                            /* !< TE_11_1 Offset */
+#define LFSS_SPMTERASE2_TE_11_1_MASK             ((uint32_t)0x00002000U)         /* !< tamper erase enable SPMEM11 - DATA1 */
+#define LFSS_SPMTERASE2_TE_11_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_11_1_ENABLE           ((uint32_t)0x00002000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_11_0] Bits */
+#define LFSS_SPMTERASE2_TE_11_0_OFS              (12)                            /* !< TE_11_0 Offset */
+#define LFSS_SPMTERASE2_TE_11_0_MASK             ((uint32_t)0x00001000U)         /* !< tamper erase enable SPMEM11 - DATA0 */
+#define LFSS_SPMTERASE2_TE_11_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_11_0_ENABLE           ((uint32_t)0x00001000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_10_3] Bits */
+#define LFSS_SPMTERASE2_TE_10_3_OFS              (11)                            /* !< TE_10_3 Offset */
+#define LFSS_SPMTERASE2_TE_10_3_MASK             ((uint32_t)0x00000800U)         /* !< tamper erase enable SPMEM10 - DATA3 */
+#define LFSS_SPMTERASE2_TE_10_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_10_3_ENABLE           ((uint32_t)0x00000800U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_10_2] Bits */
+#define LFSS_SPMTERASE2_TE_10_2_OFS              (10)                            /* !< TE_10_2 Offset */
+#define LFSS_SPMTERASE2_TE_10_2_MASK             ((uint32_t)0x00000400U)         /* !< tamper erase enable SPMEM10 - DATA2 */
+#define LFSS_SPMTERASE2_TE_10_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_10_2_ENABLE           ((uint32_t)0x00000400U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_10_1] Bits */
+#define LFSS_SPMTERASE2_TE_10_1_OFS              (9)                             /* !< TE_10_1 Offset */
+#define LFSS_SPMTERASE2_TE_10_1_MASK             ((uint32_t)0x00000200U)         /* !< tamper erase enable SPMEM10 - DATA1 */
+#define LFSS_SPMTERASE2_TE_10_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_10_1_ENABLE           ((uint32_t)0x00000200U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_10_0] Bits */
+#define LFSS_SPMTERASE2_TE_10_0_OFS              (8)                             /* !< TE_10_0 Offset */
+#define LFSS_SPMTERASE2_TE_10_0_MASK             ((uint32_t)0x00000100U)         /* !< tamper erase enable SPMEM10 - DATA0 */
+#define LFSS_SPMTERASE2_TE_10_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_10_0_ENABLE           ((uint32_t)0x00000100U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_9_3] Bits */
+#define LFSS_SPMTERASE2_TE_9_3_OFS               (7)                             /* !< TE_9_3 Offset */
+#define LFSS_SPMTERASE2_TE_9_3_MASK              ((uint32_t)0x00000080U)         /* !< tamper erase enable SPMEM9 - DATA3 */
+#define LFSS_SPMTERASE2_TE_9_3_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_9_3_ENABLE            ((uint32_t)0x00000080U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_9_2] Bits */
+#define LFSS_SPMTERASE2_TE_9_2_OFS               (6)                             /* !< TE_9_2 Offset */
+#define LFSS_SPMTERASE2_TE_9_2_MASK              ((uint32_t)0x00000040U)         /* !< tamper erase enable SPMEM9 - DATA2 */
+#define LFSS_SPMTERASE2_TE_9_2_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_9_2_ENABLE            ((uint32_t)0x00000040U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_9_1] Bits */
+#define LFSS_SPMTERASE2_TE_9_1_OFS               (5)                             /* !< TE_9_1 Offset */
+#define LFSS_SPMTERASE2_TE_9_1_MASK              ((uint32_t)0x00000020U)         /* !< tamper erase enable SPMEM9 - DATA1 */
+#define LFSS_SPMTERASE2_TE_9_1_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_9_1_ENABLE            ((uint32_t)0x00000020U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_9_0] Bits */
+#define LFSS_SPMTERASE2_TE_9_0_OFS               (4)                             /* !< TE_9_0 Offset */
+#define LFSS_SPMTERASE2_TE_9_0_MASK              ((uint32_t)0x00000010U)         /* !< tamper erase enable SPMEM9 - DATA0 */
+#define LFSS_SPMTERASE2_TE_9_0_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_9_0_ENABLE            ((uint32_t)0x00000010U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_8_3] Bits */
+#define LFSS_SPMTERASE2_TE_8_3_OFS               (3)                             /* !< TE_8_3 Offset */
+#define LFSS_SPMTERASE2_TE_8_3_MASK              ((uint32_t)0x00000008U)         /* !< tamper erase enable SPMEM8 - DATA3 */
+#define LFSS_SPMTERASE2_TE_8_3_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_8_3_ENABLE            ((uint32_t)0x00000008U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_8_2] Bits */
+#define LFSS_SPMTERASE2_TE_8_2_OFS               (2)                             /* !< TE_8_2 Offset */
+#define LFSS_SPMTERASE2_TE_8_2_MASK              ((uint32_t)0x00000004U)         /* !< tamper erase enable SPMEM8 - DATA2 */
+#define LFSS_SPMTERASE2_TE_8_2_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_8_2_ENABLE            ((uint32_t)0x00000004U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_8_1] Bits */
+#define LFSS_SPMTERASE2_TE_8_1_OFS               (1)                             /* !< TE_8_1 Offset */
+#define LFSS_SPMTERASE2_TE_8_1_MASK              ((uint32_t)0x00000002U)         /* !< tamper erase enable SPMEM8 - DATA1 */
+#define LFSS_SPMTERASE2_TE_8_1_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_8_1_ENABLE            ((uint32_t)0x00000002U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE2[TE_8_0] Bits */
+#define LFSS_SPMTERASE2_TE_8_0_OFS               (0)                             /* !< TE_8_0 Offset */
+#define LFSS_SPMTERASE2_TE_8_0_MASK              ((uint32_t)0x00000001U)         /* !< tamper erase enable SPMEM8 - DATA0 */
+#define LFSS_SPMTERASE2_TE_8_0_DISABLE           ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE2_TE_8_0_ENABLE            ((uint32_t)0x00000001U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+
+/* LFSS_SPMTERASE3 Bits */
+/* LFSS_SPMTERASE3[KEY] Bits */
+#define LFSS_SPMTERASE3_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define LFSS_SPMTERASE3_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xA3) to update
+                                                                                    this register */
+#define LFSS_SPMTERASE3_KEY_UNLOCK_W             ((uint32_t)0xA3000000U)         /* !< This field must be written with
+                                                                                    0xA3 to be update the tamper erase
+                                                                                    enable bit. */
+/* LFSS_SPMTERASE3[TE_15_3] Bits */
+#define LFSS_SPMTERASE3_TE_15_3_OFS              (15)                            /* !< TE_15_3 Offset */
+#define LFSS_SPMTERASE3_TE_15_3_MASK             ((uint32_t)0x00008000U)         /* !< tamper erase enable SPMEM15 - DATA3 */
+#define LFSS_SPMTERASE3_TE_15_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_15_3_ENABLE           ((uint32_t)0x00008000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_15_2] Bits */
+#define LFSS_SPMTERASE3_TE_15_2_OFS              (14)                            /* !< TE_15_2 Offset */
+#define LFSS_SPMTERASE3_TE_15_2_MASK             ((uint32_t)0x00004000U)         /* !< tamper erase enable SPMEM15 - DATA2 */
+#define LFSS_SPMTERASE3_TE_15_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_15_2_ENABLE           ((uint32_t)0x00004000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_15_1] Bits */
+#define LFSS_SPMTERASE3_TE_15_1_OFS              (13)                            /* !< TE_15_1 Offset */
+#define LFSS_SPMTERASE3_TE_15_1_MASK             ((uint32_t)0x00002000U)         /* !< tamper erase enable SPMEM15 - DATA1 */
+#define LFSS_SPMTERASE3_TE_15_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_15_1_ENABLE           ((uint32_t)0x00002000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_15_0] Bits */
+#define LFSS_SPMTERASE3_TE_15_0_OFS              (12)                            /* !< TE_15_0 Offset */
+#define LFSS_SPMTERASE3_TE_15_0_MASK             ((uint32_t)0x00001000U)         /* !< tamper erase enable SPMEM15 - DATA0 */
+#define LFSS_SPMTERASE3_TE_15_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_15_0_ENABLE           ((uint32_t)0x00001000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_14_3] Bits */
+#define LFSS_SPMTERASE3_TE_14_3_OFS              (11)                            /* !< TE_14_3 Offset */
+#define LFSS_SPMTERASE3_TE_14_3_MASK             ((uint32_t)0x00000800U)         /* !< tamper erase enable SPMEM14 - DATA3 */
+#define LFSS_SPMTERASE3_TE_14_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_14_3_ENABLE           ((uint32_t)0x00000800U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_14_2] Bits */
+#define LFSS_SPMTERASE3_TE_14_2_OFS              (10)                            /* !< TE_14_2 Offset */
+#define LFSS_SPMTERASE3_TE_14_2_MASK             ((uint32_t)0x00000400U)         /* !< tamper erase enable SPMEM14 - DATA2 */
+#define LFSS_SPMTERASE3_TE_14_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_14_2_ENABLE           ((uint32_t)0x00000400U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_14_1] Bits */
+#define LFSS_SPMTERASE3_TE_14_1_OFS              (9)                             /* !< TE_14_1 Offset */
+#define LFSS_SPMTERASE3_TE_14_1_MASK             ((uint32_t)0x00000200U)         /* !< tamper erase enable SPMEM14 - DATA1 */
+#define LFSS_SPMTERASE3_TE_14_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_14_1_ENABLE           ((uint32_t)0x00000200U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_14_0] Bits */
+#define LFSS_SPMTERASE3_TE_14_0_OFS              (8)                             /* !< TE_14_0 Offset */
+#define LFSS_SPMTERASE3_TE_14_0_MASK             ((uint32_t)0x00000100U)         /* !< tamper erase enable SPMEM14 - DATA0 */
+#define LFSS_SPMTERASE3_TE_14_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_14_0_ENABLE           ((uint32_t)0x00000100U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_13_3] Bits */
+#define LFSS_SPMTERASE3_TE_13_3_OFS              (7)                             /* !< TE_13_3 Offset */
+#define LFSS_SPMTERASE3_TE_13_3_MASK             ((uint32_t)0x00000080U)         /* !< tamper erase enable SPMEM13 - DATA3 */
+#define LFSS_SPMTERASE3_TE_13_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_13_3_ENABLE           ((uint32_t)0x00000080U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_13_2] Bits */
+#define LFSS_SPMTERASE3_TE_13_2_OFS              (6)                             /* !< TE_13_2 Offset */
+#define LFSS_SPMTERASE3_TE_13_2_MASK             ((uint32_t)0x00000040U)         /* !< tamper erase enable SPMEM13 - DATA2 */
+#define LFSS_SPMTERASE3_TE_13_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_13_2_ENABLE           ((uint32_t)0x00000040U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_13_1] Bits */
+#define LFSS_SPMTERASE3_TE_13_1_OFS              (5)                             /* !< TE_13_1 Offset */
+#define LFSS_SPMTERASE3_TE_13_1_MASK             ((uint32_t)0x00000020U)         /* !< tamper erase enable SPMEM13 - DATA1 */
+#define LFSS_SPMTERASE3_TE_13_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_13_1_ENABLE           ((uint32_t)0x00000020U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_13_0] Bits */
+#define LFSS_SPMTERASE3_TE_13_0_OFS              (4)                             /* !< TE_13_0 Offset */
+#define LFSS_SPMTERASE3_TE_13_0_MASK             ((uint32_t)0x00000010U)         /* !< tamper erase enable SPMEM13 - DATA0 */
+#define LFSS_SPMTERASE3_TE_13_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_13_0_ENABLE           ((uint32_t)0x00000010U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_12_3] Bits */
+#define LFSS_SPMTERASE3_TE_12_3_OFS              (3)                             /* !< TE_12_3 Offset */
+#define LFSS_SPMTERASE3_TE_12_3_MASK             ((uint32_t)0x00000008U)         /* !< tamper erase enable SPMEM12 - DATA3 */
+#define LFSS_SPMTERASE3_TE_12_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_12_3_ENABLE           ((uint32_t)0x00000008U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_12_2] Bits */
+#define LFSS_SPMTERASE3_TE_12_2_OFS              (2)                             /* !< TE_12_2 Offset */
+#define LFSS_SPMTERASE3_TE_12_2_MASK             ((uint32_t)0x00000004U)         /* !< tamper erase enable SPMEM12 - DATA2 */
+#define LFSS_SPMTERASE3_TE_12_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_12_2_ENABLE           ((uint32_t)0x00000004U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_12_1] Bits */
+#define LFSS_SPMTERASE3_TE_12_1_OFS              (1)                             /* !< TE_12_1 Offset */
+#define LFSS_SPMTERASE3_TE_12_1_MASK             ((uint32_t)0x00000002U)         /* !< tamper erase enable SPMEM12 - DATA1 */
+#define LFSS_SPMTERASE3_TE_12_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_12_1_ENABLE           ((uint32_t)0x00000002U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE3[TE_12_0] Bits */
+#define LFSS_SPMTERASE3_TE_12_0_OFS              (0)                             /* !< TE_12_0 Offset */
+#define LFSS_SPMTERASE3_TE_12_0_MASK             ((uint32_t)0x00000001U)         /* !< tamper erase enable SPMEM12 - DATA0 */
+#define LFSS_SPMTERASE3_TE_12_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE3_TE_12_0_ENABLE           ((uint32_t)0x00000001U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+
+/* LFSS_SPMTERASE4 Bits */
+/* LFSS_SPMTERASE4[KEY] Bits */
+#define LFSS_SPMTERASE4_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define LFSS_SPMTERASE4_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xA3) to update
+                                                                                    this register */
+#define LFSS_SPMTERASE4_KEY_UNLOCK_W             ((uint32_t)0xA3000000U)         /* !< This field must be written with
+                                                                                    0xA3 to be update the tamper erase
+                                                                                    enable bit. */
+/* LFSS_SPMTERASE4[TE_19_3] Bits */
+#define LFSS_SPMTERASE4_TE_19_3_OFS              (15)                            /* !< TE_19_3 Offset */
+#define LFSS_SPMTERASE4_TE_19_3_MASK             ((uint32_t)0x00008000U)         /* !< tamper erase enable SPMEM19 - DATA3 */
+#define LFSS_SPMTERASE4_TE_19_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_19_3_ENABLE           ((uint32_t)0x00008000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_19_2] Bits */
+#define LFSS_SPMTERASE4_TE_19_2_OFS              (14)                            /* !< TE_19_2 Offset */
+#define LFSS_SPMTERASE4_TE_19_2_MASK             ((uint32_t)0x00004000U)         /* !< tamper erase enable SPMEM19 - DATA2 */
+#define LFSS_SPMTERASE4_TE_19_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_19_2_ENABLE           ((uint32_t)0x00004000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_19_1] Bits */
+#define LFSS_SPMTERASE4_TE_19_1_OFS              (13)                            /* !< TE_19_1 Offset */
+#define LFSS_SPMTERASE4_TE_19_1_MASK             ((uint32_t)0x00002000U)         /* !< tamper erase enable SPMEM19 - DATA1 */
+#define LFSS_SPMTERASE4_TE_19_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_19_1_ENABLE           ((uint32_t)0x00002000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_19_0] Bits */
+#define LFSS_SPMTERASE4_TE_19_0_OFS              (12)                            /* !< TE_19_0 Offset */
+#define LFSS_SPMTERASE4_TE_19_0_MASK             ((uint32_t)0x00001000U)         /* !< tamper erase enable SPMEM19 - DATA0 */
+#define LFSS_SPMTERASE4_TE_19_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_19_0_ENABLE           ((uint32_t)0x00001000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_18_3] Bits */
+#define LFSS_SPMTERASE4_TE_18_3_OFS              (11)                            /* !< TE_18_3 Offset */
+#define LFSS_SPMTERASE4_TE_18_3_MASK             ((uint32_t)0x00000800U)         /* !< tamper erase enable SPMEM18 - DATA3 */
+#define LFSS_SPMTERASE4_TE_18_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_18_3_ENABLE           ((uint32_t)0x00000800U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_18_2] Bits */
+#define LFSS_SPMTERASE4_TE_18_2_OFS              (10)                            /* !< TE_18_2 Offset */
+#define LFSS_SPMTERASE4_TE_18_2_MASK             ((uint32_t)0x00000400U)         /* !< tamper erase enable SPMEM18 - DATA2 */
+#define LFSS_SPMTERASE4_TE_18_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_18_2_ENABLE           ((uint32_t)0x00000400U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_18_1] Bits */
+#define LFSS_SPMTERASE4_TE_18_1_OFS              (9)                             /* !< TE_18_1 Offset */
+#define LFSS_SPMTERASE4_TE_18_1_MASK             ((uint32_t)0x00000200U)         /* !< tamper erase enable SPMEM18 - DATA1 */
+#define LFSS_SPMTERASE4_TE_18_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_18_1_ENABLE           ((uint32_t)0x00000200U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_18_0] Bits */
+#define LFSS_SPMTERASE4_TE_18_0_OFS              (8)                             /* !< TE_18_0 Offset */
+#define LFSS_SPMTERASE4_TE_18_0_MASK             ((uint32_t)0x00000100U)         /* !< tamper erase enable SPMEM18 - DATA0 */
+#define LFSS_SPMTERASE4_TE_18_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_18_0_ENABLE           ((uint32_t)0x00000100U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_17_3] Bits */
+#define LFSS_SPMTERASE4_TE_17_3_OFS              (7)                             /* !< TE_17_3 Offset */
+#define LFSS_SPMTERASE4_TE_17_3_MASK             ((uint32_t)0x00000080U)         /* !< tamper erase enable SPMEM17 - DATA3 */
+#define LFSS_SPMTERASE4_TE_17_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_17_3_ENABLE           ((uint32_t)0x00000080U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_17_2] Bits */
+#define LFSS_SPMTERASE4_TE_17_2_OFS              (6)                             /* !< TE_17_2 Offset */
+#define LFSS_SPMTERASE4_TE_17_2_MASK             ((uint32_t)0x00000040U)         /* !< tamper erase enable SPMEM17 - DATA2 */
+#define LFSS_SPMTERASE4_TE_17_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_17_2_ENABLE           ((uint32_t)0x00000040U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_17_1] Bits */
+#define LFSS_SPMTERASE4_TE_17_1_OFS              (5)                             /* !< TE_17_1 Offset */
+#define LFSS_SPMTERASE4_TE_17_1_MASK             ((uint32_t)0x00000020U)         /* !< tamper erase enable SPMEM17 - DATA1 */
+#define LFSS_SPMTERASE4_TE_17_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_17_1_ENABLE           ((uint32_t)0x00000020U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_17_0] Bits */
+#define LFSS_SPMTERASE4_TE_17_0_OFS              (4)                             /* !< TE_17_0 Offset */
+#define LFSS_SPMTERASE4_TE_17_0_MASK             ((uint32_t)0x00000010U)         /* !< tamper erase enable SPMEM17 - DATA0 */
+#define LFSS_SPMTERASE4_TE_17_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_17_0_ENABLE           ((uint32_t)0x00000010U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_16_3] Bits */
+#define LFSS_SPMTERASE4_TE_16_3_OFS              (3)                             /* !< TE_16_3 Offset */
+#define LFSS_SPMTERASE4_TE_16_3_MASK             ((uint32_t)0x00000008U)         /* !< tamper erase enable SPMEM16 - DATA3 */
+#define LFSS_SPMTERASE4_TE_16_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_16_3_ENABLE           ((uint32_t)0x00000008U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_16_2] Bits */
+#define LFSS_SPMTERASE4_TE_16_2_OFS              (2)                             /* !< TE_16_2 Offset */
+#define LFSS_SPMTERASE4_TE_16_2_MASK             ((uint32_t)0x00000004U)         /* !< tamper erase enable SPMEM16 - DATA2 */
+#define LFSS_SPMTERASE4_TE_16_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_16_2_ENABLE           ((uint32_t)0x00000004U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_16_1] Bits */
+#define LFSS_SPMTERASE4_TE_16_1_OFS              (1)                             /* !< TE_16_1 Offset */
+#define LFSS_SPMTERASE4_TE_16_1_MASK             ((uint32_t)0x00000002U)         /* !< tamper erase enable SPMEM16 - DATA1 */
+#define LFSS_SPMTERASE4_TE_16_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_16_1_ENABLE           ((uint32_t)0x00000002U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE4[TE_16_0] Bits */
+#define LFSS_SPMTERASE4_TE_16_0_OFS              (0)                             /* !< TE_16_0 Offset */
+#define LFSS_SPMTERASE4_TE_16_0_MASK             ((uint32_t)0x00000001U)         /* !< tamper erase enable SPMEM16 - DATA0 */
+#define LFSS_SPMTERASE4_TE_16_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE4_TE_16_0_ENABLE           ((uint32_t)0x00000001U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+
+/* LFSS_SPMTERASE5 Bits */
+/* LFSS_SPMTERASE5[KEY] Bits */
+#define LFSS_SPMTERASE5_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define LFSS_SPMTERASE5_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xA3) to update
+                                                                                    this register */
+#define LFSS_SPMTERASE5_KEY_UNLOCK_W             ((uint32_t)0xA3000000U)         /* !< This field must be written with
+                                                                                    0xA3 to be update the tamper erase
+                                                                                    enable bit. */
+/* LFSS_SPMTERASE5[TE_23_3] Bits */
+#define LFSS_SPMTERASE5_TE_23_3_OFS              (15)                            /* !< TE_23_3 Offset */
+#define LFSS_SPMTERASE5_TE_23_3_MASK             ((uint32_t)0x00008000U)         /* !< tamper erase enable SPMEM23 - DATA3 */
+#define LFSS_SPMTERASE5_TE_23_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_23_3_ENABLE           ((uint32_t)0x00008000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_23_2] Bits */
+#define LFSS_SPMTERASE5_TE_23_2_OFS              (14)                            /* !< TE_23_2 Offset */
+#define LFSS_SPMTERASE5_TE_23_2_MASK             ((uint32_t)0x00004000U)         /* !< tamper erase enable SPMEM23 - DATA2 */
+#define LFSS_SPMTERASE5_TE_23_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_23_2_ENABLE           ((uint32_t)0x00004000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_23_1] Bits */
+#define LFSS_SPMTERASE5_TE_23_1_OFS              (13)                            /* !< TE_23_1 Offset */
+#define LFSS_SPMTERASE5_TE_23_1_MASK             ((uint32_t)0x00002000U)         /* !< tamper erase enable SPMEM23 - DATA1 */
+#define LFSS_SPMTERASE5_TE_23_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_23_1_ENABLE           ((uint32_t)0x00002000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_23_0] Bits */
+#define LFSS_SPMTERASE5_TE_23_0_OFS              (12)                            /* !< TE_23_0 Offset */
+#define LFSS_SPMTERASE5_TE_23_0_MASK             ((uint32_t)0x00001000U)         /* !< tamper erase enable SPMEM23 - DATA0 */
+#define LFSS_SPMTERASE5_TE_23_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_23_0_ENABLE           ((uint32_t)0x00001000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_22_3] Bits */
+#define LFSS_SPMTERASE5_TE_22_3_OFS              (11)                            /* !< TE_22_3 Offset */
+#define LFSS_SPMTERASE5_TE_22_3_MASK             ((uint32_t)0x00000800U)         /* !< tamper erase enable SPMEM22 - DATA3 */
+#define LFSS_SPMTERASE5_TE_22_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_22_3_ENABLE           ((uint32_t)0x00000800U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_22_2] Bits */
+#define LFSS_SPMTERASE5_TE_22_2_OFS              (10)                            /* !< TE_22_2 Offset */
+#define LFSS_SPMTERASE5_TE_22_2_MASK             ((uint32_t)0x00000400U)         /* !< tamper erase enable SPMEM22 - DATA2 */
+#define LFSS_SPMTERASE5_TE_22_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_22_2_ENABLE           ((uint32_t)0x00000400U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_22_1] Bits */
+#define LFSS_SPMTERASE5_TE_22_1_OFS              (9)                             /* !< TE_22_1 Offset */
+#define LFSS_SPMTERASE5_TE_22_1_MASK             ((uint32_t)0x00000200U)         /* !< tamper erase enable SPMEM22 - DATA1 */
+#define LFSS_SPMTERASE5_TE_22_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_22_1_ENABLE           ((uint32_t)0x00000200U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_22_0] Bits */
+#define LFSS_SPMTERASE5_TE_22_0_OFS              (8)                             /* !< TE_22_0 Offset */
+#define LFSS_SPMTERASE5_TE_22_0_MASK             ((uint32_t)0x00000100U)         /* !< tamper erase enable SPMEM22 - DATA0 */
+#define LFSS_SPMTERASE5_TE_22_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_22_0_ENABLE           ((uint32_t)0x00000100U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_21_3] Bits */
+#define LFSS_SPMTERASE5_TE_21_3_OFS              (7)                             /* !< TE_21_3 Offset */
+#define LFSS_SPMTERASE5_TE_21_3_MASK             ((uint32_t)0x00000080U)         /* !< tamper erase enable SPMEM21 - DATA3 */
+#define LFSS_SPMTERASE5_TE_21_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_21_3_ENABLE           ((uint32_t)0x00000080U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_21_2] Bits */
+#define LFSS_SPMTERASE5_TE_21_2_OFS              (6)                             /* !< TE_21_2 Offset */
+#define LFSS_SPMTERASE5_TE_21_2_MASK             ((uint32_t)0x00000040U)         /* !< tamper erase enable SPMEM21 - DATA2 */
+#define LFSS_SPMTERASE5_TE_21_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_21_2_ENABLE           ((uint32_t)0x00000040U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_21_1] Bits */
+#define LFSS_SPMTERASE5_TE_21_1_OFS              (5)                             /* !< TE_21_1 Offset */
+#define LFSS_SPMTERASE5_TE_21_1_MASK             ((uint32_t)0x00000020U)         /* !< tamper erase enable SPMEM21 - DATA1 */
+#define LFSS_SPMTERASE5_TE_21_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_21_1_ENABLE           ((uint32_t)0x00000020U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_21_0] Bits */
+#define LFSS_SPMTERASE5_TE_21_0_OFS              (4)                             /* !< TE_21_0 Offset */
+#define LFSS_SPMTERASE5_TE_21_0_MASK             ((uint32_t)0x00000010U)         /* !< tamper erase enable SPMEM21 - DATA0 */
+#define LFSS_SPMTERASE5_TE_21_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_21_0_ENABLE           ((uint32_t)0x00000010U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_20_3] Bits */
+#define LFSS_SPMTERASE5_TE_20_3_OFS              (3)                             /* !< TE_20_3 Offset */
+#define LFSS_SPMTERASE5_TE_20_3_MASK             ((uint32_t)0x00000008U)         /* !< tamper erase enable SPMEM20 - DATA3 */
+#define LFSS_SPMTERASE5_TE_20_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_20_3_ENABLE           ((uint32_t)0x00000008U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_20_2] Bits */
+#define LFSS_SPMTERASE5_TE_20_2_OFS              (2)                             /* !< TE_20_2 Offset */
+#define LFSS_SPMTERASE5_TE_20_2_MASK             ((uint32_t)0x00000004U)         /* !< tamper erase enable SPMEM20 - DATA2 */
+#define LFSS_SPMTERASE5_TE_20_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_20_2_ENABLE           ((uint32_t)0x00000004U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_20_1] Bits */
+#define LFSS_SPMTERASE5_TE_20_1_OFS              (1)                             /* !< TE_20_1 Offset */
+#define LFSS_SPMTERASE5_TE_20_1_MASK             ((uint32_t)0x00000002U)         /* !< tamper erase enable SPMEM20 - DATA1 */
+#define LFSS_SPMTERASE5_TE_20_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_20_1_ENABLE           ((uint32_t)0x00000002U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE5[TE_20_0] Bits */
+#define LFSS_SPMTERASE5_TE_20_0_OFS              (0)                             /* !< TE_20_0 Offset */
+#define LFSS_SPMTERASE5_TE_20_0_MASK             ((uint32_t)0x00000001U)         /* !< tamper erase enable SPMEM20 - DATA0 */
+#define LFSS_SPMTERASE5_TE_20_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE5_TE_20_0_ENABLE           ((uint32_t)0x00000001U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+
+/* LFSS_SPMTERASE6 Bits */
+/* LFSS_SPMTERASE6[KEY] Bits */
+#define LFSS_SPMTERASE6_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define LFSS_SPMTERASE6_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xA3) to update
+                                                                                    this register */
+#define LFSS_SPMTERASE6_KEY_UNLOCK_W             ((uint32_t)0xA3000000U)         /* !< This field must be written with
+                                                                                    0xA3 to be update the tamper erase
+                                                                                    enable bit. */
+/* LFSS_SPMTERASE6[TE_27_3] Bits */
+#define LFSS_SPMTERASE6_TE_27_3_OFS              (15)                            /* !< TE_27_3 Offset */
+#define LFSS_SPMTERASE6_TE_27_3_MASK             ((uint32_t)0x00008000U)         /* !< tamper erase enable SPMEM27 - DATA3 */
+#define LFSS_SPMTERASE6_TE_27_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_27_3_ENABLE           ((uint32_t)0x00008000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_27_2] Bits */
+#define LFSS_SPMTERASE6_TE_27_2_OFS              (14)                            /* !< TE_27_2 Offset */
+#define LFSS_SPMTERASE6_TE_27_2_MASK             ((uint32_t)0x00004000U)         /* !< tamper erase enable SPMEM27 - DATA2 */
+#define LFSS_SPMTERASE6_TE_27_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_27_2_ENABLE           ((uint32_t)0x00004000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_27_1] Bits */
+#define LFSS_SPMTERASE6_TE_27_1_OFS              (13)                            /* !< TE_27_1 Offset */
+#define LFSS_SPMTERASE6_TE_27_1_MASK             ((uint32_t)0x00002000U)         /* !< tamper erase enable SPMEM27 - DATA1 */
+#define LFSS_SPMTERASE6_TE_27_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_27_1_ENABLE           ((uint32_t)0x00002000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_27_0] Bits */
+#define LFSS_SPMTERASE6_TE_27_0_OFS              (12)                            /* !< TE_27_0 Offset */
+#define LFSS_SPMTERASE6_TE_27_0_MASK             ((uint32_t)0x00001000U)         /* !< tamper erase enable SPMEM27 - DATA0 */
+#define LFSS_SPMTERASE6_TE_27_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_27_0_ENABLE           ((uint32_t)0x00001000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_26_3] Bits */
+#define LFSS_SPMTERASE6_TE_26_3_OFS              (11)                            /* !< TE_26_3 Offset */
+#define LFSS_SPMTERASE6_TE_26_3_MASK             ((uint32_t)0x00000800U)         /* !< tamper erase enable SPMEM26 - DATA3 */
+#define LFSS_SPMTERASE6_TE_26_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_26_3_ENABLE           ((uint32_t)0x00000800U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_26_2] Bits */
+#define LFSS_SPMTERASE6_TE_26_2_OFS              (10)                            /* !< TE_26_2 Offset */
+#define LFSS_SPMTERASE6_TE_26_2_MASK             ((uint32_t)0x00000400U)         /* !< tamper erase enable SPMEM26 - DATA2 */
+#define LFSS_SPMTERASE6_TE_26_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_26_2_ENABLE           ((uint32_t)0x00000400U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_26_1] Bits */
+#define LFSS_SPMTERASE6_TE_26_1_OFS              (9)                             /* !< TE_26_1 Offset */
+#define LFSS_SPMTERASE6_TE_26_1_MASK             ((uint32_t)0x00000200U)         /* !< tamper erase enable SPMEM26 - DATA1 */
+#define LFSS_SPMTERASE6_TE_26_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_26_1_ENABLE           ((uint32_t)0x00000200U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_26_0] Bits */
+#define LFSS_SPMTERASE6_TE_26_0_OFS              (8)                             /* !< TE_26_0 Offset */
+#define LFSS_SPMTERASE6_TE_26_0_MASK             ((uint32_t)0x00000100U)         /* !< tamper erase enable SPMEM26 - DATA0 */
+#define LFSS_SPMTERASE6_TE_26_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_26_0_ENABLE           ((uint32_t)0x00000100U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_25_3] Bits */
+#define LFSS_SPMTERASE6_TE_25_3_OFS              (7)                             /* !< TE_25_3 Offset */
+#define LFSS_SPMTERASE6_TE_25_3_MASK             ((uint32_t)0x00000080U)         /* !< tamper erase enable SPMEM25 - DATA3 */
+#define LFSS_SPMTERASE6_TE_25_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_25_3_ENABLE           ((uint32_t)0x00000080U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_25_2] Bits */
+#define LFSS_SPMTERASE6_TE_25_2_OFS              (6)                             /* !< TE_25_2 Offset */
+#define LFSS_SPMTERASE6_TE_25_2_MASK             ((uint32_t)0x00000040U)         /* !< tamper erase enable SPMEM25 - DATA2 */
+#define LFSS_SPMTERASE6_TE_25_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_25_2_ENABLE           ((uint32_t)0x00000040U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_25_1] Bits */
+#define LFSS_SPMTERASE6_TE_25_1_OFS              (5)                             /* !< TE_25_1 Offset */
+#define LFSS_SPMTERASE6_TE_25_1_MASK             ((uint32_t)0x00000020U)         /* !< tamper erase enable SPMEM25 - DATA1 */
+#define LFSS_SPMTERASE6_TE_25_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_25_1_ENABLE           ((uint32_t)0x00000020U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_25_0] Bits */
+#define LFSS_SPMTERASE6_TE_25_0_OFS              (4)                             /* !< TE_25_0 Offset */
+#define LFSS_SPMTERASE6_TE_25_0_MASK             ((uint32_t)0x00000010U)         /* !< tamper erase enable SPMEM25 - DATA0 */
+#define LFSS_SPMTERASE6_TE_25_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_25_0_ENABLE           ((uint32_t)0x00000010U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_24_3] Bits */
+#define LFSS_SPMTERASE6_TE_24_3_OFS              (3)                             /* !< TE_24_3 Offset */
+#define LFSS_SPMTERASE6_TE_24_3_MASK             ((uint32_t)0x00000008U)         /* !< tamper erase enable SPMEM24 - DATA3 */
+#define LFSS_SPMTERASE6_TE_24_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_24_3_ENABLE           ((uint32_t)0x00000008U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_24_2] Bits */
+#define LFSS_SPMTERASE6_TE_24_2_OFS              (2)                             /* !< TE_24_2 Offset */
+#define LFSS_SPMTERASE6_TE_24_2_MASK             ((uint32_t)0x00000004U)         /* !< tamper erase enable SPMEM24 - DATA2 */
+#define LFSS_SPMTERASE6_TE_24_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_24_2_ENABLE           ((uint32_t)0x00000004U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_24_1] Bits */
+#define LFSS_SPMTERASE6_TE_24_1_OFS              (1)                             /* !< TE_24_1 Offset */
+#define LFSS_SPMTERASE6_TE_24_1_MASK             ((uint32_t)0x00000002U)         /* !< tamper erase enable SPMEM24 - DATA1 */
+#define LFSS_SPMTERASE6_TE_24_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_24_1_ENABLE           ((uint32_t)0x00000002U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE6[TE_24_0] Bits */
+#define LFSS_SPMTERASE6_TE_24_0_OFS              (0)                             /* !< TE_24_0 Offset */
+#define LFSS_SPMTERASE6_TE_24_0_MASK             ((uint32_t)0x00000001U)         /* !< tamper erase enable SPMEM24 - DATA0 */
+#define LFSS_SPMTERASE6_TE_24_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE6_TE_24_0_ENABLE           ((uint32_t)0x00000001U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+
+/* LFSS_SPMTERASE7 Bits */
+/* LFSS_SPMTERASE7[KEY] Bits */
+#define LFSS_SPMTERASE7_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define LFSS_SPMTERASE7_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xA3) to update
+                                                                                    this register */
+#define LFSS_SPMTERASE7_KEY_UNLOCK_W             ((uint32_t)0xA3000000U)         /* !< This field must be written with
+                                                                                    0xA3 to be update the tamper erase
+                                                                                    enable bit. */
+/* LFSS_SPMTERASE7[TE_31_3] Bits */
+#define LFSS_SPMTERASE7_TE_31_3_OFS              (15)                            /* !< TE_31_3 Offset */
+#define LFSS_SPMTERASE7_TE_31_3_MASK             ((uint32_t)0x00008000U)         /* !< tamper erase enable SPMEM31 - DATA3 */
+#define LFSS_SPMTERASE7_TE_31_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_31_3_ENABLE           ((uint32_t)0x00008000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_31_2] Bits */
+#define LFSS_SPMTERASE7_TE_31_2_OFS              (14)                            /* !< TE_31_2 Offset */
+#define LFSS_SPMTERASE7_TE_31_2_MASK             ((uint32_t)0x00004000U)         /* !< tamper erase enable SPMEM31 - DATA2 */
+#define LFSS_SPMTERASE7_TE_31_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_31_2_ENABLE           ((uint32_t)0x00004000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_31_1] Bits */
+#define LFSS_SPMTERASE7_TE_31_1_OFS              (13)                            /* !< TE_31_1 Offset */
+#define LFSS_SPMTERASE7_TE_31_1_MASK             ((uint32_t)0x00002000U)         /* !< tamper erase enable SPMEM31 - DATA1 */
+#define LFSS_SPMTERASE7_TE_31_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_31_1_ENABLE           ((uint32_t)0x00002000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_31_0] Bits */
+#define LFSS_SPMTERASE7_TE_31_0_OFS              (12)                            /* !< TE_31_0 Offset */
+#define LFSS_SPMTERASE7_TE_31_0_MASK             ((uint32_t)0x00001000U)         /* !< tamper erase enable SPMEM31 - DATA0 */
+#define LFSS_SPMTERASE7_TE_31_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_31_0_ENABLE           ((uint32_t)0x00001000U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_30_3] Bits */
+#define LFSS_SPMTERASE7_TE_30_3_OFS              (11)                            /* !< TE_30_3 Offset */
+#define LFSS_SPMTERASE7_TE_30_3_MASK             ((uint32_t)0x00000800U)         /* !< tamper erase enable SPMEM30 - DATA3 */
+#define LFSS_SPMTERASE7_TE_30_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_30_3_ENABLE           ((uint32_t)0x00000800U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_30_2] Bits */
+#define LFSS_SPMTERASE7_TE_30_2_OFS              (10)                            /* !< TE_30_2 Offset */
+#define LFSS_SPMTERASE7_TE_30_2_MASK             ((uint32_t)0x00000400U)         /* !< tamper erase enable SPMEM30 - DATA2 */
+#define LFSS_SPMTERASE7_TE_30_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_30_2_ENABLE           ((uint32_t)0x00000400U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_30_1] Bits */
+#define LFSS_SPMTERASE7_TE_30_1_OFS              (9)                             /* !< TE_30_1 Offset */
+#define LFSS_SPMTERASE7_TE_30_1_MASK             ((uint32_t)0x00000200U)         /* !< tamper erase enable SPMEM30 - DATA1 */
+#define LFSS_SPMTERASE7_TE_30_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_30_1_ENABLE           ((uint32_t)0x00000200U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_30_0] Bits */
+#define LFSS_SPMTERASE7_TE_30_0_OFS              (8)                             /* !< TE_30_0 Offset */
+#define LFSS_SPMTERASE7_TE_30_0_MASK             ((uint32_t)0x00000100U)         /* !< tamper erase enable SPMEM30 - DATA0 */
+#define LFSS_SPMTERASE7_TE_30_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_30_0_ENABLE           ((uint32_t)0x00000100U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_29_3] Bits */
+#define LFSS_SPMTERASE7_TE_29_3_OFS              (7)                             /* !< TE_29_3 Offset */
+#define LFSS_SPMTERASE7_TE_29_3_MASK             ((uint32_t)0x00000080U)         /* !< tamper erase enable SPMEM29 - DATA3 */
+#define LFSS_SPMTERASE7_TE_29_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_29_3_ENABLE           ((uint32_t)0x00000080U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_29_2] Bits */
+#define LFSS_SPMTERASE7_TE_29_2_OFS              (6)                             /* !< TE_29_2 Offset */
+#define LFSS_SPMTERASE7_TE_29_2_MASK             ((uint32_t)0x00000040U)         /* !< tamper erase enable SPMEM29 - DATA2 */
+#define LFSS_SPMTERASE7_TE_29_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_29_2_ENABLE           ((uint32_t)0x00000040U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_29_1] Bits */
+#define LFSS_SPMTERASE7_TE_29_1_OFS              (5)                             /* !< TE_29_1 Offset */
+#define LFSS_SPMTERASE7_TE_29_1_MASK             ((uint32_t)0x00000020U)         /* !< tamper erase enable SPMEM29 - DATA1 */
+#define LFSS_SPMTERASE7_TE_29_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_29_1_ENABLE           ((uint32_t)0x00000020U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_29_0] Bits */
+#define LFSS_SPMTERASE7_TE_29_0_OFS              (4)                             /* !< TE_29_0 Offset */
+#define LFSS_SPMTERASE7_TE_29_0_MASK             ((uint32_t)0x00000010U)         /* !< tamper erase enable SPMEM29 - DATA0 */
+#define LFSS_SPMTERASE7_TE_29_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_29_0_ENABLE           ((uint32_t)0x00000010U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_28_3] Bits */
+#define LFSS_SPMTERASE7_TE_28_3_OFS              (3)                             /* !< TE_28_3 Offset */
+#define LFSS_SPMTERASE7_TE_28_3_MASK             ((uint32_t)0x00000008U)         /* !< tamper erase enable SPMEM28 - DATA3 */
+#define LFSS_SPMTERASE7_TE_28_3_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_28_3_ENABLE           ((uint32_t)0x00000008U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_28_2] Bits */
+#define LFSS_SPMTERASE7_TE_28_2_OFS              (2)                             /* !< TE_28_2 Offset */
+#define LFSS_SPMTERASE7_TE_28_2_MASK             ((uint32_t)0x00000004U)         /* !< tamper erase enable SPMEM28 - DATA2 */
+#define LFSS_SPMTERASE7_TE_28_2_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_28_2_ENABLE           ((uint32_t)0x00000004U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_28_1] Bits */
+#define LFSS_SPMTERASE7_TE_28_1_OFS              (1)                             /* !< TE_28_1 Offset */
+#define LFSS_SPMTERASE7_TE_28_1_MASK             ((uint32_t)0x00000002U)         /* !< tamper erase enable SPMEM28 - DATA1 */
+#define LFSS_SPMTERASE7_TE_28_1_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_28_1_ENABLE           ((uint32_t)0x00000002U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+/* LFSS_SPMTERASE7[TE_28_0] Bits */
+#define LFSS_SPMTERASE7_TE_28_0_OFS              (0)                             /* !< TE_28_0 Offset */
+#define LFSS_SPMTERASE7_TE_28_0_MASK             ((uint32_t)0x00000001U)         /* !< tamper erase enable SPMEM28 - DATA0 */
+#define LFSS_SPMTERASE7_TE_28_0_DISABLE          ((uint32_t)0x00000000U)         /* !< SPMEM is unmodified during tamper
+                                                                                    event */
+#define LFSS_SPMTERASE7_TE_28_0_ENABLE           ((uint32_t)0x00000001U)         /* !< SPMEM will be erased with tamper
+                                                                                    event */
+
+/* LFSS_WDTEN Bits */
+/* LFSS_WDTEN[ENABLE] Bits */
+#define LFSS_WDTEN_ENABLE_OFS                    (0)                             /* !< ENABLE Offset */
+#define LFSS_WDTEN_ENABLE_MASK                   ((uint32_t)0x00000001U)         /* !< Enable bit for the WDT. */
+#define LFSS_WDTEN_ENABLE_CLR                    ((uint32_t)0x00000000U)         /* !< Disable WDT */
+#define LFSS_WDTEN_ENABLE_SET                    ((uint32_t)0x00000001U)         /* !< Enable WDT */
+/* LFSS_WDTEN[KEY] Bits */
+#define LFSS_WDTEN_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define LFSS_WDTEN_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< KEY to allow write access to this
+                                                                                    register. Writing to this register
+                                                                                    with an incorrect key causes a POR
+                                                                                    level reset. Read as 0. */
+#define LFSS_WDTEN_KEY_UNLOCK_W                  ((uint32_t)0xEE000000U)         /* !< This field must be written with
+                                                                                    0xEE to be update the enable bit. */
+
+/* LFSS_WDTDBGCTL Bits */
+/* LFSS_WDTDBGCTL[FREE] Bits */
+#define LFSS_WDTDBGCTL_FREE_OFS                  (0)                             /* !< FREE Offset */
+#define LFSS_WDTDBGCTL_FREE_MASK                 ((uint32_t)0x00000001U)         /* !< Free run control */
+#define LFSS_WDTDBGCTL_FREE_STOP                 ((uint32_t)0x00000000U)         /* !< The WDT freezes functionality while
+                                                                                    the CPU is Halted during debug and
+                                                                                    resumes when the CPU is active. */
+#define LFSS_WDTDBGCTL_FREE_RUN                  ((uint32_t)0x00000001U)         /* !< The WDT ignores the state of the
+                                                                                    CPU Halted debug state. */
+
+/* LFSS_WDTCTL Bits */
+/* LFSS_WDTCTL[CLKDIV] Bits */
+#define LFSS_WDTCTL_CLKDIV_OFS                   (0)                             /* !< CLKDIV Offset */
+#define LFSS_WDTCTL_CLKDIV_MASK                  ((uint32_t)0x00000007U)         /* !< Module Clock Divider, Divide the
+                                                                                    clock source by CLKDIV+1. Divider
+                                                                                    values from /1 to /8 are possible. */
+#define LFSS_WDTCTL_CLKDIV_MIN                   ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define LFSS_WDTCTL_CLKDIV_MAX                   ((uint32_t)0x00000007U)         /* !< Maximum value */
+/* LFSS_WDTCTL[PER] Bits */
+#define LFSS_WDTCTL_PER_OFS                      (4)                             /* !< PER Offset */
+#define LFSS_WDTCTL_PER_MASK                     ((uint32_t)0x00000070U)         /* !< Timer Period of the WDT. These bits
+                                                                                    select the total watchdog timer
+                                                                                    count. */
+#define LFSS_WDTCTL_PER_PER_EN_25                ((uint32_t)0x00000000U)         /* !< Total timer count is 2^25 */
+#define LFSS_WDTCTL_PER_PER_EN_21                ((uint32_t)0x00000010U)         /* !< Total timer count is 2^21 */
+#define LFSS_WDTCTL_PER_PER_EN_18                ((uint32_t)0x00000020U)         /* !< Total timer count is 2^18 */
+#define LFSS_WDTCTL_PER_PER_EN_15                ((uint32_t)0x00000030U)         /* !< Total timer count is 2^15 */
+#define LFSS_WDTCTL_PER_PER_EN_12                ((uint32_t)0x00000040U)         /* !< Total timer count is 2^12 (default) */
+#define LFSS_WDTCTL_PER_PER_EN_10                ((uint32_t)0x00000050U)         /* !< Total timer count is 2^10 */
+#define LFSS_WDTCTL_PER_PER_EN_8                 ((uint32_t)0x00000060U)         /* !< Total timer count is 2^8 */
+#define LFSS_WDTCTL_PER_PER_EN_6                 ((uint32_t)0x00000070U)         /* !< Total timer count is 2^6 */
+/* LFSS_WDTCTL[KEY] Bits */
+#define LFSS_WDTCTL_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define LFSS_WDTCTL_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< KEY to allow write access to this
+                                                                                    register. Writing to this register
+                                                                                    with an incorrect key causes a POR
+                                                                                    level reset. Read as 0. */
+#define LFSS_WDTCTL_KEY_UNLOCK_W                 ((uint32_t)0xC6000000U)         /* !< This field must be written with
+                                                                                    0xC6 to be able to write any of the
+                                                                                    enable bits */
+
+/* LFSS_WDTCNTRST Bits */
+/* LFSS_WDTCNTRST[RESTART] Bits */
+#define LFSS_WDTCNTRST_RESTART_OFS               (0)                             /* !< RESTART Offset */
+#define LFSS_WDTCNTRST_RESTART_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< Writing 03A7h to this register
+                                                                                    restarts the WDT Counter. Writing any
+                                                                                    other value causes a POR level reset.
+                                                                                    Read as 0x0h. */
+#define LFSS_WDTCNTRST_RESTART_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define LFSS_WDTCNTRST_RESTART_VALUE             ((uint32_t)0x000003A7U)         /* !< VALUE to restart the WDT counter */
+#define LFSS_WDTCNTRST_RESTART_MAXIMUM           ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value */
+
+/* LFSS_WDTSTAT Bits */
+/* LFSS_WDTSTAT[RUN] Bits */
+#define LFSS_WDTSTAT_RUN_OFS                     (0)                             /* !< RUN Offset */
+#define LFSS_WDTSTAT_RUN_MASK                    ((uint32_t)0x00000001U)         /* !< Watchdog running status flag. */
+#define LFSS_WDTSTAT_RUN_STOP                    ((uint32_t)0x00000000U)         /* !< Watchdog counter stopped. */
+#define LFSS_WDTSTAT_RUN_RUN                     ((uint32_t)0x00000001U)         /* !< Watchdog running. */
+
+/* LFSS_WDTLOCK Bits */
+/* LFSS_WDTLOCK[PROTECT] Bits */
+#define LFSS_WDTLOCK_PROTECT_OFS                 (0)                             /* !< PROTECT Offset */
+#define LFSS_WDTLOCK_PROTECT_MASK                ((uint32_t)0x00000001U)         /* !< If set, the register bit will
+                                                                                    protect the WDTEN and WDTCTL from
+                                                                                    accidental writes. */
+#define LFSS_WDTLOCK_PROTECT_CLR                 ((uint32_t)0x00000000U)         /* !< Watchdog timer control is writable. */
+#define LFSS_WDTLOCK_PROTECT_SET                 ((uint32_t)0x00000001U)         /* !< Watchdog timer control is read only
+                                                                                    access. */
+/* LFSS_WDTLOCK[KEY] Bits */
+#define LFSS_WDTLOCK_KEY_OFS                     (24)                            /* !< KEY Offset */
+#define LFSS_WDTLOCK_KEY_MASK                    ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xBD) to update
+                                                                                    this register */
+#define LFSS_WDTLOCK_KEY_UNLOCK_W                ((uint32_t)0xBD000000U)         /* !< This field must be written with
+                                                                                    0xBD to be able to clear any of the
+                                                                                    enable bits */
+
+/* LFSS_TIOCTL Bits */
+/* LFSS_TIOCTL[IOMUX] Bits */
+#define LFSS_TIOCTL_IOMUX_OFS                    (0)                             /* !< IOMUX Offset */
+#define LFSS_TIOCTL_IOMUX_MASK                   ((uint32_t)0x00000001U)         /* !< tamper I/O is controlled by SoC
+                                                                                    IOMUX module */
+#define LFSS_TIOCTL_IOMUX_IOMUX                  ((uint32_t)0x00000000U)         /* !< The tamper I/O is controlled by the
+                                                                                    IOMUX of the SoC and does allow
+                                                                                    assignment to a peripheral function.
+                                                                                    In the case the main supply (VDD) is
+                                                                                    lost, this I/O will go into a Hi-Z
+                                                                                    state. */
+#define LFSS_TIOCTL_IOMUX_TAMPER                 ((uint32_t)0x00000001U)         /* !< The tamper I/O is controlled by the
+                                                                                    TIOCTL register and stays functional
+                                                                                    during loss of the main supply (VDD). */
+/* LFSS_TIOCTL[PIPD] Bits */
+#define LFSS_TIOCTL_PIPD_OFS                     (16)                            /* !< PIPD Offset */
+#define LFSS_TIOCTL_PIPD_MASK                    ((uint32_t)0x00010000U)         /* !< pull down enable */
+#define LFSS_TIOCTL_PIPD_DISABLE                 ((uint32_t)0x00000000U)         /* !< The pull-down function is disabled. */
+#define LFSS_TIOCTL_PIPD_ENABLE                  ((uint32_t)0x00010000U)         /* !< The pull-down function is enabled. */
+/* LFSS_TIOCTL[PIPU] Bits */
+#define LFSS_TIOCTL_PIPU_OFS                     (17)                            /* !< PIPU Offset */
+#define LFSS_TIOCTL_PIPU_MASK                    ((uint32_t)0x00020000U)         /* !< pull up enable */
+#define LFSS_TIOCTL_PIPU_DISABLE                 ((uint32_t)0x00000000U)         /* !< The pull-up function is disabled. */
+#define LFSS_TIOCTL_PIPU_ENABLE                  ((uint32_t)0x00020000U)         /* !< The pull-up function is enabled. */
+/* LFSS_TIOCTL[INENA] Bits */
+#define LFSS_TIOCTL_INENA_OFS                    (18)                            /* !< INENA Offset */
+#define LFSS_TIOCTL_INENA_MASK                   ((uint32_t)0x00040000U)         /* !< input enable */
+#define LFSS_TIOCTL_INENA_DISABLE                ((uint32_t)0x00000000U)         /* !< The input path is disabled. */
+#define LFSS_TIOCTL_INENA_ENABLE                 ((uint32_t)0x00040000U)         /* !< The input path is enabled. */
+/* LFSS_TIOCTL[POLARITY] Bits */
+#define LFSS_TIOCTL_POLARITY_OFS                 (8)                             /* !< POLARITY Offset */
+#define LFSS_TIOCTL_POLARITY_MASK                ((uint32_t)0x00000300U)         /* !< Enables and configures edge
+                                                                                    detection polarity for TIO */
+#define LFSS_TIOCTL_POLARITY_DISABLE             ((uint32_t)0x00000000U)         /* !< Edge detection disabled */
+#define LFSS_TIOCTL_POLARITY_RISE                ((uint32_t)0x00000100U)         /* !< Detects rising edge of input event */
+#define LFSS_TIOCTL_POLARITY_FALL                ((uint32_t)0x00000200U)         /* !< Detects falling edge of input event */
+#define LFSS_TIOCTL_POLARITY_BOTH                ((uint32_t)0x00000300U)         /* !< Detects both rising and falling
+                                                                                    edge of input event */
+/* LFSS_TIOCTL[FILTEREN] Bits */
+#define LFSS_TIOCTL_FILTEREN_OFS                 (12)                            /* !< FILTEREN Offset */
+#define LFSS_TIOCTL_FILTEREN_MASK                ((uint32_t)0x00003000U)         /* !< Programmable counter length of
+                                                                                    digital glitch filter for TIO0 */
+#define LFSS_TIOCTL_FILTEREN_NO_FLT              ((uint32_t)0x00000000U)         /* !< no filter on the tamper I/O beyond
+                                                                                    CDC synchronization sample */
+#define LFSS_TIOCTL_FILTEREN_FLT_1               ((uint32_t)0x00001000U)         /* !< 1 FLCLK minimum sample (30us) */
+#define LFSS_TIOCTL_FILTEREN_FLT_2               ((uint32_t)0x00002000U)         /* !< 3 LFCLK minimum sample (100us) */
+#define LFSS_TIOCTL_FILTEREN_FLT_3               ((uint32_t)0x00003000U)         /* !< 6 LFCLK minimum sample (200us) */
+/* LFSS_TIOCTL[TOUTSEL] Bits */
+#define LFSS_TIOCTL_TOUTSEL_OFS                  (4)                             /* !< TOUTSEL Offset */
+#define LFSS_TIOCTL_TOUTSEL_MASK                 ((uint32_t)0x00000030U)         /* !< Selects the source for TOUT control */
+#define LFSS_TIOCTL_TOUTSEL_TOUT                 ((uint32_t)0x00000000U)         /* !< The TOUT register is the source for
+                                                                                    TOUT */
+#define LFSS_TIOCTL_TOUTSEL_LFCLKEXT             ((uint32_t)0x00000010U)         /* !< The LFCLK is the source for TOUT */
+#define LFSS_TIOCTL_TOUTSEL_HEARTBEAT            ((uint32_t)0x00000020U)         /* !< The heart beat generatore is the
+                                                                                    source for TOUT */
+#define LFSS_TIOCTL_TOUTSEL_TSEVTSTAT            ((uint32_t)0x00000030U)         /* !< The time stamp event status is the
+                                                                                    source for TOUT */
+/* LFSS_TIOCTL[OUTINV] Bits */
+#define LFSS_TIOCTL_OUTINV_OFS                   (19)                            /* !< OUTINV Offset */
+#define LFSS_TIOCTL_OUTINV_MASK                  ((uint32_t)0x00080000U)         /* !< Output inversion enable */
+#define LFSS_TIOCTL_OUTINV_DISBALE               ((uint32_t)0x00000000U)         /* !< The output inversion is disabled. */
+#define LFSS_TIOCTL_OUTINV_ENABLE                ((uint32_t)0x00080000U)         /* !< The output inversion is enabled. */
+
+/* LFSS_TOUT3_0 Bits */
+/* LFSS_TOUT3_0[TIO0] Bits */
+#define LFSS_TOUT3_0_TIO0_OFS                    (0)                             /* !< TIO0 Offset */
+#define LFSS_TOUT3_0_TIO0_MASK                   ((uint32_t)0x00000001U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 0 (TIO0) when the output
+                                                                                    is enabled through TOE0 register. */
+#define LFSS_TOUT3_0_TIO0_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT3_0_TIO0_ONE                    ((uint32_t)0x00000001U)         /* !< Output is set to 1 */
+/* LFSS_TOUT3_0[TIO1] Bits */
+#define LFSS_TOUT3_0_TIO1_OFS                    (8)                             /* !< TIO1 Offset */
+#define LFSS_TOUT3_0_TIO1_MASK                   ((uint32_t)0x00000100U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 1 (TIO1) when the output
+                                                                                    is enabled through TOE1 register. */
+#define LFSS_TOUT3_0_TIO1_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT3_0_TIO1_ONE                    ((uint32_t)0x00000100U)         /* !< Output is set to 1 */
+/* LFSS_TOUT3_0[TIO2] Bits */
+#define LFSS_TOUT3_0_TIO2_OFS                    (16)                            /* !< TIO2 Offset */
+#define LFSS_TOUT3_0_TIO2_MASK                   ((uint32_t)0x00010000U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 2 (TIO0) when the output
+                                                                                    is enabled through TOE2 register. */
+#define LFSS_TOUT3_0_TIO2_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT3_0_TIO2_ONE                    ((uint32_t)0x00010000U)         /* !< Output is set to 1 */
+/* LFSS_TOUT3_0[TIO3] Bits */
+#define LFSS_TOUT3_0_TIO3_OFS                    (24)                            /* !< TIO3 Offset */
+#define LFSS_TOUT3_0_TIO3_MASK                   ((uint32_t)0x01000000U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 3 (TIO3) when the output
+                                                                                    is enabled through TOE3 register. */
+#define LFSS_TOUT3_0_TIO3_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT3_0_TIO3_ONE                    ((uint32_t)0x01000000U)         /* !< Output is set to 1 */
+
+/* LFSS_TOUT7_4 Bits */
+/* LFSS_TOUT7_4[TIO4] Bits */
+#define LFSS_TOUT7_4_TIO4_OFS                    (0)                             /* !< TIO4 Offset */
+#define LFSS_TOUT7_4_TIO4_MASK                   ((uint32_t)0x00000001U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 4 (TIO4) when the output
+                                                                                    is enabled through TOE4 register. */
+#define LFSS_TOUT7_4_TIO4_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT7_4_TIO4_ONE                    ((uint32_t)0x00000001U)         /* !< Output is set to 1 */
+/* LFSS_TOUT7_4[TIO5] Bits */
+#define LFSS_TOUT7_4_TIO5_OFS                    (8)                             /* !< TIO5 Offset */
+#define LFSS_TOUT7_4_TIO5_MASK                   ((uint32_t)0x00000100U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 5 (TIO5) when the output
+                                                                                    is enabled through TOE5 register. */
+#define LFSS_TOUT7_4_TIO5_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT7_4_TIO5_ONE                    ((uint32_t)0x00000100U)         /* !< Output is set to 1 */
+/* LFSS_TOUT7_4[TIO6] Bits */
+#define LFSS_TOUT7_4_TIO6_OFS                    (16)                            /* !< TIO6 Offset */
+#define LFSS_TOUT7_4_TIO6_MASK                   ((uint32_t)0x00010000U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 2 (TIO6) when the output
+                                                                                    is enabled through TOE6 register. */
+#define LFSS_TOUT7_4_TIO6_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT7_4_TIO6_ONE                    ((uint32_t)0x00010000U)         /* !< Output is set to 1 */
+/* LFSS_TOUT7_4[TIO7] Bits */
+#define LFSS_TOUT7_4_TIO7_OFS                    (24)                            /* !< TIO7 Offset */
+#define LFSS_TOUT7_4_TIO7_MASK                   ((uint32_t)0x01000000U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 7 (TIO7) when the output
+                                                                                    is enabled through TOE7 register. */
+#define LFSS_TOUT7_4_TIO7_ZERO                   ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT7_4_TIO7_ONE                    ((uint32_t)0x01000000U)         /* !< Output is set to 1 */
+
+/* LFSS_TOUT11_8 Bits */
+/* LFSS_TOUT11_8[TIO8] Bits */
+#define LFSS_TOUT11_8_TIO8_OFS                   (0)                             /* !< TIO8 Offset */
+#define LFSS_TOUT11_8_TIO8_MASK                  ((uint32_t)0x00000001U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 8 (TIO8) when the output
+                                                                                    is enabled through TOE8 register. */
+#define LFSS_TOUT11_8_TIO8_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT11_8_TIO8_ONE                   ((uint32_t)0x00000001U)         /* !< Output is set to 1 */
+/* LFSS_TOUT11_8[TIO9] Bits */
+#define LFSS_TOUT11_8_TIO9_OFS                   (8)                             /* !< TIO9 Offset */
+#define LFSS_TOUT11_8_TIO9_MASK                  ((uint32_t)0x00000100U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 9 (TIO9) when the output
+                                                                                    is enabled through TOE9 register. */
+#define LFSS_TOUT11_8_TIO9_ZERO                  ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT11_8_TIO9_ONE                   ((uint32_t)0x00000100U)         /* !< Output is set to 1 */
+/* LFSS_TOUT11_8[TIO10] Bits */
+#define LFSS_TOUT11_8_TIO10_OFS                  (16)                            /* !< TIO10 Offset */
+#define LFSS_TOUT11_8_TIO10_MASK                 ((uint32_t)0x00010000U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 10 (TIO10) when the output
+                                                                                    is enabled through TOE10 register. */
+#define LFSS_TOUT11_8_TIO10_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT11_8_TIO10_ONE                  ((uint32_t)0x00010000U)         /* !< Output is set to 1 */
+/* LFSS_TOUT11_8[TIO11] Bits */
+#define LFSS_TOUT11_8_TIO11_OFS                  (24)                            /* !< TIO11 Offset */
+#define LFSS_TOUT11_8_TIO11_MASK                 ((uint32_t)0x01000000U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 11 (TIO11) when the output
+                                                                                    is enabled through TOE11 register. */
+#define LFSS_TOUT11_8_TIO11_ZERO                 ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT11_8_TIO11_ONE                  ((uint32_t)0x01000000U)         /* !< Output is set to 1 */
+
+/* LFSS_TOUT15_12 Bits */
+/* LFSS_TOUT15_12[TIO12] Bits */
+#define LFSS_TOUT15_12_TIO12_OFS                 (0)                             /* !< TIO12 Offset */
+#define LFSS_TOUT15_12_TIO12_MASK                ((uint32_t)0x00000001U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 12 (TIO12) when the output
+                                                                                    is enabled through TOE12 register. */
+#define LFSS_TOUT15_12_TIO12_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT15_12_TIO12_ONE                 ((uint32_t)0x00000001U)         /* !< Output is set to 1 */
+/* LFSS_TOUT15_12[TIO13] Bits */
+#define LFSS_TOUT15_12_TIO13_OFS                 (8)                             /* !< TIO13 Offset */
+#define LFSS_TOUT15_12_TIO13_MASK                ((uint32_t)0x00000100U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 13 (TIO13) when the output
+                                                                                    is enabled through TOE13 register. */
+#define LFSS_TOUT15_12_TIO13_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT15_12_TIO13_ONE                 ((uint32_t)0x00000100U)         /* !< Output is set to 1 */
+/* LFSS_TOUT15_12[TIO14] Bits */
+#define LFSS_TOUT15_12_TIO14_OFS                 (16)                            /* !< TIO14 Offset */
+#define LFSS_TOUT15_12_TIO14_MASK                ((uint32_t)0x00010000U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 14 (TIO14) when the output
+                                                                                    is enabled through TOE14 register. */
+#define LFSS_TOUT15_12_TIO14_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT15_12_TIO14_ONE                 ((uint32_t)0x00010000U)         /* !< Output is set to 1 */
+/* LFSS_TOUT15_12[TIO15] Bits */
+#define LFSS_TOUT15_12_TIO15_OFS                 (24)                            /* !< TIO15 Offset */
+#define LFSS_TOUT15_12_TIO15_MASK                ((uint32_t)0x01000000U)         /* !< This bit sets the value of the pin
+                                                                                    tamper I/O 15 (TIO15) when the output
+                                                                                    is enabled through TOE15 register. */
+#define LFSS_TOUT15_12_TIO15_ZERO                ((uint32_t)0x00000000U)         /* !< Output is set to 0 */
+#define LFSS_TOUT15_12_TIO15_ONE                 ((uint32_t)0x01000000U)         /* !< Output is set to 1 */
+
+/* LFSS_TOE3_0 Bits */
+/* LFSS_TOE3_0[TIO0] Bits */
+#define LFSS_TOE3_0_TIO0_OFS                     (0)                             /* !< TIO0 Offset */
+#define LFSS_TOE3_0_TIO0_MASK                    ((uint32_t)0x00000001U)         /* !< Enables data output for tamper I/O
+                                                                                    0 */
+#define LFSS_TOE3_0_TIO0_DISABLE                 ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE3_0_TIO0_ENABLE                  ((uint32_t)0x00000001U)         /* !< output enabled */
+/* LFSS_TOE3_0[TIO1] Bits */
+#define LFSS_TOE3_0_TIO1_OFS                     (8)                             /* !< TIO1 Offset */
+#define LFSS_TOE3_0_TIO1_MASK                    ((uint32_t)0x00000100U)         /* !< Enables data output for tamper I/O
+                                                                                    1 */
+#define LFSS_TOE3_0_TIO1_DISABLE                 ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE3_0_TIO1_ENABLE                  ((uint32_t)0x00000100U)         /* !< output enabled */
+/* LFSS_TOE3_0[TIO2] Bits */
+#define LFSS_TOE3_0_TIO2_OFS                     (16)                            /* !< TIO2 Offset */
+#define LFSS_TOE3_0_TIO2_MASK                    ((uint32_t)0x00010000U)         /* !< Enables data output for tamper I/O
+                                                                                    2 */
+#define LFSS_TOE3_0_TIO2_DISABLE                 ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE3_0_TIO2_ENABLE                  ((uint32_t)0x00010000U)         /* !< output enabled */
+/* LFSS_TOE3_0[TIO3] Bits */
+#define LFSS_TOE3_0_TIO3_OFS                     (24)                            /* !< TIO3 Offset */
+#define LFSS_TOE3_0_TIO3_MASK                    ((uint32_t)0x01000000U)         /* !< Enables data output for tamper I/O
+                                                                                    3 */
+#define LFSS_TOE3_0_TIO3_DISABLE                 ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE3_0_TIO3_ENABLE                  ((uint32_t)0x01000000U)         /* !< output enabled */
+
+/* LFSS_TOE7_4 Bits */
+/* LFSS_TOE7_4[TIO4] Bits */
+#define LFSS_TOE7_4_TIO4_OFS                     (0)                             /* !< TIO4 Offset */
+#define LFSS_TOE7_4_TIO4_MASK                    ((uint32_t)0x00000001U)         /* !< Enables data output for tamper I/O
+                                                                                    4 */
+#define LFSS_TOE7_4_TIO4_DISABLE                 ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE7_4_TIO4_ENABLE                  ((uint32_t)0x00000001U)         /* !< output enabled */
+/* LFSS_TOE7_4[TIO5] Bits */
+#define LFSS_TOE7_4_TIO5_OFS                     (8)                             /* !< TIO5 Offset */
+#define LFSS_TOE7_4_TIO5_MASK                    ((uint32_t)0x00000100U)         /* !< Enables data output for tamper I/O
+                                                                                    5 */
+#define LFSS_TOE7_4_TIO5_DISABLE                 ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE7_4_TIO5_ENABLE                  ((uint32_t)0x00000100U)         /* !< output enabled */
+/* LFSS_TOE7_4[TIO6] Bits */
+#define LFSS_TOE7_4_TIO6_OFS                     (16)                            /* !< TIO6 Offset */
+#define LFSS_TOE7_4_TIO6_MASK                    ((uint32_t)0x00010000U)         /* !< Enables data output for tamper I/O
+                                                                                    6 */
+#define LFSS_TOE7_4_TIO6_DISABLE                 ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE7_4_TIO6_ENABLE                  ((uint32_t)0x00010000U)         /* !< output enabled */
+/* LFSS_TOE7_4[TIO7] Bits */
+#define LFSS_TOE7_4_TIO7_OFS                     (24)                            /* !< TIO7 Offset */
+#define LFSS_TOE7_4_TIO7_MASK                    ((uint32_t)0x01000000U)         /* !< Enables data output for tamper I/O
+                                                                                    7 */
+#define LFSS_TOE7_4_TIO7_DISABLE                 ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE7_4_TIO7_ENABLE                  ((uint32_t)0x01000000U)         /* !< output enabled */
+
+/* LFSS_TOE11_8 Bits */
+/* LFSS_TOE11_8[TIO8] Bits */
+#define LFSS_TOE11_8_TIO8_OFS                    (0)                             /* !< TIO8 Offset */
+#define LFSS_TOE11_8_TIO8_MASK                   ((uint32_t)0x00000001U)         /* !< Enables data output for tamper I/O
+                                                                                    8 */
+#define LFSS_TOE11_8_TIO8_DISABLE                ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE11_8_TIO8_ENABLE                 ((uint32_t)0x00000001U)         /* !< output enabled */
+/* LFSS_TOE11_8[TIO9] Bits */
+#define LFSS_TOE11_8_TIO9_OFS                    (8)                             /* !< TIO9 Offset */
+#define LFSS_TOE11_8_TIO9_MASK                   ((uint32_t)0x00000100U)         /* !< Enables data output for tamper I/O
+                                                                                    9 */
+#define LFSS_TOE11_8_TIO9_DISABLE                ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE11_8_TIO9_ENABLE                 ((uint32_t)0x00000100U)         /* !< output enabled */
+/* LFSS_TOE11_8[TIO10] Bits */
+#define LFSS_TOE11_8_TIO10_OFS                   (16)                            /* !< TIO10 Offset */
+#define LFSS_TOE11_8_TIO10_MASK                  ((uint32_t)0x00010000U)         /* !< Enables data output for tamper I/O
+                                                                                    10 */
+#define LFSS_TOE11_8_TIO10_DISABLE               ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE11_8_TIO10_ENABLE                ((uint32_t)0x00010000U)         /* !< output enabled */
+/* LFSS_TOE11_8[TIO11] Bits */
+#define LFSS_TOE11_8_TIO11_OFS                   (24)                            /* !< TIO11 Offset */
+#define LFSS_TOE11_8_TIO11_MASK                  ((uint32_t)0x01000000U)         /* !< Enables data output for tamper I/O
+                                                                                    11 */
+#define LFSS_TOE11_8_TIO11_DISABLE               ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE11_8_TIO11_ENABLE                ((uint32_t)0x01000000U)         /* !< output enabled */
+
+/* LFSS_TOE15_12 Bits */
+/* LFSS_TOE15_12[TIO12] Bits */
+#define LFSS_TOE15_12_TIO12_OFS                  (0)                             /* !< TIO12 Offset */
+#define LFSS_TOE15_12_TIO12_MASK                 ((uint32_t)0x00000001U)         /* !< Enables data output for tamper I/O
+                                                                                    12 */
+#define LFSS_TOE15_12_TIO12_DISABLE              ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE15_12_TIO12_ENABLE               ((uint32_t)0x00000001U)         /* !< output enabled */
+/* LFSS_TOE15_12[TIO13] Bits */
+#define LFSS_TOE15_12_TIO13_OFS                  (8)                             /* !< TIO13 Offset */
+#define LFSS_TOE15_12_TIO13_MASK                 ((uint32_t)0x00000100U)         /* !< Enables data output for tamper I/O
+                                                                                    13 */
+#define LFSS_TOE15_12_TIO13_DISABLE              ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE15_12_TIO13_ENABLE               ((uint32_t)0x00000100U)         /* !< output enabled */
+/* LFSS_TOE15_12[TIO14] Bits */
+#define LFSS_TOE15_12_TIO14_OFS                  (16)                            /* !< TIO14 Offset */
+#define LFSS_TOE15_12_TIO14_MASK                 ((uint32_t)0x00010000U)         /* !< Enables data output for tamper I/O
+                                                                                    14 */
+#define LFSS_TOE15_12_TIO14_DISABLE              ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE15_12_TIO14_ENABLE               ((uint32_t)0x00010000U)         /* !< output enabled */
+/* LFSS_TOE15_12[TIO15] Bits */
+#define LFSS_TOE15_12_TIO15_OFS                  (24)                            /* !< TIO15 Offset */
+#define LFSS_TOE15_12_TIO15_MASK                 ((uint32_t)0x01000000U)         /* !< Enables data output for tamper I/O
+                                                                                    15 */
+#define LFSS_TOE15_12_TIO15_DISABLE              ((uint32_t)0x00000000U)         /* !< output disabled */
+#define LFSS_TOE15_12_TIO15_ENABLE               ((uint32_t)0x01000000U)         /* !< output enabled */
+
+/* LFSS_TIN3_0 Bits */
+/* LFSS_TIN3_0[TIO0] Bits */
+#define LFSS_TIN3_0_TIO0_OFS                     (0)                             /* !< TIO0 Offset */
+#define LFSS_TIN3_0_TIO0_MASK                    ((uint32_t)0x00000001U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 0. */
+#define LFSS_TIN3_0_TIO0_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN3_0_TIO0_ONE                     ((uint32_t)0x00000001U)         /* !< Input value is 1 */
+/* LFSS_TIN3_0[TIO1] Bits */
+#define LFSS_TIN3_0_TIO1_OFS                     (8)                             /* !< TIO1 Offset */
+#define LFSS_TIN3_0_TIO1_MASK                    ((uint32_t)0x00000100U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 1. */
+#define LFSS_TIN3_0_TIO1_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN3_0_TIO1_ONE                     ((uint32_t)0x00000100U)         /* !< Input value is 1 */
+/* LFSS_TIN3_0[TIO2] Bits */
+#define LFSS_TIN3_0_TIO2_OFS                     (16)                            /* !< TIO2 Offset */
+#define LFSS_TIN3_0_TIO2_MASK                    ((uint32_t)0x00010000U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 2. */
+#define LFSS_TIN3_0_TIO2_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN3_0_TIO2_ONE                     ((uint32_t)0x00010000U)         /* !< Input value is 1 */
+/* LFSS_TIN3_0[TIO3] Bits */
+#define LFSS_TIN3_0_TIO3_OFS                     (24)                            /* !< TIO3 Offset */
+#define LFSS_TIN3_0_TIO3_MASK                    ((uint32_t)0x01000000U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 3. */
+#define LFSS_TIN3_0_TIO3_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN3_0_TIO3_ONE                     ((uint32_t)0x01000000U)         /* !< Input value is 1 */
+
+/* LFSS_TIN7_4 Bits */
+/* LFSS_TIN7_4[TIO4] Bits */
+#define LFSS_TIN7_4_TIO4_OFS                     (0)                             /* !< TIO4 Offset */
+#define LFSS_TIN7_4_TIO4_MASK                    ((uint32_t)0x00000001U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 4. */
+#define LFSS_TIN7_4_TIO4_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN7_4_TIO4_ONE                     ((uint32_t)0x00000001U)         /* !< Input value is 1 */
+/* LFSS_TIN7_4[TIO5] Bits */
+#define LFSS_TIN7_4_TIO5_OFS                     (8)                             /* !< TIO5 Offset */
+#define LFSS_TIN7_4_TIO5_MASK                    ((uint32_t)0x00000100U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 5. */
+#define LFSS_TIN7_4_TIO5_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN7_4_TIO5_ONE                     ((uint32_t)0x00000100U)         /* !< Input value is 1 */
+/* LFSS_TIN7_4[TIO6] Bits */
+#define LFSS_TIN7_4_TIO6_OFS                     (16)                            /* !< TIO6 Offset */
+#define LFSS_TIN7_4_TIO6_MASK                    ((uint32_t)0x00010000U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 6. */
+#define LFSS_TIN7_4_TIO6_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN7_4_TIO6_ONE                     ((uint32_t)0x00010000U)         /* !< Input value is 1 */
+/* LFSS_TIN7_4[TIO7] Bits */
+#define LFSS_TIN7_4_TIO7_OFS                     (24)                            /* !< TIO7 Offset */
+#define LFSS_TIN7_4_TIO7_MASK                    ((uint32_t)0x01000000U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 7. */
+#define LFSS_TIN7_4_TIO7_ZERO                    ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN7_4_TIO7_ONE                     ((uint32_t)0x01000000U)         /* !< Input value is 1 */
+
+/* LFSS_TIN11_8 Bits */
+/* LFSS_TIN11_8[TIO8] Bits */
+#define LFSS_TIN11_8_TIO8_OFS                    (0)                             /* !< TIO8 Offset */
+#define LFSS_TIN11_8_TIO8_MASK                   ((uint32_t)0x00000001U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 8. */
+#define LFSS_TIN11_8_TIO8_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN11_8_TIO8_ONE                    ((uint32_t)0x00000001U)         /* !< Input value is 1 */
+/* LFSS_TIN11_8[TIO9] Bits */
+#define LFSS_TIN11_8_TIO9_OFS                    (8)                             /* !< TIO9 Offset */
+#define LFSS_TIN11_8_TIO9_MASK                   ((uint32_t)0x00000100U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 9. */
+#define LFSS_TIN11_8_TIO9_ZERO                   ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN11_8_TIO9_ONE                    ((uint32_t)0x00000100U)         /* !< Input value is 1 */
+/* LFSS_TIN11_8[TIO10] Bits */
+#define LFSS_TIN11_8_TIO10_OFS                   (16)                            /* !< TIO10 Offset */
+#define LFSS_TIN11_8_TIO10_MASK                  ((uint32_t)0x00010000U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 10. */
+#define LFSS_TIN11_8_TIO10_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN11_8_TIO10_ONE                   ((uint32_t)0x00010000U)         /* !< Input value is 1 */
+/* LFSS_TIN11_8[TIO11] Bits */
+#define LFSS_TIN11_8_TIO11_OFS                   (24)                            /* !< TIO11 Offset */
+#define LFSS_TIN11_8_TIO11_MASK                  ((uint32_t)0x01000000U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 11. */
+#define LFSS_TIN11_8_TIO11_ZERO                  ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN11_8_TIO11_ONE                   ((uint32_t)0x01000000U)         /* !< Input value is 1 */
+
+/* LFSS_TIN15_12 Bits */
+/* LFSS_TIN15_12[TIO12] Bits */
+#define LFSS_TIN15_12_TIO12_OFS                  (0)                             /* !< TIO12 Offset */
+#define LFSS_TIN15_12_TIO12_MASK                 ((uint32_t)0x00000001U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 12. */
+#define LFSS_TIN15_12_TIO12_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN15_12_TIO12_ONE                  ((uint32_t)0x00000001U)         /* !< Input value is 1 */
+/* LFSS_TIN15_12[TIO13] Bits */
+#define LFSS_TIN15_12_TIO13_OFS                  (8)                             /* !< TIO13 Offset */
+#define LFSS_TIN15_12_TIO13_MASK                 ((uint32_t)0x00000100U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 13. */
+#define LFSS_TIN15_12_TIO13_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN15_12_TIO13_ONE                  ((uint32_t)0x00000100U)         /* !< Input value is 1 */
+/* LFSS_TIN15_12[TIO14] Bits */
+#define LFSS_TIN15_12_TIO14_OFS                  (16)                            /* !< TIO14 Offset */
+#define LFSS_TIN15_12_TIO14_MASK                 ((uint32_t)0x00010000U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 14. */
+#define LFSS_TIN15_12_TIO14_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN15_12_TIO14_ONE                  ((uint32_t)0x00010000U)         /* !< Input value is 1 */
+/* LFSS_TIN15_12[TIO15] Bits */
+#define LFSS_TIN15_12_TIO15_OFS                  (24)                            /* !< TIO15 Offset */
+#define LFSS_TIN15_12_TIO15_MASK                 ((uint32_t)0x01000000U)         /* !< This bit reads the data input value
+                                                                                    of tamper I/O 15. */
+#define LFSS_TIN15_12_TIO15_ZERO                 ((uint32_t)0x00000000U)         /* !< Input value is 0 */
+#define LFSS_TIN15_12_TIO15_ONE                  ((uint32_t)0x01000000U)         /* !< Input value is 1 */
+
+/* LFSS_HEARTBEAT Bits */
+/* LFSS_HEARTBEAT[HBINTERVAL] Bits */
+#define LFSS_HEARTBEAT_HBINTERVAL_OFS            (0)                             /* !< HBINTERVAL Offset */
+#define LFSS_HEARTBEAT_HBINTERVAL_MASK           ((uint32_t)0x00000007U)         /* !< Heart beat interval */
+#define LFSS_HEARTBEAT_HBINTERVAL_HBINT0P125     ((uint32_t)0x00000000U)         /* !< Heart beat interval 0.125 sec */
+#define LFSS_HEARTBEAT_HBINTERVAL_HBINT0P25      ((uint32_t)0x00000001U)         /* !< Heart beat interval 0.25 sec */
+#define LFSS_HEARTBEAT_HBINTERVAL_HBINT0P5       ((uint32_t)0x00000002U)         /* !< Heart beat interval 0.5 sec */
+#define LFSS_HEARTBEAT_HBINTERVAL_HBINT1         ((uint32_t)0x00000003U)         /* !< Heart beat interval 1 sec */
+#define LFSS_HEARTBEAT_HBINTERVAL_HBINT2         ((uint32_t)0x00000004U)         /* !< Heart beat interval 2 sec */
+#define LFSS_HEARTBEAT_HBINTERVAL_HBINT4         ((uint32_t)0x00000005U)         /* !< Heart beat interval 4 sec */
+#define LFSS_HEARTBEAT_HBINTERVAL_HBINT8         ((uint32_t)0x00000006U)         /* !< Heart beat interval 8 sec */
+#define LFSS_HEARTBEAT_HBINTERVAL_HBINT16        ((uint32_t)0x00000007U)         /* !< Heart beat interval 16 sec */
+/* LFSS_HEARTBEAT[HBWIDTH] Bits */
+#define LFSS_HEARTBEAT_HBWIDTH_OFS               (8)                             /* !< HBWIDTH Offset */
+#define LFSS_HEARTBEAT_HBWIDTH_MASK              ((uint32_t)0x00000700U)         /* !< Heart beat interval width */
+#define LFSS_HEARTBEAT_HBWIDTH_HBPWDTH1          ((uint32_t)0x00000000U)         /* !< Heart beat pulse width 1 msec */
+#define LFSS_HEARTBEAT_HBWIDTH_HBPWDTH2          ((uint32_t)0x00000100U)         /* !< Heart beat pulse width 2 msec */
+#define LFSS_HEARTBEAT_HBWIDTH_HBPWDTH4          ((uint32_t)0x00000200U)         /* !< Heart beat pulse width 4 msec */
+#define LFSS_HEARTBEAT_HBWIDTH_HBPWDTH8          ((uint32_t)0x00000300U)         /* !< Heart beat pulse width 8 msec */
+#define LFSS_HEARTBEAT_HBWIDTH_HBPWDTH16         ((uint32_t)0x00000400U)         /* !< Heart beat pulse width 16 msec */
+#define LFSS_HEARTBEAT_HBWIDTH_HBPWDTH32         ((uint32_t)0x00000500U)         /* !< Heart beat pulse width 32 msec */
+#define LFSS_HEARTBEAT_HBWIDTH_HBPWDTH64         ((uint32_t)0x00000600U)         /* !< Heart beat pulse width 64 msec */
+#define LFSS_HEARTBEAT_HBWIDTH_HBPWDTH128        ((uint32_t)0x00000700U)         /* !< Heart beat pulse width 128 msec */
+/* LFSS_HEARTBEAT[HBMODE] Bits */
+#define LFSS_HEARTBEAT_HBMODE_OFS                (16)                            /* !< HBMODE Offset */
+#define LFSS_HEARTBEAT_HBMODE_MASK               ((uint32_t)0x00030000U)         /* !< Heart beat mode */
+#define LFSS_HEARTBEAT_HBMODE_HB_DIS             ((uint32_t)0x00000000U)         /* !< Heart beat disabled */
+#define LFSS_HEARTBEAT_HBMODE_HB_ALLWAYS         ((uint32_t)0x00010000U)         /* !< Heart beat allways enabled */
+#define LFSS_HEARTBEAT_HBMODE_HB_TS              ((uint32_t)0x00020000U)         /* !< Heart beat enabled when time stamp
+                                                                                    event detected */
+#define LFSS_HEARTBEAT_HBMODE_HB_VDDFAIL         ((uint32_t)0x00030000U)         /* !< Heart beat when VDD has fail
+                                                                                    condition */
+
+/* LFSS_TIOLOCK Bits */
+/* LFSS_TIOLOCK[PROTECT] Bits */
+#define LFSS_TIOLOCK_PROTECT_OFS                 (0)                             /* !< PROTECT Offset */
+#define LFSS_TIOLOCK_PROTECT_MASK                ((uint32_t)0x00000001U)         /* !< If set, the register bit will
+                                                                                    protect the TIOCTL and HEARTBEAT from
+                                                                                    accidental writes. */
+#define LFSS_TIOLOCK_PROTECT_CLR                 ((uint32_t)0x00000000U)         /* !< Tamper I/O control is writable. */
+#define LFSS_TIOLOCK_PROTECT_SET                 ((uint32_t)0x00000001U)         /* !< Tamper I/O control is read only
+                                                                                    access. */
+/* LFSS_TIOLOCK[KEY] Bits */
+#define LFSS_TIOLOCK_KEY_OFS                     (24)                            /* !< KEY Offset */
+#define LFSS_TIOLOCK_KEY_MASK                    ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0x18) to update
+                                                                                    this register */
+#define LFSS_TIOLOCK_KEY_UNLOCK_W                ((uint32_t)0x18000000U)         /* !< This field must be written with
+                                                                                    0x18 to be able to clear any of the
+                                                                                    enable bits */
+
+/* LFSS_CLKCTL Bits */
+/* LFSS_CLKCTL[MODCLKEN] Bits */
+#define LFSS_CLKCTL_MODCLKEN_OFS                 (31)                            /* !< MODCLKEN Offset */
+#define LFSS_CLKCTL_MODCLKEN_MASK                ((uint32_t)0x80000000U)         /* !< This bit enables the supply of the
+                                                                                    32kHz clock to the RTC. It will not
+                                                                                    power-up the 32kHz crystal oscillator
+                                                                                    this needs to be done in the Clock
+                                                                                    System Module. */
+#define LFSS_CLKCTL_MODCLKEN_DISABLE             ((uint32_t)0x00000000U)         /* !< 32kHz clock is not supplied to the
+                                                                                    RTC. */
+#define LFSS_CLKCTL_MODCLKEN_ENABLE              ((uint32_t)0x80000000U)         /* !< 32kHz clock is supplied to the RTC. */
+
+/* LFSS_DBGCTL Bits */
+/* LFSS_DBGCTL[DBGRUN] Bits */
+#define LFSS_DBGCTL_DBGRUN_OFS                   (0)                             /* !< DBGRUN Offset */
+#define LFSS_DBGCTL_DBGRUN_MASK                  ((uint32_t)0x00000001U)         /* !< Debug Run. */
+#define LFSS_DBGCTL_DBGRUN_HALT                  ((uint32_t)0x00000000U)         /* !< Counter is halted if CPU is in
+                                                                                    debug state. */
+#define LFSS_DBGCTL_DBGRUN_RUN                   ((uint32_t)0x00000001U)         /* !< Continue to operate normally
+                                                                                    ignoring the debug state of the CPU. */
+/* LFSS_DBGCTL[DBGINT] Bits */
+#define LFSS_DBGCTL_DBGINT_OFS                   (1)                             /* !< DBGINT Offset */
+#define LFSS_DBGCTL_DBGINT_MASK                  ((uint32_t)0x00000002U)         /* !< Debug Interrupt Enable. */
+#define LFSS_DBGCTL_DBGINT_OFF                   ((uint32_t)0x00000000U)         /* !< Interrupts of the module will not
+                                                                                    be captured anymore if CPU is in
+                                                                                    debug state. Which means no update to
+                                                                                    the RTCRIS, RTCMISC and RTCIIDX
+                                                                                    register. */
+#define LFSS_DBGCTL_DBGINT_ON                    ((uint32_t)0x00000002U)         /* !< Interrupts are enabled in debug
+                                                                                    mode. Interrupt requests are signaled
+                                                                                    to the interrupt controller. If the
+                                                                                    flags are required by software
+                                                                                    (polling mode) the DGBINT bit need to
+                                                                                    be set to 1. */
+
+/* LFSS_CTL Bits */
+/* LFSS_CTL[RTCTEVTX] Bits */
+#define LFSS_CTL_RTCTEVTX_OFS                    (0)                             /* !< RTCTEVTX Offset */
+#define LFSS_CTL_RTCTEVTX_MASK                   ((uint32_t)0x00000003U)         /* !< Real-time clock time event 0x0 =
+                                                                                    Minute changed 0x1 = Hour changed 0x2
+                                                                                    = Every day at midnight (00:00) 0x3 =
+                                                                                    Every day at noon (12:00) */
+#define LFSS_CTL_RTCTEVTX_MINUTE                 ((uint32_t)0x00000000U)         /* !< Generate RTC event every minute. */
+#define LFSS_CTL_RTCTEVTX_HOUR                   ((uint32_t)0x00000001U)         /* !< Generate RTC event every hour. */
+#define LFSS_CTL_RTCTEVTX_MIDNIGHT               ((uint32_t)0x00000002U)         /* !< Generate RTC event at midnight. */
+#define LFSS_CTL_RTCTEVTX_NOON                   ((uint32_t)0x00000003U)         /* !< Generate RTC event at noon. */
+/* LFSS_CTL[RTCBCD] Bits */
+#define LFSS_CTL_RTCBCD_OFS                      (7)                             /* !< RTCBCD Offset */
+#define LFSS_CTL_RTCBCD_MASK                     ((uint32_t)0x00000080U)         /* !< Real-time clock BCD select. Selects
+                                                                                    BCD counting for real-time clock. */
+#define LFSS_CTL_RTCBCD_BINARY                   ((uint32_t)0x00000000U)         /* !< Binary code selected */
+#define LFSS_CTL_RTCBCD_BCD                      ((uint32_t)0x00000080U)         /* !< Binary coded decimal (BCD) code
+                                                                                    selected */
+
+/* LFSS_STA Bits */
+/* LFSS_STA[RTCRDY] Bits */
+#define LFSS_STA_RTCRDY_OFS                      (0)                             /* !< RTCRDY Offset */
+#define LFSS_STA_RTCRDY_MASK                     ((uint32_t)0x00000001U)         /* !< Real-time clock ready. This bit
+                                                                                    indicates when the real-time clock
+                                                                                    time values are safe for reading. */
+#define LFSS_STA_RTCRDY_NOT_READY                ((uint32_t)0x00000000U)         /* !< RTC time values in transition */
+#define LFSS_STA_RTCRDY_READY                    ((uint32_t)0x00000001U)         /* !< RTC time values safe for reading. */
+/* LFSS_STA[RTCTCRDY] Bits */
+#define LFSS_STA_RTCTCRDY_OFS                    (1)                             /* !< RTCTCRDY Offset */
+#define LFSS_STA_RTCTCRDY_MASK                   ((uint32_t)0x00000002U)         /* !< Real-time clock temperature
+                                                                                    compensation ready. This is a read
+                                                                                    only bit that indicates when the
+                                                                                    RTCTCMPx can be written. Write to
+                                                                                    RTCTCMPx should be avoided when
+                                                                                    RTCTCRDY is reset. */
+#define LFSS_STA_RTCTCRDY_NOT_READY              ((uint32_t)0x00000000U)         /* !< RTC temperature compensation in
+                                                                                    transition */
+#define LFSS_STA_RTCTCRDY_READY                  ((uint32_t)0x00000002U)         /* !< RTC temperature compensation ready */
+/* LFSS_STA[RTCTCOK] Bits */
+#define LFSS_STA_RTCTCOK_OFS                     (2)                             /* !< RTCTCOK Offset */
+#define LFSS_STA_RTCTCOK_MASK                    ((uint32_t)0x00000004U)         /* !< Real-time clock temperature
+                                                                                    compensation write OK. This is a
+                                                                                    read-only bit that indicates if the
+                                                                                    write to RTCTCMP is successful or
+                                                                                    not. */
+#define LFSS_STA_RTCTCOK_NOT_OK                  ((uint32_t)0x00000000U)         /* !< Write to RTCTCMPx is unsuccessful */
+#define LFSS_STA_RTCTCOK_OK                      ((uint32_t)0x00000004U)         /* !< Write to RTCTCMPx is successful */
+
+/* LFSS_CAL Bits */
+/* LFSS_CAL[RTCOCALX] Bits */
+#define LFSS_CAL_RTCOCALX_OFS                    (0)                             /* !< RTCOCALX Offset */
+#define LFSS_CAL_RTCOCALX_MASK                   ((uint32_t)0x000000FFU)         /* !< Real-time clock offset error
+                                                                                    calibration. Each LSB represents
+                                                                                    approximately +1ppm (RTCOCALXS = 1)
+                                                                                    or -1ppm (RTCOCALXS = 0) adjustment
+                                                                                    in frequency. Maximum effective
+                                                                                    calibration value is +/-240ppm.
+                                                                                    Excess values written above +/-240ppm
+                                                                                    will be ignored by hardware. */
+#define LFSS_CAL_RTCOCALX_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_CAL_RTCOCALX_MAXIMUM                ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+/* LFSS_CAL[RTCOCALS] Bits */
+#define LFSS_CAL_RTCOCALS_OFS                    (15)                            /* !< RTCOCALS Offset */
+#define LFSS_CAL_RTCOCALS_MASK                   ((uint32_t)0x00008000U)         /* !< Real-time clock offset error
+                                                                                    calibration sign. This bit decides
+                                                                                    the sign of offset error calibration. */
+#define LFSS_CAL_RTCOCALS_DOWN                   ((uint32_t)0x00000000U)         /* !< Down calibration. Frequency
+                                                                                    adjusted down. */
+#define LFSS_CAL_RTCOCALS_UP                     ((uint32_t)0x00008000U)         /* !< Up calibration. Frequency adjusted
+                                                                                    up. */
+/* LFSS_CAL[RTCCALFX] Bits */
+#define LFSS_CAL_RTCCALFX_OFS                    (16)                            /* !< RTCCALFX Offset */
+#define LFSS_CAL_RTCCALFX_MASK                   ((uint32_t)0x00030000U)         /* !< Real-time clock calibration
+                                                                                    frequency. Selects frequency output
+                                                                                    to RTCCLK pin for calibration
+                                                                                    measurement. The corresponding port
+                                                                                    must be configured for the peripheral
+                                                                                    module function. */
+#define LFSS_CAL_RTCCALFX_F32KHZ                 ((uint32_t)0x00000000U)         /* !< 32 kHz */
+#define LFSS_CAL_RTCCALFX_F512HZ                 ((uint32_t)0x00010000U)         /* !< 512 Hz */
+#define LFSS_CAL_RTCCALFX_F256HZ                 ((uint32_t)0x00020000U)         /* !< 256 Hz */
+#define LFSS_CAL_RTCCALFX_F1HZ                   ((uint32_t)0x00030000U)         /* !< 1 Hz */
+
+/* LFSS_TCMP Bits */
+/* LFSS_TCMP[RTCTCMPX] Bits */
+#define LFSS_TCMP_RTCTCMPX_OFS                   (0)                             /* !< RTCTCMPX Offset */
+#define LFSS_TCMP_RTCTCMPX_MASK                  ((uint32_t)0x000000FFU)         /* !< Real-time clock temperature
+                                                                                    compensation. Value written into this
+                                                                                    register is used for temperature
+                                                                                    compensation of RTC. Each LSB
+                                                                                    represents approximately +1ppm
+                                                                                    (RTCTCMPS = 1) or -1ppm (RTCTCMPS =
+                                                                                    0) adjustment in frequency. Maximum
+                                                                                    effective calibration value is
+                                                                                    +/-240ppm. Excess values written
+                                                                                    above +/-240ppm are ignored by
+                                                                                    hardware. Reading from RTCTCMP
+                                                                                    register at any time returns the
+                                                                                    cumulative value which is the signed
+                                                                                    addition of RTCOCALx and RTCTCMPX
+                                                                                    values, and the updated sign bit
+                                                                                    (RTCTCMPS) of the addition result. */
+#define LFSS_TCMP_RTCTCMPX_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TCMP_RTCTCMPX_MAXIMUM               ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+/* LFSS_TCMP[RTCTCMPS] Bits */
+#define LFSS_TCMP_RTCTCMPS_OFS                   (15)                            /* !< RTCTCMPS Offset */
+#define LFSS_TCMP_RTCTCMPS_MASK                  ((uint32_t)0x00008000U)         /* !< Real-time clock temperature
+                                                                                    compensation sign. This bit decides
+                                                                                    the sign of temperature compensation. */
+#define LFSS_TCMP_RTCTCMPS_DOWN                  ((uint32_t)0x00000000U)         /* !< Down calibration. Frequency
+                                                                                    adjusted down. */
+#define LFSS_TCMP_RTCTCMPS_UP                    ((uint32_t)0x00008000U)         /* !< Up calibration. Frequency adjusted
+                                                                                    up. */
+
+/* LFSS_SEC Bits */
+/* LFSS_SEC[SECBIN] Bits */
+#define LFSS_SEC_SECBIN_OFS                      (0)                             /* !< SECBIN Offset */
+#define LFSS_SEC_SECBIN_MASK                     ((uint32_t)0x0000003FU)         /* !< Seconds Binary (0 to 59). If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_SEC_SECBIN_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_SEC_SECBIN_MAXIMUM                  ((uint32_t)0x0000003BU)         /* !< Highest possible value */
+/* LFSS_SEC[SECLOWBCD] Bits */
+#define LFSS_SEC_SECLOWBCD_OFS                   (8)                             /* !< SECLOWBCD Offset */
+#define LFSS_SEC_SECLOWBCD_MASK                  ((uint32_t)0x00000F00U)         /* !< Seconds BCD  low digit (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_SEC_SECLOWBCD_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_SEC_SECLOWBCD_MAXIMUM               ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* LFSS_SEC[SECHIGHBCD] Bits */
+#define LFSS_SEC_SECHIGHBCD_OFS                  (12)                            /* !< SECHIGHBCD Offset */
+#define LFSS_SEC_SECHIGHBCD_MASK                 ((uint32_t)0x00007000U)         /* !< Seconds BCD  high digit (0 to 5).
+                                                                                    If RTCBCD=0 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define LFSS_SEC_SECHIGHBCD_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_SEC_SECHIGHBCD_MAXIMUM              ((uint32_t)0x00005000U)         /* !< Highest possible value */
+
+/* LFSS_MIN Bits */
+/* LFSS_MIN[MINBIN] Bits */
+#define LFSS_MIN_MINBIN_OFS                      (0)                             /* !< MINBIN Offset */
+#define LFSS_MIN_MINBIN_MASK                     ((uint32_t)0x0000003FU)         /* !< Minutes Binary (0 to 59). If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_MIN_MINBIN_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_MIN_MINBIN_MAXIMUM                  ((uint32_t)0x0000003BU)         /* !< Highest possible value */
+/* LFSS_MIN[MINLOWBCD] Bits */
+#define LFSS_MIN_MINLOWBCD_OFS                   (8)                             /* !< MINLOWBCD Offset */
+#define LFSS_MIN_MINLOWBCD_MASK                  ((uint32_t)0x00000F00U)         /* !< Minutes BCD  low digit (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_MIN_MINLOWBCD_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_MIN_MINLOWBCD_MAXIMUM               ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* LFSS_MIN[MINHIGHBCD] Bits */
+#define LFSS_MIN_MINHIGHBCD_OFS                  (12)                            /* !< MINHIGHBCD Offset */
+#define LFSS_MIN_MINHIGHBCD_MASK                 ((uint32_t)0x00007000U)         /* !< Minutes BCD  high digit (0 to 5).
+                                                                                    If RTCBCD=0 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define LFSS_MIN_MINHIGHBCD_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_MIN_MINHIGHBCD_MAXIMUM              ((uint32_t)0x00005000U)         /* !< Highest possible value */
+
+/* LFSS_HOUR Bits */
+/* LFSS_HOUR[HOURBIN] Bits */
+#define LFSS_HOUR_HOURBIN_OFS                    (0)                             /* !< HOURBIN Offset */
+#define LFSS_HOUR_HOURBIN_MASK                   ((uint32_t)0x0000001FU)         /* !< Hours Binary (0 to 23). If RTCBCD=1
+                                                                                    write to these bits will be ignored
+                                                                                    and read give the value 0. */
+#define LFSS_HOUR_HOURBIN_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_HOUR_HOURBIN_MAXIMUM                ((uint32_t)0x00000017U)         /* !< Highest possible value */
+/* LFSS_HOUR[HOURLOWBCD] Bits */
+#define LFSS_HOUR_HOURLOWBCD_OFS                 (8)                             /* !< HOURLOWBCD Offset */
+#define LFSS_HOUR_HOURLOWBCD_MASK                ((uint32_t)0x00000F00U)         /* !< Hours BCD  low digit (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_HOUR_HOURLOWBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_HOUR_HOURLOWBCD_MAXIMUM             ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* LFSS_HOUR[HOURHIGHBCD] Bits */
+#define LFSS_HOUR_HOURHIGHBCD_OFS                (12)                            /* !< HOURHIGHBCD Offset */
+#define LFSS_HOUR_HOURHIGHBCD_MASK               ((uint32_t)0x00003000U)         /* !< Hours BCD  high digit (0 to 2). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_HOUR_HOURHIGHBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_HOUR_HOURHIGHBCD_MAXIMUM            ((uint32_t)0x00002000U)         /* !< Highest possible value */
+
+/* LFSS_DAY Bits */
+/* LFSS_DAY[DOW] Bits */
+#define LFSS_DAY_DOW_OFS                         (0)                             /* !< DOW Offset */
+#define LFSS_DAY_DOW_MASK                        ((uint32_t)0x00000007U)         /* !< Day of week (0 to 6). These bits
+                                                                                    are valid if RTCBCD=1 or RTCBCD=0. */
+#define LFSS_DAY_DOW_MINIMUM                     ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_DAY_DOW_MAXIMUM                     ((uint32_t)0x00000006U)         /* !< Highest possible value */
+/* LFSS_DAY[DOMBIN] Bits */
+#define LFSS_DAY_DOMBIN_OFS                      (8)                             /* !< DOMBIN Offset */
+#define LFSS_DAY_DOMBIN_MASK                     ((uint32_t)0x00001F00U)         /* !< Day of month Binary (1 to 28, 29,
+                                                                                    30, 31). If RTCBCD=1 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_DAY_DOMBIN_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_DAY_DOMBIN_MAXIMUM                  ((uint32_t)0x00001F00U)         /* !< Highest possible value */
+/* LFSS_DAY[DOMLOWBCD] Bits */
+#define LFSS_DAY_DOMLOWBCD_OFS                   (16)                            /* !< DOMLOWBCD Offset */
+#define LFSS_DAY_DOMLOWBCD_MASK                  ((uint32_t)0x000F0000U)         /* !< Day of month BCD  low digit (0 to
+                                                                                    9). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define LFSS_DAY_DOMLOWBCD_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_DAY_DOMLOWBCD_MAXIMUM               ((uint32_t)0x00090000U)         /* !< Highest possible value */
+/* LFSS_DAY[DOMHIGHBCD] Bits */
+#define LFSS_DAY_DOMHIGHBCD_OFS                  (20)                            /* !< DOMHIGHBCD Offset */
+#define LFSS_DAY_DOMHIGHBCD_MASK                 ((uint32_t)0x00300000U)         /* !< Day of month BCD  high digit (0 to
+                                                                                    3). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define LFSS_DAY_DOMHIGHBCD_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_DAY_DOMHIGHBCD_MAXIMUM              ((uint32_t)0x00300000U)         /* !< Highest possible value */
+
+/* LFSS_MON Bits */
+/* LFSS_MON[MONBIN] Bits */
+#define LFSS_MON_MONBIN_OFS                      (0)                             /* !< MONBIN Offset */
+#define LFSS_MON_MONBIN_MASK                     ((uint32_t)0x0000000FU)         /* !< Month Binary (1 to 12). If RTCBCD=1
+                                                                                    write to these bits will be ignored
+                                                                                    and read give the value 0. */
+#define LFSS_MON_MONBIN_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_MON_MONBIN_MAXIMUM                  ((uint32_t)0x0000000CU)         /* !< Highest possible value */
+/* LFSS_MON[MONLOWBCD] Bits */
+#define LFSS_MON_MONLOWBCD_OFS                   (8)                             /* !< MONLOWBCD Offset */
+#define LFSS_MON_MONLOWBCD_MASK                  ((uint32_t)0x00000F00U)         /* !< Month BCD  low digit (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_MON_MONLOWBCD_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_MON_MONLOWBCD_MAXIMUM               ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* LFSS_MON[MONHIGHBCD] Bits */
+#define LFSS_MON_MONHIGHBCD_OFS                  (12)                            /* !< MONHIGHBCD Offset */
+#define LFSS_MON_MONHIGHBCD_MASK                 ((uint32_t)0x00001000U)         /* !< Month BCD  high digit (0 or 1). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_MON_MONHIGHBCD_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_MON_MONHIGHBCD_MAXIMUM              ((uint32_t)0x00001000U)         /* !< Highest possible value */
+
+/* LFSS_YEAR Bits */
+/* LFSS_YEAR[YEARLOWBIN] Bits */
+#define LFSS_YEAR_YEARLOWBIN_OFS                 (0)                             /* !< YEARLOWBIN Offset */
+#define LFSS_YEAR_YEARLOWBIN_MASK                ((uint32_t)0x000000FFU)         /* !< Year Binary  low byte. Valid values
+                                                                                    for Year are 0 to 4095. If RTCBCD=1
+                                                                                    write to these bits will be ignored
+                                                                                    and read give the value 0. */
+#define LFSS_YEAR_YEARLOWBIN_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_YEAR_YEARLOWBIN_MAXIMUM             ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+/* LFSS_YEAR[YEARHIGHBIN] Bits */
+#define LFSS_YEAR_YEARHIGHBIN_OFS                (8)                             /* !< YEARHIGHBIN Offset */
+#define LFSS_YEAR_YEARHIGHBIN_MASK               ((uint32_t)0x00000F00U)         /* !< Year Binary  high byte. Valid
+                                                                                    values for Year are 0 to 4095. If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_YEAR_YEARHIGHBIN_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_YEAR_YEARHIGHBIN_MAXIMUM            ((uint32_t)0x00000F00U)         /* !< Highest possible value */
+/* LFSS_YEAR[YEARLOWESTBCD] Bits */
+#define LFSS_YEAR_YEARLOWESTBCD_OFS              (16)                            /* !< YEARLOWESTBCD Offset */
+#define LFSS_YEAR_YEARLOWESTBCD_MASK             ((uint32_t)0x000F0000U)         /* !< Year BCD  lowest digit (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_YEAR_YEARLOWESTBCD_MINIMUM          ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_YEAR_YEARLOWESTBCD_MAXIMUM          ((uint32_t)0x00090000U)         /* !< Highest possible value */
+/* LFSS_YEAR[DECADEBCD] Bits */
+#define LFSS_YEAR_DECADEBCD_OFS                  (20)                            /* !< DECADEBCD Offset */
+#define LFSS_YEAR_DECADEBCD_MASK                 ((uint32_t)0x00F00000U)         /* !< Decade BCD (0 to 9). If RTCBCD=0
+                                                                                    write to these bits will be ignored
+                                                                                    and read give the value 0. */
+#define LFSS_YEAR_DECADEBCD_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_YEAR_DECADEBCD_MAXIMUM              ((uint32_t)0x00900000U)         /* !< Highest possible value */
+/* LFSS_YEAR[CENTLOWBCD] Bits */
+#define LFSS_YEAR_CENTLOWBCD_OFS                 (24)                            /* !< CENTLOWBCD Offset */
+#define LFSS_YEAR_CENTLOWBCD_MASK                ((uint32_t)0x0F000000U)         /* !< Century BCD  low digit (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_YEAR_CENTLOWBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_YEAR_CENTLOWBCD_MAXIMUM             ((uint32_t)0x09000000U)         /* !< Highest possible value */
+/* LFSS_YEAR[CENTHIGHBCD] Bits */
+#define LFSS_YEAR_CENTHIGHBCD_OFS                (28)                            /* !< CENTHIGHBCD Offset */
+#define LFSS_YEAR_CENTHIGHBCD_MASK               ((uint32_t)0x70000000U)         /* !< Century BCD  high digit (0 to 4).
+                                                                                    If RTCBCD=0 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define LFSS_YEAR_CENTHIGHBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_YEAR_CENTHIGHBCD_MAXIMUM            ((uint32_t)0x40000000U)         /* !< Highest possible value */
+
+/* LFSS_A1MIN Bits */
+/* LFSS_A1MIN[AMINBIN] Bits */
+#define LFSS_A1MIN_AMINBIN_OFS                   (0)                             /* !< AMINBIN Offset */
+#define LFSS_A1MIN_AMINBIN_MASK                  ((uint32_t)0x0000003FU)         /* !< Alarm Minutes Binary (0 to 59). If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_A1MIN_AMINBIN_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A1MIN_AMINBIN_MAXIMUM               ((uint32_t)0x0000003BU)         /* !< Highest possible value */
+/* LFSS_A1MIN[AMINAEBIN] Bits */
+#define LFSS_A1MIN_AMINAEBIN_OFS                 (7)                             /* !< AMINAEBIN Offset */
+#define LFSS_A1MIN_AMINAEBIN_MASK                ((uint32_t)0x00000080U)         /* !< Alarm Minutes Binary enable. If
+                                                                                    RTCBCD=1 this bit is always 0. Write
+                                                                                    to this bit will be ignored.   0x0=
+                                                                                    Alarm disabled.   0x1= Alarm enabled. */
+#define LFSS_A1MIN_AMINAEBIN_DISABLE             ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A1MIN_AMINAEBIN_ENABLE              ((uint32_t)0x00000080U)         /* !< Alarm enabled */
+/* LFSS_A1MIN[AMINLOWBCD] Bits */
+#define LFSS_A1MIN_AMINLOWBCD_OFS                (8)                             /* !< AMINLOWBCD Offset */
+#define LFSS_A1MIN_AMINLOWBCD_MASK               ((uint32_t)0x00000F00U)         /* !< Alarm Minutes BCD  low digit (0 to
+                                                                                    9). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define LFSS_A1MIN_AMINLOWBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A1MIN_AMINLOWBCD_MAXIMUM            ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* LFSS_A1MIN[AMINHIGHBCD] Bits */
+#define LFSS_A1MIN_AMINHIGHBCD_OFS               (12)                            /* !< AMINHIGHBCD Offset */
+#define LFSS_A1MIN_AMINHIGHBCD_MASK              ((uint32_t)0x00007000U)         /* !< Alarm Minutes BCD  high digit (0 to
+                                                                                    5). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define LFSS_A1MIN_AMINHIGHBCD_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A1MIN_AMINHIGHBCD_MAXIMUM           ((uint32_t)0x00005000U)         /* !< Highest possible value */
+/* LFSS_A1MIN[AMINAEBCD] Bits */
+#define LFSS_A1MIN_AMINAEBCD_OFS                 (15)                            /* !< AMINAEBCD Offset */
+#define LFSS_A1MIN_AMINAEBCD_MASK                ((uint32_t)0x00008000U)         /* !< Alarm Minutes BCD enable. If
+                                                                                    RTCBCD=0 this bit is always 0. Write
+                                                                                    to this bit will be ignored.   0x0=
+                                                                                    Alarm disabled.   0x1= Alarm enabled. */
+#define LFSS_A1MIN_AMINAEBCD_DISABLE             ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A1MIN_AMINAEBCD_ENABLE              ((uint32_t)0x00008000U)         /* !< Alarm enabled */
+
+/* LFSS_A1HOUR Bits */
+/* LFSS_A1HOUR[AHOURBIN] Bits */
+#define LFSS_A1HOUR_AHOURBIN_OFS                 (0)                             /* !< AHOURBIN Offset */
+#define LFSS_A1HOUR_AHOURBIN_MASK                ((uint32_t)0x0000001FU)         /* !< Alarm Hours Binary (0 to 23). If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_A1HOUR_AHOURBIN_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A1HOUR_AHOURBIN_MAXIMUM             ((uint32_t)0x00000017U)         /* !< Highest possible value */
+/* LFSS_A1HOUR[AHOURAEBIN] Bits */
+#define LFSS_A1HOUR_AHOURAEBIN_OFS               (7)                             /* !< AHOURAEBIN Offset */
+#define LFSS_A1HOUR_AHOURAEBIN_MASK              ((uint32_t)0x00000080U)         /* !< Alarm Hours Binary enable. If
+                                                                                    RTCBCD=1 this bit is always 0. Write
+                                                                                    to this bit will be ignored.   0x0=
+                                                                                    Alarm disabled.   0x1= Alarm enabled. */
+#define LFSS_A1HOUR_AHOURAEBIN_DISABLE           ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A1HOUR_AHOURAEBIN_ENABLE            ((uint32_t)0x00000080U)         /* !< Alarm enabled */
+/* LFSS_A1HOUR[AHOURLOWBCD] Bits */
+#define LFSS_A1HOUR_AHOURLOWBCD_OFS              (8)                             /* !< AHOURLOWBCD Offset */
+#define LFSS_A1HOUR_AHOURLOWBCD_MASK             ((uint32_t)0x00000F00U)         /* !< Alarm Hours BCD  low digit (0 to
+                                                                                    9). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define LFSS_A1HOUR_AHOURLOWBCD_MINIMUM          ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A1HOUR_AHOURLOWBCD_MAXIMUM          ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* LFSS_A1HOUR[AHOURHIGHBCD] Bits */
+#define LFSS_A1HOUR_AHOURHIGHBCD_OFS             (12)                            /* !< AHOURHIGHBCD Offset */
+#define LFSS_A1HOUR_AHOURHIGHBCD_MASK            ((uint32_t)0x00003000U)         /* !< Alarm Hours BCD  high digit (0 to
+                                                                                    2). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0.. */
+#define LFSS_A1HOUR_AHOURHIGHBCD_MINIMUM         ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A1HOUR_AHOURHIGHBCD_MAXIMUM         ((uint32_t)0x00002000U)         /* !< Highest possible value */
+/* LFSS_A1HOUR[AHOURAEBCD] Bits */
+#define LFSS_A1HOUR_AHOURAEBCD_OFS               (15)                            /* !< AHOURAEBCD Offset */
+#define LFSS_A1HOUR_AHOURAEBCD_MASK              ((uint32_t)0x00008000U)         /* !< Alarm Hours BCD enable. If RTCBCD=0
+                                                                                    this bit is always 0. Write to this
+                                                                                    bit will be ignored.   0x0= Alarm
+                                                                                    disabled.   0x1= Alarm enabled. */
+#define LFSS_A1HOUR_AHOURAEBCD_DISABLE           ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A1HOUR_AHOURAEBCD_ENABLE            ((uint32_t)0x00008000U)         /* !< Alarm enabled */
+
+/* LFSS_A1DAY Bits */
+/* LFSS_A1DAY[ADOW] Bits */
+#define LFSS_A1DAY_ADOW_OFS                      (0)                             /* !< ADOW Offset */
+#define LFSS_A1DAY_ADOW_MASK                     ((uint32_t)0x00000007U)         /* !< Alarm Day of week (0 to 6). These
+                                                                                    bits are valid if RTCBCD=1 or
+                                                                                    RTCBCD=0. */
+#define LFSS_A1DAY_ADOW_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A1DAY_ADOW_MAXIMUM                  ((uint32_t)0x00000006U)         /* !< Highest possible value */
+/* LFSS_A1DAY[ADOWAE] Bits */
+#define LFSS_A1DAY_ADOWAE_OFS                    (7)                             /* !< ADOWAE Offset */
+#define LFSS_A1DAY_ADOWAE_MASK                   ((uint32_t)0x00000080U)         /* !< Alarm Day of week enable. This bit
+                                                                                    are valid if RTCBCD=1 or RTCBCD=0. */
+#define LFSS_A1DAY_ADOWAE_DISABLE                ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A1DAY_ADOWAE_ENABLE                 ((uint32_t)0x00000080U)         /* !< Alarm enabled */
+/* LFSS_A1DAY[ADOMBIN] Bits */
+#define LFSS_A1DAY_ADOMBIN_OFS                   (8)                             /* !< ADOMBIN Offset */
+#define LFSS_A1DAY_ADOMBIN_MASK                  ((uint32_t)0x00001F00U)         /* !< Alarm Day of month Binary (1 to 28,
+                                                                                    29, 30, 31) If RTCBCD=1 write to
+                                                                                    these bits will be ignored and read
+                                                                                    give the value 0. */
+#define LFSS_A1DAY_ADOMBIN_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A1DAY_ADOMBIN_MAXIMUM               ((uint32_t)0x00001F00U)         /* !< Highest possible value */
+/* LFSS_A1DAY[ADOMAEBIN] Bits */
+#define LFSS_A1DAY_ADOMAEBIN_OFS                 (15)                            /* !< ADOMAEBIN Offset */
+#define LFSS_A1DAY_ADOMAEBIN_MASK                ((uint32_t)0x00008000U)         /* !< Alarm Day of month Binary enable.
+                                                                                    If RTCBCD=1 this bit is always 0.
+                                                                                    Write to this bit will be ignored.
+                                                                                    0x0= Alarm disabled.   0x1= Alarm
+                                                                                    enabled. */
+#define LFSS_A1DAY_ADOMAEBIN_DISABLE             ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A1DAY_ADOMAEBIN_ENABLE              ((uint32_t)0x00008000U)         /* !< Alarm enabled */
+/* LFSS_A1DAY[ADOMLOWBCD] Bits */
+#define LFSS_A1DAY_ADOMLOWBCD_OFS                (16)                            /* !< ADOMLOWBCD Offset */
+#define LFSS_A1DAY_ADOMLOWBCD_MASK               ((uint32_t)0x000F0000U)         /* !< Alarm Day of month BCD  low digit
+                                                                                    (0 to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_A1DAY_ADOMLOWBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A1DAY_ADOMLOWBCD_MAXIMUM            ((uint32_t)0x00090000U)         /* !< Highest possible value */
+/* LFSS_A1DAY[ADOMHIGHBCD] Bits */
+#define LFSS_A1DAY_ADOMHIGHBCD_OFS               (20)                            /* !< ADOMHIGHBCD Offset */
+#define LFSS_A1DAY_ADOMHIGHBCD_MASK              ((uint32_t)0x00300000U)         /* !< Alarm Day of month BCD  high digit
+                                                                                    (0 to 3). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_A1DAY_ADOMHIGHBCD_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A1DAY_ADOMHIGHBCD_MAXIMUM           ((uint32_t)0x00300000U)         /* !< Highest possible value */
+/* LFSS_A1DAY[ADOMAEBCD] Bits */
+#define LFSS_A1DAY_ADOMAEBCD_OFS                 (23)                            /* !< ADOMAEBCD Offset */
+#define LFSS_A1DAY_ADOMAEBCD_MASK                ((uint32_t)0x00800000U)         /* !< Alarm Day of month BCD enable. If
+                                                                                    RTCBCD=0 this bit is always 0. Write
+                                                                                    to this bit will be ignored.   0x0=
+                                                                                    Alarm disabled.   0x1= Alarm enabled. */
+#define LFSS_A1DAY_ADOMAEBCD_DISABLE             ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A1DAY_ADOMAEBCD_ENABLE              ((uint32_t)0x00800000U)         /* !< Alarm enabled */
+
+/* LFSS_A2MIN Bits */
+/* LFSS_A2MIN[AMINBIN] Bits */
+#define LFSS_A2MIN_AMINBIN_OFS                   (0)                             /* !< AMINBIN Offset */
+#define LFSS_A2MIN_AMINBIN_MASK                  ((uint32_t)0x0000003FU)         /* !< Alarm Minutes Binary (0 to 59). If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_A2MIN_AMINBIN_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A2MIN_AMINBIN_MAXIMUM               ((uint32_t)0x0000003BU)         /* !< Highest possible value */
+/* LFSS_A2MIN[AMINAEBIN] Bits */
+#define LFSS_A2MIN_AMINAEBIN_OFS                 (7)                             /* !< AMINAEBIN Offset */
+#define LFSS_A2MIN_AMINAEBIN_MASK                ((uint32_t)0x00000080U)         /* !< Alarm Minutes Binary enable. If
+                                                                                    RTCBCD=1 this bit is always 0. Write
+                                                                                    to this bit will be ignored.   0x0=
+                                                                                    Alarm disabled.   0x1= Alarm enabled. */
+#define LFSS_A2MIN_AMINAEBIN_DISABLE             ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A2MIN_AMINAEBIN_ENABLE              ((uint32_t)0x00000080U)         /* !< Alarm enabled */
+/* LFSS_A2MIN[AMINLOWBCD] Bits */
+#define LFSS_A2MIN_AMINLOWBCD_OFS                (8)                             /* !< AMINLOWBCD Offset */
+#define LFSS_A2MIN_AMINLOWBCD_MASK               ((uint32_t)0x00000F00U)         /* !< Alarm Minutes BCD  low digit (0 to
+                                                                                    9). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define LFSS_A2MIN_AMINLOWBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A2MIN_AMINLOWBCD_MAXIMUM            ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* LFSS_A2MIN[AMINHIGHBCD] Bits */
+#define LFSS_A2MIN_AMINHIGHBCD_OFS               (12)                            /* !< AMINHIGHBCD Offset */
+#define LFSS_A2MIN_AMINHIGHBCD_MASK              ((uint32_t)0x00007000U)         /* !< Alarm Minutes BCD  high digit (0 to
+                                                                                    5). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define LFSS_A2MIN_AMINHIGHBCD_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A2MIN_AMINHIGHBCD_MAXIMUM           ((uint32_t)0x00005000U)         /* !< Highest possible value */
+/* LFSS_A2MIN[AMINAEBCD] Bits */
+#define LFSS_A2MIN_AMINAEBCD_OFS                 (15)                            /* !< AMINAEBCD Offset */
+#define LFSS_A2MIN_AMINAEBCD_MASK                ((uint32_t)0x00008000U)         /* !< Alarm Minutes BCD enable. If
+                                                                                    RTCBCD=0 this bit is always 0. Write
+                                                                                    to this bit will be ignored.   0x0=
+                                                                                    Alarm disabled.   0x1= Alarm enabled. */
+#define LFSS_A2MIN_AMINAEBCD_DISABLE             ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A2MIN_AMINAEBCD_ENABLE              ((uint32_t)0x00008000U)         /* !< Alarm enabled */
+
+/* LFSS_A2HOUR Bits */
+/* LFSS_A2HOUR[AHOURBIN] Bits */
+#define LFSS_A2HOUR_AHOURBIN_OFS                 (0)                             /* !< AHOURBIN Offset */
+#define LFSS_A2HOUR_AHOURBIN_MASK                ((uint32_t)0x0000001FU)         /* !< Alarm Hours Binary (0 to 23). If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_A2HOUR_AHOURBIN_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A2HOUR_AHOURBIN_MAXIMUM             ((uint32_t)0x00000017U)         /* !< Highest possible value */
+/* LFSS_A2HOUR[AHOURAEBIN] Bits */
+#define LFSS_A2HOUR_AHOURAEBIN_OFS               (7)                             /* !< AHOURAEBIN Offset */
+#define LFSS_A2HOUR_AHOURAEBIN_MASK              ((uint32_t)0x00000080U)         /* !< Alarm Hours Binary enable. If
+                                                                                    RTCBCD=1 this bit is always 0. Write
+                                                                                    to this bit will be ignored.   0x0=
+                                                                                    Alarm disabled.   0x1= Alarm enabled. */
+#define LFSS_A2HOUR_AHOURAEBIN_DISABLE           ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A2HOUR_AHOURAEBIN_ENABLE            ((uint32_t)0x00000080U)         /* !< Alarm enabled */
+/* LFSS_A2HOUR[AHOURLOWBCD] Bits */
+#define LFSS_A2HOUR_AHOURLOWBCD_OFS              (8)                             /* !< AHOURLOWBCD Offset */
+#define LFSS_A2HOUR_AHOURLOWBCD_MASK             ((uint32_t)0x00000F00U)         /* !< Alarm Hours BCD  low digit (0 to
+                                                                                    9). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define LFSS_A2HOUR_AHOURLOWBCD_MINIMUM          ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A2HOUR_AHOURLOWBCD_MAXIMUM          ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* LFSS_A2HOUR[AHOURHIGHBCD] Bits */
+#define LFSS_A2HOUR_AHOURHIGHBCD_OFS             (12)                            /* !< AHOURHIGHBCD Offset */
+#define LFSS_A2HOUR_AHOURHIGHBCD_MASK            ((uint32_t)0x00003000U)         /* !< Alarm Hours BCD  high digit (0 to
+                                                                                    2). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0.. */
+#define LFSS_A2HOUR_AHOURHIGHBCD_MINIMUM         ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A2HOUR_AHOURHIGHBCD_MAXIMUM         ((uint32_t)0x00002000U)         /* !< Highest possible value */
+/* LFSS_A2HOUR[AHOURAEBCD] Bits */
+#define LFSS_A2HOUR_AHOURAEBCD_OFS               (15)                            /* !< AHOURAEBCD Offset */
+#define LFSS_A2HOUR_AHOURAEBCD_MASK              ((uint32_t)0x00008000U)         /* !< Alarm Hours BCD enable. If RTCBCD=0
+                                                                                    this bit is always 0. Write to this
+                                                                                    bit will be ignored.   0x0= Alarm
+                                                                                    disabled.   0x1= Alarm enabled. */
+#define LFSS_A2HOUR_AHOURAEBCD_DISABLE           ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A2HOUR_AHOURAEBCD_ENABLE            ((uint32_t)0x00008000U)         /* !< Alarm enabled */
+
+/* LFSS_A2DAY Bits */
+/* LFSS_A2DAY[ADOW] Bits */
+#define LFSS_A2DAY_ADOW_OFS                      (0)                             /* !< ADOW Offset */
+#define LFSS_A2DAY_ADOW_MASK                     ((uint32_t)0x00000007U)         /* !< Alarm Day of week (0 to 6). These
+                                                                                    bits are valid if RTCBCD=1 or
+                                                                                    RTCBCD=0. */
+#define LFSS_A2DAY_ADOW_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A2DAY_ADOW_MAXIMUM                  ((uint32_t)0x00000006U)         /* !< Highest possible value */
+/* LFSS_A2DAY[ADOWAE] Bits */
+#define LFSS_A2DAY_ADOWAE_OFS                    (7)                             /* !< ADOWAE Offset */
+#define LFSS_A2DAY_ADOWAE_MASK                   ((uint32_t)0x00000080U)         /* !< Alarm Day of week enable. This bit
+                                                                                    are valid if RTCBCD=1 or RTCBCD=0. */
+#define LFSS_A2DAY_ADOWAE_DISABLE                ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A2DAY_ADOWAE_ENABLE                 ((uint32_t)0x00000080U)         /* !< Alarm enabled */
+/* LFSS_A2DAY[ADOMBIN] Bits */
+#define LFSS_A2DAY_ADOMBIN_OFS                   (8)                             /* !< ADOMBIN Offset */
+#define LFSS_A2DAY_ADOMBIN_MASK                  ((uint32_t)0x00001F00U)         /* !< Alarm Day of month Binary (1 to 28,
+                                                                                    29, 30, 31) If RTCBCD=1 write to
+                                                                                    these bits will be ignored and read
+                                                                                    give the value 0. */
+#define LFSS_A2DAY_ADOMBIN_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A2DAY_ADOMBIN_MAXIMUM               ((uint32_t)0x00001F00U)         /* !< Highest possible value */
+/* LFSS_A2DAY[ADOMAEBIN] Bits */
+#define LFSS_A2DAY_ADOMAEBIN_OFS                 (15)                            /* !< ADOMAEBIN Offset */
+#define LFSS_A2DAY_ADOMAEBIN_MASK                ((uint32_t)0x00008000U)         /* !< Alarm Day of month Binary enable.
+                                                                                    If RTCBCD=1 this bit is always 0.
+                                                                                    Write to this bit will be ignored.
+                                                                                    0x0= Alarm disabled.   0x1= Alarm
+                                                                                    enabled. */
+#define LFSS_A2DAY_ADOMAEBIN_DISABLE             ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A2DAY_ADOMAEBIN_ENABLE              ((uint32_t)0x00008000U)         /* !< Alarm enabled */
+/* LFSS_A2DAY[ADOMLOWBCD] Bits */
+#define LFSS_A2DAY_ADOMLOWBCD_OFS                (16)                            /* !< ADOMLOWBCD Offset */
+#define LFSS_A2DAY_ADOMLOWBCD_MASK               ((uint32_t)0x000F0000U)         /* !< Alarm Day of month BCD  low digit
+                                                                                    (0 to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_A2DAY_ADOMLOWBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A2DAY_ADOMLOWBCD_MAXIMUM            ((uint32_t)0x00090000U)         /* !< Highest possible value */
+/* LFSS_A2DAY[ADOMHIGHBCD] Bits */
+#define LFSS_A2DAY_ADOMHIGHBCD_OFS               (20)                            /* !< ADOMHIGHBCD Offset */
+#define LFSS_A2DAY_ADOMHIGHBCD_MASK              ((uint32_t)0x00300000U)         /* !< Alarm Day of month BCD  high digit
+                                                                                    (0 to 3). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_A2DAY_ADOMHIGHBCD_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_A2DAY_ADOMHIGHBCD_MAXIMUM           ((uint32_t)0x00300000U)         /* !< Highest possible value */
+/* LFSS_A2DAY[ADOMAEBCD] Bits */
+#define LFSS_A2DAY_ADOMAEBCD_OFS                 (23)                            /* !< ADOMAEBCD Offset */
+#define LFSS_A2DAY_ADOMAEBCD_MASK                ((uint32_t)0x00800000U)         /* !< Alarm Day of month BCD enable. If
+                                                                                    RTCBCD=0 this bit is always 0. Write
+                                                                                    to this bit will be ignored.   0x0=
+                                                                                    Alarm disabled.   0x1= Alarm enabled. */
+#define LFSS_A2DAY_ADOMAEBCD_DISABLE             ((uint32_t)0x00000000U)         /* !< No alarm */
+#define LFSS_A2DAY_ADOMAEBCD_ENABLE              ((uint32_t)0x00800000U)         /* !< Alarm enabled */
+
+/* LFSS_PSCTL Bits */
+/* LFSS_PSCTL[RT0IP] Bits */
+#define LFSS_PSCTL_RT0IP_OFS                     (2)                             /* !< RT0IP Offset */
+#define LFSS_PSCTL_RT0IP_MASK                    ((uint32_t)0x0000001CU)         /* !< Prescale timer 0 interrupt interval */
+#define LFSS_PSCTL_RT0IP_INT244US                ((uint32_t)0x00000008U)         /* !< Interval every 244 microsecond */
+#define LFSS_PSCTL_RT0IP_INT488US                ((uint32_t)0x0000000CU)         /* !< Interval every 488 microsecond */
+#define LFSS_PSCTL_RT0IP_INT0P98MS               ((uint32_t)0x00000010U)         /* !< Interval every 0.98 milisecond */
+#define LFSS_PSCTL_RT0IP_INT1P95MS               ((uint32_t)0x00000014U)         /* !< Interval every 1.95 milisecond */
+#define LFSS_PSCTL_RT0IP_INT3P91MS               ((uint32_t)0x00000018U)         /* !< Interval every 3.91 milisecond */
+#define LFSS_PSCTL_RT0IP_INT7P81MS               ((uint32_t)0x0000001CU)         /* !< Interval every 7.81 milisecond */
+/* LFSS_PSCTL[RT1IP] Bits */
+#define LFSS_PSCTL_RT1IP_OFS                     (18)                            /* !< RT1IP Offset */
+#define LFSS_PSCTL_RT1IP_MASK                    ((uint32_t)0x001C0000U)         /* !< Prescale timer 1 interrupt interval */
+#define LFSS_PSCTL_RT1IP_INT15P6MS               ((uint32_t)0x00000000U)         /* !< Interval every 15.6 milisecond */
+#define LFSS_PSCTL_RT1IP_INT31P3MS               ((uint32_t)0x00040000U)         /* !< Interval every 31.3 milisecond */
+#define LFSS_PSCTL_RT1IP_INT62P5MS               ((uint32_t)0x00080000U)         /* !< Interval every 62.5 milisecond */
+#define LFSS_PSCTL_RT1IP_INT125MS                ((uint32_t)0x000C0000U)         /* !< Interval every 125 milisecond */
+#define LFSS_PSCTL_RT1IP_INT250MS                ((uint32_t)0x00100000U)         /* !< Interval every 250 milisecond */
+#define LFSS_PSCTL_RT1IP_INT500MS                ((uint32_t)0x00140000U)         /* !< Interval every 500 milisecond */
+#define LFSS_PSCTL_RT1IP_INT1S                   ((uint32_t)0x00180000U)         /* !< Interval every 1 second */
+#define LFSS_PSCTL_RT1IP_INT2S                   ((uint32_t)0x001C0000U)         /* !< Interval every 2 second */
+
+/* LFSS_EXTPSCTL Bits */
+/* LFSS_EXTPSCTL[RT2PS] Bits */
+#define LFSS_EXTPSCTL_RT2PS_OFS                  (2)                             /* !< RT2PS Offset */
+#define LFSS_EXTPSCTL_RT2PS_MASK                 ((uint32_t)0x0000000CU)         /* !< Prescale timer 2 interrupt interval */
+#define LFSS_EXTPSCTL_RT2PS_INT4S                ((uint32_t)0x00000000U)         /* !< Interval every 4 second */
+#define LFSS_EXTPSCTL_RT2PS_INT8S                ((uint32_t)0x00000004U)         /* !< Interval every 8 second */
+#define LFSS_EXTPSCTL_RT2PS_INT16S               ((uint32_t)0x00000008U)         /* !< Interval every 16 second */
+
+/* LFSS_TSSEC Bits */
+/* LFSS_TSSEC[SECBIN] Bits */
+#define LFSS_TSSEC_SECBIN_OFS                    (0)                             /* !< SECBIN Offset */
+#define LFSS_TSSEC_SECBIN_MASK                   ((uint32_t)0x0000003FU)         /* !< Time Stamp Second Binary (0 to 59).
+                                                                                    If RTCBCD=1 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define LFSS_TSSEC_SECBIN_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSSEC_SECBIN_MAXIMUM                ((uint32_t)0x0000003BU)         /* !< Highest possible value */
+/* LFSS_TSSEC[SECLOWBCD] Bits */
+#define LFSS_TSSEC_SECLOWBCD_OFS                 (8)                             /* !< SECLOWBCD Offset */
+#define LFSS_TSSEC_SECLOWBCD_MASK                ((uint32_t)0x00000F00U)         /* !< Time Stamp Seconds BCD  low digit
+                                                                                    (0 to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_TSSEC_SECLOWBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSSEC_SECLOWBCD_MAXIMUM             ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* LFSS_TSSEC[SECHIGHBCD] Bits */
+#define LFSS_TSSEC_SECHIGHBCD_OFS                (12)                            /* !< SECHIGHBCD Offset */
+#define LFSS_TSSEC_SECHIGHBCD_MASK               ((uint32_t)0x00007000U)         /* !< Time Stamp Seconds BCD  high digit
+                                                                                    (0 to 5). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_TSSEC_SECHIGHBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSSEC_SECHIGHBCD_MAXIMUM            ((uint32_t)0x00005000U)         /* !< Highest possible value */
+
+/* LFSS_TSMIN Bits */
+/* LFSS_TSMIN[MINBIN] Bits */
+#define LFSS_TSMIN_MINBIN_OFS                    (0)                             /* !< MINBIN Offset */
+#define LFSS_TSMIN_MINBIN_MASK                   ((uint32_t)0x0000003FU)         /* !< Time Stamp Minutes Binary (0 to
+                                                                                    59). If RTCBCD=1 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define LFSS_TSMIN_MINBIN_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSMIN_MINBIN_MAXIMUM                ((uint32_t)0x0000003BU)         /* !< Highest possible value */
+/* LFSS_TSMIN[MINLOWBCD] Bits */
+#define LFSS_TSMIN_MINLOWBCD_OFS                 (8)                             /* !< MINLOWBCD Offset */
+#define LFSS_TSMIN_MINLOWBCD_MASK                ((uint32_t)0x00000F00U)         /* !< Time Stamp Minutes BCD  low digit
+                                                                                    (0 to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_TSMIN_MINLOWBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSMIN_MINLOWBCD_MAXIMUM             ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* LFSS_TSMIN[MINHIGHBCD] Bits */
+#define LFSS_TSMIN_MINHIGHBCD_OFS                (12)                            /* !< MINHIGHBCD Offset */
+#define LFSS_TSMIN_MINHIGHBCD_MASK               ((uint32_t)0x00007000U)         /* !< Time Stamp Minutes BCD  high digit
+                                                                                    (0 to 5). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_TSMIN_MINHIGHBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSMIN_MINHIGHBCD_MAXIMUM            ((uint32_t)0x00005000U)         /* !< Highest possible value */
+
+/* LFSS_TSHOUR Bits */
+/* LFSS_TSHOUR[HOURBIN] Bits */
+#define LFSS_TSHOUR_HOURBIN_OFS                  (0)                             /* !< HOURBIN Offset */
+#define LFSS_TSHOUR_HOURBIN_MASK                 ((uint32_t)0x0000001FU)         /* !< Time Stamp Hours Binary (0 to 23).
+                                                                                    If RTCBCD=1 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define LFSS_TSHOUR_HOURBIN_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSHOUR_HOURBIN_MAXIMUM              ((uint32_t)0x00000017U)         /* !< Highest possible value */
+/* LFSS_TSHOUR[HOURLOWBCD] Bits */
+#define LFSS_TSHOUR_HOURLOWBCD_OFS               (8)                             /* !< HOURLOWBCD Offset */
+#define LFSS_TSHOUR_HOURLOWBCD_MASK              ((uint32_t)0x00000F00U)         /* !< Time Stamp Hours BCD  low digit (0
+                                                                                    to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_TSHOUR_HOURLOWBCD_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSHOUR_HOURLOWBCD_MAXIMUM           ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* LFSS_TSHOUR[HOURHIGHBCD] Bits */
+#define LFSS_TSHOUR_HOURHIGHBCD_OFS              (12)                            /* !< HOURHIGHBCD Offset */
+#define LFSS_TSHOUR_HOURHIGHBCD_MASK             ((uint32_t)0x00003000U)         /* !< Time Stamp Hours BCD  high digit (0
+                                                                                    to 2). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_TSHOUR_HOURHIGHBCD_MINIMUM          ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSHOUR_HOURHIGHBCD_MAXIMUM          ((uint32_t)0x00002000U)         /* !< Highest possible value */
+
+/* LFSS_TSDAY Bits */
+/* LFSS_TSDAY[DOW] Bits */
+#define LFSS_TSDAY_DOW_OFS                       (0)                             /* !< DOW Offset */
+#define LFSS_TSDAY_DOW_MASK                      ((uint32_t)0x00000007U)         /* !< Time Stamp Day of week (0 to 6).
+                                                                                    These bits are valid if RTCBCD=1 or
+                                                                                    RTCBCD=0. */
+#define LFSS_TSDAY_DOW_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSDAY_DOW_MAXIMUM                   ((uint32_t)0x00000006U)         /* !< Highest possible value */
+/* LFSS_TSDAY[DOMBIN] Bits */
+#define LFSS_TSDAY_DOMBIN_OFS                    (8)                             /* !< DOMBIN Offset */
+#define LFSS_TSDAY_DOMBIN_MASK                   ((uint32_t)0x00001F00U)         /* !< Time Stamp Day of month Binary (1
+                                                                                    to 28, 29, 30, 31) If RTCBCD=1 write
+                                                                                    to these bits will be ignored and
+                                                                                    read give the value 0. */
+#define LFSS_TSDAY_DOMBIN_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSDAY_DOMBIN_MAXIMUM                ((uint32_t)0x00001F00U)         /* !< Highest possible value */
+/* LFSS_TSDAY[DOMLOWBCD] Bits */
+#define LFSS_TSDAY_DOMLOWBCD_OFS                 (16)                            /* !< DOMLOWBCD Offset */
+#define LFSS_TSDAY_DOMLOWBCD_MASK                ((uint32_t)0x000F0000U)         /* !< Time Stamp Day of month BCD  low
+                                                                                    digit (0 to 9). If RTCBCD=0 write to
+                                                                                    these bits will be ignored and read
+                                                                                    give the value 0. */
+#define LFSS_TSDAY_DOMLOWBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSDAY_DOMLOWBCD_MAXIMUM             ((uint32_t)0x00090000U)         /* !< Highest possible value */
+/* LFSS_TSDAY[DOMHIGHBCD] Bits */
+#define LFSS_TSDAY_DOMHIGHBCD_OFS                (20)                            /* !< DOMHIGHBCD Offset */
+#define LFSS_TSDAY_DOMHIGHBCD_MASK               ((uint32_t)0x00300000U)         /* !< Time Stamp Day of month BCD  high
+                                                                                    digit (0 to 3). If RTCBCD=0 write to
+                                                                                    these bits will be ignored and read
+                                                                                    give the value 0. */
+#define LFSS_TSDAY_DOMHIGHBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSDAY_DOMHIGHBCD_MAXIMUM            ((uint32_t)0x00300000U)         /* !< Highest possible value */
+
+/* LFSS_TSMON Bits */
+/* LFSS_TSMON[MONBIN] Bits */
+#define LFSS_TSMON_MONBIN_OFS                    (0)                             /* !< MONBIN Offset */
+#define LFSS_TSMON_MONBIN_MASK                   ((uint32_t)0x0000000FU)         /* !< Time Stamp Month Binary (1 to 12).
+                                                                                    If RTCBCD=1 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define LFSS_TSMON_MONBIN_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSMON_MONBIN_MAXIMUM                ((uint32_t)0x0000000CU)         /* !< Highest possible value */
+/* LFSS_TSMON[MONLOWBCD] Bits */
+#define LFSS_TSMON_MONLOWBCD_OFS                 (8)                             /* !< MONLOWBCD Offset */
+#define LFSS_TSMON_MONLOWBCD_MASK                ((uint32_t)0x00000F00U)         /* !< Time Stamp Month BCD  low digit (0
+                                                                                    to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_TSMON_MONLOWBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSMON_MONLOWBCD_MAXIMUM             ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* LFSS_TSMON[MONHIGHBCD] Bits */
+#define LFSS_TSMON_MONHIGHBCD_OFS                (12)                            /* !< MONHIGHBCD Offset */
+#define LFSS_TSMON_MONHIGHBCD_MASK               ((uint32_t)0x00001000U)         /* !< Time Stamp Month BCD  high digit (0
+                                                                                    or 1). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_TSMON_MONHIGHBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSMON_MONHIGHBCD_MAXIMUM            ((uint32_t)0x00001000U)         /* !< Highest possible value */
+
+/* LFSS_TSYEAR Bits */
+/* LFSS_TSYEAR[YEARLOWBIN] Bits */
+#define LFSS_TSYEAR_YEARLOWBIN_OFS               (0)                             /* !< YEARLOWBIN Offset */
+#define LFSS_TSYEAR_YEARLOWBIN_MASK              ((uint32_t)0x000000FFU)         /* !< Time Stamp Year Binary  low byte.
+                                                                                    Valid values for Year are 0 to 4095.
+                                                                                    If RTCBCD=1 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define LFSS_TSYEAR_YEARLOWBIN_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSYEAR_YEARLOWBIN_MAXIMUM           ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+/* LFSS_TSYEAR[YEARHIGHBIN] Bits */
+#define LFSS_TSYEAR_YEARHIGHBIN_OFS              (8)                             /* !< YEARHIGHBIN Offset */
+#define LFSS_TSYEAR_YEARHIGHBIN_MASK             ((uint32_t)0x00000F00U)         /* !< Time Stamp Year Binary  high byte.
+                                                                                    Valid values for Year are 0 to 4095.
+                                                                                    If RTCBCD=1 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define LFSS_TSYEAR_YEARHIGHBIN_MINIMUM          ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSYEAR_YEARHIGHBIN_MAXIMUM          ((uint32_t)0x00000F00U)         /* !< Highest possible value */
+/* LFSS_TSYEAR[YERARLOWESTBCD] Bits */
+#define LFSS_TSYEAR_YERARLOWESTBCD_OFS           (16)                            /* !< YERARLOWESTBCD Offset */
+#define LFSS_TSYEAR_YERARLOWESTBCD_MASK          ((uint32_t)0x000F0000U)         /* !< Time Stamp Year BCD  lowest digit
+                                                                                    (0 to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_TSYEAR_YERARLOWESTBCD_MINIMUM       ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSYEAR_YERARLOWESTBCD_MAXIMUM       ((uint32_t)0x00090000U)         /* !< Highest possible value */
+/* LFSS_TSYEAR[DECADEBCD] Bits */
+#define LFSS_TSYEAR_DECADEBCD_OFS                (20)                            /* !< DECADEBCD Offset */
+#define LFSS_TSYEAR_DECADEBCD_MASK               ((uint32_t)0x00F00000U)         /* !< Time Stamp Decade BCD (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define LFSS_TSYEAR_DECADEBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSYEAR_DECADEBCD_MAXIMUM            ((uint32_t)0x00900000U)         /* !< Highest possible value */
+/* LFSS_TSYEAR[CENTLOWBCD] Bits */
+#define LFSS_TSYEAR_CENTLOWBCD_OFS               (24)                            /* !< CENTLOWBCD Offset */
+#define LFSS_TSYEAR_CENTLOWBCD_MASK              ((uint32_t)0x0F000000U)         /* !< Time Stamp Century BCD  low digit
+                                                                                    (0 to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_TSYEAR_CENTLOWBCD_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSYEAR_CENTLOWBCD_MAXIMUM           ((uint32_t)0x09000000U)         /* !< Highest possible value */
+/* LFSS_TSYEAR[CENTHIGHBCD] Bits */
+#define LFSS_TSYEAR_CENTHIGHBCD_OFS              (28)                            /* !< CENTHIGHBCD Offset */
+#define LFSS_TSYEAR_CENTHIGHBCD_MASK             ((uint32_t)0x70000000U)         /* !< Time Stamp Century BCD  high digit
+                                                                                    (0 to 4). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define LFSS_TSYEAR_CENTHIGHBCD_MINIMUM          ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_TSYEAR_CENTHIGHBCD_MAXIMUM          ((uint32_t)0x40000000U)         /* !< Highest possible value */
+
+/* LFSS_TSSTAT Bits */
+/* LFSS_TSSTAT[TSTIOEVT0] Bits */
+#define LFSS_TSSTAT_TSTIOEVT0_OFS                (0)                             /* !< TSTIOEVT0 Offset */
+#define LFSS_TSSTAT_TSTIOEVT0_MASK               ((uint32_t)0x00000001U)         /* !< Tamper I/O 0 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT0_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT0_SET                ((uint32_t)0x00000001U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT1] Bits */
+#define LFSS_TSSTAT_TSTIOEVT1_OFS                (1)                             /* !< TSTIOEVT1 Offset */
+#define LFSS_TSSTAT_TSTIOEVT1_MASK               ((uint32_t)0x00000002U)         /* !< Tamper I/O 1 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT1_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT1_SET                ((uint32_t)0x00000002U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT2] Bits */
+#define LFSS_TSSTAT_TSTIOEVT2_OFS                (2)                             /* !< TSTIOEVT2 Offset */
+#define LFSS_TSSTAT_TSTIOEVT2_MASK               ((uint32_t)0x00000004U)         /* !< Tamper I/O 2 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT2_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT2_SET                ((uint32_t)0x00000004U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT3] Bits */
+#define LFSS_TSSTAT_TSTIOEVT3_OFS                (3)                             /* !< TSTIOEVT3 Offset */
+#define LFSS_TSSTAT_TSTIOEVT3_MASK               ((uint32_t)0x00000008U)         /* !< Tamper I/O 3 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT3_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT3_SET                ((uint32_t)0x00000008U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT4] Bits */
+#define LFSS_TSSTAT_TSTIOEVT4_OFS                (4)                             /* !< TSTIOEVT4 Offset */
+#define LFSS_TSSTAT_TSTIOEVT4_MASK               ((uint32_t)0x00000010U)         /* !< Tamper I/O 4 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT4_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT4_SET                ((uint32_t)0x00000010U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT5] Bits */
+#define LFSS_TSSTAT_TSTIOEVT5_OFS                (5)                             /* !< TSTIOEVT5 Offset */
+#define LFSS_TSSTAT_TSTIOEVT5_MASK               ((uint32_t)0x00000020U)         /* !< Tamper I/O 5 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT5_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT5_SET                ((uint32_t)0x00000020U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT6] Bits */
+#define LFSS_TSSTAT_TSTIOEVT6_OFS                (6)                             /* !< TSTIOEVT6 Offset */
+#define LFSS_TSSTAT_TSTIOEVT6_MASK               ((uint32_t)0x00000040U)         /* !< Tamper I/O 6 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT6_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT6_SET                ((uint32_t)0x00000040U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT7] Bits */
+#define LFSS_TSSTAT_TSTIOEVT7_OFS                (7)                             /* !< TSTIOEVT7 Offset */
+#define LFSS_TSSTAT_TSTIOEVT7_MASK               ((uint32_t)0x00000080U)         /* !< Tamper I/O 7 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT7_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT7_SET                ((uint32_t)0x00000080U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT8] Bits */
+#define LFSS_TSSTAT_TSTIOEVT8_OFS                (8)                             /* !< TSTIOEVT8 Offset */
+#define LFSS_TSSTAT_TSTIOEVT8_MASK               ((uint32_t)0x00000100U)         /* !< Tamper I/O 8 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT8_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT8_SET                ((uint32_t)0x00000100U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT9] Bits */
+#define LFSS_TSSTAT_TSTIOEVT9_OFS                (9)                             /* !< TSTIOEVT9 Offset */
+#define LFSS_TSSTAT_TSTIOEVT9_MASK               ((uint32_t)0x00000200U)         /* !< Tamper I/O 9 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT9_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT9_SET                ((uint32_t)0x00000200U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT10] Bits */
+#define LFSS_TSSTAT_TSTIOEVT10_OFS               (10)                            /* !< TSTIOEVT10 Offset */
+#define LFSS_TSSTAT_TSTIOEVT10_MASK              ((uint32_t)0x00000400U)         /* !< Tamper I/O 10 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT10_CLR               ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT10_SET               ((uint32_t)0x00000400U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT11] Bits */
+#define LFSS_TSSTAT_TSTIOEVT11_OFS               (11)                            /* !< TSTIOEVT11 Offset */
+#define LFSS_TSSTAT_TSTIOEVT11_MASK              ((uint32_t)0x00000800U)         /* !< Tamper I/O 11 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT11_CLR               ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT11_SET               ((uint32_t)0x00000800U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT12] Bits */
+#define LFSS_TSSTAT_TSTIOEVT12_OFS               (12)                            /* !< TSTIOEVT12 Offset */
+#define LFSS_TSSTAT_TSTIOEVT12_MASK              ((uint32_t)0x00001000U)         /* !< Tamper I/O 12 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT12_CLR               ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT12_SET               ((uint32_t)0x00001000U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT13] Bits */
+#define LFSS_TSSTAT_TSTIOEVT13_OFS               (13)                            /* !< TSTIOEVT13 Offset */
+#define LFSS_TSSTAT_TSTIOEVT13_MASK              ((uint32_t)0x00002000U)         /* !< Tamper I/O 13 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT13_CLR               ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT13_SET               ((uint32_t)0x00002000U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT14] Bits */
+#define LFSS_TSSTAT_TSTIOEVT14_OFS               (14)                            /* !< TSTIOEVT14 Offset */
+#define LFSS_TSSTAT_TSTIOEVT14_MASK              ((uint32_t)0x00004000U)         /* !< Tamper I/O 14 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT14_CLR               ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT14_SET               ((uint32_t)0x00004000U)         /* !< event detected */
+/* LFSS_TSSTAT[TSTIOEVT15] Bits */
+#define LFSS_TSSTAT_TSTIOEVT15_OFS               (15)                            /* !< TSTIOEVT15 Offset */
+#define LFSS_TSSTAT_TSTIOEVT15_MASK              ((uint32_t)0x00008000U)         /* !< Tamper I/O 15 caused time stamp
+                                                                                    event */
+#define LFSS_TSSTAT_TSTIOEVT15_CLR               ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSTIOEVT15_SET               ((uint32_t)0x00008000U)         /* !< event detected */
+/* LFSS_TSSTAT[TSVDDEVT] Bits */
+#define LFSS_TSSTAT_TSVDDEVT_OFS                 (16)                            /* !< TSVDDEVT Offset */
+#define LFSS_TSSTAT_TSVDDEVT_MASK                ((uint32_t)0x00010000U)         /* !< Loss of VDD caused time stamp event */
+#define LFSS_TSSTAT_TSVDDEVT_CLR                 ((uint32_t)0x00000000U)         /* !< no event detected */
+#define LFSS_TSSTAT_TSVDDEVT_SET                 ((uint32_t)0x00010000U)         /* !< event detected */
+
+/* LFSS_TSCTL Bits */
+/* LFSS_TSCTL[TSTIOEN0] Bits */
+#define LFSS_TSCTL_TSTIOEN0_OFS                  (0)                             /* !< TSTIOEN0 Offset */
+#define LFSS_TSCTL_TSTIOEN0_MASK                 ((uint32_t)0x00000001U)         /* !< Time Stamp by Tamper I/O 0 enable */
+#define LFSS_TSCTL_TSTIOEN0_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN0_ENABLE               ((uint32_t)0x00000001U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN1] Bits */
+#define LFSS_TSCTL_TSTIOEN1_OFS                  (1)                             /* !< TSTIOEN1 Offset */
+#define LFSS_TSCTL_TSTIOEN1_MASK                 ((uint32_t)0x00000002U)         /* !< Time Stamp by Tamper I/O 1 enable */
+#define LFSS_TSCTL_TSTIOEN1_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN1_ENABLE               ((uint32_t)0x00000002U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN2] Bits */
+#define LFSS_TSCTL_TSTIOEN2_OFS                  (2)                             /* !< TSTIOEN2 Offset */
+#define LFSS_TSCTL_TSTIOEN2_MASK                 ((uint32_t)0x00000004U)         /* !< Time Stamp by Tamper I/O 2 enable */
+#define LFSS_TSCTL_TSTIOEN2_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN2_ENABLE               ((uint32_t)0x00000004U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN3] Bits */
+#define LFSS_TSCTL_TSTIOEN3_OFS                  (3)                             /* !< TSTIOEN3 Offset */
+#define LFSS_TSCTL_TSTIOEN3_MASK                 ((uint32_t)0x00000008U)         /* !< Time Stamp by Tamper I/O 3 enable */
+#define LFSS_TSCTL_TSTIOEN3_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN3_ENABLE               ((uint32_t)0x00000008U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN4] Bits */
+#define LFSS_TSCTL_TSTIOEN4_OFS                  (4)                             /* !< TSTIOEN4 Offset */
+#define LFSS_TSCTL_TSTIOEN4_MASK                 ((uint32_t)0x00000010U)         /* !< Time Stamp by Tamper I/O 4 enable */
+#define LFSS_TSCTL_TSTIOEN4_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN4_ENABLE               ((uint32_t)0x00000010U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN5] Bits */
+#define LFSS_TSCTL_TSTIOEN5_OFS                  (5)                             /* !< TSTIOEN5 Offset */
+#define LFSS_TSCTL_TSTIOEN5_MASK                 ((uint32_t)0x00000020U)         /* !< Time Stamp by Tamper I/O 5 enable */
+#define LFSS_TSCTL_TSTIOEN5_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN5_ENABLE               ((uint32_t)0x00000020U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN6] Bits */
+#define LFSS_TSCTL_TSTIOEN6_OFS                  (6)                             /* !< TSTIOEN6 Offset */
+#define LFSS_TSCTL_TSTIOEN6_MASK                 ((uint32_t)0x00000040U)         /* !< Time Stamp by Tamper I/O 6 enable */
+#define LFSS_TSCTL_TSTIOEN6_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN6_ENABLE               ((uint32_t)0x00000040U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN7] Bits */
+#define LFSS_TSCTL_TSTIOEN7_OFS                  (7)                             /* !< TSTIOEN7 Offset */
+#define LFSS_TSCTL_TSTIOEN7_MASK                 ((uint32_t)0x00000080U)         /* !< Time Stamp by Tamper I/O 7 enable */
+#define LFSS_TSCTL_TSTIOEN7_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN7_ENABLE               ((uint32_t)0x00000080U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN8] Bits */
+#define LFSS_TSCTL_TSTIOEN8_OFS                  (8)                             /* !< TSTIOEN8 Offset */
+#define LFSS_TSCTL_TSTIOEN8_MASK                 ((uint32_t)0x00000100U)         /* !< Time Stamp by Tamper I/O 8 enable */
+#define LFSS_TSCTL_TSTIOEN8_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN8_ENABLE               ((uint32_t)0x00000100U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN9] Bits */
+#define LFSS_TSCTL_TSTIOEN9_OFS                  (9)                             /* !< TSTIOEN9 Offset */
+#define LFSS_TSCTL_TSTIOEN9_MASK                 ((uint32_t)0x00000200U)         /* !< Time Stamp by Tamper I/O 9 enable */
+#define LFSS_TSCTL_TSTIOEN9_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN9_ENABLE               ((uint32_t)0x00000200U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN10] Bits */
+#define LFSS_TSCTL_TSTIOEN10_OFS                 (10)                            /* !< TSTIOEN10 Offset */
+#define LFSS_TSCTL_TSTIOEN10_MASK                ((uint32_t)0x00000400U)         /* !< Time Stamp by Tamper I/O 10 enable */
+#define LFSS_TSCTL_TSTIOEN10_DISABLE             ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN10_ENABLE              ((uint32_t)0x00000400U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN11] Bits */
+#define LFSS_TSCTL_TSTIOEN11_OFS                 (11)                            /* !< TSTIOEN11 Offset */
+#define LFSS_TSCTL_TSTIOEN11_MASK                ((uint32_t)0x00000800U)         /* !< Time Stamp by Tamper I/O 11 enable */
+#define LFSS_TSCTL_TSTIOEN11_DISABLE             ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN11_ENABLE              ((uint32_t)0x00000800U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN12] Bits */
+#define LFSS_TSCTL_TSTIOEN12_OFS                 (12)                            /* !< TSTIOEN12 Offset */
+#define LFSS_TSCTL_TSTIOEN12_MASK                ((uint32_t)0x00001000U)         /* !< Time Stamp by Tamper I/O 12 enable */
+#define LFSS_TSCTL_TSTIOEN12_DISABLE             ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN12_ENABLE              ((uint32_t)0x00001000U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN13] Bits */
+#define LFSS_TSCTL_TSTIOEN13_OFS                 (13)                            /* !< TSTIOEN13 Offset */
+#define LFSS_TSCTL_TSTIOEN13_MASK                ((uint32_t)0x00002000U)         /* !< Time Stamp by Tamper I/O 13 enable */
+#define LFSS_TSCTL_TSTIOEN13_DISABLE             ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN13_ENABLE              ((uint32_t)0x00002000U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN14] Bits */
+#define LFSS_TSCTL_TSTIOEN14_OFS                 (14)                            /* !< TSTIOEN14 Offset */
+#define LFSS_TSCTL_TSTIOEN14_MASK                ((uint32_t)0x00004000U)         /* !< Time Stamp by Tamper I/O 14 enable */
+#define LFSS_TSCTL_TSTIOEN14_DISABLE             ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN14_ENABLE              ((uint32_t)0x00004000U)         /* !< function enabled */
+/* LFSS_TSCTL[TSTIOEN15] Bits */
+#define LFSS_TSCTL_TSTIOEN15_OFS                 (15)                            /* !< TSTIOEN15 Offset */
+#define LFSS_TSCTL_TSTIOEN15_MASK                ((uint32_t)0x00008000U)         /* !< Time Stamp by Tamper I/O 15 enable */
+#define LFSS_TSCTL_TSTIOEN15_DISABLE             ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSTIOEN15_ENABLE              ((uint32_t)0x00008000U)         /* !< function enabled */
+/* LFSS_TSCTL[TSVDDEN] Bits */
+#define LFSS_TSCTL_TSVDDEN_OFS                   (16)                            /* !< TSVDDEN Offset */
+#define LFSS_TSCTL_TSVDDEN_MASK                  ((uint32_t)0x00010000U)         /* !< Time Stamp by VDD Loss detection
+                                                                                    enable */
+#define LFSS_TSCTL_TSVDDEN_DISABLE               ((uint32_t)0x00000000U)         /* !< function disabled */
+#define LFSS_TSCTL_TSVDDEN_ENABLE                ((uint32_t)0x00010000U)         /* !< function enabled */
+/* LFSS_TSCTL[TSCAPTURE] Bits */
+#define LFSS_TSCTL_TSCAPTURE_OFS                 (20)                            /* !< TSCAPTURE Offset */
+#define LFSS_TSCTL_TSCAPTURE_MASK                ((uint32_t)0x00100000U)         /* !< Defines the capture method of the
+                                                                                    RTC timestamp when a time stamp event
+                                                                                    occurens. */
+#define LFSS_TSCTL_TSCAPTURE_FIRST               ((uint32_t)0x00000000U)         /* !< Time stamp holds RTC capture at
+                                                                                    first occurrence of time stamp event. */
+#define LFSS_TSCTL_TSCAPTURE_LAST                ((uint32_t)0x00100000U)         /* !< Time stamp holds RTC capture at
+                                                                                    last occurrence of time stamp event. */
+/* LFSS_TSCTL[KEY] Bits */
+#define LFSS_TSCTL_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define LFSS_TSCTL_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xC5) to update
+                                                                                    this register */
+#define LFSS_TSCTL_KEY_UNLOCK_W                  ((uint32_t)0xC5000000U)         /* !< This field must be written with
+                                                                                    0xC5 to be able to clear any of the
+                                                                                    enable bits */
+
+/* LFSS_TSCLR Bits */
+/* LFSS_TSCLR[CLR] Bits */
+#define LFSS_TSCLR_CLR_OFS                       (0)                             /* !< CLR Offset */
+#define LFSS_TSCLR_CLR_MASK                      ((uint32_t)0x00000001U)         /* !< Clear time stamp and status
+                                                                                    register. */
+#define LFSS_TSCLR_CLR_NO_EFFECT                 ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_TSCLR_CLR_CLR                       ((uint32_t)0x00000001U)         /* !< clear time stamp event */
+/* LFSS_TSCLR[KEY] Bits */
+#define LFSS_TSCLR_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define LFSS_TSCLR_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xE2) to update
+                                                                                    this register */
+#define LFSS_TSCLR_KEY_UNLOCK_W                  ((uint32_t)0xE2000000U)         /* !< This field must be written with
+                                                                                    0xE2 to be able to clear any of the
+                                                                                    enable bits */
+
+/* LFSS_LFSSRST Bits */
+/* LFSS_LFSSRST[VBATPOR] Bits */
+#define LFSS_LFSSRST_VBATPOR_OFS                 (0)                             /* !< VBATPOR Offset */
+#define LFSS_LFSSRST_VBATPOR_MASK                ((uint32_t)0x00000001U)         /* !< If set, the register bit will
+                                                                                    request a power on reset to the PMU
+                                                                                    of the LFSS. */
+#define LFSS_LFSSRST_VBATPOR_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< Writing this value has no effect. */
+#define LFSS_LFSSRST_VBATPOR_SET                 ((uint32_t)0x00000001U)         /* !< Request power on reset to the LFSS. */
+/* LFSS_LFSSRST[KEY] Bits */
+#define LFSS_LFSSRST_KEY_OFS                     (24)                            /* !< KEY Offset */
+#define LFSS_LFSSRST_KEY_MASK                    ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0x12) to update
+                                                                                    this register */
+#define LFSS_LFSSRST_KEY_UNLOCK_W                ((uint32_t)0x12000000U)         /* !< This field must be written with
+                                                                                    0x12 to be able to request the power
+                                                                                    on reset. */
+
+/* LFSS_RTCLOCK Bits */
+/* LFSS_RTCLOCK[PROTECT] Bits */
+#define LFSS_RTCLOCK_PROTECT_OFS                 (0)                             /* !< PROTECT Offset */
+#define LFSS_RTCLOCK_PROTECT_MASK                ((uint32_t)0x00000001U)         /* !< If set, the register bit will
+                                                                                    protect the CLKCTL, SEC, MIN, HOUR,
+                                                                                    DAY, MON, YEAR and LFSSRST from
+                                                                                    accidental writes. */
+#define LFSS_RTCLOCK_PROTECT_CLR                 ((uint32_t)0x00000000U)         /* !< RTC counter is writable. */
+#define LFSS_RTCLOCK_PROTECT_SET                 ((uint32_t)0x00000001U)         /* !< RTC counter is read only access. */
+/* LFSS_RTCLOCK[KEY] Bits */
+#define LFSS_RTCLOCK_KEY_OFS                     (24)                            /* !< KEY Offset */
+#define LFSS_RTCLOCK_KEY_MASK                    ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0x22) to update
+                                                                                    this register */
+#define LFSS_RTCLOCK_KEY_UNLOCK_W                ((uint32_t)0x22000000U)         /* !< This field must be written with
+                                                                                    0x22 to be able to update any of the
+                                                                                    bits. */
+
+/* LFSS_GEN_EVENT_IIDX Bits */
+/* LFSS_GEN_EVENT_IIDX[STAT] Bits */
+#define LFSS_GEN_EVENT_IIDX_STAT_OFS             (0)                             /* !< STAT Offset */
+#define LFSS_GEN_EVENT_IIDX_STAT_MASK            ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define LFSS_GEN_EVENT_IIDX_STAT_NO_INTR         ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define LFSS_GEN_EVENT_IIDX_STAT_RTCRDY          ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define LFSS_GEN_EVENT_IIDX_STAT_RTCTEV          ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define LFSS_GEN_EVENT_IIDX_STAT_RTCA1           ((uint32_t)0x00000003U)         /* !< RTC alarm 1 */
+#define LFSS_GEN_EVENT_IIDX_STAT_RTCA2           ((uint32_t)0x00000004U)         /* !< RTC alarm 2 */
+#define LFSS_GEN_EVENT_IIDX_STAT_RT0PS           ((uint32_t)0x00000005U)         /* !< RTC prescale timer 0 */
+#define LFSS_GEN_EVENT_IIDX_STAT_RT1PS           ((uint32_t)0x00000006U)         /* !< RTC prescale timer 1 */
+#define LFSS_GEN_EVENT_IIDX_STAT_RT2PS           ((uint32_t)0x00000007U)         /* !< RTC prescale timer 2 */
+#define LFSS_GEN_EVENT_IIDX_STAT_TSEVT           ((uint32_t)0x00000008U)         /* !< Time stamp event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO0            ((uint32_t)0x00000009U)         /* !< Tamper I/O 0 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO1            ((uint32_t)0x0000000AU)         /* !< Tamper I/O 1 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO2            ((uint32_t)0x0000000BU)         /* !< Tamper I/O 2 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO3            ((uint32_t)0x0000000CU)         /* !< Tamper I/O 3 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO4            ((uint32_t)0x0000000DU)         /* !< Tamper I/O 4 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO5            ((uint32_t)0x0000000EU)         /* !< Tamper I/O 5 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO6            ((uint32_t)0x0000000FU)         /* !< Tamper I/O 6 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO7            ((uint32_t)0x00000010U)         /* !< Tamper I/O 7 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO8            ((uint32_t)0x00000011U)         /* !< Tamper I/O 8 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO9            ((uint32_t)0x00000012U)         /* !< Tamper I/O 9 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO10           ((uint32_t)0x00000013U)         /* !< Tamper I/O 10 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO11           ((uint32_t)0x00000014U)         /* !< Tamper I/O 11 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO12           ((uint32_t)0x00000015U)         /* !< Tamper I/O 12 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO13           ((uint32_t)0x00000016U)         /* !< Tamper I/O 13 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO14           ((uint32_t)0x00000017U)         /* !< Tamper I/O 14 event */
+#define LFSS_GEN_EVENT_IIDX_STAT_TIO15           ((uint32_t)0x00000018U)         /* !< Tamper I/O 15 event */
+
+/* LFSS_GEN_EVENT_IMASK Bits */
+/* LFSS_GEN_EVENT_IMASK[RTCRDY] Bits */
+#define LFSS_GEN_EVENT_IMASK_RTCRDY_OFS          (0)                             /* !< RTCRDY Offset */
+#define LFSS_GEN_EVENT_IMASK_RTCRDY_MASK         ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define LFSS_GEN_EVENT_IMASK_RTCRDY_CLR          ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_RTCRDY_SET          ((uint32_t)0x00000001U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[RTCTEV] Bits */
+#define LFSS_GEN_EVENT_IMASK_RTCTEV_OFS          (1)                             /* !< RTCTEV Offset */
+#define LFSS_GEN_EVENT_IMASK_RTCTEV_MASK         ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define LFSS_GEN_EVENT_IMASK_RTCTEV_CLR          ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_RTCTEV_SET          ((uint32_t)0x00000002U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[RTCA1] Bits */
+#define LFSS_GEN_EVENT_IMASK_RTCA1_OFS           (2)                             /* !< RTCA1 Offset */
+#define LFSS_GEN_EVENT_IMASK_RTCA1_MASK          ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define LFSS_GEN_EVENT_IMASK_RTCA1_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_RTCA1_SET           ((uint32_t)0x00000004U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[RTCA2] Bits */
+#define LFSS_GEN_EVENT_IMASK_RTCA2_OFS           (3)                             /* !< RTCA2 Offset */
+#define LFSS_GEN_EVENT_IMASK_RTCA2_MASK          ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define LFSS_GEN_EVENT_IMASK_RTCA2_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_RTCA2_SET           ((uint32_t)0x00000008U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[RT0PS] Bits */
+#define LFSS_GEN_EVENT_IMASK_RT0PS_OFS           (4)                             /* !< RT0PS Offset */
+#define LFSS_GEN_EVENT_IMASK_RT0PS_MASK          ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define LFSS_GEN_EVENT_IMASK_RT0PS_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_RT0PS_SET           ((uint32_t)0x00000010U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[RT1PS] Bits */
+#define LFSS_GEN_EVENT_IMASK_RT1PS_OFS           (5)                             /* !< RT1PS Offset */
+#define LFSS_GEN_EVENT_IMASK_RT1PS_MASK          ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define LFSS_GEN_EVENT_IMASK_RT1PS_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_RT1PS_SET           ((uint32_t)0x00000020U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[RT2PS] Bits */
+#define LFSS_GEN_EVENT_IMASK_RT2PS_OFS           (6)                             /* !< RT2PS Offset */
+#define LFSS_GEN_EVENT_IMASK_RT2PS_MASK          ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define LFSS_GEN_EVENT_IMASK_RT2PS_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_RT2PS_SET           ((uint32_t)0x00000040U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TSEVT] Bits */
+#define LFSS_GEN_EVENT_IMASK_TSEVT_OFS           (7)                             /* !< TSEVT Offset */
+#define LFSS_GEN_EVENT_IMASK_TSEVT_MASK          ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define LFSS_GEN_EVENT_IMASK_TSEVT_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TSEVT_SET           ((uint32_t)0x00000080U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO0] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO0_OFS            (8)                             /* !< TIO0 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO0_MASK           ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define LFSS_GEN_EVENT_IMASK_TIO0_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO0_SET            ((uint32_t)0x00000100U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO1] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO1_OFS            (9)                             /* !< TIO1 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO1_MASK           ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define LFSS_GEN_EVENT_IMASK_TIO1_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO1_SET            ((uint32_t)0x00000200U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO2] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO2_OFS            (10)                            /* !< TIO2 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO2_MASK           ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define LFSS_GEN_EVENT_IMASK_TIO2_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO2_SET            ((uint32_t)0x00000400U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO3] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO3_OFS            (11)                            /* !< TIO3 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO3_MASK           ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define LFSS_GEN_EVENT_IMASK_TIO3_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO3_SET            ((uint32_t)0x00000800U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO4] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO4_OFS            (12)                            /* !< TIO4 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO4_MASK           ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define LFSS_GEN_EVENT_IMASK_TIO4_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO4_SET            ((uint32_t)0x00001000U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO5] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO5_OFS            (13)                            /* !< TIO5 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO5_MASK           ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define LFSS_GEN_EVENT_IMASK_TIO5_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO5_SET            ((uint32_t)0x00002000U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO6] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO6_OFS            (14)                            /* !< TIO6 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO6_MASK           ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define LFSS_GEN_EVENT_IMASK_TIO6_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO6_SET            ((uint32_t)0x00004000U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO7] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO7_OFS            (15)                            /* !< TIO7 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO7_MASK           ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define LFSS_GEN_EVENT_IMASK_TIO7_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO7_SET            ((uint32_t)0x00008000U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO8] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO8_OFS            (16)                            /* !< TIO8 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO8_MASK           ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define LFSS_GEN_EVENT_IMASK_TIO8_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO8_SET            ((uint32_t)0x00010000U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO9] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO9_OFS            (17)                            /* !< TIO9 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO9_MASK           ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define LFSS_GEN_EVENT_IMASK_TIO9_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO9_SET            ((uint32_t)0x00020000U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO10] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO10_OFS           (18)                            /* !< TIO10 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO10_MASK          ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define LFSS_GEN_EVENT_IMASK_TIO10_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO10_SET           ((uint32_t)0x00040000U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO11] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO11_OFS           (19)                            /* !< TIO11 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO11_MASK          ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define LFSS_GEN_EVENT_IMASK_TIO11_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO11_SET           ((uint32_t)0x00080000U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO12] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO12_OFS           (20)                            /* !< TIO12 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO12_MASK          ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define LFSS_GEN_EVENT_IMASK_TIO12_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO12_SET           ((uint32_t)0x00100000U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO13] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO13_OFS           (21)                            /* !< TIO13 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO13_MASK          ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define LFSS_GEN_EVENT_IMASK_TIO13_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO13_SET           ((uint32_t)0x00200000U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO14] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO14_OFS           (22)                            /* !< TIO14 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO14_MASK          ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define LFSS_GEN_EVENT_IMASK_TIO14_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO14_SET           ((uint32_t)0x00400000U)         /* !< Set Interrrupt Mask */
+/* LFSS_GEN_EVENT_IMASK[TIO15] Bits */
+#define LFSS_GEN_EVENT_IMASK_TIO15_OFS           (23)                            /* !< TIO15 Offset */
+#define LFSS_GEN_EVENT_IMASK_TIO15_MASK          ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define LFSS_GEN_EVENT_IMASK_TIO15_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_GEN_EVENT_IMASK_TIO15_SET           ((uint32_t)0x00800000U)         /* !< Set Interrrupt Mask */
+
+/* LFSS_GEN_EVENT_RIS Bits */
+/* LFSS_GEN_EVENT_RIS[RTCRDY] Bits */
+#define LFSS_GEN_EVENT_RIS_RTCRDY_OFS            (0)                             /* !< RTCRDY Offset */
+#define LFSS_GEN_EVENT_RIS_RTCRDY_MASK           ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define LFSS_GEN_EVENT_RIS_RTCRDY_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_RTCRDY_SET            ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[RTCTEV] Bits */
+#define LFSS_GEN_EVENT_RIS_RTCTEV_OFS            (1)                             /* !< RTCTEV Offset */
+#define LFSS_GEN_EVENT_RIS_RTCTEV_MASK           ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define LFSS_GEN_EVENT_RIS_RTCTEV_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_RTCTEV_SET            ((uint32_t)0x00000002U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[RTCA1] Bits */
+#define LFSS_GEN_EVENT_RIS_RTCA1_OFS             (2)                             /* !< RTCA1 Offset */
+#define LFSS_GEN_EVENT_RIS_RTCA1_MASK            ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define LFSS_GEN_EVENT_RIS_RTCA1_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_RTCA1_SET             ((uint32_t)0x00000004U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[RTCA2] Bits */
+#define LFSS_GEN_EVENT_RIS_RTCA2_OFS             (3)                             /* !< RTCA2 Offset */
+#define LFSS_GEN_EVENT_RIS_RTCA2_MASK            ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define LFSS_GEN_EVENT_RIS_RTCA2_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_RTCA2_SET             ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[RT0PS] Bits */
+#define LFSS_GEN_EVENT_RIS_RT0PS_OFS             (4)                             /* !< RT0PS Offset */
+#define LFSS_GEN_EVENT_RIS_RT0PS_MASK            ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define LFSS_GEN_EVENT_RIS_RT0PS_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_RT0PS_SET             ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[RT1PS] Bits */
+#define LFSS_GEN_EVENT_RIS_RT1PS_OFS             (5)                             /* !< RT1PS Offset */
+#define LFSS_GEN_EVENT_RIS_RT1PS_MASK            ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define LFSS_GEN_EVENT_RIS_RT1PS_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_RT1PS_SET             ((uint32_t)0x00000020U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[RT2PS] Bits */
+#define LFSS_GEN_EVENT_RIS_RT2PS_OFS             (6)                             /* !< RT2PS Offset */
+#define LFSS_GEN_EVENT_RIS_RT2PS_MASK            ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define LFSS_GEN_EVENT_RIS_RT2PS_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_RT2PS_SET             ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TSEVT] Bits */
+#define LFSS_GEN_EVENT_RIS_TSEVT_OFS             (7)                             /* !< TSEVT Offset */
+#define LFSS_GEN_EVENT_RIS_TSEVT_MASK            ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define LFSS_GEN_EVENT_RIS_TSEVT_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TSEVT_SET             ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO0] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO0_OFS              (8)                             /* !< TIO0 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO0_MASK             ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define LFSS_GEN_EVENT_RIS_TIO0_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO0_SET              ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO1] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO1_OFS              (9)                             /* !< TIO1 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO1_MASK             ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define LFSS_GEN_EVENT_RIS_TIO1_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO1_SET              ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO2] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO2_OFS              (10)                            /* !< TIO2 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO2_MASK             ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define LFSS_GEN_EVENT_RIS_TIO2_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO2_SET              ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO3] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO3_OFS              (11)                            /* !< TIO3 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO3_MASK             ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define LFSS_GEN_EVENT_RIS_TIO3_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO3_SET              ((uint32_t)0x00000800U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO4] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO4_OFS              (12)                            /* !< TIO4 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO4_MASK             ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define LFSS_GEN_EVENT_RIS_TIO4_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO4_SET              ((uint32_t)0x00001000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO5] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO5_OFS              (13)                            /* !< TIO5 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO5_MASK             ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define LFSS_GEN_EVENT_RIS_TIO5_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO5_SET              ((uint32_t)0x00002000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO6] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO6_OFS              (14)                            /* !< TIO6 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO6_MASK             ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define LFSS_GEN_EVENT_RIS_TIO6_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO6_SET              ((uint32_t)0x00004000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO7] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO7_OFS              (15)                            /* !< TIO7 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO7_MASK             ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define LFSS_GEN_EVENT_RIS_TIO7_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO7_SET              ((uint32_t)0x00008000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO8] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO8_OFS              (16)                            /* !< TIO8 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO8_MASK             ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define LFSS_GEN_EVENT_RIS_TIO8_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO8_SET              ((uint32_t)0x00010000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO9] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO9_OFS              (17)                            /* !< TIO9 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO9_MASK             ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define LFSS_GEN_EVENT_RIS_TIO9_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO9_SET              ((uint32_t)0x00020000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO10] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO10_OFS             (18)                            /* !< TIO10 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO10_MASK            ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define LFSS_GEN_EVENT_RIS_TIO10_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO10_SET             ((uint32_t)0x00040000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO11] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO11_OFS             (19)                            /* !< TIO11 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO11_MASK            ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define LFSS_GEN_EVENT_RIS_TIO11_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO11_SET             ((uint32_t)0x00080000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO12] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO12_OFS             (20)                            /* !< TIO12 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO12_MASK            ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define LFSS_GEN_EVENT_RIS_TIO12_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO12_SET             ((uint32_t)0x00100000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO13] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO13_OFS             (21)                            /* !< TIO13 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO13_MASK            ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define LFSS_GEN_EVENT_RIS_TIO13_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO13_SET             ((uint32_t)0x00200000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO14] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO14_OFS             (22)                            /* !< TIO14 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO14_MASK            ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define LFSS_GEN_EVENT_RIS_TIO14_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO14_SET             ((uint32_t)0x00400000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_RIS[TIO15] Bits */
+#define LFSS_GEN_EVENT_RIS_TIO15_OFS             (23)                            /* !< TIO15 Offset */
+#define LFSS_GEN_EVENT_RIS_TIO15_MASK            ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define LFSS_GEN_EVENT_RIS_TIO15_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_GEN_EVENT_RIS_TIO15_SET             ((uint32_t)0x00800000U)         /* !< Interrupt occurred */
+
+/* LFSS_GEN_EVENT_MIS Bits */
+/* LFSS_GEN_EVENT_MIS[RTCRDY] Bits */
+#define LFSS_GEN_EVENT_MIS_RTCRDY_OFS            (0)                             /* !< RTCRDY Offset */
+#define LFSS_GEN_EVENT_MIS_RTCRDY_MASK           ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define LFSS_GEN_EVENT_MIS_RTCRDY_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_RTCRDY_SET            ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[RTCTEV] Bits */
+#define LFSS_GEN_EVENT_MIS_RTCTEV_OFS            (1)                             /* !< RTCTEV Offset */
+#define LFSS_GEN_EVENT_MIS_RTCTEV_MASK           ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define LFSS_GEN_EVENT_MIS_RTCTEV_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_RTCTEV_SET            ((uint32_t)0x00000002U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[RTCA1] Bits */
+#define LFSS_GEN_EVENT_MIS_RTCA1_OFS             (2)                             /* !< RTCA1 Offset */
+#define LFSS_GEN_EVENT_MIS_RTCA1_MASK            ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define LFSS_GEN_EVENT_MIS_RTCA1_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_RTCA1_SET             ((uint32_t)0x00000004U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[RTCA2] Bits */
+#define LFSS_GEN_EVENT_MIS_RTCA2_OFS             (3)                             /* !< RTCA2 Offset */
+#define LFSS_GEN_EVENT_MIS_RTCA2_MASK            ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define LFSS_GEN_EVENT_MIS_RTCA2_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_RTCA2_SET             ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[RT0PS] Bits */
+#define LFSS_GEN_EVENT_MIS_RT0PS_OFS             (4)                             /* !< RT0PS Offset */
+#define LFSS_GEN_EVENT_MIS_RT0PS_MASK            ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define LFSS_GEN_EVENT_MIS_RT0PS_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_RT0PS_SET             ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[RT1PS] Bits */
+#define LFSS_GEN_EVENT_MIS_RT1PS_OFS             (5)                             /* !< RT1PS Offset */
+#define LFSS_GEN_EVENT_MIS_RT1PS_MASK            ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define LFSS_GEN_EVENT_MIS_RT1PS_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_RT1PS_SET             ((uint32_t)0x00000020U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[RT2PS] Bits */
+#define LFSS_GEN_EVENT_MIS_RT2PS_OFS             (6)                             /* !< RT2PS Offset */
+#define LFSS_GEN_EVENT_MIS_RT2PS_MASK            ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define LFSS_GEN_EVENT_MIS_RT2PS_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_RT2PS_SET             ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TSEVT] Bits */
+#define LFSS_GEN_EVENT_MIS_TSEVT_OFS             (7)                             /* !< TSEVT Offset */
+#define LFSS_GEN_EVENT_MIS_TSEVT_MASK            ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define LFSS_GEN_EVENT_MIS_TSEVT_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TSEVT_SET             ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO0] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO0_OFS              (8)                             /* !< TIO0 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO0_MASK             ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define LFSS_GEN_EVENT_MIS_TIO0_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO0_SET              ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO1] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO1_OFS              (9)                             /* !< TIO1 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO1_MASK             ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define LFSS_GEN_EVENT_MIS_TIO1_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO1_SET              ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO2] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO2_OFS              (10)                            /* !< TIO2 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO2_MASK             ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define LFSS_GEN_EVENT_MIS_TIO2_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO2_SET              ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO3] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO3_OFS              (11)                            /* !< TIO3 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO3_MASK             ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define LFSS_GEN_EVENT_MIS_TIO3_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO3_SET              ((uint32_t)0x00000800U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO4] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO4_OFS              (12)                            /* !< TIO4 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO4_MASK             ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define LFSS_GEN_EVENT_MIS_TIO4_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO4_SET              ((uint32_t)0x00001000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO5] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO5_OFS              (13)                            /* !< TIO5 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO5_MASK             ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define LFSS_GEN_EVENT_MIS_TIO5_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO5_SET              ((uint32_t)0x00002000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO6] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO6_OFS              (14)                            /* !< TIO6 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO6_MASK             ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define LFSS_GEN_EVENT_MIS_TIO6_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO6_SET              ((uint32_t)0x00004000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO7] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO7_OFS              (15)                            /* !< TIO7 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO7_MASK             ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define LFSS_GEN_EVENT_MIS_TIO7_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO7_SET              ((uint32_t)0x00008000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO8] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO8_OFS              (16)                            /* !< TIO8 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO8_MASK             ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define LFSS_GEN_EVENT_MIS_TIO8_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO8_SET              ((uint32_t)0x00010000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO9] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO9_OFS              (17)                            /* !< TIO9 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO9_MASK             ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define LFSS_GEN_EVENT_MIS_TIO9_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO9_SET              ((uint32_t)0x00020000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO10] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO10_OFS             (18)                            /* !< TIO10 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO10_MASK            ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define LFSS_GEN_EVENT_MIS_TIO10_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO10_SET             ((uint32_t)0x00040000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO11] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO11_OFS             (19)                            /* !< TIO11 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO11_MASK            ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define LFSS_GEN_EVENT_MIS_TIO11_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO11_SET             ((uint32_t)0x00080000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO12] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO12_OFS             (20)                            /* !< TIO12 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO12_MASK            ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define LFSS_GEN_EVENT_MIS_TIO12_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO12_SET             ((uint32_t)0x00100000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO13] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO13_OFS             (21)                            /* !< TIO13 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO13_MASK            ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define LFSS_GEN_EVENT_MIS_TIO13_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO13_SET             ((uint32_t)0x00200000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO14] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO14_OFS             (22)                            /* !< TIO14 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO14_MASK            ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define LFSS_GEN_EVENT_MIS_TIO14_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO14_SET             ((uint32_t)0x00400000U)         /* !< Interrupt occurred */
+/* LFSS_GEN_EVENT_MIS[TIO15] Bits */
+#define LFSS_GEN_EVENT_MIS_TIO15_OFS             (23)                            /* !< TIO15 Offset */
+#define LFSS_GEN_EVENT_MIS_TIO15_MASK            ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define LFSS_GEN_EVENT_MIS_TIO15_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_GEN_EVENT_MIS_TIO15_SET             ((uint32_t)0x00800000U)         /* !< Interrupt occurred */
+
+/* LFSS_GEN_EVENT_ISET Bits */
+/* LFSS_GEN_EVENT_ISET[RTCRDY] Bits */
+#define LFSS_GEN_EVENT_ISET_RTCRDY_OFS           (0)                             /* !< RTCRDY Offset */
+#define LFSS_GEN_EVENT_ISET_RTCRDY_MASK          ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define LFSS_GEN_EVENT_ISET_RTCRDY_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_RTCRDY_SET           ((uint32_t)0x00000001U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[RTCTEV] Bits */
+#define LFSS_GEN_EVENT_ISET_RTCTEV_OFS           (1)                             /* !< RTCTEV Offset */
+#define LFSS_GEN_EVENT_ISET_RTCTEV_MASK          ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define LFSS_GEN_EVENT_ISET_RTCTEV_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_RTCTEV_SET           ((uint32_t)0x00000002U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[RTCA1] Bits */
+#define LFSS_GEN_EVENT_ISET_RTCA1_OFS            (2)                             /* !< RTCA1 Offset */
+#define LFSS_GEN_EVENT_ISET_RTCA1_MASK           ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define LFSS_GEN_EVENT_ISET_RTCA1_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_RTCA1_SET            ((uint32_t)0x00000004U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[RTCA2] Bits */
+#define LFSS_GEN_EVENT_ISET_RTCA2_OFS            (3)                             /* !< RTCA2 Offset */
+#define LFSS_GEN_EVENT_ISET_RTCA2_MASK           ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define LFSS_GEN_EVENT_ISET_RTCA2_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_RTCA2_SET            ((uint32_t)0x00000008U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[RT0PS] Bits */
+#define LFSS_GEN_EVENT_ISET_RT0PS_OFS            (4)                             /* !< RT0PS Offset */
+#define LFSS_GEN_EVENT_ISET_RT0PS_MASK           ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define LFSS_GEN_EVENT_ISET_RT0PS_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_RT0PS_SET            ((uint32_t)0x00000010U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[RT1PS] Bits */
+#define LFSS_GEN_EVENT_ISET_RT1PS_OFS            (5)                             /* !< RT1PS Offset */
+#define LFSS_GEN_EVENT_ISET_RT1PS_MASK           ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define LFSS_GEN_EVENT_ISET_RT1PS_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_RT1PS_SET            ((uint32_t)0x00000020U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[RT2PS] Bits */
+#define LFSS_GEN_EVENT_ISET_RT2PS_OFS            (6)                             /* !< RT2PS Offset */
+#define LFSS_GEN_EVENT_ISET_RT2PS_MASK           ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define LFSS_GEN_EVENT_ISET_RT2PS_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_RT2PS_SET            ((uint32_t)0x00000040U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TSEVT] Bits */
+#define LFSS_GEN_EVENT_ISET_TSEVT_OFS            (7)                             /* !< TSEVT Offset */
+#define LFSS_GEN_EVENT_ISET_TSEVT_MASK           ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define LFSS_GEN_EVENT_ISET_TSEVT_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TSEVT_SET            ((uint32_t)0x00000080U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO0] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO0_OFS             (8)                             /* !< TIO0 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO0_MASK            ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define LFSS_GEN_EVENT_ISET_TIO0_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO0_SET             ((uint32_t)0x00000100U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO1] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO1_OFS             (9)                             /* !< TIO1 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO1_MASK            ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define LFSS_GEN_EVENT_ISET_TIO1_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO1_SET             ((uint32_t)0x00000200U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO2] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO2_OFS             (10)                            /* !< TIO2 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO2_MASK            ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define LFSS_GEN_EVENT_ISET_TIO2_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO2_SET             ((uint32_t)0x00000400U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO3] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO3_OFS             (11)                            /* !< TIO3 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO3_MASK            ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define LFSS_GEN_EVENT_ISET_TIO3_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO3_SET             ((uint32_t)0x00000800U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO4] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO4_OFS             (12)                            /* !< TIO4 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO4_MASK            ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define LFSS_GEN_EVENT_ISET_TIO4_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO4_SET             ((uint32_t)0x00001000U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO5] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO5_OFS             (13)                            /* !< TIO5 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO5_MASK            ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define LFSS_GEN_EVENT_ISET_TIO5_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO5_SET             ((uint32_t)0x00002000U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO6] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO6_OFS             (14)                            /* !< TIO6 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO6_MASK            ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define LFSS_GEN_EVENT_ISET_TIO6_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO6_SET             ((uint32_t)0x00004000U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO7] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO7_OFS             (15)                            /* !< TIO7 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO7_MASK            ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define LFSS_GEN_EVENT_ISET_TIO7_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO7_SET             ((uint32_t)0x00008000U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO8] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO8_OFS             (16)                            /* !< TIO8 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO8_MASK            ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define LFSS_GEN_EVENT_ISET_TIO8_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO8_SET             ((uint32_t)0x00010000U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO9] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO9_OFS             (17)                            /* !< TIO9 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO9_MASK            ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define LFSS_GEN_EVENT_ISET_TIO9_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO9_SET             ((uint32_t)0x00020000U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO10] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO10_OFS            (18)                            /* !< TIO10 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO10_MASK           ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define LFSS_GEN_EVENT_ISET_TIO10_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO10_SET            ((uint32_t)0x00040000U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO11] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO11_OFS            (19)                            /* !< TIO11 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO11_MASK           ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define LFSS_GEN_EVENT_ISET_TIO11_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO11_SET            ((uint32_t)0x00080000U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO12] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO12_OFS            (20)                            /* !< TIO12 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO12_MASK           ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define LFSS_GEN_EVENT_ISET_TIO12_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO12_SET            ((uint32_t)0x00100000U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO13] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO13_OFS            (21)                            /* !< TIO13 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO13_MASK           ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define LFSS_GEN_EVENT_ISET_TIO13_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO13_SET            ((uint32_t)0x00200000U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO14] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO14_OFS            (22)                            /* !< TIO14 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO14_MASK           ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define LFSS_GEN_EVENT_ISET_TIO14_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO14_SET            ((uint32_t)0x00400000U)         /* !< Set interrupt */
+/* LFSS_GEN_EVENT_ISET[TIO15] Bits */
+#define LFSS_GEN_EVENT_ISET_TIO15_OFS            (23)                            /* !< TIO15 Offset */
+#define LFSS_GEN_EVENT_ISET_TIO15_MASK           ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define LFSS_GEN_EVENT_ISET_TIO15_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ISET_TIO15_SET            ((uint32_t)0x00800000U)         /* !< Set interrupt */
+
+/* LFSS_GEN_EVENT_ICLR Bits */
+/* LFSS_GEN_EVENT_ICLR[RTCRDY] Bits */
+#define LFSS_GEN_EVENT_ICLR_RTCRDY_OFS           (0)                             /* !< RTCRDY Offset */
+#define LFSS_GEN_EVENT_ICLR_RTCRDY_MASK          ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define LFSS_GEN_EVENT_ICLR_RTCRDY_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_RTCRDY_CLR           ((uint32_t)0x00000001U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[RTCTEV] Bits */
+#define LFSS_GEN_EVENT_ICLR_RTCTEV_OFS           (1)                             /* !< RTCTEV Offset */
+#define LFSS_GEN_EVENT_ICLR_RTCTEV_MASK          ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define LFSS_GEN_EVENT_ICLR_RTCTEV_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_RTCTEV_CLR           ((uint32_t)0x00000002U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[RTCA1] Bits */
+#define LFSS_GEN_EVENT_ICLR_RTCA1_OFS            (2)                             /* !< RTCA1 Offset */
+#define LFSS_GEN_EVENT_ICLR_RTCA1_MASK           ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define LFSS_GEN_EVENT_ICLR_RTCA1_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_RTCA1_CLR            ((uint32_t)0x00000004U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[RTCA2] Bits */
+#define LFSS_GEN_EVENT_ICLR_RTCA2_OFS            (3)                             /* !< RTCA2 Offset */
+#define LFSS_GEN_EVENT_ICLR_RTCA2_MASK           ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define LFSS_GEN_EVENT_ICLR_RTCA2_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_RTCA2_CLR            ((uint32_t)0x00000008U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[RT0PS] Bits */
+#define LFSS_GEN_EVENT_ICLR_RT0PS_OFS            (4)                             /* !< RT0PS Offset */
+#define LFSS_GEN_EVENT_ICLR_RT0PS_MASK           ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define LFSS_GEN_EVENT_ICLR_RT0PS_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_RT0PS_CLR            ((uint32_t)0x00000010U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[RT1PS] Bits */
+#define LFSS_GEN_EVENT_ICLR_RT1PS_OFS            (5)                             /* !< RT1PS Offset */
+#define LFSS_GEN_EVENT_ICLR_RT1PS_MASK           ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define LFSS_GEN_EVENT_ICLR_RT1PS_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_RT1PS_CLR            ((uint32_t)0x00000020U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[RT2PS] Bits */
+#define LFSS_GEN_EVENT_ICLR_RT2PS_OFS            (6)                             /* !< RT2PS Offset */
+#define LFSS_GEN_EVENT_ICLR_RT2PS_MASK           ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define LFSS_GEN_EVENT_ICLR_RT2PS_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_RT2PS_CLR            ((uint32_t)0x00000040U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TSEVT] Bits */
+#define LFSS_GEN_EVENT_ICLR_TSEVT_OFS            (7)                             /* !< TSEVT Offset */
+#define LFSS_GEN_EVENT_ICLR_TSEVT_MASK           ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define LFSS_GEN_EVENT_ICLR_TSEVT_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TSEVT_CLR            ((uint32_t)0x00000080U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO0] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO0_OFS             (8)                             /* !< TIO0 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO0_MASK            ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define LFSS_GEN_EVENT_ICLR_TIO0_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO0_CLR             ((uint32_t)0x00000100U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO1] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO1_OFS             (9)                             /* !< TIO1 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO1_MASK            ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define LFSS_GEN_EVENT_ICLR_TIO1_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO1_CLR             ((uint32_t)0x00000200U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO2] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO2_OFS             (10)                            /* !< TIO2 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO2_MASK            ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define LFSS_GEN_EVENT_ICLR_TIO2_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO2_CLR             ((uint32_t)0x00000400U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO3] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO3_OFS             (11)                            /* !< TIO3 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO3_MASK            ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define LFSS_GEN_EVENT_ICLR_TIO3_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO3_CLR             ((uint32_t)0x00000800U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO4] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO4_OFS             (12)                            /* !< TIO4 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO4_MASK            ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define LFSS_GEN_EVENT_ICLR_TIO4_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO4_CLR             ((uint32_t)0x00001000U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO5] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO5_OFS             (13)                            /* !< TIO5 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO5_MASK            ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define LFSS_GEN_EVENT_ICLR_TIO5_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO5_CLR             ((uint32_t)0x00002000U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO6] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO6_OFS             (14)                            /* !< TIO6 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO6_MASK            ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define LFSS_GEN_EVENT_ICLR_TIO6_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO6_CLR             ((uint32_t)0x00004000U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO7] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO7_OFS             (15)                            /* !< TIO7 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO7_MASK            ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define LFSS_GEN_EVENT_ICLR_TIO7_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO7_CLR             ((uint32_t)0x00008000U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO8] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO8_OFS             (16)                            /* !< TIO8 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO8_MASK            ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define LFSS_GEN_EVENT_ICLR_TIO8_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO8_CLR             ((uint32_t)0x00010000U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO9] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO9_OFS             (17)                            /* !< TIO9 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO9_MASK            ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define LFSS_GEN_EVENT_ICLR_TIO9_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO9_CLR             ((uint32_t)0x00020000U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO10] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO10_OFS            (18)                            /* !< TIO10 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO10_MASK           ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define LFSS_GEN_EVENT_ICLR_TIO10_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO10_CLR            ((uint32_t)0x00040000U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO11] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO11_OFS            (19)                            /* !< TIO11 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO11_MASK           ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define LFSS_GEN_EVENT_ICLR_TIO11_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO11_CLR            ((uint32_t)0x00080000U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO12] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO12_OFS            (20)                            /* !< TIO12 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO12_MASK           ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define LFSS_GEN_EVENT_ICLR_TIO12_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO12_CLR            ((uint32_t)0x00100000U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO13] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO13_OFS            (21)                            /* !< TIO13 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO13_MASK           ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define LFSS_GEN_EVENT_ICLR_TIO13_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO13_CLR            ((uint32_t)0x00200000U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO14] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO14_OFS            (22)                            /* !< TIO14 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO14_MASK           ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define LFSS_GEN_EVENT_ICLR_TIO14_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO14_CLR            ((uint32_t)0x00400000U)         /* !< Clear interrupt */
+/* LFSS_GEN_EVENT_ICLR[TIO15] Bits */
+#define LFSS_GEN_EVENT_ICLR_TIO15_OFS            (23)                            /* !< TIO15 Offset */
+#define LFSS_GEN_EVENT_ICLR_TIO15_MASK           ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define LFSS_GEN_EVENT_ICLR_TIO15_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_GEN_EVENT_ICLR_TIO15_CLR            ((uint32_t)0x00800000U)         /* !< Clear interrupt */
+
+/* LFSS_CPU_INT_IIDX Bits */
+/* LFSS_CPU_INT_IIDX[STAT] Bits */
+#define LFSS_CPU_INT_IIDX_STAT_OFS               (0)                             /* !< STAT Offset */
+#define LFSS_CPU_INT_IIDX_STAT_MASK              ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define LFSS_CPU_INT_IIDX_STAT_NO_INTR           ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define LFSS_CPU_INT_IIDX_STAT_RTCRDY            ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define LFSS_CPU_INT_IIDX_STAT_RTCTEV            ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define LFSS_CPU_INT_IIDX_STAT_RTCA1             ((uint32_t)0x00000003U)         /* !< RTC alarm 1 */
+#define LFSS_CPU_INT_IIDX_STAT_RTCA2             ((uint32_t)0x00000004U)         /* !< RTC alarm 2 */
+#define LFSS_CPU_INT_IIDX_STAT_RT0PS             ((uint32_t)0x00000005U)         /* !< RTC prescale timer 0 */
+#define LFSS_CPU_INT_IIDX_STAT_RT1PS             ((uint32_t)0x00000006U)         /* !< RTC prescale timer 1 */
+#define LFSS_CPU_INT_IIDX_STAT_RT2PS             ((uint32_t)0x00000007U)         /* !< RTC prescale timer 2 */
+#define LFSS_CPU_INT_IIDX_STAT_TSEVT             ((uint32_t)0x00000008U)         /* !< Time stamp event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO0              ((uint32_t)0x00000009U)         /* !< Tamper I/O 0 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO1              ((uint32_t)0x0000000AU)         /* !< Tamper I/O 1 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO2              ((uint32_t)0x0000000BU)         /* !< Tamper I/O 2 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO3              ((uint32_t)0x0000000CU)         /* !< Tamper I/O 3 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO4              ((uint32_t)0x0000000DU)         /* !< Tamper I/O 4 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO5              ((uint32_t)0x0000000EU)         /* !< Tamper I/O 5 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO6              ((uint32_t)0x0000000FU)         /* !< Tamper I/O 6 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO7              ((uint32_t)0x00000010U)         /* !< Tamper I/O 7 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO8              ((uint32_t)0x00000011U)         /* !< Tamper I/O 8 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO9              ((uint32_t)0x00000012U)         /* !< Tamper I/O 9 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO10             ((uint32_t)0x00000013U)         /* !< Tamper I/O 10 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO11             ((uint32_t)0x00000014U)         /* !< Tamper I/O 11 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO12             ((uint32_t)0x00000015U)         /* !< Tamper I/O 12 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO13             ((uint32_t)0x00000016U)         /* !< Tamper I/O 13 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO14             ((uint32_t)0x00000017U)         /* !< Tamper I/O 14 event */
+#define LFSS_CPU_INT_IIDX_STAT_TIO15             ((uint32_t)0x00000018U)         /* !< Tamper I/O 15 event */
+
+/* LFSS_CPU_INT_IMASK Bits */
+/* LFSS_CPU_INT_IMASK[RTCRDY] Bits */
+#define LFSS_CPU_INT_IMASK_RTCRDY_OFS            (0)                             /* !< RTCRDY Offset */
+#define LFSS_CPU_INT_IMASK_RTCRDY_MASK           ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define LFSS_CPU_INT_IMASK_RTCRDY_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_RTCRDY_SET            ((uint32_t)0x00000001U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[RTCTEV] Bits */
+#define LFSS_CPU_INT_IMASK_RTCTEV_OFS            (1)                             /* !< RTCTEV Offset */
+#define LFSS_CPU_INT_IMASK_RTCTEV_MASK           ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define LFSS_CPU_INT_IMASK_RTCTEV_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_RTCTEV_SET            ((uint32_t)0x00000002U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[RTCA1] Bits */
+#define LFSS_CPU_INT_IMASK_RTCA1_OFS             (2)                             /* !< RTCA1 Offset */
+#define LFSS_CPU_INT_IMASK_RTCA1_MASK            ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define LFSS_CPU_INT_IMASK_RTCA1_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_RTCA1_SET             ((uint32_t)0x00000004U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[RTCA2] Bits */
+#define LFSS_CPU_INT_IMASK_RTCA2_OFS             (3)                             /* !< RTCA2 Offset */
+#define LFSS_CPU_INT_IMASK_RTCA2_MASK            ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define LFSS_CPU_INT_IMASK_RTCA2_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_RTCA2_SET             ((uint32_t)0x00000008U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[RT0PS] Bits */
+#define LFSS_CPU_INT_IMASK_RT0PS_OFS             (4)                             /* !< RT0PS Offset */
+#define LFSS_CPU_INT_IMASK_RT0PS_MASK            ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define LFSS_CPU_INT_IMASK_RT0PS_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_RT0PS_SET             ((uint32_t)0x00000010U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[RT1PS] Bits */
+#define LFSS_CPU_INT_IMASK_RT1PS_OFS             (5)                             /* !< RT1PS Offset */
+#define LFSS_CPU_INT_IMASK_RT1PS_MASK            ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define LFSS_CPU_INT_IMASK_RT1PS_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_RT1PS_SET             ((uint32_t)0x00000020U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[RT2PS] Bits */
+#define LFSS_CPU_INT_IMASK_RT2PS_OFS             (6)                             /* !< RT2PS Offset */
+#define LFSS_CPU_INT_IMASK_RT2PS_MASK            ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define LFSS_CPU_INT_IMASK_RT2PS_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_RT2PS_SET             ((uint32_t)0x00000040U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TSEVT] Bits */
+#define LFSS_CPU_INT_IMASK_TSEVT_OFS             (7)                             /* !< TSEVT Offset */
+#define LFSS_CPU_INT_IMASK_TSEVT_MASK            ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define LFSS_CPU_INT_IMASK_TSEVT_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TSEVT_SET             ((uint32_t)0x00000080U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO0] Bits */
+#define LFSS_CPU_INT_IMASK_TIO0_OFS              (8)                             /* !< TIO0 Offset */
+#define LFSS_CPU_INT_IMASK_TIO0_MASK             ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define LFSS_CPU_INT_IMASK_TIO0_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO0_SET              ((uint32_t)0x00000100U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO1] Bits */
+#define LFSS_CPU_INT_IMASK_TIO1_OFS              (9)                             /* !< TIO1 Offset */
+#define LFSS_CPU_INT_IMASK_TIO1_MASK             ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define LFSS_CPU_INT_IMASK_TIO1_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO1_SET              ((uint32_t)0x00000200U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO2] Bits */
+#define LFSS_CPU_INT_IMASK_TIO2_OFS              (10)                            /* !< TIO2 Offset */
+#define LFSS_CPU_INT_IMASK_TIO2_MASK             ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define LFSS_CPU_INT_IMASK_TIO2_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO2_SET              ((uint32_t)0x00000400U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO3] Bits */
+#define LFSS_CPU_INT_IMASK_TIO3_OFS              (11)                            /* !< TIO3 Offset */
+#define LFSS_CPU_INT_IMASK_TIO3_MASK             ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define LFSS_CPU_INT_IMASK_TIO3_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO3_SET              ((uint32_t)0x00000800U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO4] Bits */
+#define LFSS_CPU_INT_IMASK_TIO4_OFS              (12)                            /* !< TIO4 Offset */
+#define LFSS_CPU_INT_IMASK_TIO4_MASK             ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define LFSS_CPU_INT_IMASK_TIO4_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO4_SET              ((uint32_t)0x00001000U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO5] Bits */
+#define LFSS_CPU_INT_IMASK_TIO5_OFS              (13)                            /* !< TIO5 Offset */
+#define LFSS_CPU_INT_IMASK_TIO5_MASK             ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define LFSS_CPU_INT_IMASK_TIO5_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO5_SET              ((uint32_t)0x00002000U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO6] Bits */
+#define LFSS_CPU_INT_IMASK_TIO6_OFS              (14)                            /* !< TIO6 Offset */
+#define LFSS_CPU_INT_IMASK_TIO6_MASK             ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define LFSS_CPU_INT_IMASK_TIO6_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO6_SET              ((uint32_t)0x00004000U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO7] Bits */
+#define LFSS_CPU_INT_IMASK_TIO7_OFS              (15)                            /* !< TIO7 Offset */
+#define LFSS_CPU_INT_IMASK_TIO7_MASK             ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define LFSS_CPU_INT_IMASK_TIO7_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO7_SET              ((uint32_t)0x00008000U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO8] Bits */
+#define LFSS_CPU_INT_IMASK_TIO8_OFS              (16)                            /* !< TIO8 Offset */
+#define LFSS_CPU_INT_IMASK_TIO8_MASK             ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define LFSS_CPU_INT_IMASK_TIO8_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO8_SET              ((uint32_t)0x00010000U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO9] Bits */
+#define LFSS_CPU_INT_IMASK_TIO9_OFS              (17)                            /* !< TIO9 Offset */
+#define LFSS_CPU_INT_IMASK_TIO9_MASK             ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define LFSS_CPU_INT_IMASK_TIO9_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO9_SET              ((uint32_t)0x00020000U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO10] Bits */
+#define LFSS_CPU_INT_IMASK_TIO10_OFS             (18)                            /* !< TIO10 Offset */
+#define LFSS_CPU_INT_IMASK_TIO10_MASK            ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define LFSS_CPU_INT_IMASK_TIO10_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO10_SET             ((uint32_t)0x00040000U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO11] Bits */
+#define LFSS_CPU_INT_IMASK_TIO11_OFS             (19)                            /* !< TIO11 Offset */
+#define LFSS_CPU_INT_IMASK_TIO11_MASK            ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define LFSS_CPU_INT_IMASK_TIO11_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO11_SET             ((uint32_t)0x00080000U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO12] Bits */
+#define LFSS_CPU_INT_IMASK_TIO12_OFS             (20)                            /* !< TIO12 Offset */
+#define LFSS_CPU_INT_IMASK_TIO12_MASK            ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define LFSS_CPU_INT_IMASK_TIO12_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO12_SET             ((uint32_t)0x00100000U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO13] Bits */
+#define LFSS_CPU_INT_IMASK_TIO13_OFS             (21)                            /* !< TIO13 Offset */
+#define LFSS_CPU_INT_IMASK_TIO13_MASK            ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define LFSS_CPU_INT_IMASK_TIO13_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO13_SET             ((uint32_t)0x00200000U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO14] Bits */
+#define LFSS_CPU_INT_IMASK_TIO14_OFS             (22)                            /* !< TIO14 Offset */
+#define LFSS_CPU_INT_IMASK_TIO14_MASK            ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define LFSS_CPU_INT_IMASK_TIO14_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO14_SET             ((uint32_t)0x00400000U)         /* !< Set Interrrupt Mask */
+/* LFSS_CPU_INT_IMASK[TIO15] Bits */
+#define LFSS_CPU_INT_IMASK_TIO15_OFS             (23)                            /* !< TIO15 Offset */
+#define LFSS_CPU_INT_IMASK_TIO15_MASK            ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define LFSS_CPU_INT_IMASK_TIO15_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define LFSS_CPU_INT_IMASK_TIO15_SET             ((uint32_t)0x00800000U)         /* !< Set Interrrupt Mask */
+
+/* LFSS_CPU_INT_RIS Bits */
+/* LFSS_CPU_INT_RIS[RTCRDY] Bits */
+#define LFSS_CPU_INT_RIS_RTCRDY_OFS              (0)                             /* !< RTCRDY Offset */
+#define LFSS_CPU_INT_RIS_RTCRDY_MASK             ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define LFSS_CPU_INT_RIS_RTCRDY_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_RTCRDY_SET              ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[RTCTEV] Bits */
+#define LFSS_CPU_INT_RIS_RTCTEV_OFS              (1)                             /* !< RTCTEV Offset */
+#define LFSS_CPU_INT_RIS_RTCTEV_MASK             ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define LFSS_CPU_INT_RIS_RTCTEV_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_RTCTEV_SET              ((uint32_t)0x00000002U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[RTCA1] Bits */
+#define LFSS_CPU_INT_RIS_RTCA1_OFS               (2)                             /* !< RTCA1 Offset */
+#define LFSS_CPU_INT_RIS_RTCA1_MASK              ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define LFSS_CPU_INT_RIS_RTCA1_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_RTCA1_SET               ((uint32_t)0x00000004U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[RTCA2] Bits */
+#define LFSS_CPU_INT_RIS_RTCA2_OFS               (3)                             /* !< RTCA2 Offset */
+#define LFSS_CPU_INT_RIS_RTCA2_MASK              ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define LFSS_CPU_INT_RIS_RTCA2_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_RTCA2_SET               ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[RT0PS] Bits */
+#define LFSS_CPU_INT_RIS_RT0PS_OFS               (4)                             /* !< RT0PS Offset */
+#define LFSS_CPU_INT_RIS_RT0PS_MASK              ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define LFSS_CPU_INT_RIS_RT0PS_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_RT0PS_SET               ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[RT1PS] Bits */
+#define LFSS_CPU_INT_RIS_RT1PS_OFS               (5)                             /* !< RT1PS Offset */
+#define LFSS_CPU_INT_RIS_RT1PS_MASK              ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define LFSS_CPU_INT_RIS_RT1PS_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_RT1PS_SET               ((uint32_t)0x00000020U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[RT2PS] Bits */
+#define LFSS_CPU_INT_RIS_RT2PS_OFS               (6)                             /* !< RT2PS Offset */
+#define LFSS_CPU_INT_RIS_RT2PS_MASK              ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define LFSS_CPU_INT_RIS_RT2PS_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_RT2PS_SET               ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TSEVT] Bits */
+#define LFSS_CPU_INT_RIS_TSEVT_OFS               (7)                             /* !< TSEVT Offset */
+#define LFSS_CPU_INT_RIS_TSEVT_MASK              ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define LFSS_CPU_INT_RIS_TSEVT_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TSEVT_SET               ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO0] Bits */
+#define LFSS_CPU_INT_RIS_TIO0_OFS                (8)                             /* !< TIO0 Offset */
+#define LFSS_CPU_INT_RIS_TIO0_MASK               ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define LFSS_CPU_INT_RIS_TIO0_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO0_SET                ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO1] Bits */
+#define LFSS_CPU_INT_RIS_TIO1_OFS                (9)                             /* !< TIO1 Offset */
+#define LFSS_CPU_INT_RIS_TIO1_MASK               ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define LFSS_CPU_INT_RIS_TIO1_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO1_SET                ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO2] Bits */
+#define LFSS_CPU_INT_RIS_TIO2_OFS                (10)                            /* !< TIO2 Offset */
+#define LFSS_CPU_INT_RIS_TIO2_MASK               ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define LFSS_CPU_INT_RIS_TIO2_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO2_SET                ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO3] Bits */
+#define LFSS_CPU_INT_RIS_TIO3_OFS                (11)                            /* !< TIO3 Offset */
+#define LFSS_CPU_INT_RIS_TIO3_MASK               ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define LFSS_CPU_INT_RIS_TIO3_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO3_SET                ((uint32_t)0x00000800U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO4] Bits */
+#define LFSS_CPU_INT_RIS_TIO4_OFS                (12)                            /* !< TIO4 Offset */
+#define LFSS_CPU_INT_RIS_TIO4_MASK               ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define LFSS_CPU_INT_RIS_TIO4_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO4_SET                ((uint32_t)0x00001000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO5] Bits */
+#define LFSS_CPU_INT_RIS_TIO5_OFS                (13)                            /* !< TIO5 Offset */
+#define LFSS_CPU_INT_RIS_TIO5_MASK               ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define LFSS_CPU_INT_RIS_TIO5_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO5_SET                ((uint32_t)0x00002000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO6] Bits */
+#define LFSS_CPU_INT_RIS_TIO6_OFS                (14)                            /* !< TIO6 Offset */
+#define LFSS_CPU_INT_RIS_TIO6_MASK               ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define LFSS_CPU_INT_RIS_TIO6_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO6_SET                ((uint32_t)0x00004000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO7] Bits */
+#define LFSS_CPU_INT_RIS_TIO7_OFS                (15)                            /* !< TIO7 Offset */
+#define LFSS_CPU_INT_RIS_TIO7_MASK               ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define LFSS_CPU_INT_RIS_TIO7_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO7_SET                ((uint32_t)0x00008000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO8] Bits */
+#define LFSS_CPU_INT_RIS_TIO8_OFS                (16)                            /* !< TIO8 Offset */
+#define LFSS_CPU_INT_RIS_TIO8_MASK               ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define LFSS_CPU_INT_RIS_TIO8_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO8_SET                ((uint32_t)0x00010000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO9] Bits */
+#define LFSS_CPU_INT_RIS_TIO9_OFS                (17)                            /* !< TIO9 Offset */
+#define LFSS_CPU_INT_RIS_TIO9_MASK               ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define LFSS_CPU_INT_RIS_TIO9_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO9_SET                ((uint32_t)0x00020000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO10] Bits */
+#define LFSS_CPU_INT_RIS_TIO10_OFS               (18)                            /* !< TIO10 Offset */
+#define LFSS_CPU_INT_RIS_TIO10_MASK              ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define LFSS_CPU_INT_RIS_TIO10_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO10_SET               ((uint32_t)0x00040000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO11] Bits */
+#define LFSS_CPU_INT_RIS_TIO11_OFS               (19)                            /* !< TIO11 Offset */
+#define LFSS_CPU_INT_RIS_TIO11_MASK              ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define LFSS_CPU_INT_RIS_TIO11_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO11_SET               ((uint32_t)0x00080000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO12] Bits */
+#define LFSS_CPU_INT_RIS_TIO12_OFS               (20)                            /* !< TIO12 Offset */
+#define LFSS_CPU_INT_RIS_TIO12_MASK              ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define LFSS_CPU_INT_RIS_TIO12_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO12_SET               ((uint32_t)0x00100000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO13] Bits */
+#define LFSS_CPU_INT_RIS_TIO13_OFS               (21)                            /* !< TIO13 Offset */
+#define LFSS_CPU_INT_RIS_TIO13_MASK              ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define LFSS_CPU_INT_RIS_TIO13_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO13_SET               ((uint32_t)0x00200000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO14] Bits */
+#define LFSS_CPU_INT_RIS_TIO14_OFS               (22)                            /* !< TIO14 Offset */
+#define LFSS_CPU_INT_RIS_TIO14_MASK              ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define LFSS_CPU_INT_RIS_TIO14_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO14_SET               ((uint32_t)0x00400000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_RIS[TIO15] Bits */
+#define LFSS_CPU_INT_RIS_TIO15_OFS               (23)                            /* !< TIO15 Offset */
+#define LFSS_CPU_INT_RIS_TIO15_MASK              ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define LFSS_CPU_INT_RIS_TIO15_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define LFSS_CPU_INT_RIS_TIO15_SET               ((uint32_t)0x00800000U)         /* !< Interrupt occurred */
+
+/* LFSS_CPU_INT_MIS Bits */
+/* LFSS_CPU_INT_MIS[RTCRDY] Bits */
+#define LFSS_CPU_INT_MIS_RTCRDY_OFS              (0)                             /* !< RTCRDY Offset */
+#define LFSS_CPU_INT_MIS_RTCRDY_MASK             ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define LFSS_CPU_INT_MIS_RTCRDY_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_RTCRDY_SET              ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[RTCTEV] Bits */
+#define LFSS_CPU_INT_MIS_RTCTEV_OFS              (1)                             /* !< RTCTEV Offset */
+#define LFSS_CPU_INT_MIS_RTCTEV_MASK             ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define LFSS_CPU_INT_MIS_RTCTEV_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_RTCTEV_SET              ((uint32_t)0x00000002U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[RTCA1] Bits */
+#define LFSS_CPU_INT_MIS_RTCA1_OFS               (2)                             /* !< RTCA1 Offset */
+#define LFSS_CPU_INT_MIS_RTCA1_MASK              ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define LFSS_CPU_INT_MIS_RTCA1_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_RTCA1_SET               ((uint32_t)0x00000004U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[RTCA2] Bits */
+#define LFSS_CPU_INT_MIS_RTCA2_OFS               (3)                             /* !< RTCA2 Offset */
+#define LFSS_CPU_INT_MIS_RTCA2_MASK              ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define LFSS_CPU_INT_MIS_RTCA2_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_RTCA2_SET               ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[RT0PS] Bits */
+#define LFSS_CPU_INT_MIS_RT0PS_OFS               (4)                             /* !< RT0PS Offset */
+#define LFSS_CPU_INT_MIS_RT0PS_MASK              ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define LFSS_CPU_INT_MIS_RT0PS_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_RT0PS_SET               ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[RT1PS] Bits */
+#define LFSS_CPU_INT_MIS_RT1PS_OFS               (5)                             /* !< RT1PS Offset */
+#define LFSS_CPU_INT_MIS_RT1PS_MASK              ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define LFSS_CPU_INT_MIS_RT1PS_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_RT1PS_SET               ((uint32_t)0x00000020U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[RT2PS] Bits */
+#define LFSS_CPU_INT_MIS_RT2PS_OFS               (6)                             /* !< RT2PS Offset */
+#define LFSS_CPU_INT_MIS_RT2PS_MASK              ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define LFSS_CPU_INT_MIS_RT2PS_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_RT2PS_SET               ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TSEVT] Bits */
+#define LFSS_CPU_INT_MIS_TSEVT_OFS               (7)                             /* !< TSEVT Offset */
+#define LFSS_CPU_INT_MIS_TSEVT_MASK              ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define LFSS_CPU_INT_MIS_TSEVT_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TSEVT_SET               ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO0] Bits */
+#define LFSS_CPU_INT_MIS_TIO0_OFS                (8)                             /* !< TIO0 Offset */
+#define LFSS_CPU_INT_MIS_TIO0_MASK               ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define LFSS_CPU_INT_MIS_TIO0_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO0_SET                ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO1] Bits */
+#define LFSS_CPU_INT_MIS_TIO1_OFS                (9)                             /* !< TIO1 Offset */
+#define LFSS_CPU_INT_MIS_TIO1_MASK               ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define LFSS_CPU_INT_MIS_TIO1_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO1_SET                ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO2] Bits */
+#define LFSS_CPU_INT_MIS_TIO2_OFS                (10)                            /* !< TIO2 Offset */
+#define LFSS_CPU_INT_MIS_TIO2_MASK               ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define LFSS_CPU_INT_MIS_TIO2_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO2_SET                ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO3] Bits */
+#define LFSS_CPU_INT_MIS_TIO3_OFS                (11)                            /* !< TIO3 Offset */
+#define LFSS_CPU_INT_MIS_TIO3_MASK               ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define LFSS_CPU_INT_MIS_TIO3_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO3_SET                ((uint32_t)0x00000800U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO4] Bits */
+#define LFSS_CPU_INT_MIS_TIO4_OFS                (12)                            /* !< TIO4 Offset */
+#define LFSS_CPU_INT_MIS_TIO4_MASK               ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define LFSS_CPU_INT_MIS_TIO4_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO4_SET                ((uint32_t)0x00001000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO5] Bits */
+#define LFSS_CPU_INT_MIS_TIO5_OFS                (13)                            /* !< TIO5 Offset */
+#define LFSS_CPU_INT_MIS_TIO5_MASK               ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define LFSS_CPU_INT_MIS_TIO5_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO5_SET                ((uint32_t)0x00002000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO6] Bits */
+#define LFSS_CPU_INT_MIS_TIO6_OFS                (14)                            /* !< TIO6 Offset */
+#define LFSS_CPU_INT_MIS_TIO6_MASK               ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define LFSS_CPU_INT_MIS_TIO6_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO6_SET                ((uint32_t)0x00004000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO7] Bits */
+#define LFSS_CPU_INT_MIS_TIO7_OFS                (15)                            /* !< TIO7 Offset */
+#define LFSS_CPU_INT_MIS_TIO7_MASK               ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define LFSS_CPU_INT_MIS_TIO7_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO7_SET                ((uint32_t)0x00008000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO8] Bits */
+#define LFSS_CPU_INT_MIS_TIO8_OFS                (16)                            /* !< TIO8 Offset */
+#define LFSS_CPU_INT_MIS_TIO8_MASK               ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define LFSS_CPU_INT_MIS_TIO8_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO8_SET                ((uint32_t)0x00010000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO9] Bits */
+#define LFSS_CPU_INT_MIS_TIO9_OFS                (17)                            /* !< TIO9 Offset */
+#define LFSS_CPU_INT_MIS_TIO9_MASK               ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define LFSS_CPU_INT_MIS_TIO9_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO9_SET                ((uint32_t)0x00020000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO10] Bits */
+#define LFSS_CPU_INT_MIS_TIO10_OFS               (18)                            /* !< TIO10 Offset */
+#define LFSS_CPU_INT_MIS_TIO10_MASK              ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define LFSS_CPU_INT_MIS_TIO10_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO10_SET               ((uint32_t)0x00040000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO11] Bits */
+#define LFSS_CPU_INT_MIS_TIO11_OFS               (19)                            /* !< TIO11 Offset */
+#define LFSS_CPU_INT_MIS_TIO11_MASK              ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define LFSS_CPU_INT_MIS_TIO11_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO11_SET               ((uint32_t)0x00080000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO12] Bits */
+#define LFSS_CPU_INT_MIS_TIO12_OFS               (20)                            /* !< TIO12 Offset */
+#define LFSS_CPU_INT_MIS_TIO12_MASK              ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define LFSS_CPU_INT_MIS_TIO12_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO12_SET               ((uint32_t)0x00100000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO13] Bits */
+#define LFSS_CPU_INT_MIS_TIO13_OFS               (21)                            /* !< TIO13 Offset */
+#define LFSS_CPU_INT_MIS_TIO13_MASK              ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define LFSS_CPU_INT_MIS_TIO13_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO13_SET               ((uint32_t)0x00200000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO14] Bits */
+#define LFSS_CPU_INT_MIS_TIO14_OFS               (22)                            /* !< TIO14 Offset */
+#define LFSS_CPU_INT_MIS_TIO14_MASK              ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define LFSS_CPU_INT_MIS_TIO14_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO14_SET               ((uint32_t)0x00400000U)         /* !< Interrupt occurred */
+/* LFSS_CPU_INT_MIS[TIO15] Bits */
+#define LFSS_CPU_INT_MIS_TIO15_OFS               (23)                            /* !< TIO15 Offset */
+#define LFSS_CPU_INT_MIS_TIO15_MASK              ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define LFSS_CPU_INT_MIS_TIO15_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define LFSS_CPU_INT_MIS_TIO15_SET               ((uint32_t)0x00800000U)         /* !< Interrupt occurred */
+
+/* LFSS_CPU_INT_ISET Bits */
+/* LFSS_CPU_INT_ISET[RTCRDY] Bits */
+#define LFSS_CPU_INT_ISET_RTCRDY_OFS             (0)                             /* !< RTCRDY Offset */
+#define LFSS_CPU_INT_ISET_RTCRDY_MASK            ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define LFSS_CPU_INT_ISET_RTCRDY_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_RTCRDY_SET             ((uint32_t)0x00000001U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[RTCTEV] Bits */
+#define LFSS_CPU_INT_ISET_RTCTEV_OFS             (1)                             /* !< RTCTEV Offset */
+#define LFSS_CPU_INT_ISET_RTCTEV_MASK            ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define LFSS_CPU_INT_ISET_RTCTEV_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_RTCTEV_SET             ((uint32_t)0x00000002U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[RTCA1] Bits */
+#define LFSS_CPU_INT_ISET_RTCA1_OFS              (2)                             /* !< RTCA1 Offset */
+#define LFSS_CPU_INT_ISET_RTCA1_MASK             ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define LFSS_CPU_INT_ISET_RTCA1_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_RTCA1_SET              ((uint32_t)0x00000004U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[RTCA2] Bits */
+#define LFSS_CPU_INT_ISET_RTCA2_OFS              (3)                             /* !< RTCA2 Offset */
+#define LFSS_CPU_INT_ISET_RTCA2_MASK             ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define LFSS_CPU_INT_ISET_RTCA2_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_RTCA2_SET              ((uint32_t)0x00000008U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[RT0PS] Bits */
+#define LFSS_CPU_INT_ISET_RT0PS_OFS              (4)                             /* !< RT0PS Offset */
+#define LFSS_CPU_INT_ISET_RT0PS_MASK             ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define LFSS_CPU_INT_ISET_RT0PS_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_RT0PS_SET              ((uint32_t)0x00000010U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[RT1PS] Bits */
+#define LFSS_CPU_INT_ISET_RT1PS_OFS              (5)                             /* !< RT1PS Offset */
+#define LFSS_CPU_INT_ISET_RT1PS_MASK             ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define LFSS_CPU_INT_ISET_RT1PS_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_RT1PS_SET              ((uint32_t)0x00000020U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[RT2PS] Bits */
+#define LFSS_CPU_INT_ISET_RT2PS_OFS              (6)                             /* !< RT2PS Offset */
+#define LFSS_CPU_INT_ISET_RT2PS_MASK             ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define LFSS_CPU_INT_ISET_RT2PS_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_RT2PS_SET              ((uint32_t)0x00000040U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TSEVT] Bits */
+#define LFSS_CPU_INT_ISET_TSEVT_OFS              (7)                             /* !< TSEVT Offset */
+#define LFSS_CPU_INT_ISET_TSEVT_MASK             ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define LFSS_CPU_INT_ISET_TSEVT_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TSEVT_SET              ((uint32_t)0x00000080U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO0] Bits */
+#define LFSS_CPU_INT_ISET_TIO0_OFS               (8)                             /* !< TIO0 Offset */
+#define LFSS_CPU_INT_ISET_TIO0_MASK              ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define LFSS_CPU_INT_ISET_TIO0_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO0_SET               ((uint32_t)0x00000100U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO1] Bits */
+#define LFSS_CPU_INT_ISET_TIO1_OFS               (9)                             /* !< TIO1 Offset */
+#define LFSS_CPU_INT_ISET_TIO1_MASK              ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define LFSS_CPU_INT_ISET_TIO1_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO1_SET               ((uint32_t)0x00000200U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO2] Bits */
+#define LFSS_CPU_INT_ISET_TIO2_OFS               (10)                            /* !< TIO2 Offset */
+#define LFSS_CPU_INT_ISET_TIO2_MASK              ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define LFSS_CPU_INT_ISET_TIO2_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO2_SET               ((uint32_t)0x00000400U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO3] Bits */
+#define LFSS_CPU_INT_ISET_TIO3_OFS               (11)                            /* !< TIO3 Offset */
+#define LFSS_CPU_INT_ISET_TIO3_MASK              ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define LFSS_CPU_INT_ISET_TIO3_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO3_SET               ((uint32_t)0x00000800U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO4] Bits */
+#define LFSS_CPU_INT_ISET_TIO4_OFS               (12)                            /* !< TIO4 Offset */
+#define LFSS_CPU_INT_ISET_TIO4_MASK              ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define LFSS_CPU_INT_ISET_TIO4_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO4_SET               ((uint32_t)0x00001000U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO5] Bits */
+#define LFSS_CPU_INT_ISET_TIO5_OFS               (13)                            /* !< TIO5 Offset */
+#define LFSS_CPU_INT_ISET_TIO5_MASK              ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define LFSS_CPU_INT_ISET_TIO5_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO5_SET               ((uint32_t)0x00002000U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO6] Bits */
+#define LFSS_CPU_INT_ISET_TIO6_OFS               (14)                            /* !< TIO6 Offset */
+#define LFSS_CPU_INT_ISET_TIO6_MASK              ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define LFSS_CPU_INT_ISET_TIO6_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO6_SET               ((uint32_t)0x00004000U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO7] Bits */
+#define LFSS_CPU_INT_ISET_TIO7_OFS               (15)                            /* !< TIO7 Offset */
+#define LFSS_CPU_INT_ISET_TIO7_MASK              ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define LFSS_CPU_INT_ISET_TIO7_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO7_SET               ((uint32_t)0x00008000U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO8] Bits */
+#define LFSS_CPU_INT_ISET_TIO8_OFS               (16)                            /* !< TIO8 Offset */
+#define LFSS_CPU_INT_ISET_TIO8_MASK              ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define LFSS_CPU_INT_ISET_TIO8_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO8_SET               ((uint32_t)0x00010000U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO9] Bits */
+#define LFSS_CPU_INT_ISET_TIO9_OFS               (17)                            /* !< TIO9 Offset */
+#define LFSS_CPU_INT_ISET_TIO9_MASK              ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define LFSS_CPU_INT_ISET_TIO9_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO9_SET               ((uint32_t)0x00020000U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO10] Bits */
+#define LFSS_CPU_INT_ISET_TIO10_OFS              (18)                            /* !< TIO10 Offset */
+#define LFSS_CPU_INT_ISET_TIO10_MASK             ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define LFSS_CPU_INT_ISET_TIO10_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO10_SET              ((uint32_t)0x00040000U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO11] Bits */
+#define LFSS_CPU_INT_ISET_TIO11_OFS              (19)                            /* !< TIO11 Offset */
+#define LFSS_CPU_INT_ISET_TIO11_MASK             ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define LFSS_CPU_INT_ISET_TIO11_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO11_SET              ((uint32_t)0x00080000U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO12] Bits */
+#define LFSS_CPU_INT_ISET_TIO12_OFS              (20)                            /* !< TIO12 Offset */
+#define LFSS_CPU_INT_ISET_TIO12_MASK             ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define LFSS_CPU_INT_ISET_TIO12_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO12_SET              ((uint32_t)0x00100000U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO13] Bits */
+#define LFSS_CPU_INT_ISET_TIO13_OFS              (21)                            /* !< TIO13 Offset */
+#define LFSS_CPU_INT_ISET_TIO13_MASK             ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define LFSS_CPU_INT_ISET_TIO13_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO13_SET              ((uint32_t)0x00200000U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO14] Bits */
+#define LFSS_CPU_INT_ISET_TIO14_OFS              (22)                            /* !< TIO14 Offset */
+#define LFSS_CPU_INT_ISET_TIO14_MASK             ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define LFSS_CPU_INT_ISET_TIO14_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO14_SET              ((uint32_t)0x00400000U)         /* !< Set interrupt */
+/* LFSS_CPU_INT_ISET[TIO15] Bits */
+#define LFSS_CPU_INT_ISET_TIO15_OFS              (23)                            /* !< TIO15 Offset */
+#define LFSS_CPU_INT_ISET_TIO15_MASK             ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define LFSS_CPU_INT_ISET_TIO15_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ISET_TIO15_SET              ((uint32_t)0x00800000U)         /* !< Set interrupt */
+
+/* LFSS_CPU_INT_ICLR Bits */
+/* LFSS_CPU_INT_ICLR[RTCRDY] Bits */
+#define LFSS_CPU_INT_ICLR_RTCRDY_OFS             (0)                             /* !< RTCRDY Offset */
+#define LFSS_CPU_INT_ICLR_RTCRDY_MASK            ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define LFSS_CPU_INT_ICLR_RTCRDY_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_RTCRDY_CLR             ((uint32_t)0x00000001U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[RTCTEV] Bits */
+#define LFSS_CPU_INT_ICLR_RTCTEV_OFS             (1)                             /* !< RTCTEV Offset */
+#define LFSS_CPU_INT_ICLR_RTCTEV_MASK            ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define LFSS_CPU_INT_ICLR_RTCTEV_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_RTCTEV_CLR             ((uint32_t)0x00000002U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[RTCA1] Bits */
+#define LFSS_CPU_INT_ICLR_RTCA1_OFS              (2)                             /* !< RTCA1 Offset */
+#define LFSS_CPU_INT_ICLR_RTCA1_MASK             ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define LFSS_CPU_INT_ICLR_RTCA1_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_RTCA1_CLR              ((uint32_t)0x00000004U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[RTCA2] Bits */
+#define LFSS_CPU_INT_ICLR_RTCA2_OFS              (3)                             /* !< RTCA2 Offset */
+#define LFSS_CPU_INT_ICLR_RTCA2_MASK             ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define LFSS_CPU_INT_ICLR_RTCA2_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_RTCA2_CLR              ((uint32_t)0x00000008U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[RT0PS] Bits */
+#define LFSS_CPU_INT_ICLR_RT0PS_OFS              (4)                             /* !< RT0PS Offset */
+#define LFSS_CPU_INT_ICLR_RT0PS_MASK             ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define LFSS_CPU_INT_ICLR_RT0PS_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_RT0PS_CLR              ((uint32_t)0x00000010U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[RT1PS] Bits */
+#define LFSS_CPU_INT_ICLR_RT1PS_OFS              (5)                             /* !< RT1PS Offset */
+#define LFSS_CPU_INT_ICLR_RT1PS_MASK             ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define LFSS_CPU_INT_ICLR_RT1PS_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_RT1PS_CLR              ((uint32_t)0x00000020U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[RT2PS] Bits */
+#define LFSS_CPU_INT_ICLR_RT2PS_OFS              (6)                             /* !< RT2PS Offset */
+#define LFSS_CPU_INT_ICLR_RT2PS_MASK             ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define LFSS_CPU_INT_ICLR_RT2PS_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_RT2PS_CLR              ((uint32_t)0x00000040U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TSEVT] Bits */
+#define LFSS_CPU_INT_ICLR_TSEVT_OFS              (7)                             /* !< TSEVT Offset */
+#define LFSS_CPU_INT_ICLR_TSEVT_MASK             ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define LFSS_CPU_INT_ICLR_TSEVT_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TSEVT_CLR              ((uint32_t)0x00000080U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO0] Bits */
+#define LFSS_CPU_INT_ICLR_TIO0_OFS               (8)                             /* !< TIO0 Offset */
+#define LFSS_CPU_INT_ICLR_TIO0_MASK              ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define LFSS_CPU_INT_ICLR_TIO0_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO0_CLR               ((uint32_t)0x00000100U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO1] Bits */
+#define LFSS_CPU_INT_ICLR_TIO1_OFS               (9)                             /* !< TIO1 Offset */
+#define LFSS_CPU_INT_ICLR_TIO1_MASK              ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define LFSS_CPU_INT_ICLR_TIO1_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO1_CLR               ((uint32_t)0x00000200U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO2] Bits */
+#define LFSS_CPU_INT_ICLR_TIO2_OFS               (10)                            /* !< TIO2 Offset */
+#define LFSS_CPU_INT_ICLR_TIO2_MASK              ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define LFSS_CPU_INT_ICLR_TIO2_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO2_CLR               ((uint32_t)0x00000400U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO3] Bits */
+#define LFSS_CPU_INT_ICLR_TIO3_OFS               (11)                            /* !< TIO3 Offset */
+#define LFSS_CPU_INT_ICLR_TIO3_MASK              ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define LFSS_CPU_INT_ICLR_TIO3_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO3_CLR               ((uint32_t)0x00000800U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO4] Bits */
+#define LFSS_CPU_INT_ICLR_TIO4_OFS               (12)                            /* !< TIO4 Offset */
+#define LFSS_CPU_INT_ICLR_TIO4_MASK              ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define LFSS_CPU_INT_ICLR_TIO4_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO4_CLR               ((uint32_t)0x00001000U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO5] Bits */
+#define LFSS_CPU_INT_ICLR_TIO5_OFS               (13)                            /* !< TIO5 Offset */
+#define LFSS_CPU_INT_ICLR_TIO5_MASK              ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define LFSS_CPU_INT_ICLR_TIO5_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO5_CLR               ((uint32_t)0x00002000U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO6] Bits */
+#define LFSS_CPU_INT_ICLR_TIO6_OFS               (14)                            /* !< TIO6 Offset */
+#define LFSS_CPU_INT_ICLR_TIO6_MASK              ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define LFSS_CPU_INT_ICLR_TIO6_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO6_CLR               ((uint32_t)0x00004000U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO7] Bits */
+#define LFSS_CPU_INT_ICLR_TIO7_OFS               (15)                            /* !< TIO7 Offset */
+#define LFSS_CPU_INT_ICLR_TIO7_MASK              ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define LFSS_CPU_INT_ICLR_TIO7_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO7_CLR               ((uint32_t)0x00008000U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO8] Bits */
+#define LFSS_CPU_INT_ICLR_TIO8_OFS               (16)                            /* !< TIO8 Offset */
+#define LFSS_CPU_INT_ICLR_TIO8_MASK              ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define LFSS_CPU_INT_ICLR_TIO8_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO8_CLR               ((uint32_t)0x00010000U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO9] Bits */
+#define LFSS_CPU_INT_ICLR_TIO9_OFS               (17)                            /* !< TIO9 Offset */
+#define LFSS_CPU_INT_ICLR_TIO9_MASK              ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define LFSS_CPU_INT_ICLR_TIO9_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO9_CLR               ((uint32_t)0x00020000U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO10] Bits */
+#define LFSS_CPU_INT_ICLR_TIO10_OFS              (18)                            /* !< TIO10 Offset */
+#define LFSS_CPU_INT_ICLR_TIO10_MASK             ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define LFSS_CPU_INT_ICLR_TIO10_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO10_CLR              ((uint32_t)0x00040000U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO11] Bits */
+#define LFSS_CPU_INT_ICLR_TIO11_OFS              (19)                            /* !< TIO11 Offset */
+#define LFSS_CPU_INT_ICLR_TIO11_MASK             ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define LFSS_CPU_INT_ICLR_TIO11_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO11_CLR              ((uint32_t)0x00080000U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO12] Bits */
+#define LFSS_CPU_INT_ICLR_TIO12_OFS              (20)                            /* !< TIO12 Offset */
+#define LFSS_CPU_INT_ICLR_TIO12_MASK             ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define LFSS_CPU_INT_ICLR_TIO12_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO12_CLR              ((uint32_t)0x00100000U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO13] Bits */
+#define LFSS_CPU_INT_ICLR_TIO13_OFS              (21)                            /* !< TIO13 Offset */
+#define LFSS_CPU_INT_ICLR_TIO13_MASK             ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define LFSS_CPU_INT_ICLR_TIO13_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO13_CLR              ((uint32_t)0x00200000U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO14] Bits */
+#define LFSS_CPU_INT_ICLR_TIO14_OFS              (22)                            /* !< TIO14 Offset */
+#define LFSS_CPU_INT_ICLR_TIO14_MASK             ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define LFSS_CPU_INT_ICLR_TIO14_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO14_CLR              ((uint32_t)0x00400000U)         /* !< Clear interrupt */
+/* LFSS_CPU_INT_ICLR[TIO15] Bits */
+#define LFSS_CPU_INT_ICLR_TIO15_OFS              (23)                            /* !< TIO15 Offset */
+#define LFSS_CPU_INT_ICLR_TIO15_MASK             ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define LFSS_CPU_INT_ICLR_TIO15_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define LFSS_CPU_INT_ICLR_TIO15_CLR              ((uint32_t)0x00800000U)         /* !< Clear interrupt */
+
+/* LFSS_FSUB_0 Bits */
+/* LFSS_FSUB_0[CHANID] Bits */
+#define LFSS_FSUB_0_CHANID_OFS                   (0)                             /* !< CHANID Offset */
+#define LFSS_FSUB_0_CHANID_MASK                  ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define LFSS_FSUB_0_CHANID_MNIMUM                ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define LFSS_FSUB_0_CHANID_UNCONNECTED           ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define LFSS_FSUB_0_CHANID_MAXIMUM               ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* LFSS_FPUB_0 Bits */
+/* LFSS_FPUB_0[CHANID] Bits */
+#define LFSS_FPUB_0_CHANID_OFS                   (0)                             /* !< CHANID Offset */
+#define LFSS_FPUB_0_CHANID_MASK                  ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define LFSS_FPUB_0_CHANID_MNIMUM                ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define LFSS_FPUB_0_CHANID_UNCONNECTED           ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define LFSS_FPUB_0_CHANID_MAXIMUM               ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* LFSS_CLKSEL Bits */
+/* LFSS_CLKSEL[LFCLK_SEL] Bits */
+#define LFSS_CLKSEL_LFCLK_SEL_OFS                (1)                             /* !< LFCLK_SEL Offset */
+#define LFSS_CLKSEL_LFCLK_SEL_MASK               ((uint32_t)0x00000002U)         /* !< Selects LFCLK as clock source if
+                                                                                    enabled */
+#define LFSS_CLKSEL_LFCLK_SEL_DISABLE            ((uint32_t)0x00000000U)         /* !< LFCLK is disabled */
+#define LFSS_CLKSEL_LFCLK_SEL_ENABLE             ((uint32_t)0x00000002U)         /* !< LFCLK is enabled */
+
+/* LFSS_EVT_MODE Bits */
+/* LFSS_EVT_MODE[EVT0_CFG] Bits */
+#define LFSS_EVT_MODE_EVT0_CFG_OFS               (0)                             /* !< EVT0_CFG Offset */
+#define LFSS_EVT_MODE_EVT0_CFG_MASK              ((uint32_t)0x00000003U)         /* !< Event line mode 0 select */
+#define LFSS_EVT_MODE_EVT0_CFG_SOFTWARE          ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. The software ISR
+                                                                                    clears the associated RIS flag. */
+/* LFSS_EVT_MODE[EVT1_CFG] Bits */
+#define LFSS_EVT_MODE_EVT1_CFG_OFS               (2)                             /* !< EVT1_CFG Offset */
+#define LFSS_EVT_MODE_EVT1_CFG_MASK              ((uint32_t)0x0000000CU)         /* !< Event line mode 1 select */
+#define LFSS_EVT_MODE_EVT1_CFG_HARDWARE          ((uint32_t)0x00000008U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* LFSS_DESC Bits */
+/* LFSS_DESC[MINREV] Bits */
+#define LFSS_DESC_MINREV_OFS                     (0)                             /* !< MINREV Offset */
+#define LFSS_DESC_MINREV_MASK                    ((uint32_t)0x0000000FU)         /* !< Minor revision. This number holds
+                                                                                    the module revision and is
+                                                                                    incremented by the module developers.
+                                                                                    n = Minor module revision (see
+                                                                                    device-specific data sheet) */
+#define LFSS_DESC_MINREV_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_DESC_MINREV_MAXIMUM                 ((uint32_t)0x0000000FU)         /* !< Highest possible value */
+/* LFSS_DESC[MAJREV] Bits */
+#define LFSS_DESC_MAJREV_OFS                     (4)                             /* !< MAJREV Offset */
+#define LFSS_DESC_MAJREV_MASK                    ((uint32_t)0x000000F0U)         /* !< Major revision. This number holds
+                                                                                    the module revision and is
+                                                                                    incremented by the module developers.
+                                                                                    n = Major version (see
+                                                                                    device-specific data sheet) */
+#define LFSS_DESC_MAJREV_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_DESC_MAJREV_MAXIMUM                 ((uint32_t)0x000000F0U)         /* !< Highest possible value */
+/* LFSS_DESC[INSTNUM] Bits */
+#define LFSS_DESC_INSTNUM_OFS                    (8)                             /* !< INSTNUM Offset */
+#define LFSS_DESC_INSTNUM_MASK                   ((uint32_t)0x00000F00U)         /* !< Instantiated version. Describes
+                                                                                    which instance of the module
+                                                                                    accessed. */
+#define LFSS_DESC_INSTNUM_INST0                  ((uint32_t)0x00000000U)         /* !< This is the default, if there is
+                                                                                    only one instance - like for SSIM */
+/* LFSS_DESC[FEATUREVER] Bits */
+#define LFSS_DESC_FEATUREVER_OFS                 (12)                            /* !< FEATUREVER Offset */
+#define LFSS_DESC_FEATUREVER_MASK                ((uint32_t)0x0000F000U)         /* !< Feature set of this module.
+                                                                                    Differentiates the complexity of the
+                                                                                    actually instantiated module if there
+                                                                                    are differences. */
+#define LFSS_DESC_FEATUREVER_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_DESC_FEATUREVER_MAXIMUM             ((uint32_t)0x0000F000U)         /* !< Highest possible value */
+/* LFSS_DESC[MODULEID] Bits */
+#define LFSS_DESC_MODULEID_OFS                   (16)                            /* !< MODULEID Offset */
+#define LFSS_DESC_MODULEID_MASK                  ((uint32_t)0xFFFF0000U)         /* !< Module identifier. This ID is
+                                                                                    unique for each module. 0x2911 =
+                                                                                    Module ID of the LFSS Module */
+#define LFSS_DESC_MODULEID_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define LFSS_DESC_MODULEID_MAXIMUM               ((uint32_t)0xFFFF0000U)         /* !< Highest possible value */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_lfss__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_mathacl.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_mathacl.h
@@ -1,0 +1,328 @@
+/*****************************************************************************
+
+  Copyright (C) 2022 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_mathacl__include
+#define ti_devices_msp_peripherals_hw_mathacl__include
+
+/* This preliminary header file does not have a version number */
+/* MMR repo: https://bitbucket.itg.ti.com/projects/cmcu_msp65ip/repos/f65mspmathacl */
+/* MMR revision: 9080fe468791d796cb4aed2ae9531011e6786af0 */
+/* Generator revision: 77992b62fb4e9926f5a9143aae1e89fec6a84738
+   (MInT: ec7ec7482a60c6871be32db8b378ec27aa4771f6) */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* MATHACL Registers
+******************************************************************************/
+#define MATHACL_GPRCM_OFS                        ((uint32_t)0x00000800U)
+
+
+/** @addtogroup MATHACL_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} MATHACL_GPRCM_Regs;
+
+/*@}*/ /* end of group MATHACL_GPRCM */
+
+/** @addtogroup MATHACL
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  MATHACL_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED1[570];
+  __IO uint32_t CTL;                               /* !< (@ 0x00001100) Control Register */
+       uint32_t RESERVED2[5];
+  __IO uint32_t OP2;                               /* !< (@ 0x00001118) Operand 2 register. */
+  __IO uint32_t OP1;                               /* !< (@ 0x0000111C) Operand 1 register. */
+  __IO uint32_t RES1;                              /* !< (@ 0x00001120) Result 1 register. */
+  __IO uint32_t RES2;                              /* !< (@ 0x00001124) Result 2 register. */
+       uint32_t RESERVED3[2];
+  __I  uint32_t STATUS;                            /* !< (@ 0x00001130) Status Register */
+       uint32_t RESERVED4[3];
+  __O  uint32_t STATUSCLR;                         /* !< (@ 0x00001140) Status flag clear register */
+} MATHACL_Regs;
+
+/*@}*/ /* end of group MATHACL */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* MATHACL Register Control Bits
+******************************************************************************/
+
+/* MATHACL_PWREN Bits */
+/* MATHACL_PWREN[ENABLE] Bits */
+#define MATHACL_PWREN_ENABLE_OFS                 (0)                             /* !< ENABLE Offset */
+#define MATHACL_PWREN_ENABLE_MASK                ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define MATHACL_PWREN_ENABLE_DISABLE             ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define MATHACL_PWREN_ENABLE_ENABLE              ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* MATHACL_PWREN[KEY] Bits */
+#define MATHACL_PWREN_KEY_OFS                    (24)                            /* !< KEY Offset */
+#define MATHACL_PWREN_KEY_MASK                   ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define MATHACL_PWREN_KEY_UNLOCK_W               ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* MATHACL_RSTCTL Bits */
+/* MATHACL_RSTCTL[RESETSTKYCLR] Bits */
+#define MATHACL_RSTCTL_RESETSTKYCLR_OFS          (1)                             /* !< RESETSTKYCLR Offset */
+#define MATHACL_RSTCTL_RESETSTKYCLR_MASK         ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define MATHACL_RSTCTL_RESETSTKYCLR_NOP          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MATHACL_RSTCTL_RESETSTKYCLR_CLR          ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* MATHACL_RSTCTL[RESETASSERT] Bits */
+#define MATHACL_RSTCTL_RESETASSERT_OFS           (0)                             /* !< RESETASSERT Offset */
+#define MATHACL_RSTCTL_RESETASSERT_MASK          ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define MATHACL_RSTCTL_RESETASSERT_NOP           ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MATHACL_RSTCTL_RESETASSERT_ASSERT        ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* MATHACL_RSTCTL[KEY] Bits */
+#define MATHACL_RSTCTL_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define MATHACL_RSTCTL_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define MATHACL_RSTCTL_KEY_UNLOCK_W              ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* MATHACL_STAT Bits */
+/* MATHACL_STAT[RESETSTKY] Bits */
+#define MATHACL_STAT_RESETSTKY_OFS               (16)                            /* !< RESETSTKY Offset */
+#define MATHACL_STAT_RESETSTKY_MASK              ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define MATHACL_STAT_RESETSTKY_NORES             ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define MATHACL_STAT_RESETSTKY_RESET             ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* MATHACL_CTL Bits */
+/* MATHACL_CTL[FUNC] Bits */
+#define MATHACL_CTL_FUNC_OFS                     (0)                             /* !< FUNC Offset */
+#define MATHACL_CTL_FUNC_MASK                    ((uint32_t)0x0000001FU)         /* !< ULP_ADCHP Enable Conversions. */
+#define MATHACL_CTL_FUNC_NOP                     ((uint32_t)0x00000000U)         /* !< No operation */
+#define MATHACL_CTL_FUNC_SINCOS                  ((uint32_t)0x00000001U)         /* !< Sine and Cosine operation */
+#define MATHACL_CTL_FUNC_ATAN2                   ((uint32_t)0x00000002U)         /* !< Arc tangent with x and y values as
+                                                                                    operands. */
+#define MATHACL_CTL_FUNC_DIV                     ((uint32_t)0x00000004U)         /* !< Divide, the operands are numerator,
+                                                                                    denominator, and the divide type.
+                                                                                    Result is the quotient and reminder. */
+#define MATHACL_CTL_FUNC_SQRT                    ((uint32_t)0x00000005U)         /* !< Do square root. Operand is the
+                                                                                    number whoose square root needs to be
+                                                                                    computed. The number if outside the
+                                                                                    range needs to be scaled up down by
+                                                                                    2 power 2n to bring it with in the
+                                                                                    range. */
+#define MATHACL_CTL_FUNC_MPY32                   ((uint32_t)0x00000006U)         /* !< 32-bit Multiply Result */
+#define MATHACL_CTL_FUNC_SQUARE32                ((uint32_t)0x00000007U)         /* !< 32-bit square result */
+#define MATHACL_CTL_FUNC_MPY64                   ((uint32_t)0x00000008U)         /* !< 64-bit multiply result */
+#define MATHACL_CTL_FUNC_SQUARE64                ((uint32_t)0x00000009U)         /* !< 64-bit multiply result */
+#define MATHACL_CTL_FUNC_MAC                     ((uint32_t)0x0000000AU)         /* !< Multiply and accumulate operation */
+#define MATHACL_CTL_FUNC_SAC                     ((uint32_t)0x0000000BU)         /* !< Square and accumulate operation */
+/* MATHACL_CTL[QVAL] Bits */
+#define MATHACL_CTL_QVAL_OFS                     (8)                             /* !< QVAL Offset */
+#define MATHACL_CTL_QVAL_MASK                    ((uint32_t)0x00001F00U)         /* !< Indicates the fractional bits in
+                                                                                    the operands, ranges from 0 to 31.
+                                                                                    Applicable to DIV function. */
+#define MATHACL_CTL_QVAL_Q0                      ((uint32_t)0x00000000U)         /* !< Q0 operands */
+#define MATHACL_CTL_QVAL_Q1                      ((uint32_t)0x00000100U)         /* !< Q1 operands */
+#define MATHACL_CTL_QVAL_Q2                      ((uint32_t)0x00000200U)         /* !< Q2 operands */
+#define MATHACL_CTL_QVAL_Q3                      ((uint32_t)0x00000300U)         /* !< Q3 operands */
+#define MATHACL_CTL_QVAL_Q4                      ((uint32_t)0x00000400U)         /* !< Q4 operands */
+#define MATHACL_CTL_QVAL_Q5                      ((uint32_t)0x00000500U)         /* !< Q5 operands */
+#define MATHACL_CTL_QVAL_Q6                      ((uint32_t)0x00000600U)         /* !< Q6 operands */
+#define MATHACL_CTL_QVAL_Q7                      ((uint32_t)0x00000700U)         /* !< Q7 operands */
+#define MATHACL_CTL_QVAL_Q8                      ((uint32_t)0x00000800U)         /* !< Q8 operands */
+#define MATHACL_CTL_QVAL_Q9                      ((uint32_t)0x00000900U)         /* !< Q9 operands */
+#define MATHACL_CTL_QVAL_Q10                     ((uint32_t)0x00000A00U)         /* !< Q10 operands */
+#define MATHACL_CTL_QVAL_Q11                     ((uint32_t)0x00000B00U)         /* !< Q11 operands */
+#define MATHACL_CTL_QVAL_Q12                     ((uint32_t)0x00000C00U)         /* !< Q12 operands */
+#define MATHACL_CTL_QVAL_Q13                     ((uint32_t)0x00000D00U)         /* !< Q13 operands */
+#define MATHACL_CTL_QVAL_Q14                     ((uint32_t)0x00000E00U)         /* !< Q14 operands */
+#define MATHACL_CTL_QVAL_Q15                     ((uint32_t)0x00000F00U)         /* !< Q15 operands */
+#define MATHACL_CTL_QVAL_Q16                     ((uint32_t)0x00001000U)         /* !< Q16 operands */
+#define MATHACL_CTL_QVAL_Q17                     ((uint32_t)0x00001100U)         /* !< Q17 operands */
+#define MATHACL_CTL_QVAL_Q18                     ((uint32_t)0x00001200U)         /* !< Q18 operands */
+#define MATHACL_CTL_QVAL_Q19                     ((uint32_t)0x00001300U)         /* !< Q19 operands */
+#define MATHACL_CTL_QVAL_Q20                     ((uint32_t)0x00001400U)         /* !< Q20 operands */
+#define MATHACL_CTL_QVAL_Q21                     ((uint32_t)0x00001500U)         /* !< Q21 operands */
+#define MATHACL_CTL_QVAL_Q22                     ((uint32_t)0x00001600U)         /* !< Q22 operands */
+#define MATHACL_CTL_QVAL_Q23                     ((uint32_t)0x00001700U)         /* !< Q23 operands */
+#define MATHACL_CTL_QVAL_Q24                     ((uint32_t)0x00001800U)         /* !< Q24 operands */
+#define MATHACL_CTL_QVAL_Q25                     ((uint32_t)0x00001900U)         /* !< Q25 operands */
+#define MATHACL_CTL_QVAL_Q26                     ((uint32_t)0x00001A00U)         /* !< Q26 operands */
+#define MATHACL_CTL_QVAL_Q27                     ((uint32_t)0x00001B00U)         /* !< Q27 operands */
+#define MATHACL_CTL_QVAL_Q28                     ((uint32_t)0x00001C00U)         /* !< Q28 operands */
+#define MATHACL_CTL_QVAL_Q29                     ((uint32_t)0x00001D00U)         /* !< Q29 operands */
+#define MATHACL_CTL_QVAL_Q30                     ((uint32_t)0x00001E00U)         /* !< Q30 operands */
+#define MATHACL_CTL_QVAL_Q31                     ((uint32_t)0x00001F00U)         /* !< Q31 operands */
+/* MATHACL_CTL[OPTYPE] Bits */
+#define MATHACL_CTL_OPTYPE_OFS                   (5)                             /* !< OPTYPE Offset */
+#define MATHACL_CTL_OPTYPE_MASK                  ((uint32_t)0x00000020U)         /* !< Operand type, could signed or
+                                                                                    unsigned. applicable to DIV function. */
+#define MATHACL_CTL_OPTYPE_UNSIGNED              ((uint32_t)0x00000000U)         /* !< Unsigned operands */
+#define MATHACL_CTL_OPTYPE_SIGNED                ((uint32_t)0x00000020U)         /* !< Signed operands. */
+/* MATHACL_CTL[NUMITER] Bits */
+#define MATHACL_CTL_NUMITER_OFS                  (24)                            /* !< NUMITER Offset */
+#define MATHACL_CTL_NUMITER_MASK                 ((uint32_t)0x1F000000U)         /* !< Number of iterations, applicable if
+                                                                                    the function does the computations
+                                                                                    iteratively, for example
+                                                                                    sine/cosine/atan2/sqrt. Note: A value
+                                                                                    of 0 is interpreted as 31. */
+/* MATHACL_CTL[SFACTOR] Bits */
+#define MATHACL_CTL_SFACTOR_OFS                  (16)                            /* !< SFACTOR Offset */
+#define MATHACL_CTL_SFACTOR_MASK                 ((uint32_t)0x003F0000U)         /* !< Scaling factor. In case of SQRT
+                                                                                    function, the input operand needs to
+                                                                                    be in a range. If not it has to be
+                                                                                    scaled to 2^(+/-n). This field should
+                                                                                    be written with the value 'n'. */
+/* MATHACL_CTL[SATEN] Bits */
+#define MATHACL_CTL_SATEN_OFS                    (22)                            /* !< SATEN Offset */
+#define MATHACL_CTL_SATEN_MASK                   ((uint32_t)0x00400000U)         /* !< Saturation enable This bit is
+                                                                                    shared among DIV, SQUARE32, MPY32,
+                                                                                    MAC and SAC functions. When enabled,
+                                                                                    it will make the result to saturate
+                                                                                    to maximum value in case of an
+                                                                                    overflow event When disabled, the
+                                                                                    result will overflow to an unknown
+                                                                                    value. */
+#define MATHACL_CTL_SATEN_DISABLE                ((uint32_t)0x00000000U)         /* !< Saturation is disabled */
+#define MATHACL_CTL_SATEN_ENABLE                 ((uint32_t)0x00400000U)         /* !< Saturation is enabled */
+
+/* MATHACL_OP2 Bits */
+/* MATHACL_OP2[DATA] Bits */
+#define MATHACL_OP2_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define MATHACL_OP2_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< Operand 2 Register */
+
+/* MATHACL_OP1 Bits */
+/* MATHACL_OP1[DATA] Bits */
+#define MATHACL_OP1_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define MATHACL_OP1_DATA_MASK                    ((uint32_t)0xFFFFFFFFU)         /* !< Operand 1 register. */
+
+/* MATHACL_RES1 Bits */
+/* MATHACL_RES1[DATA] Bits */
+#define MATHACL_RES1_DATA_OFS                    (0)                             /* !< DATA Offset */
+#define MATHACL_RES1_DATA_MASK                   ((uint32_t)0xFFFFFFFFU)         /* !< Result 1 register */
+
+/* MATHACL_RES2 Bits */
+/* MATHACL_RES2[DATA] Bits */
+#define MATHACL_RES2_DATA_OFS                    (0)                             /* !< DATA Offset */
+#define MATHACL_RES2_DATA_MASK                   ((uint32_t)0xFFFFFFFFU)         /* !< Result 2 register */
+
+/* MATHACL_STATUS Bits */
+/* MATHACL_STATUS[UF] Bits */
+#define MATHACL_STATUS_UF_OFS                    (0)                             /* !< UF Offset */
+#define MATHACL_STATUS_UF_MASK                   ((uint32_t)0x00000001U)         /* !< Underflow Flag */
+#define MATHACL_STATUS_UF_NO_UNDERFLOW           ((uint32_t)0x00000000U)         /* !< No undreflow error. */
+#define MATHACL_STATUS_UF_UNDERFLOW              ((uint32_t)0x00000001U)         /* !< Underflow error. */
+/* MATHACL_STATUS[OVF] Bits */
+#define MATHACL_STATUS_OVF_OFS                   (1)                             /* !< OVF Offset */
+#define MATHACL_STATUS_OVF_MASK                  ((uint32_t)0x00000002U)         /* !< Overflow bit for MPY32, SQUARE32,
+                                                                                    DIV, MAC, and SAC functions This bit
+                                                                                    will be set on overflow and will
+                                                                                    retain its value until cleared by
+                                                                                    writing 1 into CLR.CLR_OVF */
+#define MATHACL_STATUS_OVF_NO_OVERFLOW           ((uint32_t)0x00000000U)         /* !< No overflow error. */
+#define MATHACL_STATUS_OVF_OVERFLOW              ((uint32_t)0x00000000U)         /* !< Overflow error. */
+/* MATHACL_STATUS[ERR] Bits */
+#define MATHACL_STATUS_ERR_OFS                   (2)                             /* !< ERR Offset */
+#define MATHACL_STATUS_ERR_MASK                  ((uint32_t)0x0000000CU)         /* !< Incorrect inputs/outputs. */
+#define MATHACL_STATUS_ERR_NOERROR               ((uint32_t)0x00000000U)         /* !< No Error in computation. */
+#define MATHACL_STATUS_ERR_DIVBY0                ((uint32_t)0x00000004U)         /* !< DIVBY0 error */
+/* MATHACL_STATUS[BUSY] Bits */
+#define MATHACL_STATUS_BUSY_OFS                  (8)                             /* !< BUSY Offset */
+#define MATHACL_STATUS_BUSY_MASK                 ((uint32_t)0x00000100U)         /* !< MATHACL busy bit. */
+#define MATHACL_STATUS_BUSY_DONE                 ((uint32_t)0x00000000U)         /* !< Compute has completed. */
+#define MATHACL_STATUS_BUSY_NOTDONE              ((uint32_t)0x00000100U)         /* !< Compute ongoing */
+
+/* MATHACL_STATUSCLR Bits */
+/* MATHACL_STATUSCLR[CLR_OVF] Bits */
+#define MATHACL_STATUSCLR_CLR_OVF_OFS            (1)                             /* !< CLR_OVF Offset */
+#define MATHACL_STATUSCLR_CLR_OVF_MASK           ((uint32_t)0x00000002U)         /* !< Write 1 to this bit to clear
+                                                                                    STATUS.OVF bit */
+#define MATHACL_STATUSCLR_CLR_OVF_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MATHACL_STATUSCLR_CLR_OVF_CLR            ((uint32_t)0x00000002U)         /* !< Clear STATUS.OVF */
+/* MATHACL_STATUSCLR[CLR_UF] Bits */
+#define MATHACL_STATUSCLR_CLR_UF_OFS             (0)                             /* !< CLR_UF Offset */
+#define MATHACL_STATUSCLR_CLR_UF_MASK            ((uint32_t)0x00000001U)         /* !< Write 1 to this bit to clear
+                                                                                    STATUS.UF bit */
+#define MATHACL_STATUSCLR_CLR_UF_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MATHACL_STATUSCLR_CLR_UF_CLR             ((uint32_t)0x00000001U)         /* !< Clear STATUS.UF */
+/* MATHACL_STATUSCLR[CLR_ERR] Bits */
+#define MATHACL_STATUSCLR_CLR_ERR_OFS            (2)                             /* !< CLR_ERR Offset */
+#define MATHACL_STATUSCLR_CLR_ERR_MASK           ((uint32_t)0x00000004U)         /* !< Write 1 to this bit to clear
+                                                                                    STATUS.ERR field */
+#define MATHACL_STATUSCLR_CLR_ERR_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MATHACL_STATUSCLR_CLR_ERR_CLR            ((uint32_t)0x00000004U)         /* !< Clear STATUS.ERR */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_mathacl__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_mcan.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_mcan.h
@@ -1,0 +1,4555 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_mcan__include
+#define ti_devices_msp_peripherals_hw_mcan__include
+
+/* Filename: hw_mcan.h */
+/* Revised: 2023-06-13 16:25:08 */
+/* Revision: 80c507b5f57e662daefb523742741547f0b08eb5 */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* MCAN Registers
+******************************************************************************/
+#define MCAN_CPU_INT_OFS                         ((uint32_t)0x00007820U)
+#define MCAN_MSP_OFS                             ((uint32_t)0x00007800U)
+#define MCAN_ECC_REGS_OFS                        ((uint32_t)0x00007400U)
+#define MCAN_REGS_OFS                            ((uint32_t)0x00007200U)
+#define MCAN_PROCESSORS_OFS                      ((uint32_t)0x00007200U)
+#define MCAN_TI_WRAPPER_OFS                      ((uint32_t)0x00007200U)
+#define MCAN_MCAN_OFS                            ((uint32_t)0x00007000U)
+#define MCAN_MCANSS_OFS                          ((uint32_t)0x00006000U)
+
+
+/** @addtogroup MCAN_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00007820) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00007828) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00007830) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00007838) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00007840) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00007848) Interrupt clear */
+} MCAN_CPU_INT_Regs;
+
+/*@}*/ /* end of group MCAN_CPU_INT */
+
+/** @addtogroup MCAN_MSP
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[8];
+  MCAN_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00007820) */
+       uint32_t RESERVED1[37];
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000078E0) Event Mode */
+       uint32_t RESERVED2[6];
+  __I  uint32_t DESC;                              /* !< (@ 0x000078FC) Module Description */
+  __IO uint32_t MCANSS_CLKEN;                      /* !< (@ 0x00007900) MCAN module clock enable */
+  __IO uint32_t MCANSS_CLKDIV;                     /* !< (@ 0x00007904) Clock divider */
+  __IO uint32_t MCANSS_CLKCTL;                     /* !< (@ 0x00007908) MCAN-SS clock stop control register */
+  __I  uint32_t MCANSS_CLKSTS;                     /* !< (@ 0x0000790C) MCANSS clock stop status register */
+} MCAN_MSP_Regs;
+
+/*@}*/ /* end of group MCAN_MSP */
+
+/** @addtogroup MCAN_ECC_REGS
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t MCANERR_REV;                       /* !< (@ 0x00007400) MCAN Error Aggregator Revision Register */
+       uint32_t RESERVED0;
+  __IO uint32_t MCANERR_VECTOR;                    /* !< (@ 0x00007408) MCAN ECC Vector Register */
+  __I  uint32_t MCANERR_STAT;                      /* !< (@ 0x0000740C) MCAN Error Misc Status */
+  __I  uint32_t MCANERR_WRAP_REV;                  /* !< (@ 0x00007410) MCAN ECC Wrapper Revision Register */
+  __IO uint32_t MCANERR_CTRL;                      /* !< (@ 0x00007414) MCAN ECC Control */
+  __IO uint32_t MCANERR_ERR_CTRL1;                 /* !< (@ 0x00007418) MCAN ECC Error Control 1 Register */
+  __IO uint32_t MCANERR_ERR_CTRL2;                 /* !< (@ 0x0000741C) MCAN ECC Error Control 2 Register */
+  __IO uint32_t MCANERR_ERR_STAT1;                 /* !< (@ 0x00007420) MCAN ECC Error Status 1 Register */
+  __I  uint32_t MCANERR_ERR_STAT2;                 /* !< (@ 0x00007424) MCAN ECC Error Status 2 Register */
+  __IO uint32_t MCANERR_ERR_STAT3;                 /* !< (@ 0x00007428) MCAN ECC Error Status 3 Register */
+       uint32_t RESERVED1[4];
+  __IO uint32_t MCANERR_SEC_EOI;                   /* !< (@ 0x0000743C) MCAN Single Error Corrected End of Interrupt
+                                                      Register */
+  __IO uint32_t MCANERR_SEC_STATUS;                /* !< (@ 0x00007440) MCAN Single Error Corrected Interrupt Status
+                                                      Register */
+       uint32_t RESERVED2[15];
+  __IO uint32_t MCANERR_SEC_ENABLE_SET;            /* !< (@ 0x00007480) MCAN Single Error Corrected Interrupt Enable Set
+                                                      Register */
+       uint32_t RESERVED3[15];
+  __IO uint32_t MCANERR_SEC_ENABLE_CLR;            /* !< (@ 0x000074C0) MCAN Single Error Corrected Interrupt Enable Clear
+                                                      Register */
+       uint32_t RESERVED4[30];
+  __IO uint32_t MCANERR_DED_EOI;                   /* !< (@ 0x0000753C) MCAN Double Error Detected End of Interrupt
+                                                      Register */
+  __IO uint32_t MCANERR_DED_STATUS;                /* !< (@ 0x00007540) MCAN Double Error Detected Interrupt Status
+                                                      Register */
+       uint32_t RESERVED5[15];
+  __IO uint32_t MCANERR_DED_ENABLE_SET;            /* !< (@ 0x00007580) MCAN Double Error Detected Interrupt Enable Set
+                                                      Register */
+       uint32_t RESERVED6[15];
+  __IO uint32_t MCANERR_DED_ENABLE_CLR;            /* !< (@ 0x000075C0) MCAN Double Error Detected Interrupt Enable Clear
+                                                      Register */
+       uint32_t RESERVED7[15];
+  __IO uint32_t MCANERR_AGGR_ENABLE_SET;           /* !< (@ 0x00007600) MCAN Error Aggregator Enable Set Register */
+  __IO uint32_t MCANERR_AGGR_ENABLE_CLR;           /* !< (@ 0x00007604) MCAN Error Aggregator Enable Clear Register */
+  __IO uint32_t MCANERR_AGGR_STATUS_SET;           /* !< (@ 0x00007608) MCAN Error Aggregator Status Set Register */
+  __IO uint32_t MCANERR_AGGR_STATUS_CLR;           /* !< (@ 0x0000760C) MCAN Error Aggregator Status Clear Register */
+} MCAN_ECC_REGS_Regs;
+
+/*@}*/ /* end of group MCAN_ECC_REGS */
+
+/** @addtogroup MCAN_REGS
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t MCANSS_PID;                        /* !< (@ 0x00007200) MCAN Subsystem Revision Register */
+  __IO uint32_t MCANSS_CTRL;                       /* !< (@ 0x00007204) MCAN Subsystem Control Register */
+  __I  uint32_t MCANSS_STAT;                       /* !< (@ 0x00007208) MCAN Subsystem Status Register */
+  __IO uint32_t MCANSS_ICS;                        /* !< (@ 0x0000720C) MCAN Subsystem Interrupt Clear Shadow Register */
+  __IO uint32_t MCANSS_IRS;                        /* !< (@ 0x00007210) MCAN Subsystem Interrupt Raw Satus Register */
+  __IO uint32_t MCANSS_IECS;                       /* !< (@ 0x00007214) MCAN Subsystem Interrupt Enable Clear Shadow
+                                                      Register */
+  __IO uint32_t MCANSS_IE;                         /* !< (@ 0x00007218) MCAN Subsystem Interrupt Enable Register */
+  __I  uint32_t MCANSS_IES;                        /* !< (@ 0x0000721C) MCAN Subsystem Interrupt Enable Status */
+  __IO uint32_t MCANSS_EOI;                        /* !< (@ 0x00007220) MCAN Subsystem End of Interrupt */
+  __IO uint32_t MCANSS_EXT_TS_PRESCALER;           /* !< (@ 0x00007224) MCAN Subsystem External Timestamp Prescaler 0 */
+  __I  uint32_t MCANSS_EXT_TS_UNSERVICED_INTR_CNTR;/* !< (@ 0x00007228) MCAN Subsystem External Timestamp Unserviced
+                                                      Interrupts Counter */
+} MCAN_REGS_Regs;
+
+/*@}*/ /* end of group MCAN_REGS */
+
+/** @addtogroup MCAN_PROCESSORS
+  @{
+*/
+
+typedef struct {
+  MCAN_REGS_Regs  MCANSS_REGS;                       /* !< (@ 0x00007200) */
+       uint32_t RESERVED0[117];
+  MCAN_ECC_REGS_Regs  MCAN_ECC_REGS;                     /* !< (@ 0x00007400) */
+} MCAN_PROCESSORS_Regs;
+
+/*@}*/ /* end of group MCAN_PROCESSORS */
+
+/** @addtogroup MCAN_TI_WRAPPER
+  @{
+*/
+
+typedef struct {
+  MCAN_PROCESSORS_Regs  PROCESSORS;                        /* !< (@ 0x00007200) */
+       uint32_t RESERVED0[124];
+  MCAN_MSP_Regs  MSP;                               /* !< (@ 0x00007800) */
+} MCAN_TI_WRAPPER_Regs;
+
+/*@}*/ /* end of group MCAN_TI_WRAPPER */
+
+/** @addtogroup MCAN_MCAN
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t MCAN_CREL;                         /* !< (@ 0x00007000) MCAN Core Release Register */
+  __I  uint32_t MCAN_ENDN;                         /* !< (@ 0x00007004) MCAN Endian Register */
+       uint32_t RESERVED0;
+  __IO uint32_t MCAN_DBTP;                         /* !< (@ 0x0000700C) MCAN Data Bit Timing and Prescaler Register */
+  __IO uint32_t MCAN_TEST;                         /* !< (@ 0x00007010) MCAN Test Register */
+  __IO uint32_t MCAN_RWD;                          /* !< (@ 0x00007014) MCAN RAM Watchdog */
+  __IO uint32_t MCAN_CCCR;                         /* !< (@ 0x00007018) MCAN CC Control Register */
+  __IO uint32_t MCAN_NBTP;                         /* !< (@ 0x0000701C) MCAN Nominal Bit Timing and Prescaler Register */
+  __IO uint32_t MCAN_TSCC;                         /* !< (@ 0x00007020) MCAN Timestamp Counter Configuration */
+  __IO uint32_t MCAN_TSCV;                         /* !< (@ 0x00007024) MCAN Timestamp Counter Value */
+  __IO uint32_t MCAN_TOCC;                         /* !< (@ 0x00007028) MCAN Timeout Counter Configuration */
+  __IO uint32_t MCAN_TOCV;                         /* !< (@ 0x0000702C) MCAN Timeout Counter Value */
+       uint32_t RESERVED1[4];
+  __I  uint32_t MCAN_ECR;                          /* !< (@ 0x00007040) MCAN Error Counter Register */
+  __I  uint32_t MCAN_PSR;                          /* !< (@ 0x00007044) MCAN Protocol Status Register */
+  __IO uint32_t MCAN_TDCR;                         /* !< (@ 0x00007048) MCAN Transmitter Delay Compensation Register */
+       uint32_t RESERVED2;
+  __IO uint32_t MCAN_IR;                           /* !< (@ 0x00007050) MCAN Interrupt Register */
+  __IO uint32_t MCAN_IE;                           /* !< (@ 0x00007054) MCAN Interrupt Enable */
+  __IO uint32_t MCAN_ILS;                          /* !< (@ 0x00007058) MCAN Interrupt Line Select */
+  __IO uint32_t MCAN_ILE;                          /* !< (@ 0x0000705C) MCAN Interrupt Line Enable */
+       uint32_t RESERVED3[8];
+  __IO uint32_t MCAN_GFC;                          /* !< (@ 0x00007080) MCAN Global Filter Configuration */
+  __IO uint32_t MCAN_SIDFC;                        /* !< (@ 0x00007084) MCAN Standard ID Filter Configuration */
+  __IO uint32_t MCAN_XIDFC;                        /* !< (@ 0x00007088) MCAN Extended ID Filter Configuration */
+       uint32_t RESERVED4;
+  __IO uint32_t MCAN_XIDAM;                        /* !< (@ 0x00007090) MCAN Extended ID and Mask */
+  __I  uint32_t MCAN_HPMS;                         /* !< (@ 0x00007094) MCAN High Priority Message Status */
+  __IO uint32_t MCAN_NDAT1;                        /* !< (@ 0x00007098) MCAN New Data 1 */
+  __IO uint32_t MCAN_NDAT2;                        /* !< (@ 0x0000709C) MCAN New Data 2 */
+  __IO uint32_t MCAN_RXF0C;                        /* !< (@ 0x000070A0) MCAN Rx FIFO 0 Configuration */
+  __I  uint32_t MCAN_RXF0S;                        /* !< (@ 0x000070A4) MCAN Rx FIFO 0 Status */
+  __IO uint32_t MCAN_RXF0A;                        /* !< (@ 0x000070A8) MCAN Rx FIFO 0 Acknowledge */
+  __IO uint32_t MCAN_RXBC;                         /* !< (@ 0x000070AC) MCAN Rx Buffer Configuration */
+  __IO uint32_t MCAN_RXF1C;                        /* !< (@ 0x000070B0) MCAN Rx FIFO 1 Configuration */
+  __I  uint32_t MCAN_RXF1S;                        /* !< (@ 0x000070B4) MCAN Rx FIFO 1 Status */
+  __IO uint32_t MCAN_RXF1A;                        /* !< (@ 0x000070B8) MCAN Rx FIFO 1 Acknowledge */
+  __IO uint32_t MCAN_RXESC;                        /* !< (@ 0x000070BC) MCAN Rx Buffer / FIFO Element Size Configuration */
+  __IO uint32_t MCAN_TXBC;                         /* !< (@ 0x000070C0) MCAN Tx Buffer Configuration */
+  __I  uint32_t MCAN_TXFQS;                        /* !< (@ 0x000070C4) MCAN Tx FIFO / Queue Status */
+  __IO uint32_t MCAN_TXESC;                        /* !< (@ 0x000070C8) MCAN Tx Buffer Element Size Configuration */
+  __I  uint32_t MCAN_TXBRP;                        /* !< (@ 0x000070CC) MCAN Tx Buffer Request Pending */
+  __IO uint32_t MCAN_TXBAR;                        /* !< (@ 0x000070D0) MCAN Tx Buffer Add Request */
+  __IO uint32_t MCAN_TXBCR;                        /* !< (@ 0x000070D4) MCAN Tx Buffer Cancellation Request */
+  __I  uint32_t MCAN_TXBTO;                        /* !< (@ 0x000070D8) MCAN Tx Buffer Transmission Occurred */
+  __I  uint32_t MCAN_TXBCF;                        /* !< (@ 0x000070DC) MCAN Tx Buffer Cancellation Finished */
+  __IO uint32_t MCAN_TXBTIE;                       /* !< (@ 0x000070E0) MCAN Tx Buffer Transmission Interrupt Enable */
+  __IO uint32_t MCAN_TXBCIE;                       /* !< (@ 0x000070E4) MCAN Tx Buffer Cancellation Finished Interrupt
+                                                      Enable */
+       uint32_t RESERVED5[2];
+  __IO uint32_t MCAN_TXEFC;                        /* !< (@ 0x000070F0) MCAN Tx Event FIFO Configuration */
+  __I  uint32_t MCAN_TXEFS;                        /* !< (@ 0x000070F4) MCAN Tx Event FIFO Status */
+  __IO uint32_t MCAN_TXEFA;                        /* !< (@ 0x000070F8) MCAN Tx Event FIFO Acknowledge */
+} MCAN_MCAN_Regs;
+
+/*@}*/ /* end of group MCAN_MCAN */
+
+/** @addtogroup MCAN_MCANSS
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  __IO uint32_t PWREN;                             /* !< (@ 0x00006800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00006804) Reset Control */
+       uint32_t RESERVED1[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00006814) Status Register */
+       uint32_t RESERVED2[506];
+  MCAN_MCAN_Regs  MCAN;                              /* !< (@ 0x00007000) */
+       uint32_t RESERVED3[65];
+  MCAN_TI_WRAPPER_Regs  TI_WRAPPER;                        /* !< (@ 0x00007200) */
+} MCAN_MCANSS_Regs;
+
+/*@}*/ /* end of group MCAN_MCANSS */
+
+/** @addtogroup MCAN
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[6144];
+  MCAN_MCANSS_Regs  MCANSS;                            /* !< (@ 0x00006000) */
+} MCAN_Regs;
+
+/*@}*/ /* end of group MCAN */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* MCAN Register Control Bits
+******************************************************************************/
+
+/* MCAN_IIDX Bits */
+/* MCAN_IIDX[STAT] Bits */
+#define MCAN_IIDX_STAT_OFS                       (0)                             /* !< STAT Offset */
+#define MCAN_IIDX_STAT_MASK                      ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define MCAN_IIDX_STAT_NO_INTR                   ((uint32_t)0x00000000U)         /* !< No interrupt pending. */
+#define MCAN_IIDX_STAT_INTL0                     ((uint32_t)0x00000001U)         /* !< MCAN Interrupt Line 0 interrupt
+                                                                                    pending. */
+#define MCAN_IIDX_STAT_INTL1                     ((uint32_t)0x00000002U)         /* !< MCAN Interrupt Line 1 interrupt
+                                                                                    pending. */
+#define MCAN_IIDX_STAT_SEC                       ((uint32_t)0x00000003U)         /* !< Message RAM SEC (Single Error
+                                                                                    Correction) interrupt pending. */
+#define MCAN_IIDX_STAT_DED                       ((uint32_t)0x00000004U)         /* !< Message RAM DED (Double Error
+                                                                                    Detection)  interrupt pending. */
+#define MCAN_IIDX_STAT_EXT_TS_CNTR_OVFL          ((uint32_t)0x00000005U)         /* !< External Timestamp Counter Overflow
+                                                                                    interrupt pending. */
+#define MCAN_IIDX_STAT_WAKEUP                    ((uint32_t)0x00000006U)         /* !< Clock Stop Wake Up interrupt
+                                                                                    pending. */
+
+/* MCAN_IMASK Bits */
+/* MCAN_IMASK[INTL0] Bits */
+#define MCAN_IMASK_INTL0_OFS                     (0)                             /* !< INTL0 Offset */
+#define MCAN_IMASK_INTL0_MASK                    ((uint32_t)0x00000001U)         /* !< MCAN Interrupt Line 0 mask. */
+#define MCAN_IMASK_INTL0_CLR                     ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define MCAN_IMASK_INTL0_SET                     ((uint32_t)0x00000001U)         /* !< Set Interrrupt Mask */
+/* MCAN_IMASK[INTL1] Bits */
+#define MCAN_IMASK_INTL1_OFS                     (1)                             /* !< INTL1 Offset */
+#define MCAN_IMASK_INTL1_MASK                    ((uint32_t)0x00000002U)         /* !< MCAN Interrupt Line 1 mask. */
+#define MCAN_IMASK_INTL1_CLR                     ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define MCAN_IMASK_INTL1_SET                     ((uint32_t)0x00000002U)         /* !< Set Interrrupt Mask */
+/* MCAN_IMASK[SEC] Bits */
+#define MCAN_IMASK_SEC_OFS                       (2)                             /* !< SEC Offset */
+#define MCAN_IMASK_SEC_MASK                      ((uint32_t)0x00000004U)         /* !< Message RAM SEC interrupt mask. */
+#define MCAN_IMASK_SEC_CLR                       ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define MCAN_IMASK_SEC_SET                       ((uint32_t)0x00000004U)         /* !< Set Interrrupt Mask */
+/* MCAN_IMASK[DED] Bits */
+#define MCAN_IMASK_DED_OFS                       (3)                             /* !< DED Offset */
+#define MCAN_IMASK_DED_MASK                      ((uint32_t)0x00000008U)         /* !< Massage RAM DED interrupt mask. */
+#define MCAN_IMASK_DED_CLR                       ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define MCAN_IMASK_DED_SET                       ((uint32_t)0x00000008U)         /* !< Set Interrrupt Mask */
+/* MCAN_IMASK[EXT_TS_CNTR_OVFL] Bits */
+#define MCAN_IMASK_EXT_TS_CNTR_OVFL_OFS          (4)                             /* !< EXT_TS_CNTR_OVFL Offset */
+#define MCAN_IMASK_EXT_TS_CNTR_OVFL_MASK         ((uint32_t)0x00000010U)         /* !< External Timestamp Counter Overflow
+                                                                                    interrupt mask. */
+#define MCAN_IMASK_EXT_TS_CNTR_OVFL_CLR          ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define MCAN_IMASK_EXT_TS_CNTR_OVFL_SET          ((uint32_t)0x00000010U)         /* !< Set Interrrupt Mask */
+/* MCAN_IMASK[WAKEUP] Bits */
+#define MCAN_IMASK_WAKEUP_OFS                    (5)                             /* !< WAKEUP Offset */
+#define MCAN_IMASK_WAKEUP_MASK                   ((uint32_t)0x00000020U)         /* !< Clock Stop Wake Up interrupt mask. */
+#define MCAN_IMASK_WAKEUP_CLR                    ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define MCAN_IMASK_WAKEUP_SET                    ((uint32_t)0x00000020U)         /* !< Set Interrrupt Mask */
+
+/* MCAN_RIS Bits */
+/* MCAN_RIS[INTL0] Bits */
+#define MCAN_RIS_INTL0_OFS                       (0)                             /* !< INTL0 Offset */
+#define MCAN_RIS_INTL0_MASK                      ((uint32_t)0x00000001U)         /* !< MCAN Interrupt Line 0. */
+#define MCAN_RIS_INTL0_CLR                       ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define MCAN_RIS_INTL0_SET                       ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+/* MCAN_RIS[INTL1] Bits */
+#define MCAN_RIS_INTL1_OFS                       (1)                             /* !< INTL1 Offset */
+#define MCAN_RIS_INTL1_MASK                      ((uint32_t)0x00000002U)         /* !< MCAN Interrupt Line 1. */
+#define MCAN_RIS_INTL1_CLR                       ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define MCAN_RIS_INTL1_SET                       ((uint32_t)0x00000002U)         /* !< Interrupt occured */
+/* MCAN_RIS[SEC] Bits */
+#define MCAN_RIS_SEC_OFS                         (2)                             /* !< SEC Offset */
+#define MCAN_RIS_SEC_MASK                        ((uint32_t)0x00000004U)         /* !< Message RAM SEC interrupt. */
+#define MCAN_RIS_SEC_CLR                         ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define MCAN_RIS_SEC_SET                         ((uint32_t)0x00000004U)         /* !< Interrupt occured */
+/* MCAN_RIS[DED] Bits */
+#define MCAN_RIS_DED_OFS                         (3)                             /* !< DED Offset */
+#define MCAN_RIS_DED_MASK                        ((uint32_t)0x00000008U)         /* !< Message RAM DED interrupt. */
+#define MCAN_RIS_DED_CLR                         ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define MCAN_RIS_DED_SET                         ((uint32_t)0x00000008U)         /* !< Interrupt occured */
+/* MCAN_RIS[EXT_TS_CNTR_OVFL] Bits */
+#define MCAN_RIS_EXT_TS_CNTR_OVFL_OFS            (4)                             /* !< EXT_TS_CNTR_OVFL Offset */
+#define MCAN_RIS_EXT_TS_CNTR_OVFL_MASK           ((uint32_t)0x00000010U)         /* !< External Timestamp Counter Overflow
+                                                                                    interrupt. */
+#define MCAN_RIS_EXT_TS_CNTR_OVFL_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define MCAN_RIS_EXT_TS_CNTR_OVFL_SET            ((uint32_t)0x00000010U)         /* !< Interrupt occured */
+/* MCAN_RIS[WAKEUP] Bits */
+#define MCAN_RIS_WAKEUP_OFS                      (5)                             /* !< WAKEUP Offset */
+#define MCAN_RIS_WAKEUP_MASK                     ((uint32_t)0x00000020U)         /* !< Clock Stop Wake Up interrupt. */
+#define MCAN_RIS_WAKEUP_CLR                      ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define MCAN_RIS_WAKEUP_SET                      ((uint32_t)0x00000020U)         /* !< Interrupt occured */
+
+/* MCAN_MIS Bits */
+/* MCAN_MIS[INTL0] Bits */
+#define MCAN_MIS_INTL0_OFS                       (0)                             /* !< INTL0 Offset */
+#define MCAN_MIS_INTL0_MASK                      ((uint32_t)0x00000001U)         /* !< Masked MCAN Interrupt Line 0. */
+#define MCAN_MIS_INTL0_CLR                       ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define MCAN_MIS_INTL0_SET                       ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+/* MCAN_MIS[INTL1] Bits */
+#define MCAN_MIS_INTL1_OFS                       (1)                             /* !< INTL1 Offset */
+#define MCAN_MIS_INTL1_MASK                      ((uint32_t)0x00000002U)         /* !< Masked MCAN Interrupt Line 1. */
+#define MCAN_MIS_INTL1_CLR                       ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define MCAN_MIS_INTL1_SET                       ((uint32_t)0x00000002U)         /* !< Interrupt occured */
+/* MCAN_MIS[SEC] Bits */
+#define MCAN_MIS_SEC_OFS                         (2)                             /* !< SEC Offset */
+#define MCAN_MIS_SEC_MASK                        ((uint32_t)0x00000004U)         /* !< Masked Message RAM SEC interrupt. */
+#define MCAN_MIS_SEC_CLR                         ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define MCAN_MIS_SEC_SET                         ((uint32_t)0x00000004U)         /* !< Interrupt occured */
+/* MCAN_MIS[DED] Bits */
+#define MCAN_MIS_DED_OFS                         (3)                             /* !< DED Offset */
+#define MCAN_MIS_DED_MASK                        ((uint32_t)0x00000008U)         /* !< Masked Message RAM DED interrupt. */
+#define MCAN_MIS_DED_CLR                         ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define MCAN_MIS_DED_SET                         ((uint32_t)0x00000008U)         /* !< Interrupt occured */
+/* MCAN_MIS[EXT_TS_CNTR_OVFL] Bits */
+#define MCAN_MIS_EXT_TS_CNTR_OVFL_OFS            (4)                             /* !< EXT_TS_CNTR_OVFL Offset */
+#define MCAN_MIS_EXT_TS_CNTR_OVFL_MASK           ((uint32_t)0x00000010U)         /* !< Masked External Timestamp Counter
+                                                                                    Overflow interrupt. */
+#define MCAN_MIS_EXT_TS_CNTR_OVFL_CLR            ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define MCAN_MIS_EXT_TS_CNTR_OVFL_SET            ((uint32_t)0x00000010U)         /* !< Interrupt occured */
+/* MCAN_MIS[WAKEUP] Bits */
+#define MCAN_MIS_WAKEUP_OFS                      (5)                             /* !< WAKEUP Offset */
+#define MCAN_MIS_WAKEUP_MASK                     ((uint32_t)0x00000020U)         /* !< Masked Clock Stop Wake Up
+                                                                                    interrupt. */
+#define MCAN_MIS_WAKEUP_CLR                      ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define MCAN_MIS_WAKEUP_SET                      ((uint32_t)0x00000020U)         /* !< Interrupt occured */
+
+/* MCAN_ISET Bits */
+/* MCAN_ISET[INTL0] Bits */
+#define MCAN_ISET_INTL0_OFS                      (0)                             /* !< INTL0 Offset */
+#define MCAN_ISET_INTL0_MASK                     ((uint32_t)0x00000001U)         /* !< Set MCAN Interrupt Line 0. */
+#define MCAN_ISET_INTL0_NO_EFFECT                ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_ISET_INTL0_SET                      ((uint32_t)0x00000001U)         /* !< Set Interrupt */
+/* MCAN_ISET[INTL1] Bits */
+#define MCAN_ISET_INTL1_OFS                      (1)                             /* !< INTL1 Offset */
+#define MCAN_ISET_INTL1_MASK                     ((uint32_t)0x00000002U)         /* !< Set MCAN Interrupt Line 1. */
+#define MCAN_ISET_INTL1_NO_EFFECT                ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_ISET_INTL1_SET                      ((uint32_t)0x00000002U)         /* !< Set Interrupt */
+/* MCAN_ISET[SEC] Bits */
+#define MCAN_ISET_SEC_OFS                        (2)                             /* !< SEC Offset */
+#define MCAN_ISET_SEC_MASK                       ((uint32_t)0x00000004U)         /* !< Set Message RAM SEC interrupt. */
+#define MCAN_ISET_SEC_NO_EFFECT                  ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_ISET_SEC_SET                        ((uint32_t)0x00000004U)         /* !< Set Interrupt */
+/* MCAN_ISET[DED] Bits */
+#define MCAN_ISET_DED_OFS                        (3)                             /* !< DED Offset */
+#define MCAN_ISET_DED_MASK                       ((uint32_t)0x00000008U)         /* !< Set Message RAM DED interrupt. */
+#define MCAN_ISET_DED_NO_EFFECT                  ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_ISET_DED_SET                        ((uint32_t)0x00000008U)         /* !< Set Interrupt */
+/* MCAN_ISET[EXT_TS_CNTR_OVFL] Bits */
+#define MCAN_ISET_EXT_TS_CNTR_OVFL_OFS           (4)                             /* !< EXT_TS_CNTR_OVFL Offset */
+#define MCAN_ISET_EXT_TS_CNTR_OVFL_MASK          ((uint32_t)0x00000010U)         /* !< Set External Timestamp Counter
+                                                                                    Overflow interrupt. */
+#define MCAN_ISET_EXT_TS_CNTR_OVFL_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_ISET_EXT_TS_CNTR_OVFL_SET           ((uint32_t)0x00000010U)         /* !< Set Interrupt */
+/* MCAN_ISET[WAKEUP] Bits */
+#define MCAN_ISET_WAKEUP_OFS                     (5)                             /* !< WAKEUP Offset */
+#define MCAN_ISET_WAKEUP_MASK                    ((uint32_t)0x00000020U)         /* !< Set Clock Stop Wake Up interrupt. */
+#define MCAN_ISET_WAKEUP_NO_EFFECT               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_ISET_WAKEUP_SET                     ((uint32_t)0x00000020U)         /* !< Set Interrupt */
+
+/* MCAN_ICLR Bits */
+/* MCAN_ICLR[INTL0] Bits */
+#define MCAN_ICLR_INTL0_OFS                      (0)                             /* !< INTL0 Offset */
+#define MCAN_ICLR_INTL0_MASK                     ((uint32_t)0x00000001U)         /* !< Clear MCAN Interrupt Line 0. */
+#define MCAN_ICLR_INTL0_NO_EFFECT                ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_ICLR_INTL0_CLR                      ((uint32_t)0x00000001U)         /* !< Clear Interrupt */
+/* MCAN_ICLR[INTL1] Bits */
+#define MCAN_ICLR_INTL1_OFS                      (1)                             /* !< INTL1 Offset */
+#define MCAN_ICLR_INTL1_MASK                     ((uint32_t)0x00000002U)         /* !< Clear MCAN Interrupt Line 1. */
+#define MCAN_ICLR_INTL1_NO_EFFECT                ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_ICLR_INTL1_CLR                      ((uint32_t)0x00000002U)         /* !< Clear Interrupt */
+/* MCAN_ICLR[SEC] Bits */
+#define MCAN_ICLR_SEC_OFS                        (2)                             /* !< SEC Offset */
+#define MCAN_ICLR_SEC_MASK                       ((uint32_t)0x00000004U)         /* !< Clear Message RAM SEC interrupt. */
+#define MCAN_ICLR_SEC_NO_EFFECT                  ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_ICLR_SEC_CLR                        ((uint32_t)0x00000004U)         /* !< Clear Interrupt */
+/* MCAN_ICLR[DED] Bits */
+#define MCAN_ICLR_DED_OFS                        (3)                             /* !< DED Offset */
+#define MCAN_ICLR_DED_MASK                       ((uint32_t)0x00000008U)         /* !< Clear Message RAM DED interrupt. */
+#define MCAN_ICLR_DED_NO_EFFECT                  ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_ICLR_DED_CLR                        ((uint32_t)0x00000008U)         /* !< Clear Interrupt */
+/* MCAN_ICLR[EXT_TS_CNTR_OVFL] Bits */
+#define MCAN_ICLR_EXT_TS_CNTR_OVFL_OFS           (4)                             /* !< EXT_TS_CNTR_OVFL Offset */
+#define MCAN_ICLR_EXT_TS_CNTR_OVFL_MASK          ((uint32_t)0x00000010U)         /* !< Clear External Timestamp Counter
+                                                                                    Overflow interrupt. */
+#define MCAN_ICLR_EXT_TS_CNTR_OVFL_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_ICLR_EXT_TS_CNTR_OVFL_CLR           ((uint32_t)0x00000010U)         /* !< Clear Interrupt */
+/* MCAN_ICLR[WAKEUP] Bits */
+#define MCAN_ICLR_WAKEUP_OFS                     (5)                             /* !< WAKEUP Offset */
+#define MCAN_ICLR_WAKEUP_MASK                    ((uint32_t)0x00000020U)         /* !< Clear Clock Stop Wake Up interrupt. */
+#define MCAN_ICLR_WAKEUP_NO_EFFECT               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_ICLR_WAKEUP_CLR                     ((uint32_t)0x00000020U)         /* !< Clear Interrupt */
+
+/* MCAN_EVT_MODE Bits */
+/* MCAN_EVT_MODE[INT0_CFG] Bits */
+#define MCAN_EVT_MODE_INT0_CFG_OFS               (0)                             /* !< INT0_CFG Offset */
+#define MCAN_EVT_MODE_INT0_CFG_MASK              ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT0] */
+#define MCAN_EVT_MODE_INT0_CFG_DISABLE           ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define MCAN_EVT_MODE_INT0_CFG_SOFTWARE          ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define MCAN_EVT_MODE_INT0_CFG_HARDWARE          ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* MCAN_DESC Bits */
+/* MCAN_DESC[MINREV] Bits */
+#define MCAN_DESC_MINREV_OFS                     (0)                             /* !< MINREV Offset */
+#define MCAN_DESC_MINREV_MASK                    ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+#define MCAN_DESC_MINREV_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define MCAN_DESC_MINREV_MAXIMUM                 ((uint32_t)0x0000000FU)         /* !< Highest possible value */
+/* MCAN_DESC[MAJREV] Bits */
+#define MCAN_DESC_MAJREV_OFS                     (4)                             /* !< MAJREV Offset */
+#define MCAN_DESC_MAJREV_MASK                    ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+#define MCAN_DESC_MAJREV_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define MCAN_DESC_MAJREV_MAXIMUM                 ((uint32_t)0x000000F0U)         /* !< Highest possible value */
+/* MCAN_DESC[FEATUREVER] Bits */
+#define MCAN_DESC_FEATUREVER_OFS                 (12)                            /* !< FEATUREVER Offset */
+#define MCAN_DESC_FEATUREVER_MASK                ((uint32_t)0x0000F000U)         /* !< Feature Set for the module
+                                                                                    *instance* */
+#define MCAN_DESC_FEATUREVER_VERSION_0           ((uint32_t)0x00000000U)         /* !< MCAN module with CAN-FD mode
+                                                                                    enabled  <<Internal Note: This is an
+                                                                                    in-IP paper spin variant. How does
+                                                                                    this map to the SYS_MCAN_ENABLE_FD
+                                                                                    choice value?>> */
+#define MCAN_DESC_FEATUREVER_VERSION_1           ((uint32_t)0x00001000U)         /* !< MCAN module with CAN-FD mode
+                                                                                    disabled  <<Internal Note: This is an
+                                                                                    in-IP paper spin variant. How does
+                                                                                    this map to the SYS_MCAN_ENABLE_FD
+                                                                                    choice value?>> */
+/* MCAN_DESC[MODULEID] Bits */
+#define MCAN_DESC_MODULEID_OFS                   (16)                            /* !< MODULEID Offset */
+#define MCAN_DESC_MODULEID_MASK                  ((uint32_t)0xFFFF0000U)         /* !< Module identification contains a
+                                                                                    unique peripheral identification
+                                                                                    number. The assignments are
+                                                                                    maintained in a central database for
+                                                                                    all of the platform modules to ensure
+                                                                                    uniqueness. */
+#define MCAN_DESC_MODULEID_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define MCAN_DESC_MODULEID_MAXIMUM               ((uint32_t)0xFFFF0000U)         /* !< Highest possible value */
+
+/* MCAN_CLKEN Bits */
+/* MCAN_CLKEN[CLK_REQEN] Bits */
+#define MCAN_CLKEN_CLK_REQEN_OFS                 (0)                             /* !< CLK_REQEN Offset */
+#define MCAN_CLKEN_CLK_REQEN_MASK                ((uint32_t)0x00000001U)         /* !< MCAN functional and MCAN/MCANSS MMR
+                                                                                    clock request enable bit */
+#define MCAN_CLKEN_CLK_REQEN_CLR                 ((uint32_t)0x00000000U)         /* !< MCAN module functional clock and
+                                                                                    Vbusp is not requested.  These clocks
+                                                                                    are gated to the MCAN module. */
+#define MCAN_CLKEN_CLK_REQEN_SET                 ((uint32_t)0x00000001U)         /* !< Setting this bit requests MCAN
+                                                                                    module functional clock and Vbusp.
+                                                                                    These clocks are not gated to MCAN
+                                                                                    module. */
+
+/* MCAN_CLKDIV Bits */
+/* MCAN_CLKDIV[RATIO] Bits */
+#define MCAN_CLKDIV_RATIO_OFS                    (0)                             /* !< RATIO Offset */
+#define MCAN_CLKDIV_RATIO_MASK                   ((uint32_t)0x00000003U)         /* !< Clock divide ratio specification.
+                                                                                    Enables configuring clock divide
+                                                                                    settings for the MCAN functional
+                                                                                    clock input to the MCAN-SS. */
+#define MCAN_CLKDIV_RATIO_DIV_BY_1_              ((uint32_t)0x00000000U)         /* !< Divides input clock by 1 */
+#define MCAN_CLKDIV_RATIO_DIV_BY_2_              ((uint32_t)0x00000001U)         /* !< Divides input clock by 2 */
+#define MCAN_CLKDIV_RATIO_DIV_BY_4_              ((uint32_t)0x00000002U)         /* !< Divides input clock by 4 */
+#define MCAN_CLKDIV_RATIO_DIV_BY_1_1             ((uint32_t)0x00000003U)         /* !< Divides input clock by 1 */
+
+/* MCAN_CLKCTL Bits */
+/* MCAN_CLKCTL[STOPREQ] Bits */
+#define MCAN_CLKCTL_STOPREQ_OFS                  (0)                             /* !< STOPREQ Offset */
+#define MCAN_CLKCTL_STOPREQ_MASK                 ((uint32_t)0x00000001U)         /* !< This bit is used to enable/disable
+                                                                                    MCAN clock (both host clock and
+                                                                                    functional clock) gating request.
+                                                                                    Note: This bit can be reset by HW by
+                                                                                    Clock-Stop Wake-up via CAN RX
+                                                                                    Activity. See spec for more details. */
+#define MCAN_CLKCTL_STOPREQ_DISABLE              ((uint32_t)0x00000000U)         /* !< Disable MCAN-SS clock stop request */
+#define MCAN_CLKCTL_STOPREQ_ENABLE               ((uint32_t)0x00000001U)         /* !< Enable MCAN-SS clock stop request */
+/* MCAN_CLKCTL[WAKEUP_INT_EN] Bits */
+#define MCAN_CLKCTL_WAKEUP_INT_EN_OFS            (4)                             /* !< WAKEUP_INT_EN Offset */
+#define MCAN_CLKCTL_WAKEUP_INT_EN_MASK           ((uint32_t)0x00000010U)         /* !< This bit contols enabling or
+                                                                                    disabling the MCAN IP clock stop
+                                                                                    wakeup interrupt (when
+                                                                                    MCANSS_CTRL.WAKEUPREQEN wakeup
+                                                                                    request is enabled to wakeup MCAN IP
+                                                                                    upon CAN RXD activity) */
+#define MCAN_CLKCTL_WAKEUP_INT_EN_DISABLE        ((uint32_t)0x00000000U)         /* !< Disable MCAN IP clock stop wakeup
+                                                                                    interrupt */
+#define MCAN_CLKCTL_WAKEUP_INT_EN_ENABLE         ((uint32_t)0x00000010U)         /* !< Enable MCAN IP clock stop wakeup
+                                                                                    interrupt */
+/* MCAN_CLKCTL[WKUP_GLTFLT_EN] Bits */
+#define MCAN_CLKCTL_WKUP_GLTFLT_EN_OFS           (8)                             /* !< WKUP_GLTFLT_EN Offset */
+#define MCAN_CLKCTL_WKUP_GLTFLT_EN_MASK          ((uint32_t)0x00000100U)         /* !< Setting this bit enables the glitch
+                                                                                    filter on MCAN RXD input, which wakes
+                                                                                    up the MCAN controller to exit clock
+                                                                                    gating. */
+#define MCAN_CLKCTL_WKUP_GLTFLT_EN_DISABLE       ((uint32_t)0x00000000U)         /* !< Disable glitch filter enable on RXD
+                                                                                    input when MCAN is in clock stop mode
+                                                                                    (waiting for event on RXD input for
+                                                                                    clock stop wakeup). */
+#define MCAN_CLKCTL_WKUP_GLTFLT_EN_ENABLE        ((uint32_t)0x00000100U)         /* !< Enable glitch filter enable on RXD
+                                                                                    input when MCAN is in clock stop mode
+                                                                                    (waiting for event on RXD input for
+                                                                                    clock stop wakeup). */
+
+/* MCAN_CLKSTS Bits */
+/* MCAN_CLKSTS[CLKSTOP_ACKSTS] Bits */
+#define MCAN_CLKSTS_CLKSTOP_ACKSTS_OFS           (0)                             /* !< CLKSTOP_ACKSTS Offset */
+#define MCAN_CLKSTS_CLKSTOP_ACKSTS_MASK          ((uint32_t)0x00000001U)         /* !< Clock stop acknowledge status from
+                                                                                    MCAN IP */
+#define MCAN_CLKSTS_CLKSTOP_ACKSTS_RESET         ((uint32_t)0x00000000U)         /* !< No clock stop acknowledged. */
+#define MCAN_CLKSTS_CLKSTOP_ACKSTS_SET           ((uint32_t)0x00000001U)         /* !< Clock stop has been acknowledged by
+                                                                                    MCAN IP; MCAN-SS may be clock gated
+                                                                                    by stopping both the CAN host and
+                                                                                    functional clocks. */
+/* MCAN_CLKSTS[STOPREQ_HW_OVR] Bits */
+#define MCAN_CLKSTS_STOPREQ_HW_OVR_OFS           (4)                             /* !< STOPREQ_HW_OVR Offset */
+#define MCAN_CLKSTS_STOPREQ_HW_OVR_MASK          ((uint32_t)0x00000010U)         /* !< MCANSS clock stop HW override
+                                                                                    status bit.   This bit indicates when
+                                                                                    the MCANSS_CLKCTL.STOPREQ bit has
+                                                                                    been cleared by HW when a clock-stop
+                                                                                    wake-up event via CAN RX activity is
+                                                                                    triggered. */
+#define MCAN_CLKSTS_STOPREQ_HW_OVR_RESET         ((uint32_t)0x00000000U)         /* !< MCANSS_CLKCTL.STOPREQ bit has not
+                                                                                    been cleared by HW. */
+#define MCAN_CLKSTS_STOPREQ_HW_OVR_SET           ((uint32_t)0x00000010U)         /* !< MCANSS_CLKCTL.STOPREQ bit has been
+                                                                                    cleared by HW. */
+/* MCAN_CLKSTS[CCLKDONE] Bits */
+#define MCAN_CLKSTS_CCLKDONE_OFS                 (8)                             /* !< CCLKDONE Offset */
+#define MCAN_CLKSTS_CCLKDONE_MASK                ((uint32_t)0x00000100U)         /* !< This bit indicates the status of
+                                                                                    MCAN contoller clock request from
+                                                                                    GPRCM. */
+#define MCAN_CLKSTS_CCLKDONE_RESET               ((uint32_t)0x00000000U)         /* !< MCAN controller clock is not
+                                                                                    available to the MCAN IP. */
+#define MCAN_CLKSTS_CCLKDONE_SET                 ((uint32_t)0x00000100U)         /* !< MCAN controller clock is enabled
+                                                                                    and available to the MCAN IP. */
+
+/* MCAN_REV Bits */
+/* MCAN_REV[REVMIN] Bits */
+#define MCAN_REV_REVMIN_OFS                      (0)                             /* !< REVMIN Offset */
+#define MCAN_REV_REVMIN_MASK                     ((uint32_t)0x0000003FU)         /* !< Minor Revision of the Error
+                                                                                    Aggregator */
+/* MCAN_REV[REVMAJ] Bits */
+#define MCAN_REV_REVMAJ_OFS                      (8)                             /* !< REVMAJ Offset */
+#define MCAN_REV_REVMAJ_MASK                     ((uint32_t)0x00000700U)         /* !< Major Revision of the Error
+                                                                                    Aggregator */
+/* MCAN_REV[MODULE_ID] Bits */
+#define MCAN_REV_MODULE_ID_OFS                   (16)                            /* !< MODULE_ID Offset */
+#define MCAN_REV_MODULE_ID_MASK                  ((uint32_t)0x0FFF0000U)         /* !< Module Identification Number */
+/* MCAN_REV[SCHEME] Bits */
+#define MCAN_REV_SCHEME_OFS                      (30)                            /* !< SCHEME Offset */
+#define MCAN_REV_SCHEME_MASK                     ((uint32_t)0xC0000000U)         /* !< PID Register Scheme */
+
+/* MCAN_VECTOR Bits */
+/* MCAN_VECTOR[ECC_VECTOR] Bits */
+#define MCAN_VECTOR_ECC_VECTOR_OFS               (0)                             /* !< ECC_VECTOR Offset */
+#define MCAN_VECTOR_ECC_VECTOR_MASK              ((uint32_t)0x000007FFU)         /* !< ECC RAM ID. Each error detection
+                                                                                    and correction (EDC) controller has a
+                                                                                    bank of error registers (offsets 0x10
+                                                                                    - 0x3B) associated with it. These
+                                                                                    registers are accessed via an
+                                                                                    internal serial bus (SVBUS). To
+                                                                                    access them through the ECC
+                                                                                    aggregator the controller ID desired
+                                                                                    must be written to the ECC_VECTOR
+                                                                                    field, together with the RD_SVBUS
+                                                                                    trigger and RD_SVBUS_ADDRESS bit
+                                                                                    field. This initiates the serial read
+                                                                                    which consummates by setting the
+                                                                                    RD_SVBUS_DONE bit. At this point the
+                                                                                    addressed register may be read by a
+                                                                                    normal CPU read of the appropriate
+                                                                                    offset address.   0x000  Message RAM
+                                                                                    ECC controller is selected   Others
+                                                                                    Reserved (do not use)   Subsequent
+                                                                                    writes through the SVBUS (offsets
+                                                                                    0x10 - 0x3B) have a delayed
+                                                                                    completion. To avoid conflicts,
+                                                                                    perform a read back of a register
+                                                                                    within this range after writing. */
+/* MCAN_VECTOR[RD_SVBUS] Bits */
+#define MCAN_VECTOR_RD_SVBUS_OFS                 (15)                            /* !< RD_SVBUS Offset */
+#define MCAN_VECTOR_RD_SVBUS_MASK                ((uint32_t)0x00008000U)         /* !< Read Trigger */
+/* MCAN_VECTOR[RD_SVBUS_ADDRESS] Bits */
+#define MCAN_VECTOR_RD_SVBUS_ADDRESS_OFS         (16)                            /* !< RD_SVBUS_ADDRESS Offset */
+#define MCAN_VECTOR_RD_SVBUS_ADDRESS_MASK        ((uint32_t)0x00FF0000U)         /* !< Read Address Offset */
+/* MCAN_VECTOR[RD_SVBUS_DONE] Bits */
+#define MCAN_VECTOR_RD_SVBUS_DONE_OFS            (24)                            /* !< RD_SVBUS_DONE Offset */
+#define MCAN_VECTOR_RD_SVBUS_DONE_MASK           ((uint32_t)0x01000000U)         /* !< Read Completion Flag */
+
+/* MCAN_TI_WRAPPER_PROCESSORS_ECC_REGS_STAT Bits */
+/* MCAN_TI_WRAPPER_PROCESSORS_ECC_REGS_STAT[NUM_RAMS] Bits */
+#define MCAN_TI_WRAPPER_PROCESSORS_ECC_REGS_STAT_NUM_RAMS_OFS (0)                             /* !< NUM_RAMS Offset */
+#define MCAN_TI_WRAPPER_PROCESSORS_ECC_REGS_STAT_NUM_RAMS_MASK ((uint32_t)0x000007FFU)         /* !< Number of RAMs. Number of ECC RAMs
+                                                                                    serviced by the aggregator. */
+
+/* MCAN_WRAP_REV Bits */
+/* MCAN_WRAP_REV[REVMIN] Bits */
+#define MCAN_WRAP_REV_REVMIN_OFS                 (0)                             /* !< REVMIN Offset */
+#define MCAN_WRAP_REV_REVMIN_MASK                ((uint32_t)0x0000003FU)         /* !< Minor Revision of the Error
+                                                                                    Aggregator */
+/* MCAN_WRAP_REV[REVMAJ] Bits */
+#define MCAN_WRAP_REV_REVMAJ_OFS                 (8)                             /* !< REVMAJ Offset */
+#define MCAN_WRAP_REV_REVMAJ_MASK                ((uint32_t)0x00000700U)         /* !< Major Revision of the Error
+                                                                                    Aggregator */
+/* MCAN_WRAP_REV[MODULE_ID] Bits */
+#define MCAN_WRAP_REV_MODULE_ID_OFS              (16)                            /* !< MODULE_ID Offset */
+#define MCAN_WRAP_REV_MODULE_ID_MASK             ((uint32_t)0x0FFF0000U)         /* !< Module Identification Number */
+/* MCAN_WRAP_REV[SCHEME] Bits */
+#define MCAN_WRAP_REV_SCHEME_OFS                 (30)                            /* !< SCHEME Offset */
+#define MCAN_WRAP_REV_SCHEME_MASK                ((uint32_t)0xC0000000U)         /* !< PID Register Scheme */
+
+/* MCAN_TI_WRAPPER_ECC_REGS_CTRL Bits */
+/* MCAN_TI_WRAPPER_ECC_REGS_CTRL[ECC_ENABLE] Bits */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_ECC_ENABLE_OFS (0)                             /* !< ECC_ENABLE Offset */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_ECC_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< Enable ECC Generation */
+/* MCAN_TI_WRAPPER_ECC_REGS_CTRL[ECC_CHECK] Bits */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_ECC_CHECK_OFS (1)                             /* !< ECC_CHECK Offset */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_ECC_CHECK_MASK ((uint32_t)0x00000002U)         /* !< Enable ECC Check. ECC is completely
+                                                                                    bypassed if both ECC_ENABLE and
+                                                                                    ECC_CHECK are '0'. */
+/* MCAN_TI_WRAPPER_ECC_REGS_CTRL[ENABLE_RMW] Bits */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_ENABLE_RMW_OFS (2)                             /* !< ENABLE_RMW Offset */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_ENABLE_RMW_MASK ((uint32_t)0x00000004U)         /* !< Enable read-modify-write on partial
+                                                                                    word writes */
+/* MCAN_TI_WRAPPER_ECC_REGS_CTRL[FORCE_SEC] Bits */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_FORCE_SEC_OFS (3)                             /* !< FORCE_SEC Offset */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_FORCE_SEC_MASK ((uint32_t)0x00000008U)         /* !< Force single-bit error. Cleared on
+                                                                                    a writeback or the cycle following
+                                                                                    the error if ERROR_ONCE is asserted.
+                                                                                    For write through mode, this applies
+                                                                                    to writes as well as reads.
+                                                                                    MCANERR_ERR_CTRL1 and
+                                                                                    MCANERR_ERR_CTRL2 should be
+                                                                                    configured prior to setting this bit. */
+/* MCAN_TI_WRAPPER_ECC_REGS_CTRL[FORCE_DED] Bits */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_FORCE_DED_OFS (4)                             /* !< FORCE_DED Offset */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_FORCE_DED_MASK ((uint32_t)0x00000010U)         /* !< Force double-bit error. Cleared the
+                                                                                    cycle following the error if
+                                                                                    ERROR_ONCE is asserted. For write
+                                                                                    through mode, this applies to writes
+                                                                                    as well as reads. MCANERR_ERR_CTRL1
+                                                                                    and MCANERR_ERR_CTRL2 should be
+                                                                                    configured prior to setting this bit. */
+/* MCAN_TI_WRAPPER_ECC_REGS_CTRL[FORCE_N_ROW] Bits */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_FORCE_N_ROW_OFS (5)                             /* !< FORCE_N_ROW Offset */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_FORCE_N_ROW_MASK ((uint32_t)0x00000020U)         /* !< Enable single/double-bit error on
+                                                                                    the next RAM read, regardless of the
+                                                                                    MCANERR_ERR_CTRL1.ECC_ROW setting.
+                                                                                    For write through mode, this applies
+                                                                                    to writes as well as reads. */
+/* MCAN_TI_WRAPPER_ECC_REGS_CTRL[ERROR_ONCE] Bits */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_ERROR_ONCE_OFS (6)                             /* !< ERROR_ONCE Offset */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_ERROR_ONCE_MASK ((uint32_t)0x00000040U)         /* !< If this bit is set, the
+                                                                                    FORCE_SEC/FORCE_DED will inject an
+                                                                                    error to the specified row only once.
+                                                                                    The FORCE_SEC bit will be cleared
+                                                                                    once a writeback happens. If
+                                                                                    writeback is not enabled, this error
+                                                                                    will be cleared the cycle following
+                                                                                    the read when the data is corrected.
+                                                                                    For double-bit errors, the FORCE_DED
+                                                                                    bit will be cleared the cycle
+                                                                                    following the double-bit error. Any
+                                                                                    subsequent reads will not force an
+                                                                                    error. */
+/* MCAN_TI_WRAPPER_ECC_REGS_CTRL[CHECK_SVBUS_TIMEOUT] Bits */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_CHECK_SVBUS_TIMEOUT_OFS (8)                             /* !< CHECK_SVBUS_TIMEOUT Offset */
+#define MCAN_TI_WRAPPER_ECC_REGS_CTRL_CHECK_SVBUS_TIMEOUT_MASK ((uint32_t)0x00000100U)         /* !< Enables Serial VBUS timeout
+                                                                                    mechanism */
+
+/* MCAN_ERR_CTRL1 Bits */
+/* MCAN_ERR_CTRL1[ECC_ROW] Bits */
+#define MCAN_ERR_CTRL1_ECC_ROW_OFS               (0)                             /* !< ECC_ROW Offset */
+#define MCAN_ERR_CTRL1_ECC_ROW_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< Row address where FORCE_SEC or
+                                                                                    FORCE_DED needs to be applied. This
+                                                                                    is ignored if FORCE_N_ROW is set. */
+
+/* MCAN_ERR_CTRL2 Bits */
+/* MCAN_ERR_CTRL2[ECC_BIT1] Bits */
+#define MCAN_ERR_CTRL2_ECC_BIT1_OFS              (0)                             /* !< ECC_BIT1 Offset */
+#define MCAN_ERR_CTRL2_ECC_BIT1_MASK             ((uint32_t)0x0000FFFFU)         /* !< Column/Data bit that needs to be
+                                                                                    flipped when FORCE_SEC or FORCE_DED
+                                                                                    is set */
+/* MCAN_ERR_CTRL2[ECC_BIT2] Bits */
+#define MCAN_ERR_CTRL2_ECC_BIT2_OFS              (16)                            /* !< ECC_BIT2 Offset */
+#define MCAN_ERR_CTRL2_ECC_BIT2_MASK             ((uint32_t)0xFFFF0000U)         /* !< Second column/data bit that needs
+                                                                                    to be flipped when FORCE_DED is set */
+
+/* MCAN_ERR_STAT1 Bits */
+/* MCAN_ERR_STAT1[ECC_SEC] Bits */
+#define MCAN_ERR_STAT1_ECC_SEC_OFS               (0)                             /* !< ECC_SEC Offset */
+#define MCAN_ERR_STAT1_ECC_SEC_MASK              ((uint32_t)0x00000003U)         /* !< Single Bit Error Corrected Status.
+                                                                                    A 2-bit saturating counter of the
+                                                                                    number of SEC errors that have
+                                                                                    occurred since last cleared.     0
+                                                                                    No single-bit error detected   1  One
+                                                                                    single-bit error was detected and
+                                                                                    corrected   2  Two single-bit errors
+                                                                                    were detected and corrected   3
+                                                                                    Three single-bit errors were detected
+                                                                                    and corrected   A write of a non-zero
+                                                                                    value to this bit field increments it
+                                                                                    by the value provided. */
+/* MCAN_ERR_STAT1[ECC_DED] Bits */
+#define MCAN_ERR_STAT1_ECC_DED_OFS               (2)                             /* !< ECC_DED Offset */
+#define MCAN_ERR_STAT1_ECC_DED_MASK              ((uint32_t)0x0000000CU)         /* !< Double Bit Error Detected Status. A
+                                                                                    2-bit saturating counter of the
+                                                                                    number of DED errors that have
+                                                                                    occurred since last cleared.     0
+                                                                                    No double-bit error detected   1  One
+                                                                                    double-bit error was detected   2
+                                                                                    Two double-bit errors were detected
+                                                                                    3  Three double-bit errors were
+                                                                                    detected   A write of a non-zero
+                                                                                    value to this bit field increments it
+                                                                                    by the value provided. */
+/* MCAN_ERR_STAT1[ECC_OTHER] Bits */
+#define MCAN_ERR_STAT1_ECC_OTHER_OFS             (4)                             /* !< ECC_OTHER Offset */
+#define MCAN_ERR_STAT1_ECC_OTHER_MASK            ((uint32_t)0x00000010U)         /* !< SEC While Writeback Error Status
+                                                                                    0  No SEC error while writeback
+                                                                                    pending   1  Indicates that
+                                                                                    successive single-bit errors have
+                                                                                    occurred while a writeback is still
+                                                                                    pending */
+/* MCAN_ERR_STAT1[CTRL_REG_ERROR] Bits */
+#define MCAN_ERR_STAT1_CTRL_REG_ERROR_OFS        (7)                             /* !< CTRL_REG_ERROR Offset */
+#define MCAN_ERR_STAT1_CTRL_REG_ERROR_MASK       ((uint32_t)0x00000080U)         /* !< Control Register Error. A bit field
+                                                                                    in the control register is in an
+                                                                                    ambiguous state. This means that the
+                                                                                    redundancy registers have detected a
+                                                                                    state where not all values are the
+                                                                                    same and has defaulted to the reset
+                                                                                    state. S/W needs to re-write these
+                                                                                    registers to a known state. A write
+                                                                                    of 1 will set this interrupt flag. */
+/* MCAN_ERR_STAT1[CLR_ECC_SEC] Bits */
+#define MCAN_ERR_STAT1_CLR_ECC_SEC_OFS           (8)                             /* !< CLR_ECC_SEC Offset */
+#define MCAN_ERR_STAT1_CLR_ECC_SEC_MASK          ((uint32_t)0x00000300U)         /* !< Clear ECC_SEC. A write of a
+                                                                                    non-zero value to this bit field
+                                                                                    decrements the ECC_SEC bit field by
+                                                                                    the value provided. */
+/* MCAN_ERR_STAT1[CLR_ECC_DED] Bits */
+#define MCAN_ERR_STAT1_CLR_ECC_DED_OFS           (10)                            /* !< CLR_ECC_DED Offset */
+#define MCAN_ERR_STAT1_CLR_ECC_DED_MASK          ((uint32_t)0x00000C00U)         /* !< Clear ECC_DED. A write of a
+                                                                                    non-zero value to this bit field
+                                                                                    decrements the ECC_DED bit field by
+                                                                                    the value provided. */
+/* MCAN_ERR_STAT1[CLR_ECC_OTHER] Bits */
+#define MCAN_ERR_STAT1_CLR_ECC_OTHER_OFS         (12)                            /* !< CLR_ECC_OTHER Offset */
+#define MCAN_ERR_STAT1_CLR_ECC_OTHER_MASK        ((uint32_t)0x00001000U)         /* !< Writing a '1' clears the ECC_OTHER
+                                                                                    bit. */
+/* MCAN_ERR_STAT1[CLR_CTRL_REG_ERROR] Bits */
+#define MCAN_ERR_STAT1_CLR_CTRL_REG_ERROR_OFS    (15)                            /* !< CLR_CTRL_REG_ERROR Offset */
+#define MCAN_ERR_STAT1_CLR_CTRL_REG_ERROR_MASK   ((uint32_t)0x00008000U)         /* !< Writing a '1' clears the
+                                                                                    CTRL_REG_ERROR bit */
+/* MCAN_ERR_STAT1[ECC_BIT1] Bits */
+#define MCAN_ERR_STAT1_ECC_BIT1_OFS              (16)                            /* !< ECC_BIT1 Offset */
+#define MCAN_ERR_STAT1_ECC_BIT1_MASK             ((uint32_t)0xFFFF0000U)         /* !< ECC Error Bit Position. Indicates
+                                                                                    the bit position in the RAM data that
+                                                                                    is in error on an SEC error. Only
+                                                                                    valid on an SEC error.   0  Bit 0 is
+                                                                                    in error   1  Bit 1 is in error   2
+                                                                                    Bit 2 is in error   3  Bit 3 is in
+                                                                                    error   ...   31 Bit 31 is in error
+                                                                                    >32 Invalid */
+
+/* MCAN_ERR_STAT2 Bits */
+/* MCAN_ERR_STAT2[ECC_ROW] Bits */
+#define MCAN_ERR_STAT2_ECC_ROW_OFS               (0)                             /* !< ECC_ROW Offset */
+#define MCAN_ERR_STAT2_ECC_ROW_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< Indicates the row address where the
+                                                                                    single or double-bit error occurred.
+                                                                                    This value is address offset/4. */
+
+/* MCAN_ERR_STAT3 Bits */
+/* MCAN_ERR_STAT3[WB_PEND] Bits */
+#define MCAN_ERR_STAT3_WB_PEND_OFS               (0)                             /* !< WB_PEND Offset */
+#define MCAN_ERR_STAT3_WB_PEND_MASK              ((uint32_t)0x00000001U)         /* !< Delayed Write Back Pending Status
+                                                                                    0  No write back pending   1  An ECC
+                                                                                    data correction write back is pending */
+/* MCAN_ERR_STAT3[SVBUS_TIMEOUT] Bits */
+#define MCAN_ERR_STAT3_SVBUS_TIMEOUT_OFS         (1)                             /* !< SVBUS_TIMEOUT Offset */
+#define MCAN_ERR_STAT3_SVBUS_TIMEOUT_MASK        ((uint32_t)0x00000002U)         /* !< Serial VBUS Timeout Flag. Write 1
+                                                                                    to set. */
+/* MCAN_ERR_STAT3[CLR_SVBUS_TIMEOUT] Bits */
+#define MCAN_ERR_STAT3_CLR_SVBUS_TIMEOUT_OFS     (9)                             /* !< CLR_SVBUS_TIMEOUT Offset */
+#define MCAN_ERR_STAT3_CLR_SVBUS_TIMEOUT_MASK    ((uint32_t)0x00000200U)         /* !< Write 1 to clear the Serial VBUS
+                                                                                    Timeout Flag */
+
+/* MCAN_SEC_EOI Bits */
+/* MCAN_SEC_EOI[EOI_WR] Bits */
+#define MCAN_SEC_EOI_EOI_WR_OFS                  (0)                             /* !< EOI_WR Offset */
+#define MCAN_SEC_EOI_EOI_WR_MASK                 ((uint32_t)0x00000001U)         /* !< Write to this register indicates
+                                                                                    that software has acknowledged the
+                                                                                    pending interrupt and the next
+                                                                                    interrupt can be sent to the host.
+                                                                                    Note that a write to the
+                                                                                    MCANERR_ERR_STAT1.CLR_ECC_SEC goes
+                                                                                    through the SVBUS and has a delayed
+                                                                                    completion. To avoid an additional
+                                                                                    interrupt, read the MCANERR_ERR_STAT1
+                                                                                    register back prior to writing to
+                                                                                    this bit field. */
+
+/* MCAN_SEC_STATUS Bits */
+/* MCAN_SEC_STATUS[MSGMEM_PEND] Bits */
+#define MCAN_SEC_STATUS_MSGMEM_PEND_OFS          (0)                             /* !< MSGMEM_PEND Offset */
+#define MCAN_SEC_STATUS_MSGMEM_PEND_MASK         ((uint32_t)0x00000001U)         /* !< Message RAM SEC Interrupt Pending
+                                                                                    0  No SEC interrupt is pending   1
+                                                                                    SEC interrupt is pending */
+
+/* MCAN_SEC_ENABLE_SET Bits */
+/* MCAN_SEC_ENABLE_SET[MSGMEM_ENABLE_SET] Bits */
+#define MCAN_SEC_ENABLE_SET_MSGMEM_ENABLE_SET_OFS (0)                             /* !< MSGMEM_ENABLE_SET Offset */
+#define MCAN_SEC_ENABLE_SET_MSGMEM_ENABLE_SET_MASK ((uint32_t)0x00000001U)         /* !< Message RAM SEC Interrupt Pending
+                                                                                    Enable Set. Writing a 1 to this bit
+                                                                                    enables the Message RAM SEC error
+                                                                                    interrupts. Writing a 0 has no
+                                                                                    effect. Reads return the
+                                                                                    corresponding enable bit's current
+                                                                                    value. */
+
+/* MCAN_SEC_ENABLE_CLR Bits */
+/* MCAN_SEC_ENABLE_CLR[MSGMEM_ENABLE_CLR] Bits */
+#define MCAN_SEC_ENABLE_CLR_MSGMEM_ENABLE_CLR_OFS (0)                             /* !< MSGMEM_ENABLE_CLR Offset */
+#define MCAN_SEC_ENABLE_CLR_MSGMEM_ENABLE_CLR_MASK ((uint32_t)0x00000001U)         /* !< Message RAM SEC Interrupt Pending
+                                                                                    Enable Clear. Writing a 1 to this bit
+                                                                                    disables the Message RAM SEC error
+                                                                                    interrupts. Writing a 0 has no
+                                                                                    effect. Reads return the
+                                                                                    corresponding enable bit's current
+                                                                                    value. */
+
+/* MCAN_DED_EOI Bits */
+/* MCAN_DED_EOI[EOI_WR] Bits */
+#define MCAN_DED_EOI_EOI_WR_OFS                  (0)                             /* !< EOI_WR Offset */
+#define MCAN_DED_EOI_EOI_WR_MASK                 ((uint32_t)0x00000001U)         /* !< Write to this register indicates
+                                                                                    that software has acknowledged the
+                                                                                    pending interrupt and the next
+                                                                                    interrupt can be sent to the host.
+                                                                                    Note that a write to the
+                                                                                    MCANERR_ERR_STAT1.CLR_ECC_DED goes
+                                                                                    through the SVBUS and has a delayed
+                                                                                    completion. To avoid an additional
+                                                                                    interrupt, read the MCANERR_ERR_STAT1
+                                                                                    register back prior to writing to
+                                                                                    this bit field. */
+
+/* MCAN_DED_STATUS Bits */
+/* MCAN_DED_STATUS[MSGMEM_PEND] Bits */
+#define MCAN_DED_STATUS_MSGMEM_PEND_OFS          (0)                             /* !< MSGMEM_PEND Offset */
+#define MCAN_DED_STATUS_MSGMEM_PEND_MASK         ((uint32_t)0x00000001U)         /* !< Message RAM DED Interrupt Pending
+                                                                                    0  No DED interrupt is pending   1
+                                                                                    DED interrupt is pending */
+
+/* MCAN_DED_ENABLE_SET Bits */
+/* MCAN_DED_ENABLE_SET[MSGMEM_ENABLE_SET] Bits */
+#define MCAN_DED_ENABLE_SET_MSGMEM_ENABLE_SET_OFS (0)                             /* !< MSGMEM_ENABLE_SET Offset */
+#define MCAN_DED_ENABLE_SET_MSGMEM_ENABLE_SET_MASK ((uint32_t)0x00000001U)         /* !< Message RAM DED Interrupt Pending
+                                                                                    Enable Set. Writing a 1 to this bit
+                                                                                    enables the Message RAM DED error
+                                                                                    interrupts. Writing a 0 has no
+                                                                                    effect. Reads return the
+                                                                                    corresponding enable bit's current
+                                                                                    value. */
+
+/* MCAN_DED_ENABLE_CLR Bits */
+/* MCAN_DED_ENABLE_CLR[MSGMEM_ENABLE_CLR] Bits */
+#define MCAN_DED_ENABLE_CLR_MSGMEM_ENABLE_CLR_OFS (0)                             /* !< MSGMEM_ENABLE_CLR Offset */
+#define MCAN_DED_ENABLE_CLR_MSGMEM_ENABLE_CLR_MASK ((uint32_t)0x00000001U)         /* !< Message RAM DED Interrupt Pending
+                                                                                    Enable Clear. Writing a 1 to this bit
+                                                                                    disables the Message RAM DED error
+                                                                                    interrupts. Writing a 0 has no
+                                                                                    effect. Reads return the
+                                                                                    corresponding enable bit's current
+                                                                                    value. */
+
+/* MCAN_AGGR_ENABLE_SET Bits */
+/* MCAN_AGGR_ENABLE_SET[ENABLE_PARITY_SET] Bits */
+#define MCAN_AGGR_ENABLE_SET_ENABLE_PARITY_SET_OFS (0)                             /* !< ENABLE_PARITY_SET Offset */
+#define MCAN_AGGR_ENABLE_SET_ENABLE_PARITY_SET_MASK ((uint32_t)0x00000001U)         /* !< Write 1 to enable parity errors.
+                                                                                    Reads return the corresponding enable
+                                                                                    bit's current value. */
+/* MCAN_AGGR_ENABLE_SET[ENABLE_TIMEOUT_SET] Bits */
+#define MCAN_AGGR_ENABLE_SET_ENABLE_TIMEOUT_SET_OFS (1)                             /* !< ENABLE_TIMEOUT_SET Offset */
+#define MCAN_AGGR_ENABLE_SET_ENABLE_TIMEOUT_SET_MASK ((uint32_t)0x00000002U)         /* !< Write 1 to enable timeout errors.
+                                                                                    Reads return the corresponding enable
+                                                                                    bit's current value. */
+
+/* MCAN_AGGR_ENABLE_CLR Bits */
+/* MCAN_AGGR_ENABLE_CLR[ENABLE_PARITY_CLR] Bits */
+#define MCAN_AGGR_ENABLE_CLR_ENABLE_PARITY_CLR_OFS (0)                             /* !< ENABLE_PARITY_CLR Offset */
+#define MCAN_AGGR_ENABLE_CLR_ENABLE_PARITY_CLR_MASK ((uint32_t)0x00000001U)         /* !< Write 1 to disable parity errors.
+                                                                                    Reads return the corresponding enable
+                                                                                    bit's current value. */
+/* MCAN_AGGR_ENABLE_CLR[ENABLE_TIMEOUT_CLR] Bits */
+#define MCAN_AGGR_ENABLE_CLR_ENABLE_TIMEOUT_CLR_OFS (1)                             /* !< ENABLE_TIMEOUT_CLR Offset */
+#define MCAN_AGGR_ENABLE_CLR_ENABLE_TIMEOUT_CLR_MASK ((uint32_t)0x00000002U)         /* !< Write 1 to disable timeout errors.
+                                                                                    Reads return the corresponding enable
+                                                                                    bit's current value. */
+
+/* MCAN_AGGR_STATUS_SET Bits */
+/* MCAN_AGGR_STATUS_SET[AGGR_PARITY_ERR] Bits */
+#define MCAN_AGGR_STATUS_SET_AGGR_PARITY_ERR_OFS (0)                             /* !< AGGR_PARITY_ERR Offset */
+#define MCAN_AGGR_STATUS_SET_AGGR_PARITY_ERR_MASK ((uint32_t)0x00000003U)         /* !< Aggregator Parity Error Status
+                                                                                    2-bit saturating counter of the
+                                                                                    number of parity errors that have
+                                                                                    occurred since last cleared.   0  No
+                                                                                    parity errors have occurred   1  One
+                                                                                    parity error has occurred   2  Two
+                                                                                    parity errors have occurred   3
+                                                                                    Three parity errors have occurred   A
+                                                                                    write of a non-zero value to this bit
+                                                                                    field increments it by the value
+                                                                                    provided. */
+/* MCAN_AGGR_STATUS_SET[SVBUS_TIMEOUT] Bits */
+#define MCAN_AGGR_STATUS_SET_SVBUS_TIMEOUT_OFS   (2)                             /* !< SVBUS_TIMEOUT Offset */
+#define MCAN_AGGR_STATUS_SET_SVBUS_TIMEOUT_MASK  ((uint32_t)0x0000000CU)         /* !< Aggregator Serial VBUS Timeout
+                                                                                    Error Status   2-bit saturating
+                                                                                    counter of the number of SVBUS
+                                                                                    timeout errors that have occurred
+                                                                                    since last cleared.   0  No timeout
+                                                                                    errors have occurred   1  One timeout
+                                                                                    error has occurred   2  Two timeout
+                                                                                    errors have occurred   3  Three
+                                                                                    timeout errors have occurred   A
+                                                                                    write of a non-zero value to this bit
+                                                                                    field increments it by the value
+                                                                                    provided. */
+
+/* MCAN_AGGR_STATUS_CLR Bits */
+/* MCAN_AGGR_STATUS_CLR[AGGR_PARITY_ERR] Bits */
+#define MCAN_AGGR_STATUS_CLR_AGGR_PARITY_ERR_OFS (0)                             /* !< AGGR_PARITY_ERR Offset */
+#define MCAN_AGGR_STATUS_CLR_AGGR_PARITY_ERR_MASK ((uint32_t)0x00000003U)         /* !< Aggregator Parity Error Status
+                                                                                    2-bit saturating counter of the
+                                                                                    number of parity errors that have
+                                                                                    occurred since last cleared.   0  No
+                                                                                    parity errors have occurred   1  One
+                                                                                    parity error has occurred   2  Two
+                                                                                    parity errors have occurred   3
+                                                                                    Three parity errors have occurred   A
+                                                                                    write of a non-zero value to this bit
+                                                                                    field decrements it by the value
+                                                                                    provided. */
+/* MCAN_AGGR_STATUS_CLR[SVBUS_TIMEOUT] Bits */
+#define MCAN_AGGR_STATUS_CLR_SVBUS_TIMEOUT_OFS   (2)                             /* !< SVBUS_TIMEOUT Offset */
+#define MCAN_AGGR_STATUS_CLR_SVBUS_TIMEOUT_MASK  ((uint32_t)0x0000000CU)         /* !< Aggregator Serial VBUS Timeout
+                                                                                    Error Status   2-bit saturating
+                                                                                    counter of the number of SVBUS
+                                                                                    timeout errors that have occurred
+                                                                                    since last cleared.   0  No timeout
+                                                                                    errors have occurred   1  One timeout
+                                                                                    error has occurred   2  Two timeout
+                                                                                    errors have occurred   3  Three
+                                                                                    timeout errors have occurred   A
+                                                                                    write of a non-zero value to this bit
+                                                                                    field decrements it by the value
+                                                                                    provided. */
+
+/* MCAN_PID Bits */
+/* MCAN_PID[MINOR] Bits */
+#define MCAN_PID_MINOR_OFS                       (0)                             /* !< MINOR Offset */
+#define MCAN_PID_MINOR_MASK                      ((uint32_t)0x0000003FU)         /* !< Minor Revision of the MCAN
+                                                                                    Subsystem */
+/* MCAN_PID[MAJOR] Bits */
+#define MCAN_PID_MAJOR_OFS                       (8)                             /* !< MAJOR Offset */
+#define MCAN_PID_MAJOR_MASK                      ((uint32_t)0x00000700U)         /* !< Major Revision of the MCAN
+                                                                                    Subsystem */
+/* MCAN_PID[MODULE_ID] Bits */
+#define MCAN_PID_MODULE_ID_OFS                   (16)                            /* !< MODULE_ID Offset */
+#define MCAN_PID_MODULE_ID_MASK                  ((uint32_t)0x0FFF0000U)         /* !< Module Identification Number */
+/* MCAN_PID[SCHEME] Bits */
+#define MCAN_PID_SCHEME_OFS                      (30)                            /* !< SCHEME Offset */
+#define MCAN_PID_SCHEME_MASK                     ((uint32_t)0xC0000000U)         /* !< PID Register Scheme */
+
+/* MCAN_TI_WRAPPER_REGS_CTRL Bits */
+/* MCAN_TI_WRAPPER_REGS_CTRL[DBGSUSP_FREE] Bits */
+#define MCAN_TI_WRAPPER_REGS_CTRL_DBGSUSP_FREE_OFS (3)                             /* !< DBGSUSP_FREE Offset */
+#define MCAN_TI_WRAPPER_REGS_CTRL_DBGSUSP_FREE_MASK ((uint32_t)0x00000008U)         /* !< Debug Suspend Free Bit. Enables
+                                                                                    debug suspend.   0  Disable debug
+                                                                                    suspend   1  Enable debug suspend */
+/* MCAN_TI_WRAPPER_REGS_CTRL[WAKEUPREQEN] Bits */
+#define MCAN_TI_WRAPPER_REGS_CTRL_WAKEUPREQEN_OFS (4)                             /* !< WAKEUPREQEN Offset */
+#define MCAN_TI_WRAPPER_REGS_CTRL_WAKEUPREQEN_MASK ((uint32_t)0x00000010U)         /* !< Wakeup Request Enable. Enables the
+                                                                                    MCANSS to wakeup on CAN RXD activity.
+                                                                                    0  Disable wakeup request   1
+                                                                                    Enables wakeup request */
+/* MCAN_TI_WRAPPER_REGS_CTRL[AUTOWAKEUP] Bits */
+#define MCAN_TI_WRAPPER_REGS_CTRL_AUTOWAKEUP_OFS (5)                             /* !< AUTOWAKEUP Offset */
+#define MCAN_TI_WRAPPER_REGS_CTRL_AUTOWAKEUP_MASK ((uint32_t)0x00000020U)         /* !< Automatic Wakeup Enable. Enables
+                                                                                    the MCANSS to automatically clear the
+                                                                                    MCAN CCCR.INIT bit, fully waking the
+                                                                                    MCAN up, on an enabled wakeup
+                                                                                    request.   0  Disable the automatic
+                                                                                    write to CCCR.INIT   1  Enable the
+                                                                                    automatic write to CCCR.INIT */
+/* MCAN_TI_WRAPPER_REGS_CTRL[EXT_TS_CNTR_EN] Bits */
+#define MCAN_TI_WRAPPER_REGS_CTRL_EXT_TS_CNTR_EN_OFS (6)                             /* !< EXT_TS_CNTR_EN Offset */
+#define MCAN_TI_WRAPPER_REGS_CTRL_EXT_TS_CNTR_EN_MASK ((uint32_t)0x00000040U)         /* !< External Timestamp Counter Enable.
+                                                                                    0  External timestamp counter
+                                                                                    disabled   1  External timestamp
+                                                                                    counter enabled */
+
+/* MCAN_TI_WRAPPER_PROCESSORS_REGS_STAT Bits */
+/* MCAN_TI_WRAPPER_PROCESSORS_REGS_STAT[RESET] Bits */
+#define MCAN_TI_WRAPPER_PROCESSORS_REGS_STAT_RESET_OFS (0)                             /* !< RESET Offset */
+#define MCAN_TI_WRAPPER_PROCESSORS_REGS_STAT_RESET_MASK ((uint32_t)0x00000001U)         /* !< Soft Reset Status.   0  Not in
+                                                                                    reset   1  Reset is in progress */
+/* MCAN_TI_WRAPPER_PROCESSORS_REGS_STAT[MEM_INIT_DONE] Bits */
+#define MCAN_TI_WRAPPER_PROCESSORS_REGS_STAT_MEM_INIT_DONE_OFS (1)                             /* !< MEM_INIT_DONE Offset */
+#define MCAN_TI_WRAPPER_PROCESSORS_REGS_STAT_MEM_INIT_DONE_MASK ((uint32_t)0x00000002U)         /* !< Memory Initialization Done.   0
+                                                                                    Message RAM initialization is in
+                                                                                    progress   1  Message RAM is
+                                                                                    initialized for use */
+/* MCAN_TI_WRAPPER_PROCESSORS_REGS_STAT[ENABLE_FDOE] Bits */
+#define MCAN_TI_WRAPPER_PROCESSORS_REGS_STAT_ENABLE_FDOE_OFS (2)                             /* !< ENABLE_FDOE Offset */
+#define MCAN_TI_WRAPPER_PROCESSORS_REGS_STAT_ENABLE_FDOE_MASK ((uint32_t)0x00000004U)         /* !< Enable FD (Flexible Data-Rate)
+                                                                                    Configuration Reflects the value of
+                                                                                    mcanss_enable_fdoe configuration
+                                                                                    port, -h = mcanss_enable_fdoe. */
+
+/* MCAN_ICS Bits */
+/* MCAN_ICS[EXT_TS_CNTR_OVFL] Bits */
+#define MCAN_ICS_EXT_TS_CNTR_OVFL_OFS            (0)                             /* !< EXT_TS_CNTR_OVFL Offset */
+#define MCAN_ICS_EXT_TS_CNTR_OVFL_MASK           ((uint32_t)0x00000001U)         /* !< External Timestamp Counter Overflow
+                                                                                    Interrupt Status Clear. Reads always
+                                                                                    return a 0.   0  Write of '0' has no
+                                                                                    effect   1  Write of '1' clears the
+                                                                                    MCANSS_IRS.EXT_TS_CNTR_OVFL bit */
+
+/* MCAN_IRS Bits */
+/* MCAN_IRS[EXT_TS_CNTR_OVFL] Bits */
+#define MCAN_IRS_EXT_TS_CNTR_OVFL_OFS            (0)                             /* !< EXT_TS_CNTR_OVFL Offset */
+#define MCAN_IRS_EXT_TS_CNTR_OVFL_MASK           ((uint32_t)0x00000001U)         /* !< External Timestamp Counter Overflow
+                                                                                    Interrupt Status. This bit is set by
+                                                                                    HW or by a SW write of '1'. To clear,
+                                                                                    use the MCANSS_ICS.EXT_TS_CNTR_OVFL
+                                                                                    bit.   0  External timestamp counter
+                                                                                    has not overflowed   1  External
+                                                                                    timestamp counter has overflowed
+                                                                                    When this bit is set to '1' by HW or
+                                                                                    SW, the
+                                                                                    MCANSS_EXT_TS_UNSERVICED_INTR_CNTR
+                                                                                    .EXT_TS_INTR_CNTR bit field will
+                                                                                    increment by 1. */
+
+/* MCAN_IECS Bits */
+/* MCAN_IECS[EXT_TS_CNTR_OVFL] Bits */
+#define MCAN_IECS_EXT_TS_CNTR_OVFL_OFS           (0)                             /* !< EXT_TS_CNTR_OVFL Offset */
+#define MCAN_IECS_EXT_TS_CNTR_OVFL_MASK          ((uint32_t)0x00000001U)         /* !< External Timestamp Counter Overflow
+                                                                                    Interrupt Enable Clear. Reads always
+                                                                                    return a 0.   0  Write of '0' has no
+                                                                                    effect   1  Write of '1' clears the
+                                                                                    MCANSS_IES.EXT_TS_CNTR_OVFL bit */
+
+/* MCAN_TI_WRAPPER_PROCESSORS_REGS_IE Bits */
+/* MCAN_TI_WRAPPER_PROCESSORS_REGS_IE[EXT_TS_CNTR_OVFL] Bits */
+#define MCAN_TI_WRAPPER_PROCESSORS_REGS_IE_EXT_TS_CNTR_OVFL_OFS (0)                             /* !< EXT_TS_CNTR_OVFL Offset */
+#define MCAN_TI_WRAPPER_PROCESSORS_REGS_IE_EXT_TS_CNTR_OVFL_MASK ((uint32_t)0x00000001U)         /* !< External Timestamp Counter Overflow
+                                                                                    Interrupt Enable. A write of '0' has
+                                                                                    no effect. A write of '1' sets the
+                                                                                    MCANSS_IES.EXT_TS_CNTR_OVFL bit. */
+
+/* MCAN_IES Bits */
+/* MCAN_IES[EXT_TS_CNTR_OVFL] Bits */
+#define MCAN_IES_EXT_TS_CNTR_OVFL_OFS            (0)                             /* !< EXT_TS_CNTR_OVFL Offset */
+#define MCAN_IES_EXT_TS_CNTR_OVFL_MASK           ((uint32_t)0x00000001U)         /* !< External Timestamp Counter Overflow
+                                                                                    Interrupt Enable Status. To set, use
+                                                                                    the CANSS_IE.EXT_TS_CNTR_OVFL bit. To
+                                                                                    clear, use the
+                                                                                    MCANSS_IECS.EXT_TS_CNTR_OVFL bit.   0
+                                                                                    External timestamp counter overflow
+                                                                                    interrupt is not enabled   1
+                                                                                    External timestamp counter overflow
+                                                                                    interrupt is enabled */
+
+/* MCAN_EOI Bits */
+/* MCAN_EOI[EOI] Bits */
+#define MCAN_EOI_EOI_OFS                         (0)                             /* !< EOI Offset */
+#define MCAN_EOI_EOI_MASK                        ((uint32_t)0x000000FFU)         /* !< End of Interrupt. A write to this
+                                                                                    register will clear the associated
+                                                                                    interrupt. If the unserviced
+                                                                                    interrupt counter is > 1, another
+                                                                                    interrupt is generated.   0x00
+                                                                                    External TS Interrupt is cleared
+                                                                                    0x01  MCAN(0) interrupt is cleared
+                                                                                    0x02  MCAN(1) interrupt is cleared
+                                                                                    Other writes are ignored. */
+
+/* MCAN_EXT_TS_PRESCALER Bits */
+/* MCAN_EXT_TS_PRESCALER[PRESCALER] Bits */
+#define MCAN_EXT_TS_PRESCALER_PRESCALER_OFS      (0)                             /* !< PRESCALER Offset */
+#define MCAN_EXT_TS_PRESCALER_PRESCALER_MASK     ((uint32_t)0x00FFFFFFU)         /* !< External Timestamp Prescaler Reload
+                                                                                    Value. The external timestamp count
+                                                                                    rate is the host (system) clock rate
+                                                                                    divided by this value, except in the
+                                                                                    case of 0. A zero value in this bit
+                                                                                    field will act identically to a value
+                                                                                    of 0x000001. */
+
+/* MCAN_EXT_TS_UNSERVICED_INTR_CNTR Bits */
+/* MCAN_EXT_TS_UNSERVICED_INTR_CNTR[EXT_TS_INTR_CNTR] Bits */
+#define MCAN_EXT_TS_UNSERVICED_INTR_CNTR_EXT_TS_INTR_CNTR_OFS (0)                             /* !< EXT_TS_INTR_CNTR Offset */
+#define MCAN_EXT_TS_UNSERVICED_INTR_CNTR_EXT_TS_INTR_CNTR_MASK ((uint32_t)0x0000001FU)         /* !< External Timestamp Counter
+                                                                                    Unserviced Rollover Interrupts. If
+                                                                                    this value is > 1, an MCANSS_EOI
+                                                                                    write of '1' to bit 0 will issue
+                                                                                    another interrupt.   The status of
+                                                                                    this bit field is affected by the
+                                                                                    MCANSS_IRS.EXT_TS_CNTR_OVFL bit
+                                                                                    field. */
+
+/* MCAN_CREL Bits */
+/* MCAN_CREL[DAY] Bits */
+#define MCAN_CREL_DAY_OFS                        (0)                             /* !< DAY Offset */
+#define MCAN_CREL_DAY_MASK                       ((uint32_t)0x000000FFU)         /* !< Time Stamp Day. Two digits,
+                                                                                    BCD-coded. */
+/* MCAN_CREL[MON] Bits */
+#define MCAN_CREL_MON_OFS                        (8)                             /* !< MON Offset */
+#define MCAN_CREL_MON_MASK                       ((uint32_t)0x0000FF00U)         /* !< Time Stamp Month. Two digits,
+                                                                                    BCD-coded. */
+/* MCAN_CREL[YEAR] Bits */
+#define MCAN_CREL_YEAR_OFS                       (16)                            /* !< YEAR Offset */
+#define MCAN_CREL_YEAR_MASK                      ((uint32_t)0x000F0000U)         /* !< Time Stamp Year. One digit,
+                                                                                    BCD-coded. */
+/* MCAN_CREL[SUBSTEP] Bits */
+#define MCAN_CREL_SUBSTEP_OFS                    (20)                            /* !< SUBSTEP Offset */
+#define MCAN_CREL_SUBSTEP_MASK                   ((uint32_t)0x00F00000U)         /* !< Sub-Step of Core Release. One
+                                                                                    digit, BCD-coded. */
+/* MCAN_CREL[STEP] Bits */
+#define MCAN_CREL_STEP_OFS                       (24)                            /* !< STEP Offset */
+#define MCAN_CREL_STEP_MASK                      ((uint32_t)0x0F000000U)         /* !< Step of Core Release. One digit,
+                                                                                    BCD-coded. */
+/* MCAN_CREL[REL] Bits */
+#define MCAN_CREL_REL_OFS                        (28)                            /* !< REL Offset */
+#define MCAN_CREL_REL_MASK                       ((uint32_t)0xF0000000U)         /* !< Core Release. One digit, BCD-coded. */
+
+/* MCAN_ENDN Bits */
+/* MCAN_ENDN[ETV] Bits */
+#define MCAN_ENDN_ETV_OFS                        (0)                             /* !< ETV Offset */
+#define MCAN_ENDN_ETV_MASK                       ((uint32_t)0xFFFFFFFFU)         /* !< Endianess Test Value. Reading the
+                                                                                    constant value maintained in this
+                                                                                    register allows software to determine
+                                                                                    the endianess of the host CPU. */
+
+/* MCAN_DBTP Bits */
+/* MCAN_DBTP[DSJW] Bits */
+#define MCAN_DBTP_DSJW_OFS                       (0)                             /* !< DSJW Offset */
+#define MCAN_DBTP_DSJW_MASK                      ((uint32_t)0x0000000FU)         /* !< Data Resynchronization Jump Width.
+                                                                                    Valid values are 0 to 15. The actual
+                                                                                    interpretation by the hardware of
+                                                                                    this value is such that one more than
+                                                                                    the value programmed here is used.
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_DBTP[DTSEG2] Bits */
+#define MCAN_DBTP_DTSEG2_OFS                     (4)                             /* !< DTSEG2 Offset */
+#define MCAN_DBTP_DTSEG2_MASK                    ((uint32_t)0x000000F0U)         /* !< Data Time Segment After Sample
+                                                                                    Point. Valid values are 0 to 15. The
+                                                                                    actual interpretation by the hardware
+                                                                                    of this value is such that one more
+                                                                                    than the programmed value is used.
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_DBTP[DTSEG1] Bits */
+#define MCAN_DBTP_DTSEG1_OFS                     (8)                             /* !< DTSEG1 Offset */
+#define MCAN_DBTP_DTSEG1_MASK                    ((uint32_t)0x00001F00U)         /* !< Data Time Segment Before Sample
+                                                                                    Point. Valid values are 0 to 31. The
+                                                                                    actual interpretation by the hardware
+                                                                                    of this value is such that one more
+                                                                                    than the programmed value is used.
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_DBTP[DBRP] Bits */
+#define MCAN_DBTP_DBRP_OFS                       (16)                            /* !< DBRP Offset */
+#define MCAN_DBTP_DBRP_MASK                      ((uint32_t)0x001F0000U)         /* !< Data Bit Rate Prescaler. The value
+                                                                                    by which the oscillator frequency is
+                                                                                    divided for generating the bit time
+                                                                                    quanta. The bit time is built up from
+                                                                                    a multiple of this quanta. Valid
+                                                                                    values for the Bit Rate Prescaler are
+                                                                                    0 to 31. The actual interpretation by
+                                                                                    the hardware of this value is such
+                                                                                    that one more than the value
+                                                                                    programmed here is used.   Qualified
+                                                                                    Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_DBTP[TDC] Bits */
+#define MCAN_DBTP_TDC_OFS                        (23)                            /* !< TDC Offset */
+#define MCAN_DBTP_TDC_MASK                       ((uint32_t)0x00800000U)         /* !< Transmitter Delay Compensation   0
+                                                                                    Transmitter Delay Compensation
+                                                                                    disabled   1  Transmitter Delay
+                                                                                    Compensation enabled */
+
+/* MCAN_TEST Bits */
+/* MCAN_TEST[LBCK] Bits */
+#define MCAN_TEST_LBCK_OFS                       (4)                             /* !< LBCK Offset */
+#define MCAN_TEST_LBCK_MASK                      ((uint32_t)0x00000010U)         /* !< Loop Back Mode. Qualified Write is
+                                                                                    possible only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+#define MCAN_TEST_LBCK_DISABLE                   ((uint32_t)0x00000000U)         /* !< Reset value, Loop Back Mode is
+                                                                                    disabled */
+#define MCAN_TEST_LBCK_ENABLE                    ((uint32_t)0x00000010U)         /* !< Loop Back Mode is enabled */
+/* MCAN_TEST[TX] Bits */
+#define MCAN_TEST_TX_OFS                         (5)                             /* !< TX Offset */
+#define MCAN_TEST_TX_MASK                        ((uint32_t)0x00000060U)         /* !< Control of Transmit Pin   00  CAN
+                                                                                    TX pin controlled by the CAN Core,
+                                                                                    updated at the end of the CAN bit
+                                                                                    time   01  Sample Point can be
+                                                                                    monitored at CAN TX pin   10
+                                                                                    Dominant ('0') level at CAN TX pin
+                                                                                    11  Recessive ('1') at CAN TX pin
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_TEST[RX] Bits */
+#define MCAN_TEST_RX_OFS                         (7)                             /* !< RX Offset */
+#define MCAN_TEST_RX_MASK                        ((uint32_t)0x00000080U)         /* !< Receive Pin. Monitors the actual
+                                                                                    value of the CAN receive pin. */
+#define MCAN_TEST_RX_DOMINANT                    ((uint32_t)0x00000000U)         /* !< The CAN bus is dominant (CAN RX pin
+                                                                                    = '0') */
+#define MCAN_TEST_RX_RECESSIVE                   ((uint32_t)0x00000080U)         /* !< The CAN bus is recessive (CAN RX
+                                                                                    pin = '1') */
+
+/* MCAN_RWD Bits */
+/* MCAN_RWD[WDC] Bits */
+#define MCAN_RWD_WDC_OFS                         (0)                             /* !< WDC Offset */
+#define MCAN_RWD_WDC_MASK                        ((uint32_t)0x000000FFU)         /* !< Watchdog Configuration. Start value
+                                                                                    of the Message RAM Watchdog Counter.
+                                                                                    With the reset value of "00" the
+                                                                                    counter is disabled.   Qualified
+                                                                                    Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_RWD[WDV] Bits */
+#define MCAN_RWD_WDV_OFS                         (8)                             /* !< WDV Offset */
+#define MCAN_RWD_WDV_MASK                        ((uint32_t)0x0000FF00U)         /* !< Watchdog Value. Acutal Message RAM
+                                                                                    Watchdog Counter Value.   The RAM
+                                                                                    Watchdog monitors the READY output of
+                                                                                    the Message RAM. A Message RAM access
+                                                                                    via the MCAN's Generic Master
+                                                                                    Interface starts the Message RAM
+                                                                                    Watchdog Counter with the value
+                                                                                    configured by the WDC field. The
+                                                                                    counter is reloaded with WDC when the
+                                                                                    Message RAM signals successful
+                                                                                    completion by activating its READY
+                                                                                    output. In case there is no response
+                                                                                    from the Message RAM until the
+                                                                                    counter has counted down to zero, the
+                                                                                    counter stops and interrupt flag
+                                                                                    MCAN_IR.WDI is set. The RAM Watchdog
+                                                                                    Counter is clocked by the host
+                                                                                    (system) clock. */
+
+/* MCAN_CCCR Bits */
+/* MCAN_CCCR[INIT] Bits */
+#define MCAN_CCCR_INIT_OFS                       (0)                             /* !< INIT Offset */
+#define MCAN_CCCR_INIT_MASK                      ((uint32_t)0x00000001U)         /* !< Initialization   0  Normal
+                                                                                    Operation   1  Initialization is
+                                                                                    started Note: Due to the
+                                                                                    synchronization mechanism between the
+                                                                                    two clock domains, there may be a
+                                                                                    delay until the value written to INIT
+                                                                                    can be read back. Therefore the
+                                                                                    programmer has to assure that the
+                                                                                    previous value written to INIT has
+                                                                                    been accepted by reading INIT before
+                                                                                    setting INIT to a new value. */
+/* MCAN_CCCR[CCE] Bits */
+#define MCAN_CCCR_CCE_OFS                        (1)                             /* !< CCE Offset */
+#define MCAN_CCCR_CCE_MASK                       ((uint32_t)0x00000002U)         /* !< Configuration Change Enable   0
+                                                                                    The CPU has no write access to the
+                                                                                    protected configuration registers   1
+                                                                                    The CPU has write access to the
+                                                                                    protected configuration registers
+                                                                                    (while CCCR.INIT = '1')   Qualified
+                                                                                    Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_CCCR[ASM] Bits */
+#define MCAN_CCCR_ASM_OFS                        (2)                             /* !< ASM Offset */
+#define MCAN_CCCR_ASM_MASK                       ((uint32_t)0x00000004U)         /* !< Restricted Operation Mode. Bit ASM
+                                                                                    can only be set by SW when both CCE
+                                                                                    and INIT are set to '1'. The bit can
+                                                                                    be reset by SW at any time.   0
+                                                                                    Normal CAN operation   1  Restricted
+                                                                                    Operation Mode active   Qualified
+                                                                                    Write 1 to Set is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_CCCR[CSA] Bits */
+#define MCAN_CCCR_CSA_OFS                        (3)                             /* !< CSA Offset */
+#define MCAN_CCCR_CSA_MASK                       ((uint32_t)0x00000008U)         /* !< Clock Stop Acknowledge   0  No
+                                                                                    clock stop acknowledged   1  MCAN may
+                                                                                    be set in power down by stopping the
+                                                                                    Host and CAN clocks */
+/* MCAN_CCCR[CSR] Bits */
+#define MCAN_CCCR_CSR_OFS                        (4)                             /* !< CSR Offset */
+#define MCAN_CCCR_CSR_MASK                       ((uint32_t)0x00000010U)         /* !< Clock Stop Request   0  No clock
+                                                                                    stop is requested   1  Clock stop
+                                                                                    requested. When clock stop is
+                                                                                    requested, first INIT and then CSA
+                                                                                    will be set after all pending
+                                                                                    transfer requests have been completed
+                                                                                    and the CAN bus reached idle. */
+/* MCAN_CCCR[MON] Bits */
+#define MCAN_CCCR_MON_OFS                        (5)                             /* !< MON Offset */
+#define MCAN_CCCR_MON_MASK                       ((uint32_t)0x00000020U)         /* !< Bus Monitoring Mode. Bit MON can
+                                                                                    only be set by SW when both CCE and
+                                                                                    INIT are set to '1'. The bit can be
+                                                                                    reset by SW at any time.   0  Bus
+                                                                                    Monitoring Mode is disabled   1  Bus
+                                                                                    Monitoring Mode is enabled
+                                                                                    Qualified Write 1 to Set is possible
+                                                                                    only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+/* MCAN_CCCR[DAR] Bits */
+#define MCAN_CCCR_DAR_OFS                        (6)                             /* !< DAR Offset */
+#define MCAN_CCCR_DAR_MASK                       ((uint32_t)0x00000040U)         /* !< Disable Automatic Retransmission
+                                                                                    0  Automatic retransmission of
+                                                                                    messages not transmitted successfully
+                                                                                    enabled   1  Automatic retransmission
+                                                                                    disabled   Qualified Write is
+                                                                                    possible only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+/* MCAN_CCCR[TEST] Bits */
+#define MCAN_CCCR_TEST_OFS                       (7)                             /* !< TEST Offset */
+#define MCAN_CCCR_TEST_MASK                      ((uint32_t)0x00000080U)         /* !< Test Mode Enable   0  Normal
+                                                                                    operation, register TEST holds reset
+                                                                                    values   1  Test Mode, write access
+                                                                                    to register TEST enabled   Qualified
+                                                                                    Write 1 to Set is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_CCCR[FDOE] Bits */
+#define MCAN_CCCR_FDOE_OFS                       (8)                             /* !< FDOE Offset */
+#define MCAN_CCCR_FDOE_MASK                      ((uint32_t)0x00000100U)         /* !< Flexible Datarate Operation Enable
+                                                                                    0  FD operation disabled   1  FD
+                                                                                    operation enabled   Qualified Write
+                                                                                    is possible only with CCCR.CCE='1'
+                                                                                    and CCCR.INIT='1'. */
+/* MCAN_CCCR[BRSE] Bits */
+#define MCAN_CCCR_BRSE_OFS                       (9)                             /* !< BRSE Offset */
+#define MCAN_CCCR_BRSE_MASK                      ((uint32_t)0x00000200U)         /* !< Bit Rate Switch Enable   0  Bit
+                                                                                    rate switching for transmissions
+                                                                                    disabled   1  Bit rate switching for
+                                                                                    transmissions enabled Note: When CAN
+                                                                                    FD operation is disabled FDOE = '0',
+                                                                                    BRSE is not evaluated.   Qualified
+                                                                                    Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_CCCR[PXHD] Bits */
+#define MCAN_CCCR_PXHD_OFS                       (12)                            /* !< PXHD Offset */
+#define MCAN_CCCR_PXHD_MASK                      ((uint32_t)0x00001000U)         /* !< Protocol Exception Handling Disable
+                                                                                    0  Protocol exception handling
+                                                                                    enabled   1  Protocol exception
+                                                                                    handling disabled Note: When protocol
+                                                                                    exception handling is disabled, the
+                                                                                    MCAN will transmit an error frame
+                                                                                    when it detects a protocol exception
+                                                                                    condition.   Qualified Write is
+                                                                                    possible only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+/* MCAN_CCCR[EFBI] Bits */
+#define MCAN_CCCR_EFBI_OFS                       (13)                            /* !< EFBI Offset */
+#define MCAN_CCCR_EFBI_MASK                      ((uint32_t)0x00002000U)         /* !< Edge Filtering during Bus
+                                                                                    Integration   0  Edge filtering
+                                                                                    disabled   1  Two consecutive
+                                                                                    dominant tq required to detect an
+                                                                                    edge for hard synchronization
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_CCCR[TXP] Bits */
+#define MCAN_CCCR_TXP_OFS                        (14)                            /* !< TXP Offset */
+#define MCAN_CCCR_TXP_MASK                       ((uint32_t)0x00004000U)         /* !< Transmit Pause. If this bit is set,
+                                                                                    the MCAN pauses for two CAN bit times
+                                                                                    before starting the next transmission
+                                                                                    after itself has successfully
+                                                                                    transmitted a frame.   0  Transmit
+                                                                                    pause disabled   1  Transmit pause
+                                                                                    enabled   Qualified Write is possible
+                                                                                    only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+/* MCAN_CCCR[NISO] Bits */
+#define MCAN_CCCR_NISO_OFS                       (15)                            /* !< NISO Offset */
+#define MCAN_CCCR_NISO_MASK                      ((uint32_t)0x00008000U)         /* !< Non ISO Operation. If this bit is
+                                                                                    set, the MCAN uses the CAN FD frame
+                                                                                    format as specified by the Bosch CAN
+                                                                                    FD Specification V1.0.   0  CAN FD
+                                                                                    frame format according to ISO
+                                                                                    11898-1:2015   1  CAN FD frame format
+                                                                                    according to Bosch CAN FD
+                                                                                    Specification V1.0 */
+
+/* MCAN_NBTP Bits */
+/* MCAN_NBTP[NTSEG2] Bits */
+#define MCAN_NBTP_NTSEG2_OFS                     (0)                             /* !< NTSEG2 Offset */
+#define MCAN_NBTP_NTSEG2_MASK                    ((uint32_t)0x0000007FU)         /* !< Nominal Time Segment After Sample
+                                                                                    Point. Valid values are 1 to 127. The
+                                                                                    actual interpretation by the hardware
+                                                                                    of this value is such that one more
+                                                                                    than the programmed value is used.
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_NBTP[NTSEG1] Bits */
+#define MCAN_NBTP_NTSEG1_OFS                     (8)                             /* !< NTSEG1 Offset */
+#define MCAN_NBTP_NTSEG1_MASK                    ((uint32_t)0x0000FF00U)         /* !< Nominal Time Segment Before Sample
+                                                                                    Point. Valid values are 1 to 255. The
+                                                                                    actual interpretation by the hardware
+                                                                                    of this value is such that one more
+                                                                                    than the programmed value is used.
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_NBTP[NBRP] Bits */
+#define MCAN_NBTP_NBRP_OFS                       (16)                            /* !< NBRP Offset */
+#define MCAN_NBTP_NBRP_MASK                      ((uint32_t)0x01FF0000U)         /* !< Nominal Bit Rate Prescaler. The
+                                                                                    value by which the oscillator
+                                                                                    frequency is divided for generating
+                                                                                    the bit time quanta. The bit time is
+                                                                                    built up from a multiple of this
+                                                                                    quanta. Valid values for the Bit Rate
+                                                                                    Prescaler are 0 to 511. The actual
+                                                                                    interpretation by the hardware of
+                                                                                    this value is such that one more than
+                                                                                    the value programmed here is used.
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_NBTP[NSJW] Bits */
+#define MCAN_NBTP_NSJW_OFS                       (25)                            /* !< NSJW Offset */
+#define MCAN_NBTP_NSJW_MASK                      ((uint32_t)0xFE000000U)         /* !< Nominal (Re)Synchronization Jump
+                                                                                    Width. Valid values are 0 to 127. The
+                                                                                    actual interpretation by the hardware
+                                                                                    of this value is such that one more
+                                                                                    than the value programmed here is
+                                                                                    used.   Qualified Write is possible
+                                                                                    only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+
+/* MCAN_TSCC Bits */
+/* MCAN_TSCC[TSS] Bits */
+#define MCAN_TSCC_TSS_OFS                        (0)                             /* !< TSS Offset */
+#define MCAN_TSCC_TSS_MASK                       ((uint32_t)0x00000003U)         /* !< Timestamp Select   00  Timestamp
+                                                                                    counter value always 0x0000   01
+                                                                                    Timestamp counter value incremented
+                                                                                    according to TCP   10  External
+                                                                                    timestamp counter value used   11
+                                                                                    Same as "00"   Qualified Write is
+                                                                                    possible only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+/* MCAN_TSCC[TCP] Bits */
+#define MCAN_TSCC_TCP_OFS                        (16)                            /* !< TCP Offset */
+#define MCAN_TSCC_TCP_MASK                       ((uint32_t)0x000F0000U)         /* !< Timestamp Counter Prescaler.
+                                                                                    Configures the timestamp and timeout
+                                                                                    counters time unit in multiples of
+                                                                                    CAN bit times. Valid values are 0 to
+                                                                                    15. The actual interpretation by the
+                                                                                    hardware of this value is such that
+                                                                                    one more than the value programmed
+                                                                                    here is used.   Note: With CAN FD an
+                                                                                    external counter is required for
+                                                                                    timestamp generation (TSS = "10").
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+
+/* MCAN_TSCV Bits */
+/* MCAN_TSCV[TSC] Bits */
+#define MCAN_TSCV_TSC_OFS                        (0)                             /* !< TSC Offset */
+#define MCAN_TSCV_TSC_MASK                       ((uint32_t)0x0000FFFFU)         /* !< Timestamp Counter. The
+                                                                                    internal/external Timestamp Counter
+                                                                                    value is captured on start of frame
+                                                                                    (both Rx and Tx). When TSCC.TSS =
+                                                                                    "01", the Timestamp Counter is
+                                                                                    incremented in multiples of CAN bit
+                                                                                    times, (1...16), depending on the
+                                                                                    configuration of TSCC.TCP. A wrap
+                                                                                    around sets interrupt flag IR.TSW.
+                                                                                    Write access resets the counter to
+                                                                                    zero. When TSCC.TSS = "10", TSC
+                                                                                    reflects the External Timestamp
+                                                                                    Counter value, and a write access has
+                                                                                    no impact.   Note: A "wrap around" is
+                                                                                    a change of the Timestamp Counter
+                                                                                    value from non-zero to zero not
+                                                                                    caused by write access to MCAN_TSCV. */
+
+/* MCAN_TOCC Bits */
+/* MCAN_TOCC[ETOC] Bits */
+#define MCAN_TOCC_ETOC_OFS                       (0)                             /* !< ETOC Offset */
+#define MCAN_TOCC_ETOC_MASK                      ((uint32_t)0x00000001U)         /* !< Enable Timeout Counter   0  Timeout
+                                                                                    Counter disabled   1  Timeout Counter
+                                                                                    enabled   Qualified Write is possible
+                                                                                    only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+/* MCAN_TOCC[TOS] Bits */
+#define MCAN_TOCC_TOS_OFS                        (1)                             /* !< TOS Offset */
+#define MCAN_TOCC_TOS_MASK                       ((uint32_t)0x00000006U)         /* !< Timeout Select. When operating in
+                                                                                    Continuous mode, a write to TOCV
+                                                                                    presets the counter to the value
+                                                                                    configured by TOCC.TOP and continues
+                                                                                    down-counting. When the Timeout
+                                                                                    Counter is controlled by one of the
+                                                                                    FIFOs, an empty FIFO presets the
+                                                                                    counter to the value configured by
+                                                                                    TOCC.TOP. Down-counting is started
+                                                                                    when the first FIFO element is
+                                                                                    stored.   00  Continuous operation
+                                                                                    01  Timeout controlled by Tx Event
+                                                                                    FIFO   10  Timeout controlled by Rx
+                                                                                    FIFO 0   11  Timeout controlled by Rx
+                                                                                    FIFO 1   Qualified Write is possible
+                                                                                    only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+/* MCAN_TOCC[TOP] Bits */
+#define MCAN_TOCC_TOP_OFS                        (16)                            /* !< TOP Offset */
+#define MCAN_TOCC_TOP_MASK                       ((uint32_t)0xFFFF0000U)         /* !< Timeout Period. Start value of the
+                                                                                    Timeout Counter (down-counter).
+                                                                                    Configures the Timeout Period.
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+
+/* MCAN_TOCV Bits */
+/* MCAN_TOCV[TOC] Bits */
+#define MCAN_TOCV_TOC_OFS                        (0)                             /* !< TOC Offset */
+#define MCAN_TOCV_TOC_MASK                       ((uint32_t)0x0000FFFFU)         /* !< Timeout Counter. The Timeout
+                                                                                    Counter is decremented in multiples
+                                                                                    of CAN bit times, (1...16), depending
+                                                                                    on the configuration of TSCC.TCP.
+                                                                                    When decremented to zero, interrupt
+                                                                                    flag IR.TOO is set and the Timeout
+                                                                                    Counter is stopped. Start and
+                                                                                    reset/restart conditions are
+                                                                                    configured via TOCC.TOS. */
+
+/* MCAN_ECR Bits */
+/* MCAN_ECR[TEC] Bits */
+#define MCAN_ECR_TEC_OFS                         (0)                             /* !< TEC Offset */
+#define MCAN_ECR_TEC_MASK                        ((uint32_t)0x000000FFU)         /* !< Transmit Error Counter. Actual
+                                                                                    state of the Transmit Error Counter,
+                                                                                    values between 0 and 255.   Note:
+                                                                                    When CCCR.ASM is set, the CAN
+                                                                                    protocol controller does not
+                                                                                    increment TEC and REC when a CAN
+                                                                                    protocol error is detected, but CEL
+                                                                                    is still incremented. */
+/* MCAN_ECR[REC] Bits */
+#define MCAN_ECR_REC_OFS                         (8)                             /* !< REC Offset */
+#define MCAN_ECR_REC_MASK                        ((uint32_t)0x00007F00U)         /* !< Receive Error Counter. Actual state
+                                                                                    of the Receive Error Counter, values
+                                                                                    between 0 and 127.   Note: When
+                                                                                    CCCR.ASM is set, the CAN protocol
+                                                                                    controller does not increment TEC and
+                                                                                    REC when a CAN protocol error is
+                                                                                    detected, but CEL is still
+                                                                                    incremented. */
+/* MCAN_ECR[RP] Bits */
+#define MCAN_ECR_RP_OFS                          (15)                            /* !< RP Offset */
+#define MCAN_ECR_RP_MASK                         ((uint32_t)0x00008000U)         /* !< Receive Error Passive   0  The
+                                                                                    Receive Error Counter is below the
+                                                                                    error passive level of 128   1  The
+                                                                                    Receive Error Counter has reached the
+                                                                                    error passive level of 128 */
+/* MCAN_ECR[CEL] Bits */
+#define MCAN_ECR_CEL_OFS                         (16)                            /* !< CEL Offset */
+#define MCAN_ECR_CEL_MASK                        ((uint32_t)0x00FF0000U)         /* !< CAN Error Logging. The counter is
+                                                                                    incremented each time when a CAN
+                                                                                    protocol error causes the Transmit
+                                                                                    Error Counter or the Receive Error
+                                                                                    Counter to be incremented. It is
+                                                                                    reset by read access to CEL. The
+                                                                                    counter stops at 0xFF; the next
+                                                                                    increment of TEC or REC sets
+                                                                                    interrupt flag IR.ELO.   Note: When
+                                                                                    CCCR.ASM is set, the CAN protocol
+                                                                                    controller does not increment TEC and
+                                                                                    REC when a CAN protocol error is
+                                                                                    detected, but CEL is still
+                                                                                    incremented. */
+
+/* MCAN_PSR Bits */
+/* MCAN_PSR[LEC] Bits */
+#define MCAN_PSR_LEC_OFS                         (0)                             /* !< LEC Offset */
+#define MCAN_PSR_LEC_MASK                        ((uint32_t)0x00000007U)         /* !< Last Error Code. The LEC indicates
+                                                                                    the type of the last error to occur
+                                                                                    on the CAN bus. This field will be
+                                                                                    cleared to '0' when a message has
+                                                                                    been transferred (reception or
+                                                                                    transmission) without error.   0  No
+                                                                                    Error: No error occurred since LEC
+                                                                                    has been reset by successful
+                                                                                    reception or transmission.   1  Stuff
+                                                                                    Error: More than 5 equal bits in a
+                                                                                    sequence have occurred in a part of a
+                                                                                    received message where this is not
+                                                                                    allowed.   2  Form Error: A fixed
+                                                                                    format part of a received frame has
+                                                                                    the wrong format.   3  AckError: The
+                                                                                    message transmitted by the MCAN was
+                                                                                    not acknowledged by another node.   4
+                                                                                    Bit1Error: During the transmission
+                                                                                    of a message (with the exception of
+                                                                                    the arbitration field), the device
+                                                                                    wanted to send a recessive level (bit
+                                                                                    of logical value '1'), but the
+                                                                                    monitored bus value was dominant.   5
+                                                                                    Bit0Error: During the transmission
+                                                                                    of a message (or acknowledge bit, or
+                                                                                    active error flag, or overload flag),
+                                                                                    the device wanted to send a dominant
+                                                                                    level (data or identifier bit logical
+                                                                                    value '0'), but the monitored bus
+                                                                                    value was recessive. During Bus_Off
+                                                                                    recovery this status is set each time
+                                                                                    a sequence of 11 recessive bits has
+                                                                                    been monitored. This enables the CPU
+                                                                                    to monitor the proceeding of the
+                                                                                    Bus_Off recovery sequence (indicating
+                                                                                    the bus is not stuck at dominant or
+                                                                                    continuously disturbed).   6
+                                                                                    CRCError: The CRC check sum of a
+                                                                                    received message was incorrect. The
+                                                                                    CRC of an incoming message does not
+                                                                                    match with the CRC calculated from
+                                                                                    the received data.   7  NoChange: Any
+                                                                                    read access to the Protocol Status
+                                                                                    Register re-initializes the LEC to
+                                                                                    '7'. When the LEC shows the value
+                                                                                    '7', no CAN bus event was detected
+                                                                                    since the last CPU read access to the
+                                                                                    Protocol Status Register.   Note:
+                                                                                    When a frame in CAN FD format has
+                                                                                    reached the data phase with BRS flag
+                                                                                    set, the next CAN event (error or
+                                                                                    valid frame) will be shown in DLEC
+                                                                                    instead of LEC. An error in a fixed
+                                                                                    stuff bit of a CAN FD CRC sequence
+                                                                                    will be shown as a Form Error, not
+                                                                                    Stuff Error. Note: The Bus_Off
+                                                                                    recovery sequence (see ISO
+                                                                                    11898-1:2015) cannot be shortened by
+                                                                                    setting or resetting CCCR.INIT. If
+                                                                                    the device goes Bus_Off, it will set
+                                                                                    CCCR.INIT of its own accord, stopping
+                                                                                    all bus activities. Once CCCR.INIT
+                                                                                    has been cleared by the CPU, the
+                                                                                    device will then wait for 129
+                                                                                    occurrences of Bus Idle (129 * 11
+                                                                                    consecutive recessive bits) before
+                                                                                    resuming normal operation. At the end
+                                                                                    of the Bus_Off recovery sequence, the
+                                                                                    Error Management Counters will be
+                                                                                    reset. During the waiting time after
+                                                                                    the resetting of CCCR.INIT, each time
+                                                                                    a sequence of 11 recessive bits has
+                                                                                    been monitored, a Bit0Error code is
+                                                                                    written to PSR.LEC, enabling the CPU
+                                                                                    to readily check up whether the CAN
+                                                                                    bus is stuck at dominant or
+                                                                                    continuously disturbed and to monitor
+                                                                                    the Bus_Off recovery sequence.
+                                                                                    ECR.REC is used to count these
+                                                                                    sequences. */
+/* MCAN_PSR[ACT] Bits */
+#define MCAN_PSR_ACT_OFS                         (3)                             /* !< ACT Offset */
+#define MCAN_PSR_ACT_MASK                        ((uint32_t)0x00000018U)         /* !< Node Activity.  Monitors the
+                                                                                    module's CAN communication state.
+                                                                                    00  Synchronizing - node is
+                                                                                    synchronizing on CAN communication
+                                                                                    01  Idle - node is neither receiver
+                                                                                    nor transmitter   10  Receiver - node
+                                                                                    is operating as receiver   11
+                                                                                    Transmitter - node is operating as
+                                                                                    transmitter   Note: ACT is set to
+                                                                                    "00" by a Protocol Exception Event. */
+/* MCAN_PSR[EP] Bits */
+#define MCAN_PSR_EP_OFS                          (5)                             /* !< EP Offset */
+#define MCAN_PSR_EP_MASK                         ((uint32_t)0x00000020U)         /* !< Error Passive   0  The M_CAN is in
+                                                                                    the Error_Active state. It normally
+                                                                                    takes part in bus communication and
+                                                                                    sends an active error flag when an
+                                                                                    error has been detected   1  The
+                                                                                    M_CAN is in the Error_Passive state */
+/* MCAN_PSR[EW] Bits */
+#define MCAN_PSR_EW_OFS                          (6)                             /* !< EW Offset */
+#define MCAN_PSR_EW_MASK                         ((uint32_t)0x00000040U)         /* !< Warning Status   0  Both error
+                                                                                    counters are below the Error_Warning
+                                                                                    limit of 96   1  At least one of
+                                                                                    error counter has reached the
+                                                                                    Error_Warning limit of 96 */
+/* MCAN_PSR[BO] Bits */
+#define MCAN_PSR_BO_OFS                          (7)                             /* !< BO Offset */
+#define MCAN_PSR_BO_MASK                         ((uint32_t)0x00000080U)         /* !< Bus_Off Status   0  The M_CAN is
+                                                                                    not Bus_Off   1  The M_CAN is in
+                                                                                    Bus_Off state */
+/* MCAN_PSR[DLEC] Bits */
+#define MCAN_PSR_DLEC_OFS                        (8)                             /* !< DLEC Offset */
+#define MCAN_PSR_DLEC_MASK                       ((uint32_t)0x00000700U)         /* !< Data Phase Last Error Code. Type of
+                                                                                    last error that occurred in the data
+                                                                                    phase of a CAN FD format frame with
+                                                                                    its BRS flag set. Coding is the same
+                                                                                    as for LEC. This field will be
+                                                                                    cleared to zero when a CAN FD format
+                                                                                    frame with its BRS flag set has been
+                                                                                    transferred (reception or
+                                                                                    transmission) without error. */
+/* MCAN_PSR[RESI] Bits */
+#define MCAN_PSR_RESI_OFS                        (11)                            /* !< RESI Offset */
+#define MCAN_PSR_RESI_MASK                       ((uint32_t)0x00000800U)         /* !< ESI Flag of Last Received CAN FD
+                                                                                    Message. This bit is set together
+                                                                                    with RFDF, independent of acceptance
+                                                                                    filtering.   0  Last received CAN FD
+                                                                                    message did not have its ESI flag set
+                                                                                    1  Last received CAN FD message had
+                                                                                    its ESI flag set */
+/* MCAN_PSR[RBRS] Bits */
+#define MCAN_PSR_RBRS_OFS                        (12)                            /* !< RBRS Offset */
+#define MCAN_PSR_RBRS_MASK                       ((uint32_t)0x00001000U)         /* !< BRS Flag of Last Received CAN FD
+                                                                                    Message. This bit is set together
+                                                                                    with RFDF, independent of acceptance
+                                                                                    filtering.   0  Last received CAN FD
+                                                                                    message did not have its BRS flag set
+                                                                                    1  Last received CAN FD message had
+                                                                                    its BRS flag set */
+/* MCAN_PSR[RFDF] Bits */
+#define MCAN_PSR_RFDF_OFS                        (13)                            /* !< RFDF Offset */
+#define MCAN_PSR_RFDF_MASK                       ((uint32_t)0x00002000U)         /* !< Received a CAN FD Message.  This
+                                                                                    bit is set independent of acceptance
+                                                                                    filtering.   0  Since this bit was
+                                                                                    reset by the CPU, no CAN FD message
+                                                                                    has been received   1  Message in CAN
+                                                                                    FD format with FDF flag set has been
+                                                                                    received */
+/* MCAN_PSR[PXE] Bits */
+#define MCAN_PSR_PXE_OFS                         (14)                            /* !< PXE Offset */
+#define MCAN_PSR_PXE_MASK                        ((uint32_t)0x00004000U)         /* !< Protocol Exception Event   0  No
+                                                                                    protocol exception event occurred
+                                                                                    since last read access   1  Protocol
+                                                                                    exception event occurred */
+/* MCAN_PSR[TDCV] Bits */
+#define MCAN_PSR_TDCV_OFS                        (16)                            /* !< TDCV Offset */
+#define MCAN_PSR_TDCV_MASK                       ((uint32_t)0x007F0000U)         /* !< Transmitter Delay Compensation
+                                                                                    Value. Position of the secondary
+                                                                                    sample point, defined by the sum of
+                                                                                    the measured delay from the internal
+                                                                                    CAN TX signal to the internal CAN RX
+                                                                                    signal and TDCR.TDCO. The SSP
+                                                                                    position is, in the data phase, the
+                                                                                    number of mtq between the start of
+                                                                                    the transmitted bit and the secondary
+                                                                                    sample point. Valid values are 0 to
+                                                                                    127 mtq. */
+
+/* MCAN_TDCR Bits */
+/* MCAN_TDCR[TDCF] Bits */
+#define MCAN_TDCR_TDCF_OFS                       (0)                             /* !< TDCF Offset */
+#define MCAN_TDCR_TDCF_MASK                      ((uint32_t)0x0000007FU)         /* !< Transmitter Delay Compensation
+                                                                                    Filter Window Length. Defines the
+                                                                                    minimum value for the SSP position,
+                                                                                    dominant edges on the internal CAN RX
+                                                                                    signal that would result in an
+                                                                                    earlier SSP position are ignored for
+                                                                                    transmitter delay measurement. The
+                                                                                    feature is enabled when TDCF is
+                                                                                    configured to a value greater than
+                                                                                    TDCO. Valid values are 0 to 127 mtq.
+                                                                                    Qualified Write is possible only
+                                                                                    with CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_TDCR[TDCO] Bits */
+#define MCAN_TDCR_TDCO_OFS                       (8)                             /* !< TDCO Offset */
+#define MCAN_TDCR_TDCO_MASK                      ((uint32_t)0x00007F00U)         /* !< Transmitter Delay Compensation
+                                                                                    Offset. Offset value defining the
+                                                                                    distance between the measured delay
+                                                                                    from the internal CAN TX signal to
+                                                                                    the internal CAN RX signal and the
+                                                                                    secondary sample point. Valid values
+                                                                                    are 0 to 127 mtq.   Qualified Write
+                                                                                    is possible only with CCCR.CCE='1'
+                                                                                    and CCCR.INIT='1'. */
+
+/* MCAN_IR Bits */
+/* MCAN_IR[RF0N] Bits */
+#define MCAN_IR_RF0N_OFS                         (0)                             /* !< RF0N Offset */
+#define MCAN_IR_RF0N_MASK                        ((uint32_t)0x00000001U)         /* !< Rx FIFO 0 New Message   0  No new
+                                                                                    message written to Rx FIFO 0   1  New
+                                                                                    message written to Rx FIFO 0 */
+/* MCAN_IR[RF0W] Bits */
+#define MCAN_IR_RF0W_OFS                         (1)                             /* !< RF0W Offset */
+#define MCAN_IR_RF0W_MASK                        ((uint32_t)0x00000002U)         /* !< Rx FIFO 0 Watermark Reached   0  Rx
+                                                                                    FIFO 0 fill level below watermark   1
+                                                                                    Rx FIFO 0 fill level reached
+                                                                                    watermark */
+/* MCAN_IR[RF0F] Bits */
+#define MCAN_IR_RF0F_OFS                         (2)                             /* !< RF0F Offset */
+#define MCAN_IR_RF0F_MASK                        ((uint32_t)0x00000004U)         /* !< Rx FIFO 0 Full   0  Rx FIFO 0 not
+                                                                                    full   1  Rx FIFO 0 full */
+/* MCAN_IR[RF0L] Bits */
+#define MCAN_IR_RF0L_OFS                         (3)                             /* !< RF0L Offset */
+#define MCAN_IR_RF0L_MASK                        ((uint32_t)0x00000008U)         /* !< Rx FIFO 0 Message Lost   0  No Rx
+                                                                                    FIFO 0 message lost   1  Rx FIFO 0
+                                                                                    message lost, also set after write
+                                                                                    attempt to Rx FIFO 0 of size zero */
+/* MCAN_IR[RF1N] Bits */
+#define MCAN_IR_RF1N_OFS                         (4)                             /* !< RF1N Offset */
+#define MCAN_IR_RF1N_MASK                        ((uint32_t)0x00000010U)         /* !< Rx FIFO 1 New Message   0  No new
+                                                                                    message written to Rx FIFO 1   1  New
+                                                                                    message written to Rx FIFO 1 */
+/* MCAN_IR[RF1W] Bits */
+#define MCAN_IR_RF1W_OFS                         (5)                             /* !< RF1W Offset */
+#define MCAN_IR_RF1W_MASK                        ((uint32_t)0x00000020U)         /* !< Rx FIFO 1 Watermark Reached   0  Rx
+                                                                                    FIFO 1 fill level below watermark   1
+                                                                                    Rx FIFO 1 fill level reached
+                                                                                    watermark */
+/* MCAN_IR[RF1F] Bits */
+#define MCAN_IR_RF1F_OFS                         (6)                             /* !< RF1F Offset */
+#define MCAN_IR_RF1F_MASK                        ((uint32_t)0x00000040U)         /* !< Rx FIFO 1 Full   0  Rx FIFO 1 not
+                                                                                    full   1  Rx FIFO 1 full */
+/* MCAN_IR[RF1L] Bits */
+#define MCAN_IR_RF1L_OFS                         (7)                             /* !< RF1L Offset */
+#define MCAN_IR_RF1L_MASK                        ((uint32_t)0x00000080U)         /* !< Rx FIFO 1 Message Lost   0  No Rx
+                                                                                    FIFO 1 message lost   1  Rx FIFO 1
+                                                                                    message lost, also set after write
+                                                                                    attempt to Rx FIFO 1 of size zero */
+/* MCAN_IR[HPM] Bits */
+#define MCAN_IR_HPM_OFS                          (8)                             /* !< HPM Offset */
+#define MCAN_IR_HPM_MASK                         ((uint32_t)0x00000100U)         /* !< High Priority Message   0  No high
+                                                                                    priority message received   1  High
+                                                                                    priority message received */
+/* MCAN_IR[TC] Bits */
+#define MCAN_IR_TC_OFS                           (9)                             /* !< TC Offset */
+#define MCAN_IR_TC_MASK                          ((uint32_t)0x00000200U)         /* !< Transmission Completed   0  No
+                                                                                    transmission completed   1
+                                                                                    Transmission completed */
+/* MCAN_IR[TCF] Bits */
+#define MCAN_IR_TCF_OFS                          (10)                            /* !< TCF Offset */
+#define MCAN_IR_TCF_MASK                         ((uint32_t)0x00000400U)         /* !< Transmission Cancellation Finished
+                                                                                    0  No transmission cancellation
+                                                                                    finished   1  Transmission
+                                                                                    cancellation finished */
+/* MCAN_IR[TFE] Bits */
+#define MCAN_IR_TFE_OFS                          (11)                            /* !< TFE Offset */
+#define MCAN_IR_TFE_MASK                         ((uint32_t)0x00000800U)         /* !< Tx FIFO Empty   0  Tx FIFO
+                                                                                    non-empty   1  Tx FIFO empty */
+/* MCAN_IR[TEFN] Bits */
+#define MCAN_IR_TEFN_OFS                         (12)                            /* !< TEFN Offset */
+#define MCAN_IR_TEFN_MASK                        ((uint32_t)0x00001000U)         /* !< Tx Event FIFO New Entry   0  Tx
+                                                                                    Event FIFO unchanged   1  Tx Handler
+                                                                                    wrote Tx Event FIFO element */
+/* MCAN_IR[TEFW] Bits */
+#define MCAN_IR_TEFW_OFS                         (13)                            /* !< TEFW Offset */
+#define MCAN_IR_TEFW_MASK                        ((uint32_t)0x00002000U)         /* !< Tx Event FIFO Watermark Reached   0
+                                                                                    Tx Event FIFO fill level below
+                                                                                    watermark   1  Tx Event FIFO fill
+                                                                                    level reached watermark */
+/* MCAN_IR[TEFF] Bits */
+#define MCAN_IR_TEFF_OFS                         (14)                            /* !< TEFF Offset */
+#define MCAN_IR_TEFF_MASK                        ((uint32_t)0x00004000U)         /* !< Tx Event FIFO Full   0  Tx Event
+                                                                                    FIFO not full   1  Tx Event FIFO full */
+/* MCAN_IR[TEFL] Bits */
+#define MCAN_IR_TEFL_OFS                         (15)                            /* !< TEFL Offset */
+#define MCAN_IR_TEFL_MASK                        ((uint32_t)0x00008000U)         /* !< Tx Event FIFO Element Lost   0  No
+                                                                                    Tx Event FIFO element lost   1  Tx
+                                                                                    Event FIFO element lost, also set
+                                                                                    after write attempt to Tx Event FIFO
+                                                                                    of size zero */
+/* MCAN_IR[TSW] Bits */
+#define MCAN_IR_TSW_OFS                          (16)                            /* !< TSW Offset */
+#define MCAN_IR_TSW_MASK                         ((uint32_t)0x00010000U)         /* !< Timestamp Wraparound   0  No
+                                                                                    timestamp counter wrap-around   1
+                                                                                    Timestamp counter wrapped around */
+/* MCAN_IR[MRAF] Bits */
+#define MCAN_IR_MRAF_OFS                         (17)                            /* !< MRAF Offset */
+#define MCAN_IR_MRAF_MASK                        ((uint32_t)0x00020000U)         /* !< Message RAM Access Failure.  The
+                                                                                    flag is set, when the Rx Handler:   -
+                                                                                    has not completed acceptance
+                                                                                    filtering or storage of an accepted
+                                                                                    message until the arbitration field
+                                                                                    of the following message has been
+                                                                                    received. In this case acceptance
+                                                                                    filtering or message storage is
+                                                                                    aborted and the Rx Handler starts
+                                                                                    processing of the following message.
+                                                                                    - was not able to write a message to
+                                                                                    the Message RAM. In this case message
+                                                                                    storage is aborted.   In both cases
+                                                                                    the FIFO put index is not updated
+                                                                                    resp. the New Data flag for a
+                                                                                    dedicated Rx Buffer is not set, a
+                                                                                    partly stored message is overwritten
+                                                                                    when the next message is stored to
+                                                                                    this location.   The flag is also set
+                                                                                    when the Tx Handler was not able to
+                                                                                    read a message from the Message RAM
+                                                                                    in time. In this case message
+                                                                                    transmission is aborted. In case of a
+                                                                                    Tx Handler access failure the MCAN is
+                                                                                    switched into Restricted Operation
+                                                                                    Mode. To leave Restricted Operation
+                                                                                    Mode, the Host CPU has to reset
+                                                                                    CCCR.ASM.   0  No Message RAM access
+                                                                                    failure occurred   1  Message RAM
+                                                                                    access failure occurred */
+/* MCAN_IR[TOO] Bits */
+#define MCAN_IR_TOO_OFS                          (18)                            /* !< TOO Offset */
+#define MCAN_IR_TOO_MASK                         ((uint32_t)0x00040000U)         /* !< Timeout Occurred   0  No timeout
+                                                                                    1  Timeout reached */
+/* MCAN_IR[DRX] Bits */
+#define MCAN_IR_DRX_OFS                          (19)                            /* !< DRX Offset */
+#define MCAN_IR_DRX_MASK                         ((uint32_t)0x00080000U)         /* !< Message Stored to Dedicated Rx
+                                                                                    Buffer. The flag is set whenever a
+                                                                                    received message has been stored into
+                                                                                    a dedicated Rx Buffer.   0  No Rx
+                                                                                    Buffer updated   1  At least one
+                                                                                    received message stored into an Rx
+                                                                                    Buffer */
+/* MCAN_IR[BEU] Bits */
+#define MCAN_IR_BEU_OFS                          (21)                            /* !< BEU Offset */
+#define MCAN_IR_BEU_MASK                         ((uint32_t)0x00200000U)         /* !< Bit Error Uncorrected. Message RAM
+                                                                                    bit error detected, uncorrected. This
+                                                                                    bit is set when a double bit error is
+                                                                                    detected by the ECC aggregator
+                                                                                    attached to the Message RAM. An
+                                                                                    uncorrected Message RAM bit error
+                                                                                    sets CCCR.INIT to '1'. This is done
+                                                                                    to avoid transmission of corrupted
+                                                                                    data.   0  No bit error detected when
+                                                                                    reading from Message RAM   1  Bit
+                                                                                    error detected, uncorrected (e.g.
+                                                                                    parity logic) */
+/* MCAN_IR[ELO] Bits */
+#define MCAN_IR_ELO_OFS                          (22)                            /* !< ELO Offset */
+#define MCAN_IR_ELO_MASK                         ((uint32_t)0x00400000U)         /* !< Error Logging Overflow   0  CAN
+                                                                                    Error Logging Counter did not
+                                                                                    overflow   1  Overflow of CAN Error
+                                                                                    Logging Counter occurred */
+/* MCAN_IR[EP] Bits */
+#define MCAN_IR_EP_OFS                           (23)                            /* !< EP Offset */
+#define MCAN_IR_EP_MASK                          ((uint32_t)0x00800000U)         /* !< Error Passive   0  Error_Passive
+                                                                                    status unchanged   1  Error_Passive
+                                                                                    status changed */
+/* MCAN_IR[EW] Bits */
+#define MCAN_IR_EW_OFS                           (24)                            /* !< EW Offset */
+#define MCAN_IR_EW_MASK                          ((uint32_t)0x01000000U)         /* !< Warning Status   0  Error_Warning
+                                                                                    status unchanged   1  Error_Warning
+                                                                                    status changed */
+/* MCAN_IR[BO] Bits */
+#define MCAN_IR_BO_OFS                           (25)                            /* !< BO Offset */
+#define MCAN_IR_BO_MASK                          ((uint32_t)0x02000000U)         /* !< Bus_Off Status   0  Bus_Off status
+                                                                                    unchanged   1  Bus_Off status changed */
+/* MCAN_IR[WDI] Bits */
+#define MCAN_IR_WDI_OFS                          (26)                            /* !< WDI Offset */
+#define MCAN_IR_WDI_MASK                         ((uint32_t)0x04000000U)         /* !< Watchdog Interrupt   0  No Message
+                                                                                    RAM Watchdog event occurred   1
+                                                                                    Message RAM Watchdog event due to
+                                                                                    missing READY */
+/* MCAN_IR[PEA] Bits */
+#define MCAN_IR_PEA_OFS                          (27)                            /* !< PEA Offset */
+#define MCAN_IR_PEA_MASK                         ((uint32_t)0x08000000U)         /* !< Protocol Error in Arbitration Phase
+                                                                                    (Nominal Bit Time is used)   0  No
+                                                                                    protocol error in arbitration phase
+                                                                                    1  Protocol error in arbitration
+                                                                                    phase detected (PSR.LEC ? 0,7) */
+/* MCAN_IR[PED] Bits */
+#define MCAN_IR_PED_OFS                          (28)                            /* !< PED Offset */
+#define MCAN_IR_PED_MASK                         ((uint32_t)0x10000000U)         /* !< Protocol Error in Data Phase (Data
+                                                                                    Bit Time is used)   0  No protocol
+                                                                                    error in data phase   1  Protocol
+                                                                                    error in data phase detected
+                                                                                    (PSR.DLEC ? 0,7) */
+/* MCAN_IR[ARA] Bits */
+#define MCAN_IR_ARA_OFS                          (29)                            /* !< ARA Offset */
+#define MCAN_IR_ARA_MASK                         ((uint32_t)0x20000000U)         /* !< Access to Reserved Address   0  No
+                                                                                    access to reserved address occurred
+                                                                                    1  Access to reserved address
+                                                                                    occurred */
+
+/* MCAN_IE Bits */
+/* MCAN_IE[RF0NE] Bits */
+#define MCAN_IE_RF0NE_OFS                        (0)                             /* !< RF0NE Offset */
+#define MCAN_IE_RF0NE_MASK                       ((uint32_t)0x00000001U)         /* !< Rx FIFO 0 New Message Enable */
+/* MCAN_IE[RF0WE] Bits */
+#define MCAN_IE_RF0WE_OFS                        (1)                             /* !< RF0WE Offset */
+#define MCAN_IE_RF0WE_MASK                       ((uint32_t)0x00000002U)         /* !< Rx FIFO 0 Watermark Reached Enable */
+/* MCAN_IE[RF0FE] Bits */
+#define MCAN_IE_RF0FE_OFS                        (2)                             /* !< RF0FE Offset */
+#define MCAN_IE_RF0FE_MASK                       ((uint32_t)0x00000004U)         /* !< Rx FIFO 0 Full Enable */
+/* MCAN_IE[RF0LE] Bits */
+#define MCAN_IE_RF0LE_OFS                        (3)                             /* !< RF0LE Offset */
+#define MCAN_IE_RF0LE_MASK                       ((uint32_t)0x00000008U)         /* !< Rx FIFO 0 Message Lost Enable */
+/* MCAN_IE[RF1NE] Bits */
+#define MCAN_IE_RF1NE_OFS                        (4)                             /* !< RF1NE Offset */
+#define MCAN_IE_RF1NE_MASK                       ((uint32_t)0x00000010U)         /* !< Rx FIFO 1 New Message Enable */
+/* MCAN_IE[RF1WE] Bits */
+#define MCAN_IE_RF1WE_OFS                        (5)                             /* !< RF1WE Offset */
+#define MCAN_IE_RF1WE_MASK                       ((uint32_t)0x00000020U)         /* !< Rx FIFO 1 Watermark Reached Enable */
+/* MCAN_IE[RF1FE] Bits */
+#define MCAN_IE_RF1FE_OFS                        (6)                             /* !< RF1FE Offset */
+#define MCAN_IE_RF1FE_MASK                       ((uint32_t)0x00000040U)         /* !< Rx FIFO 1 Full Enable */
+/* MCAN_IE[RF1LE] Bits */
+#define MCAN_IE_RF1LE_OFS                        (7)                             /* !< RF1LE Offset */
+#define MCAN_IE_RF1LE_MASK                       ((uint32_t)0x00000080U)         /* !< Rx FIFO 1 Message Lost Enable */
+/* MCAN_IE[HPME] Bits */
+#define MCAN_IE_HPME_OFS                         (8)                             /* !< HPME Offset */
+#define MCAN_IE_HPME_MASK                        ((uint32_t)0x00000100U)         /* !< High Priority Message Enable */
+/* MCAN_IE[TCE] Bits */
+#define MCAN_IE_TCE_OFS                          (9)                             /* !< TCE Offset */
+#define MCAN_IE_TCE_MASK                         ((uint32_t)0x00000200U)         /* !< Transmission Completed Enable */
+/* MCAN_IE[TCFE] Bits */
+#define MCAN_IE_TCFE_OFS                         (10)                            /* !< TCFE Offset */
+#define MCAN_IE_TCFE_MASK                        ((uint32_t)0x00000400U)         /* !< Transmission Cancellation Finished
+                                                                                    Enable */
+/* MCAN_IE[TFEE] Bits */
+#define MCAN_IE_TFEE_OFS                         (11)                            /* !< TFEE Offset */
+#define MCAN_IE_TFEE_MASK                        ((uint32_t)0x00000800U)         /* !< Tx FIFO Empty Enable */
+/* MCAN_IE[TEFNE] Bits */
+#define MCAN_IE_TEFNE_OFS                        (12)                            /* !< TEFNE Offset */
+#define MCAN_IE_TEFNE_MASK                       ((uint32_t)0x00001000U)         /* !< Tx Event FIFO New Entry Enable */
+/* MCAN_IE[TEFWE] Bits */
+#define MCAN_IE_TEFWE_OFS                        (13)                            /* !< TEFWE Offset */
+#define MCAN_IE_TEFWE_MASK                       ((uint32_t)0x00002000U)         /* !< Tx Event FIFO Watermark Reached
+                                                                                    Enable */
+/* MCAN_IE[TEFFE] Bits */
+#define MCAN_IE_TEFFE_OFS                        (14)                            /* !< TEFFE Offset */
+#define MCAN_IE_TEFFE_MASK                       ((uint32_t)0x00004000U)         /* !< Tx Event FIFO Full Enable */
+/* MCAN_IE[TEFLE] Bits */
+#define MCAN_IE_TEFLE_OFS                        (15)                            /* !< TEFLE Offset */
+#define MCAN_IE_TEFLE_MASK                       ((uint32_t)0x00008000U)         /* !< Tx Event FIFO Element Lost Enable */
+/* MCAN_IE[TSWE] Bits */
+#define MCAN_IE_TSWE_OFS                         (16)                            /* !< TSWE Offset */
+#define MCAN_IE_TSWE_MASK                        ((uint32_t)0x00010000U)         /* !< Timestamp Wraparound Enable */
+/* MCAN_IE[MRAFE] Bits */
+#define MCAN_IE_MRAFE_OFS                        (17)                            /* !< MRAFE Offset */
+#define MCAN_IE_MRAFE_MASK                       ((uint32_t)0x00020000U)         /* !< Message RAM Access Failure Enable */
+/* MCAN_IE[TOOE] Bits */
+#define MCAN_IE_TOOE_OFS                         (18)                            /* !< TOOE Offset */
+#define MCAN_IE_TOOE_MASK                        ((uint32_t)0x00040000U)         /* !< Timeout Occurred Enable */
+/* MCAN_IE[DRXE] Bits */
+#define MCAN_IE_DRXE_OFS                         (19)                            /* !< DRXE Offset */
+#define MCAN_IE_DRXE_MASK                        ((uint32_t)0x00080000U)         /* !< Message Stored to Dedicated Rx
+                                                                                    Buffer Enable */
+/* MCAN_IE[BECE] Bits */
+#define MCAN_IE_BECE_OFS                         (20)                            /* !< BECE Offset */
+#define MCAN_IE_BECE_MASK                        ((uint32_t)0x00100000U)         /* !< Bit Error Corrected Enable   A
+                                                                                    separate interrupt line reserved for
+                                                                                    corrected bit errors is provided via
+                                                                                    the MCAN_ERROR_REGS. It advised for
+                                                                                    the user to use these registers and
+                                                                                    leave this bit cleared to '0'. */
+/* MCAN_IE[BEUE] Bits */
+#define MCAN_IE_BEUE_OFS                         (21)                            /* !< BEUE Offset */
+#define MCAN_IE_BEUE_MASK                        ((uint32_t)0x00200000U)         /* !< Bit Error Uncorrected Enable */
+/* MCAN_IE[ELOE] Bits */
+#define MCAN_IE_ELOE_OFS                         (22)                            /* !< ELOE Offset */
+#define MCAN_IE_ELOE_MASK                        ((uint32_t)0x00400000U)         /* !< Error Logging Overflow Enable */
+/* MCAN_IE[EPE] Bits */
+#define MCAN_IE_EPE_OFS                          (23)                            /* !< EPE Offset */
+#define MCAN_IE_EPE_MASK                         ((uint32_t)0x00800000U)         /* !< Error Passive Enable */
+/* MCAN_IE[EWE] Bits */
+#define MCAN_IE_EWE_OFS                          (24)                            /* !< EWE Offset */
+#define MCAN_IE_EWE_MASK                         ((uint32_t)0x01000000U)         /* !< Warning Status Enable */
+/* MCAN_IE[BOE] Bits */
+#define MCAN_IE_BOE_OFS                          (25)                            /* !< BOE Offset */
+#define MCAN_IE_BOE_MASK                         ((uint32_t)0x02000000U)         /* !< Bus_Off Status Enable */
+/* MCAN_IE[WDIE] Bits */
+#define MCAN_IE_WDIE_OFS                         (26)                            /* !< WDIE Offset */
+#define MCAN_IE_WDIE_MASK                        ((uint32_t)0x04000000U)         /* !< Watchdog Interrupt Enable */
+/* MCAN_IE[PEAE] Bits */
+#define MCAN_IE_PEAE_OFS                         (27)                            /* !< PEAE Offset */
+#define MCAN_IE_PEAE_MASK                        ((uint32_t)0x08000000U)         /* !< Protocol Error in Arbitration Phase
+                                                                                    Enable */
+/* MCAN_IE[PEDE] Bits */
+#define MCAN_IE_PEDE_OFS                         (28)                            /* !< PEDE Offset */
+#define MCAN_IE_PEDE_MASK                        ((uint32_t)0x10000000U)         /* !< Protocol Error in Data Phase Enable */
+/* MCAN_IE[ARAE] Bits */
+#define MCAN_IE_ARAE_OFS                         (29)                            /* !< ARAE Offset */
+#define MCAN_IE_ARAE_MASK                        ((uint32_t)0x20000000U)         /* !< Access to Reserved Address Enable */
+
+/* MCAN_ILS Bits */
+/* MCAN_ILS[RF0NL] Bits */
+#define MCAN_ILS_RF0NL_OFS                       (0)                             /* !< RF0NL Offset */
+#define MCAN_ILS_RF0NL_MASK                      ((uint32_t)0x00000001U)         /* !< Rx FIFO 0 New Message Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[RF0WL] Bits */
+#define MCAN_ILS_RF0WL_OFS                       (1)                             /* !< RF0WL Offset */
+#define MCAN_ILS_RF0WL_MASK                      ((uint32_t)0x00000002U)         /* !< Rx FIFO 0 Watermark Reached Line
+                                                                                    0  Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[RF0FL] Bits */
+#define MCAN_ILS_RF0FL_OFS                       (2)                             /* !< RF0FL Offset */
+#define MCAN_ILS_RF0FL_MASK                      ((uint32_t)0x00000004U)         /* !< Rx FIFO 0 Full Line   0  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    0   1  Interrupt source is assigned
+                                                                                    to Interrupt Line 1 */
+/* MCAN_ILS[RF0LL] Bits */
+#define MCAN_ILS_RF0LL_OFS                       (3)                             /* !< RF0LL Offset */
+#define MCAN_ILS_RF0LL_MASK                      ((uint32_t)0x00000008U)         /* !< Rx FIFO 0 Message Lost Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[RF1NL] Bits */
+#define MCAN_ILS_RF1NL_OFS                       (4)                             /* !< RF1NL Offset */
+#define MCAN_ILS_RF1NL_MASK                      ((uint32_t)0x00000010U)         /* !< Rx FIFO 1 New Message Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[RF1WL] Bits */
+#define MCAN_ILS_RF1WL_OFS                       (5)                             /* !< RF1WL Offset */
+#define MCAN_ILS_RF1WL_MASK                      ((uint32_t)0x00000020U)         /* !< Rx FIFO 1 Watermark Reached Line
+                                                                                    0  Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[RF1FL] Bits */
+#define MCAN_ILS_RF1FL_OFS                       (6)                             /* !< RF1FL Offset */
+#define MCAN_ILS_RF1FL_MASK                      ((uint32_t)0x00000040U)         /* !< Rx FIFO 1 Full Line   0  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    0   1  Interrupt source is assigned
+                                                                                    to Interrupt Line 1 */
+/* MCAN_ILS[RF1LL] Bits */
+#define MCAN_ILS_RF1LL_OFS                       (7)                             /* !< RF1LL Offset */
+#define MCAN_ILS_RF1LL_MASK                      ((uint32_t)0x00000080U)         /* !< Rx FIFO 1 Message Lost Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[HPML] Bits */
+#define MCAN_ILS_HPML_OFS                        (8)                             /* !< HPML Offset */
+#define MCAN_ILS_HPML_MASK                       ((uint32_t)0x00000100U)         /* !< High Priority Message Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[TCL] Bits */
+#define MCAN_ILS_TCL_OFS                         (9)                             /* !< TCL Offset */
+#define MCAN_ILS_TCL_MASK                        ((uint32_t)0x00000200U)         /* !< Transmission Completed Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[TCFL] Bits */
+#define MCAN_ILS_TCFL_OFS                        (10)                            /* !< TCFL Offset */
+#define MCAN_ILS_TCFL_MASK                       ((uint32_t)0x00000400U)         /* !< Transmission Cancellation Finished
+                                                                                    Line   0  Interrupt source is
+                                                                                    assigned to Interrupt Line 0   1
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 1 */
+/* MCAN_ILS[TFEL] Bits */
+#define MCAN_ILS_TFEL_OFS                        (11)                            /* !< TFEL Offset */
+#define MCAN_ILS_TFEL_MASK                       ((uint32_t)0x00000800U)         /* !< Tx FIFO Empty Line   0  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    0   1  Interrupt source is assigned
+                                                                                    to Interrupt Line 1 */
+/* MCAN_ILS[TEFNL] Bits */
+#define MCAN_ILS_TEFNL_OFS                       (12)                            /* !< TEFNL Offset */
+#define MCAN_ILS_TEFNL_MASK                      ((uint32_t)0x00001000U)         /* !< Tx Event FIFO New Entry Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[TEFWL] Bits */
+#define MCAN_ILS_TEFWL_OFS                       (13)                            /* !< TEFWL Offset */
+#define MCAN_ILS_TEFWL_MASK                      ((uint32_t)0x00002000U)         /* !< Tx Event FIFO Watermark Reached
+                                                                                    Line   0  Interrupt source is
+                                                                                    assigned to Interrupt Line 0   1
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 1 */
+/* MCAN_ILS[TEFFL] Bits */
+#define MCAN_ILS_TEFFL_OFS                       (14)                            /* !< TEFFL Offset */
+#define MCAN_ILS_TEFFL_MASK                      ((uint32_t)0x00004000U)         /* !< Tx Event FIFO Full Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[TEFLL] Bits */
+#define MCAN_ILS_TEFLL_OFS                       (15)                            /* !< TEFLL Offset */
+#define MCAN_ILS_TEFLL_MASK                      ((uint32_t)0x00008000U)         /* !< Tx Event FIFO Element Lost Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[TSWL] Bits */
+#define MCAN_ILS_TSWL_OFS                        (16)                            /* !< TSWL Offset */
+#define MCAN_ILS_TSWL_MASK                       ((uint32_t)0x00010000U)         /* !< Timestamp Wraparound Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[MRAFL] Bits */
+#define MCAN_ILS_MRAFL_OFS                       (17)                            /* !< MRAFL Offset */
+#define MCAN_ILS_MRAFL_MASK                      ((uint32_t)0x00020000U)         /* !< Message RAM Access Failure Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[TOOL] Bits */
+#define MCAN_ILS_TOOL_OFS                        (18)                            /* !< TOOL Offset */
+#define MCAN_ILS_TOOL_MASK                       ((uint32_t)0x00040000U)         /* !< Timeout Occurred Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[DRXL] Bits */
+#define MCAN_ILS_DRXL_OFS                        (19)                            /* !< DRXL Offset */
+#define MCAN_ILS_DRXL_MASK                       ((uint32_t)0x00080000U)         /* !< Message Stored to Dedicated Rx
+                                                                                    Buffer Line   0  Interrupt source is
+                                                                                    assigned to Interrupt Line 0   1
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 1 */
+/* MCAN_ILS[BECL] Bits */
+#define MCAN_ILS_BECL_OFS                        (20)                            /* !< BECL Offset */
+#define MCAN_ILS_BECL_MASK                       ((uint32_t)0x00100000U)         /* !< Bit Error Corrected Line   A
+                                                                                    separate interrupt line reserved for
+                                                                                    corrected bit errors is provided via
+                                                                                    the MCAN_ERROR_REGS. It advised for
+                                                                                    the user to use these registers and
+                                                                                    leave the MCAN_IE.BECE bit cleared to
+                                                                                    '0' (disabled), thereby relegating
+                                                                                    this bit to not applicable. */
+/* MCAN_ILS[BEUL] Bits */
+#define MCAN_ILS_BEUL_OFS                        (21)                            /* !< BEUL Offset */
+#define MCAN_ILS_BEUL_MASK                       ((uint32_t)0x00200000U)         /* !< Bit Error Uncorrected Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[ELOL] Bits */
+#define MCAN_ILS_ELOL_OFS                        (22)                            /* !< ELOL Offset */
+#define MCAN_ILS_ELOL_MASK                       ((uint32_t)0x00400000U)         /* !< Error Logging Overflow Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[EPL] Bits */
+#define MCAN_ILS_EPL_OFS                         (23)                            /* !< EPL Offset */
+#define MCAN_ILS_EPL_MASK                        ((uint32_t)0x00800000U)         /* !< Error Passive Line   0  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    0   1  Interrupt source is assigned
+                                                                                    to Interrupt Line 1 */
+/* MCAN_ILS[EWL] Bits */
+#define MCAN_ILS_EWL_OFS                         (24)                            /* !< EWL Offset */
+#define MCAN_ILS_EWL_MASK                        ((uint32_t)0x01000000U)         /* !< Warning Status Line   0  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    0   1  Interrupt source is assigned
+                                                                                    to Interrupt Line 1 */
+/* MCAN_ILS[BOL] Bits */
+#define MCAN_ILS_BOL_OFS                         (25)                            /* !< BOL Offset */
+#define MCAN_ILS_BOL_MASK                        ((uint32_t)0x02000000U)         /* !< Bus_Off Status Line   0  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    0   1  Interrupt source is assigned
+                                                                                    to Interrupt Line 1 */
+/* MCAN_ILS[WDIL] Bits */
+#define MCAN_ILS_WDIL_OFS                        (26)                            /* !< WDIL Offset */
+#define MCAN_ILS_WDIL_MASK                       ((uint32_t)0x04000000U)         /* !< Watchdog Interrupt Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[PEAL] Bits */
+#define MCAN_ILS_PEAL_OFS                        (27)                            /* !< PEAL Offset */
+#define MCAN_ILS_PEAL_MASK                       ((uint32_t)0x08000000U)         /* !< Protocol Error in Arbitration Phase
+                                                                                    Line   0  Interrupt source is
+                                                                                    assigned to Interrupt Line 0   1
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 1 */
+/* MCAN_ILS[PEDL] Bits */
+#define MCAN_ILS_PEDL_OFS                        (28)                            /* !< PEDL Offset */
+#define MCAN_ILS_PEDL_MASK                       ((uint32_t)0x10000000U)         /* !< Protocol Error in Data Phase Line
+                                                                                    0  Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+/* MCAN_ILS[ARAL] Bits */
+#define MCAN_ILS_ARAL_OFS                        (29)                            /* !< ARAL Offset */
+#define MCAN_ILS_ARAL_MASK                       ((uint32_t)0x20000000U)         /* !< Access to Reserved Address Line   0
+                                                                                    Interrupt source is assigned to
+                                                                                    Interrupt Line 0   1  Interrupt
+                                                                                    source is assigned to Interrupt Line
+                                                                                    1 */
+
+/* MCAN_ILE Bits */
+/* MCAN_ILE[EINT0] Bits */
+#define MCAN_ILE_EINT0_OFS                       (0)                             /* !< EINT0 Offset */
+#define MCAN_ILE_EINT0_MASK                      ((uint32_t)0x00000001U)         /* !< Enable Interrupt Line 0   0
+                                                                                    Interrupt Line 0 is disabled   1
+                                                                                    Interrupt Line 0 is enabled */
+/* MCAN_ILE[EINT1] Bits */
+#define MCAN_ILE_EINT1_OFS                       (1)                             /* !< EINT1 Offset */
+#define MCAN_ILE_EINT1_MASK                      ((uint32_t)0x00000002U)         /* !< Enable Interrupt Line 1   0
+                                                                                    Interrupt Line 1 is disabled   1
+                                                                                    Interrupt Line 1 is enabled */
+
+/* MCAN_GFC Bits */
+/* MCAN_GFC[RRFE] Bits */
+#define MCAN_GFC_RRFE_OFS                        (0)                             /* !< RRFE Offset */
+#define MCAN_GFC_RRFE_MASK                       ((uint32_t)0x00000001U)         /* !< Reject Remote Frames Extended   0
+                                                                                    Filter remote frames with 29-bit
+                                                                                    extended IDs   1  Reject all remote
+                                                                                    frames with 29-bit extended IDs
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_GFC[RRFS] Bits */
+#define MCAN_GFC_RRFS_OFS                        (1)                             /* !< RRFS Offset */
+#define MCAN_GFC_RRFS_MASK                       ((uint32_t)0x00000002U)         /* !< Reject Remote Frames Standard   0
+                                                                                    Filter remote frames with 11-bit
+                                                                                    standard IDs   1  Reject all remote
+                                                                                    frames with 11-bit standard IDs
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_GFC[ANFE] Bits */
+#define MCAN_GFC_ANFE_OFS                        (2)                             /* !< ANFE Offset */
+#define MCAN_GFC_ANFE_MASK                       ((uint32_t)0x0000000CU)         /* !< Accept Non-matching Frames
+                                                                                    Extended. Defines how received
+                                                                                    messages with 29-bit IDs that do not
+                                                                                    match any element of the filter list
+                                                                                    are treated.   00  Accept in Rx FIFO
+                                                                                    0   01  Accept in Rx FIFO 1   10
+                                                                                    Reject   11  Reject   Qualified Write
+                                                                                    is possible only with CCCR.CCE='1'
+                                                                                    and CCCR.INIT='1'. */
+/* MCAN_GFC[ANFS] Bits */
+#define MCAN_GFC_ANFS_OFS                        (4)                             /* !< ANFS Offset */
+#define MCAN_GFC_ANFS_MASK                       ((uint32_t)0x00000030U)         /* !< Accept Non-matching Frames
+                                                                                    Standard. Defines how received
+                                                                                    messages with 11-bit IDs that do not
+                                                                                    match any element of the filter list
+                                                                                    are treated.   00  Accept in Rx FIFO
+                                                                                    0   01  Accept in Rx FIFO 1   10
+                                                                                    Reject   11  Reject   Qualified Write
+                                                                                    is possible only with CCCR.CCE='1'
+                                                                                    and CCCR.INIT='1'. */
+
+/* MCAN_SIDFC Bits */
+/* MCAN_SIDFC[FLSSA] Bits */
+#define MCAN_SIDFC_FLSSA_OFS                     (2)                             /* !< FLSSA Offset */
+#define MCAN_SIDFC_FLSSA_MASK                    ((uint32_t)0x0000FFFCU)         /* !< Filter List Standard Start Address.
+                                                                                    Start address of standard Message ID
+                                                                                    filter list (32-bit word address). */
+/* MCAN_SIDFC[LSS] Bits */
+#define MCAN_SIDFC_LSS_OFS                       (16)                            /* !< LSS Offset */
+#define MCAN_SIDFC_LSS_MASK                      ((uint32_t)0x00FF0000U)         /* !< List Size Standard   0        No
+                                                                                    standard Message ID filter   1-128
+                                                                                    Number of standard Message ID filter
+                                                                                    elements   >128   Values greater than
+                                                                                    128 are interpreted as 128 */
+
+/* MCAN_XIDFC Bits */
+/* MCAN_XIDFC[FLESA] Bits */
+#define MCAN_XIDFC_FLESA_OFS                     (2)                             /* !< FLESA Offset */
+#define MCAN_XIDFC_FLESA_MASK                    ((uint32_t)0x0000FFFCU)         /* !< List Size Extended   0     No
+                                                                                    extended Message ID filter   1-64
+                                                                                    Number of extended Message ID filter
+                                                                                    elements   >64  Values greater than
+                                                                                    64 are interpreted as 64   Qualified
+                                                                                    Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_XIDFC[LSE] Bits */
+#define MCAN_XIDFC_LSE_OFS                       (16)                            /* !< LSE Offset */
+#define MCAN_XIDFC_LSE_MASK                      ((uint32_t)0x007F0000U)         /* !< Filter List Extended Start Address.
+                                                                                    Start address of extended Message ID
+                                                                                    filter list (32-bit word address).
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+
+/* MCAN_XIDAM Bits */
+/* MCAN_XIDAM[EIDM] Bits */
+#define MCAN_XIDAM_EIDM_OFS                      (0)                             /* !< EIDM Offset */
+#define MCAN_XIDAM_EIDM_MASK                     ((uint32_t)0x1FFFFFFFU)         /* !< Extended ID Mask. For acceptance
+                                                                                    filtering of extended frames the
+                                                                                    Extended ID AND Mask is ANDed with
+                                                                                    the Message ID of a received frame.
+                                                                                    Intended for masking of 29-bit IDs in
+                                                                                    SAE J1939. With the reset value of
+                                                                                    all bits set to one the mask is not
+                                                                                    active.   Qualified Write is possible
+                                                                                    only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+
+/* MCAN_HPMS Bits */
+/* MCAN_HPMS[BIDX] Bits */
+#define MCAN_HPMS_BIDX_OFS                       (0)                             /* !< BIDX Offset */
+#define MCAN_HPMS_BIDX_MASK                      ((uint32_t)0x0000003FU)         /* !< Buffer Index. Index of Rx FIFO
+                                                                                    element to which the message was
+                                                                                    stored. Only valid when MSI(1) = '1'. */
+/* MCAN_HPMS[MSI] Bits */
+#define MCAN_HPMS_MSI_OFS                        (6)                             /* !< MSI Offset */
+#define MCAN_HPMS_MSI_MASK                       ((uint32_t)0x000000C0U)         /* !< Message Storage Indicator   00  No
+                                                                                    FIFO selected   01  FIFO message lost
+                                                                                    10  Message stored in FIFO 0   11
+                                                                                    Message stored in FIFO 1 */
+/* MCAN_HPMS[FIDX] Bits */
+#define MCAN_HPMS_FIDX_OFS                       (8)                             /* !< FIDX Offset */
+#define MCAN_HPMS_FIDX_MASK                      ((uint32_t)0x00007F00U)         /* !< Filter Index. Index of matching
+                                                                                    filter element. Range is 0 to
+                                                                                    SIDFC.LSS - 1 resp. XIDFC.LSE - 1. */
+/* MCAN_HPMS[FLST] Bits */
+#define MCAN_HPMS_FLST_OFS                       (15)                            /* !< FLST Offset */
+#define MCAN_HPMS_FLST_MASK                      ((uint32_t)0x00008000U)         /* !< Filter List. Indicates the filter
+                                                                                    list of the matching filter element.
+                                                                                    0  Standard Filter List   1
+                                                                                    Extended Filter List */
+
+/* MCAN_NDAT1 Bits */
+/* MCAN_NDAT1[ND0] Bits */
+#define MCAN_NDAT1_ND0_OFS                       (0)                             /* !< ND0 Offset */
+#define MCAN_NDAT1_ND0_MASK                      ((uint32_t)0x00000001U)         /* !< New Data RX Buffer 0   0  Rx Buffer
+                                                                                    not updated   1  Rx Buffer updated
+                                                                                    from new message */
+/* MCAN_NDAT1[ND1] Bits */
+#define MCAN_NDAT1_ND1_OFS                       (1)                             /* !< ND1 Offset */
+#define MCAN_NDAT1_ND1_MASK                      ((uint32_t)0x00000002U)         /* !< New Data RX Buffer 1   0  Rx Buffer
+                                                                                    not updated   1  Rx Buffer updated
+                                                                                    from new message */
+/* MCAN_NDAT1[ND2] Bits */
+#define MCAN_NDAT1_ND2_OFS                       (2)                             /* !< ND2 Offset */
+#define MCAN_NDAT1_ND2_MASK                      ((uint32_t)0x00000004U)         /* !< New Data RX Buffer 2   0  Rx Buffer
+                                                                                    not updated   1  Rx Buffer updated
+                                                                                    from new message */
+/* MCAN_NDAT1[ND3] Bits */
+#define MCAN_NDAT1_ND3_OFS                       (3)                             /* !< ND3 Offset */
+#define MCAN_NDAT1_ND3_MASK                      ((uint32_t)0x00000008U)         /* !< New Data RX Buffer 3   0  Rx Buffer
+                                                                                    not updated   1  Rx Buffer updated
+                                                                                    from new message */
+/* MCAN_NDAT1[ND4] Bits */
+#define MCAN_NDAT1_ND4_OFS                       (4)                             /* !< ND4 Offset */
+#define MCAN_NDAT1_ND4_MASK                      ((uint32_t)0x00000010U)         /* !< New Data RX Buffer 4   0  Rx Buffer
+                                                                                    not updated   1  Rx Buffer updated
+                                                                                    from new message */
+/* MCAN_NDAT1[ND5] Bits */
+#define MCAN_NDAT1_ND5_OFS                       (5)                             /* !< ND5 Offset */
+#define MCAN_NDAT1_ND5_MASK                      ((uint32_t)0x00000020U)         /* !< New Data RX Buffer 5   0  Rx Buffer
+                                                                                    not updated   1  Rx Buffer updated
+                                                                                    from new message */
+/* MCAN_NDAT1[ND6] Bits */
+#define MCAN_NDAT1_ND6_OFS                       (6)                             /* !< ND6 Offset */
+#define MCAN_NDAT1_ND6_MASK                      ((uint32_t)0x00000040U)         /* !< New Data RX Buffer 6   0  Rx Buffer
+                                                                                    not updated   1  Rx Buffer updated
+                                                                                    from new message */
+/* MCAN_NDAT1[ND7] Bits */
+#define MCAN_NDAT1_ND7_OFS                       (7)                             /* !< ND7 Offset */
+#define MCAN_NDAT1_ND7_MASK                      ((uint32_t)0x00000080U)         /* !< New Data RX Buffer 7   0  Rx Buffer
+                                                                                    not updated   1  Rx Buffer updated
+                                                                                    from new message */
+/* MCAN_NDAT1[ND8] Bits */
+#define MCAN_NDAT1_ND8_OFS                       (8)                             /* !< ND8 Offset */
+#define MCAN_NDAT1_ND8_MASK                      ((uint32_t)0x00000100U)         /* !< New Data RX Buffer 8   0  Rx Buffer
+                                                                                    not updated   1  Rx Buffer updated
+                                                                                    from new message */
+/* MCAN_NDAT1[ND9] Bits */
+#define MCAN_NDAT1_ND9_OFS                       (9)                             /* !< ND9 Offset */
+#define MCAN_NDAT1_ND9_MASK                      ((uint32_t)0x00000200U)         /* !< New Data RX Buffer 9   0  Rx Buffer
+                                                                                    not updated   1  Rx Buffer updated
+                                                                                    from new message */
+/* MCAN_NDAT1[ND10] Bits */
+#define MCAN_NDAT1_ND10_OFS                      (10)                            /* !< ND10 Offset */
+#define MCAN_NDAT1_ND10_MASK                     ((uint32_t)0x00000400U)         /* !< New Data RX Buffer 10   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND11] Bits */
+#define MCAN_NDAT1_ND11_OFS                      (11)                            /* !< ND11 Offset */
+#define MCAN_NDAT1_ND11_MASK                     ((uint32_t)0x00000800U)         /* !< New Data RX Buffer 11   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND12] Bits */
+#define MCAN_NDAT1_ND12_OFS                      (12)                            /* !< ND12 Offset */
+#define MCAN_NDAT1_ND12_MASK                     ((uint32_t)0x00001000U)         /* !< New Data RX Buffer 12   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND13] Bits */
+#define MCAN_NDAT1_ND13_OFS                      (13)                            /* !< ND13 Offset */
+#define MCAN_NDAT1_ND13_MASK                     ((uint32_t)0x00002000U)         /* !< New Data RX Buffer 13   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND14] Bits */
+#define MCAN_NDAT1_ND14_OFS                      (14)                            /* !< ND14 Offset */
+#define MCAN_NDAT1_ND14_MASK                     ((uint32_t)0x00004000U)         /* !< New Data RX Buffer 14   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND15] Bits */
+#define MCAN_NDAT1_ND15_OFS                      (15)                            /* !< ND15 Offset */
+#define MCAN_NDAT1_ND15_MASK                     ((uint32_t)0x00008000U)         /* !< New Data RX Buffer 15   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND16] Bits */
+#define MCAN_NDAT1_ND16_OFS                      (16)                            /* !< ND16 Offset */
+#define MCAN_NDAT1_ND16_MASK                     ((uint32_t)0x00010000U)         /* !< New Data RX Buffer 16   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND17] Bits */
+#define MCAN_NDAT1_ND17_OFS                      (17)                            /* !< ND17 Offset */
+#define MCAN_NDAT1_ND17_MASK                     ((uint32_t)0x00020000U)         /* !< New Data RX Buffer 17   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND18] Bits */
+#define MCAN_NDAT1_ND18_OFS                      (18)                            /* !< ND18 Offset */
+#define MCAN_NDAT1_ND18_MASK                     ((uint32_t)0x00040000U)         /* !< New Data RX Buffer 18   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND19] Bits */
+#define MCAN_NDAT1_ND19_OFS                      (19)                            /* !< ND19 Offset */
+#define MCAN_NDAT1_ND19_MASK                     ((uint32_t)0x00080000U)         /* !< New Data RX Buffer 19   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND20] Bits */
+#define MCAN_NDAT1_ND20_OFS                      (20)                            /* !< ND20 Offset */
+#define MCAN_NDAT1_ND20_MASK                     ((uint32_t)0x00100000U)         /* !< New Data RX Buffer 20   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND21] Bits */
+#define MCAN_NDAT1_ND21_OFS                      (21)                            /* !< ND21 Offset */
+#define MCAN_NDAT1_ND21_MASK                     ((uint32_t)0x00200000U)         /* !< New Data RX Buffer 21   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND22] Bits */
+#define MCAN_NDAT1_ND22_OFS                      (22)                            /* !< ND22 Offset */
+#define MCAN_NDAT1_ND22_MASK                     ((uint32_t)0x00400000U)         /* !< New Data RX Buffer 22   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND23] Bits */
+#define MCAN_NDAT1_ND23_OFS                      (23)                            /* !< ND23 Offset */
+#define MCAN_NDAT1_ND23_MASK                     ((uint32_t)0x00800000U)         /* !< New Data RX Buffer 23   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND24] Bits */
+#define MCAN_NDAT1_ND24_OFS                      (24)                            /* !< ND24 Offset */
+#define MCAN_NDAT1_ND24_MASK                     ((uint32_t)0x01000000U)         /* !< New Data RX Buffer 24   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND25] Bits */
+#define MCAN_NDAT1_ND25_OFS                      (25)                            /* !< ND25 Offset */
+#define MCAN_NDAT1_ND25_MASK                     ((uint32_t)0x02000000U)         /* !< New Data RX Buffer 25   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND26] Bits */
+#define MCAN_NDAT1_ND26_OFS                      (26)                            /* !< ND26 Offset */
+#define MCAN_NDAT1_ND26_MASK                     ((uint32_t)0x04000000U)         /* !< New Data RX Buffer 26   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND27] Bits */
+#define MCAN_NDAT1_ND27_OFS                      (27)                            /* !< ND27 Offset */
+#define MCAN_NDAT1_ND27_MASK                     ((uint32_t)0x08000000U)         /* !< New Data RX Buffer 27   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND28] Bits */
+#define MCAN_NDAT1_ND28_OFS                      (28)                            /* !< ND28 Offset */
+#define MCAN_NDAT1_ND28_MASK                     ((uint32_t)0x10000000U)         /* !< New Data RX Buffer 28   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND29] Bits */
+#define MCAN_NDAT1_ND29_OFS                      (29)                            /* !< ND29 Offset */
+#define MCAN_NDAT1_ND29_MASK                     ((uint32_t)0x20000000U)         /* !< New Data RX Buffer 29   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND30] Bits */
+#define MCAN_NDAT1_ND30_OFS                      (30)                            /* !< ND30 Offset */
+#define MCAN_NDAT1_ND30_MASK                     ((uint32_t)0x40000000U)         /* !< New Data RX Buffer 30   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT1[ND31] Bits */
+#define MCAN_NDAT1_ND31_OFS                      (31)                            /* !< ND31 Offset */
+#define MCAN_NDAT1_ND31_MASK                     ((uint32_t)0x80000000U)         /* !< New Data RX Buffer 31   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+
+/* MCAN_NDAT2 Bits */
+/* MCAN_NDAT2[ND32] Bits */
+#define MCAN_NDAT2_ND32_OFS                      (0)                             /* !< ND32 Offset */
+#define MCAN_NDAT2_ND32_MASK                     ((uint32_t)0x00000001U)         /* !< New Data RX Buffer 32   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND33] Bits */
+#define MCAN_NDAT2_ND33_OFS                      (1)                             /* !< ND33 Offset */
+#define MCAN_NDAT2_ND33_MASK                     ((uint32_t)0x00000002U)         /* !< New Data RX Buffer 33   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND34] Bits */
+#define MCAN_NDAT2_ND34_OFS                      (2)                             /* !< ND34 Offset */
+#define MCAN_NDAT2_ND34_MASK                     ((uint32_t)0x00000004U)         /* !< New Data RX Buffer 34   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND35] Bits */
+#define MCAN_NDAT2_ND35_OFS                      (3)                             /* !< ND35 Offset */
+#define MCAN_NDAT2_ND35_MASK                     ((uint32_t)0x00000008U)         /* !< New Data RX Buffer 35   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND36] Bits */
+#define MCAN_NDAT2_ND36_OFS                      (4)                             /* !< ND36 Offset */
+#define MCAN_NDAT2_ND36_MASK                     ((uint32_t)0x00000010U)         /* !< New Data RX Buffer 36   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND37] Bits */
+#define MCAN_NDAT2_ND37_OFS                      (5)                             /* !< ND37 Offset */
+#define MCAN_NDAT2_ND37_MASK                     ((uint32_t)0x00000020U)         /* !< New Data RX Buffer 37   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND38] Bits */
+#define MCAN_NDAT2_ND38_OFS                      (6)                             /* !< ND38 Offset */
+#define MCAN_NDAT2_ND38_MASK                     ((uint32_t)0x00000040U)         /* !< New Data RX Buffer 38   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND39] Bits */
+#define MCAN_NDAT2_ND39_OFS                      (7)                             /* !< ND39 Offset */
+#define MCAN_NDAT2_ND39_MASK                     ((uint32_t)0x00000080U)         /* !< New Data RX Buffer 39   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND40] Bits */
+#define MCAN_NDAT2_ND40_OFS                      (8)                             /* !< ND40 Offset */
+#define MCAN_NDAT2_ND40_MASK                     ((uint32_t)0x00000100U)         /* !< New Data RX Buffer 40   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND41] Bits */
+#define MCAN_NDAT2_ND41_OFS                      (9)                             /* !< ND41 Offset */
+#define MCAN_NDAT2_ND41_MASK                     ((uint32_t)0x00000200U)         /* !< New Data RX Buffer 41   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND42] Bits */
+#define MCAN_NDAT2_ND42_OFS                      (10)                            /* !< ND42 Offset */
+#define MCAN_NDAT2_ND42_MASK                     ((uint32_t)0x00000400U)         /* !< New Data RX Buffer 42   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND43] Bits */
+#define MCAN_NDAT2_ND43_OFS                      (11)                            /* !< ND43 Offset */
+#define MCAN_NDAT2_ND43_MASK                     ((uint32_t)0x00000800U)         /* !< New Data RX Buffer 43   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND44] Bits */
+#define MCAN_NDAT2_ND44_OFS                      (12)                            /* !< ND44 Offset */
+#define MCAN_NDAT2_ND44_MASK                     ((uint32_t)0x00001000U)         /* !< New Data RX Buffer 44   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND45] Bits */
+#define MCAN_NDAT2_ND45_OFS                      (13)                            /* !< ND45 Offset */
+#define MCAN_NDAT2_ND45_MASK                     ((uint32_t)0x00002000U)         /* !< New Data RX Buffer 45   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND46] Bits */
+#define MCAN_NDAT2_ND46_OFS                      (14)                            /* !< ND46 Offset */
+#define MCAN_NDAT2_ND46_MASK                     ((uint32_t)0x00004000U)         /* !< New Data RX Buffer 46   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND47] Bits */
+#define MCAN_NDAT2_ND47_OFS                      (15)                            /* !< ND47 Offset */
+#define MCAN_NDAT2_ND47_MASK                     ((uint32_t)0x00008000U)         /* !< New Data RX Buffer 47   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND48] Bits */
+#define MCAN_NDAT2_ND48_OFS                      (16)                            /* !< ND48 Offset */
+#define MCAN_NDAT2_ND48_MASK                     ((uint32_t)0x00010000U)         /* !< New Data RX Buffer 48   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND49] Bits */
+#define MCAN_NDAT2_ND49_OFS                      (17)                            /* !< ND49 Offset */
+#define MCAN_NDAT2_ND49_MASK                     ((uint32_t)0x00020000U)         /* !< New Data RX Buffer 49   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND50] Bits */
+#define MCAN_NDAT2_ND50_OFS                      (18)                            /* !< ND50 Offset */
+#define MCAN_NDAT2_ND50_MASK                     ((uint32_t)0x00040000U)         /* !< New Data RX Buffer 50   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND51] Bits */
+#define MCAN_NDAT2_ND51_OFS                      (19)                            /* !< ND51 Offset */
+#define MCAN_NDAT2_ND51_MASK                     ((uint32_t)0x00080000U)         /* !< New Data RX Buffer 51   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND52] Bits */
+#define MCAN_NDAT2_ND52_OFS                      (20)                            /* !< ND52 Offset */
+#define MCAN_NDAT2_ND52_MASK                     ((uint32_t)0x00100000U)         /* !< New Data RX Buffer 52   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND53] Bits */
+#define MCAN_NDAT2_ND53_OFS                      (21)                            /* !< ND53 Offset */
+#define MCAN_NDAT2_ND53_MASK                     ((uint32_t)0x00200000U)         /* !< New Data RX Buffer 53   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND54] Bits */
+#define MCAN_NDAT2_ND54_OFS                      (22)                            /* !< ND54 Offset */
+#define MCAN_NDAT2_ND54_MASK                     ((uint32_t)0x00400000U)         /* !< New Data RX Buffer 54   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND55] Bits */
+#define MCAN_NDAT2_ND55_OFS                      (23)                            /* !< ND55 Offset */
+#define MCAN_NDAT2_ND55_MASK                     ((uint32_t)0x00800000U)         /* !< New Data RX Buffer 55   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND56] Bits */
+#define MCAN_NDAT2_ND56_OFS                      (24)                            /* !< ND56 Offset */
+#define MCAN_NDAT2_ND56_MASK                     ((uint32_t)0x01000000U)         /* !< New Data RX Buffer 56   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND57] Bits */
+#define MCAN_NDAT2_ND57_OFS                      (25)                            /* !< ND57 Offset */
+#define MCAN_NDAT2_ND57_MASK                     ((uint32_t)0x02000000U)         /* !< New Data RX Buffer 57   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND58] Bits */
+#define MCAN_NDAT2_ND58_OFS                      (26)                            /* !< ND58 Offset */
+#define MCAN_NDAT2_ND58_MASK                     ((uint32_t)0x04000000U)         /* !< New Data RX Buffer 58   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND59] Bits */
+#define MCAN_NDAT2_ND59_OFS                      (27)                            /* !< ND59 Offset */
+#define MCAN_NDAT2_ND59_MASK                     ((uint32_t)0x08000000U)         /* !< New Data RX Buffer 59   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND60] Bits */
+#define MCAN_NDAT2_ND60_OFS                      (28)                            /* !< ND60 Offset */
+#define MCAN_NDAT2_ND60_MASK                     ((uint32_t)0x10000000U)         /* !< New Data RX Buffer 60   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND61] Bits */
+#define MCAN_NDAT2_ND61_OFS                      (29)                            /* !< ND61 Offset */
+#define MCAN_NDAT2_ND61_MASK                     ((uint32_t)0x20000000U)         /* !< New Data RX Buffer 61   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND62] Bits */
+#define MCAN_NDAT2_ND62_OFS                      (30)                            /* !< ND62 Offset */
+#define MCAN_NDAT2_ND62_MASK                     ((uint32_t)0x40000000U)         /* !< New Data RX Buffer 62   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+/* MCAN_NDAT2[ND63] Bits */
+#define MCAN_NDAT2_ND63_OFS                      (31)                            /* !< ND63 Offset */
+#define MCAN_NDAT2_ND63_MASK                     ((uint32_t)0x80000000U)         /* !< New Data RX Buffer 63   0  Rx
+                                                                                    Buffer not updated   1  Rx Buffer
+                                                                                    updated from new message */
+
+/* MCAN_RXF0C Bits */
+/* MCAN_RXF0C[F0SA] Bits */
+#define MCAN_RXF0C_F0SA_OFS                      (2)                             /* !< F0SA Offset */
+#define MCAN_RXF0C_F0SA_MASK                     ((uint32_t)0x0000FFFCU)         /* !< Rx FIFO 0 Start Address. Start
+                                                                                    address of Rx FIFO 0 in Message RAM
+                                                                                    (32-bit word address).   Qualified
+                                                                                    Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_RXF0C[F0S] Bits */
+#define MCAN_RXF0C_F0S_OFS                       (16)                            /* !< F0S Offset */
+#define MCAN_RXF0C_F0S_MASK                      ((uint32_t)0x007F0000U)         /* !< Rx FIFO 0 Size. The Rx FIFO 0
+                                                                                    elements are indexed from 0 to F0S-1.
+                                                                                    0      No Rx FIFO 0   1-64  Number
+                                                                                    of Rx FIFO 0 elements   >64   Values
+                                                                                    greater than 64 are interpreted as 64
+                                                                                    Qualified Write is possible only
+                                                                                    with CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_RXF0C[F0WM] Bits */
+#define MCAN_RXF0C_F0WM_OFS                      (24)                            /* !< F0WM Offset */
+#define MCAN_RXF0C_F0WM_MASK                     ((uint32_t)0x7F000000U)         /* !< Rx FIFO 0 Watermark   0
+                                                                                    Watermark interrupt disabled   1-64
+                                                                                    Level for Rx FIFO 0 watermark
+                                                                                    interrupt (IR.RF0W)   >64   Watermark
+                                                                                    interrupt disabled   Qualified Write
+                                                                                    is possible only with CCCR.CCE='1'
+                                                                                    and CCCR.INIT='1'. */
+/* MCAN_RXF0C[F0OM] Bits */
+#define MCAN_RXF0C_F0OM_OFS                      (31)                            /* !< F0OM Offset */
+#define MCAN_RXF0C_F0OM_MASK                     ((uint32_t)0x80000000U)         /* !< FIFO 0 Operation Mode. FIFO 0 can
+                                                                                    be operated in blocking or in
+                                                                                    overwrite mode.   0  FIFO 0 blocking
+                                                                                    mode   1  FIFO 0 overwrite mode
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+
+/* MCAN_RXF0S Bits */
+/* MCAN_RXF0S[F0FL] Bits */
+#define MCAN_RXF0S_F0FL_OFS                      (0)                             /* !< F0FL Offset */
+#define MCAN_RXF0S_F0FL_MASK                     ((uint32_t)0x0000007FU)         /* !< Rx FIFO 0 Fill Level. Number of
+                                                                                    elements stored in Rx FIFO 0, range 0
+                                                                                    to 64. */
+/* MCAN_RXF0S[F0GI] Bits */
+#define MCAN_RXF0S_F0GI_OFS                      (8)                             /* !< F0GI Offset */
+#define MCAN_RXF0S_F0GI_MASK                     ((uint32_t)0x00003F00U)         /* !< Rx FIFO 0 Get Index. Rx FIFO 0 read
+                                                                                    index pointer, range 0 to 63. */
+/* MCAN_RXF0S[F0PI] Bits */
+#define MCAN_RXF0S_F0PI_OFS                      (16)                            /* !< F0PI Offset */
+#define MCAN_RXF0S_F0PI_MASK                     ((uint32_t)0x003F0000U)         /* !< Rx FIFO 0 Put Index. Rx FIFO 0
+                                                                                    write index pointer, range 0 to 63. */
+/* MCAN_RXF0S[F0F] Bits */
+#define MCAN_RXF0S_F0F_OFS                       (24)                            /* !< F0F Offset */
+#define MCAN_RXF0S_F0F_MASK                      ((uint32_t)0x01000000U)         /* !< Rx FIFO 0 Full   0  Rx FIFO 0 not
+                                                                                    full   1  Rx FIFO 0 full */
+/* MCAN_RXF0S[RF0L] Bits */
+#define MCAN_RXF0S_RF0L_OFS                      (25)                            /* !< RF0L Offset */
+#define MCAN_RXF0S_RF0L_MASK                     ((uint32_t)0x02000000U)         /* !< Rx FIFO 0 Message Lost. This bit is
+                                                                                    a copy of interrupt flag IR.RF0L.
+                                                                                    When IR.RF0L is reset, this bit is
+                                                                                    also reset.   0  No Rx FIFO 0 message
+                                                                                    lost   1  Rx FIFO 0 message lost,
+                                                                                    also set after write attempt to Rx
+                                                                                    FIFO 0 of size zero   Note:
+                                                                                    Overwriting the oldest message when
+                                                                                    RXF0C.F0OM = '1' will not set this
+                                                                                    flag. */
+
+/* MCAN_RXF0A Bits */
+/* MCAN_RXF0A[F0AI] Bits */
+#define MCAN_RXF0A_F0AI_OFS                      (0)                             /* !< F0AI Offset */
+#define MCAN_RXF0A_F0AI_MASK                     ((uint32_t)0x0000003FU)         /* !< Rx FIFO 0 Acknowledge Index. After
+                                                                                    the Host has read a message or a
+                                                                                    sequence of messages from Rx FIFO 0
+                                                                                    it has to write the buffer index of
+                                                                                    the last element read from Rx FIFO 0
+                                                                                    to F0AI. This will set the Rx FIFO 0
+                                                                                    Get Index RXF0S.F0GI to F0AI + 1 and
+                                                                                    update the FIFO 0 Fill Level
+                                                                                    RXF0S.F0FL. */
+
+/* MCAN_RXBC Bits */
+/* MCAN_RXBC[RBSA] Bits */
+#define MCAN_RXBC_RBSA_OFS                       (2)                             /* !< RBSA Offset */
+#define MCAN_RXBC_RBSA_MASK                      ((uint32_t)0x0000FFFCU)         /* !< Rx Buffer Start Address. Configures
+                                                                                    the start address of the Rx Buffers
+                                                                                    section in the Message RAM (32-bit
+                                                                                    word address).   +I466 */
+
+/* MCAN_RXF1C Bits */
+/* MCAN_RXF1C[F1SA] Bits */
+#define MCAN_RXF1C_F1SA_OFS                      (2)                             /* !< F1SA Offset */
+#define MCAN_RXF1C_F1SA_MASK                     ((uint32_t)0x0000FFFCU)         /* !< Rx FIFO 1 Start Address Start
+                                                                                    address of Rx FIFO 1 in Message RAM
+                                                                                    (32-bit word address). */
+/* MCAN_RXF1C[F1S] Bits */
+#define MCAN_RXF1C_F1S_OFS                       (16)                            /* !< F1S Offset */
+#define MCAN_RXF1C_F1S_MASK                      ((uint32_t)0x007F0000U)         /* !< Rx FIFO 1 Size. The Rx FIFO 1
+                                                                                    elements are indexed from 0 to F1S -
+                                                                                    1.   0      No Rx FIFO 1   1-64
+                                                                                    Number of Rx FIFO 1 elements   >64
+                                                                                    Values greater than 64 are
+                                                                                    interpreted as 64   Qualified Write
+                                                                                    is possible only with CCCR.CCE='1'
+                                                                                    and CCCR.INIT='1'. */
+/* MCAN_RXF1C[F1WM] Bits */
+#define MCAN_RXF1C_F1WM_OFS                      (24)                            /* !< F1WM Offset */
+#define MCAN_RXF1C_F1WM_MASK                     ((uint32_t)0x7F000000U)         /* !< Rx FIFO 1 Watermark   0
+                                                                                    Watermark interrupt disabled   1-64
+                                                                                    Level for Rx FIFO 1 watermark
+                                                                                    interrupt (IR.RF1W)   >64   Watermark
+                                                                                    interrupt disabled   Qualified Write
+                                                                                    is possible only with CCCR.CCE='1'
+                                                                                    and CCCR.INIT='1'. */
+/* MCAN_RXF1C[F1OM] Bits */
+#define MCAN_RXF1C_F1OM_OFS                      (31)                            /* !< F1OM Offset */
+#define MCAN_RXF1C_F1OM_MASK                     ((uint32_t)0x80000000U)         /* !< FIFO 1 Operation Mode. FIFO 1 can
+                                                                                    be operated in blocking or in
+                                                                                    overwrite mode.   0  FIFO 1 blocking
+                                                                                    mode   1  FIFO 1 overwrite mode
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+
+/* MCAN_RXF1S Bits */
+/* MCAN_RXF1S[F1FL] Bits */
+#define MCAN_RXF1S_F1FL_OFS                      (0)                             /* !< F1FL Offset */
+#define MCAN_RXF1S_F1FL_MASK                     ((uint32_t)0x0000007FU)         /* !< Rx FIFO 1 Fill Level. Number of
+                                                                                    elements stored in Rx FIFO 1, range 0
+                                                                                    to 64. */
+/* MCAN_RXF1S[F1GI] Bits */
+#define MCAN_RXF1S_F1GI_OFS                      (8)                             /* !< F1GI Offset */
+#define MCAN_RXF1S_F1GI_MASK                     ((uint32_t)0x00003F00U)         /* !< Rx FIFO 1 Get Index. Rx FIFO 1 read
+                                                                                    index pointer, range 0 to 63. */
+/* MCAN_RXF1S[F1PI] Bits */
+#define MCAN_RXF1S_F1PI_OFS                      (16)                            /* !< F1PI Offset */
+#define MCAN_RXF1S_F1PI_MASK                     ((uint32_t)0x003F0000U)         /* !< Rx FIFO 1 Put Index. Rx FIFO 1
+                                                                                    write index pointer, range 0 to 63. */
+/* MCAN_RXF1S[F1F] Bits */
+#define MCAN_RXF1S_F1F_OFS                       (24)                            /* !< F1F Offset */
+#define MCAN_RXF1S_F1F_MASK                      ((uint32_t)0x01000000U)         /* !< Rx FIFO 1 Full   0  Rx FIFO 1 not
+                                                                                    full   1  Rx FIFO 1 full */
+/* MCAN_RXF1S[RF1L] Bits */
+#define MCAN_RXF1S_RF1L_OFS                      (25)                            /* !< RF1L Offset */
+#define MCAN_RXF1S_RF1L_MASK                     ((uint32_t)0x02000000U)         /* !< Rx FIFO 1 Message Lost. This bit is
+                                                                                    a copy of interrupt flag IR.RF1L.
+                                                                                    When IR.RF1L is reset, this bit is
+                                                                                    also reset.   0  No Rx FIFO 1 message
+                                                                                    lost   1  Rx FIFO 1 message lost,
+                                                                                    also set after write attempt to Rx
+                                                                                    FIFO 1 of size zero   Note:
+                                                                                    Overwriting the oldest message when
+                                                                                    RXF1C.F1OM = '1' will not set this
+                                                                                    flag. */
+/* MCAN_RXF1S[DMS] Bits */
+#define MCAN_RXF1S_DMS_OFS                       (30)                            /* !< DMS Offset */
+#define MCAN_RXF1S_DMS_MASK                      ((uint32_t)0xC0000000U)         /* !< Debug Message Status   00  Idle
+                                                                                    state, wait for reception of debug
+                                                                                    messages   01  Debug message A
+                                                                                    received   10  Debug messages A, B
+                                                                                    received   11  Debug messages A, B, C
+                                                                                    received */
+
+/* MCAN_RXF1A Bits */
+/* MCAN_RXF1A[F1AI] Bits */
+#define MCAN_RXF1A_F1AI_OFS                      (0)                             /* !< F1AI Offset */
+#define MCAN_RXF1A_F1AI_MASK                     ((uint32_t)0x0000003FU)         /* !< Rx FIFO 1 Acknowledge Index. After
+                                                                                    the Host has read a message or a
+                                                                                    sequence of messages from Rx FIFO 1
+                                                                                    it has to write the buffer index of
+                                                                                    the last element read from Rx FIFO 1
+                                                                                    to F1AI. This will set the Rx FIFO 1
+                                                                                    Get Index RXF1S.F1GI to F1AI + 1 and
+                                                                                    update the FIFO 1 Fill Level
+                                                                                    RXF1S.F1FL. */
+
+/* MCAN_RXESC Bits */
+/* MCAN_RXESC[F0DS] Bits */
+#define MCAN_RXESC_F0DS_OFS                      (0)                             /* !< F0DS Offset */
+#define MCAN_RXESC_F0DS_MASK                     ((uint32_t)0x00000007U)         /* !< Rx FIFO 0 Data Field Size   000  8
+                                                                                    byte data field   001  12 byte data
+                                                                                    field   010  16 byte data field   011
+                                                                                    20 byte data field   100  24 byte
+                                                                                    data field   101  32 byte data field
+                                                                                    110  48 byte data field   111  64
+                                                                                    byte data field   Note: In case the
+                                                                                    data field size of an accepted CAN
+                                                                                    frame exceeds the data field size
+                                                                                    configured for the matching Rx Buffer
+                                                                                    or Rx FIFO, only the number of bytes
+                                                                                    as configured by RXESC are stored to
+                                                                                    the Rx Buffer resp. Rx FIFO element.
+                                                                                    The rest of the frame's data field is
+                                                                                    ignored.   Qualified Write is
+                                                                                    possible only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+/* MCAN_RXESC[F1DS] Bits */
+#define MCAN_RXESC_F1DS_OFS                      (4)                             /* !< F1DS Offset */
+#define MCAN_RXESC_F1DS_MASK                     ((uint32_t)0x00000070U)         /* !< Rx FIFO 1 Data Field Size   000  8
+                                                                                    byte data field   001  12 byte data
+                                                                                    field   010  16 byte data field   011
+                                                                                    20 byte data field   100  24 byte
+                                                                                    data field   101  32 byte data field
+                                                                                    110  48 byte data field   111  64
+                                                                                    byte data field   Note: In case the
+                                                                                    data field size of an accepted CAN
+                                                                                    frame exceeds the data field size
+                                                                                    configured for the matching Rx Buffer
+                                                                                    or Rx FIFO, only the number of bytes
+                                                                                    as configured by RXESC are stored to
+                                                                                    the Rx Buffer resp. Rx FIFO element.
+                                                                                    The rest of the frame's data field is
+                                                                                    ignored.   Qualified Write is
+                                                                                    possible only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+/* MCAN_RXESC[RBDS] Bits */
+#define MCAN_RXESC_RBDS_OFS                      (8)                             /* !< RBDS Offset */
+#define MCAN_RXESC_RBDS_MASK                     ((uint32_t)0x00000700U)         /* !< Rx Buffer Data Field Size   000  8
+                                                                                    byte data field   001  12 byte data
+                                                                                    field   010  16 byte data field   011
+                                                                                    20 byte data field   100  24 byte
+                                                                                    data field   101  32 byte data field
+                                                                                    110  48 byte data field   111  64
+                                                                                    byte data field   Note: In case the
+                                                                                    data field size of an accepted CAN
+                                                                                    frame exceeds the data field size
+                                                                                    configured for the matching Rx Buffer
+                                                                                    or Rx FIFO, only the number of bytes
+                                                                                    as configured by RXESC are stored to
+                                                                                    the Rx Buffer resp. Rx FIFO element.
+                                                                                    The rest of the frame's data field is
+                                                                                    ignored.   Qualified Write is
+                                                                                    possible only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+
+/* MCAN_TXBC Bits */
+/* MCAN_TXBC[TBSA] Bits */
+#define MCAN_TXBC_TBSA_OFS                       (2)                             /* !< TBSA Offset */
+#define MCAN_TXBC_TBSA_MASK                      ((uint32_t)0x0000FFFCU)         /* !< Tx Buffers Start Address. Start
+                                                                                    address of Tx Buffers section in
+                                                                                    Message RAM (32-bit word address).
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_TXBC[NDTB] Bits */
+#define MCAN_TXBC_NDTB_OFS                       (16)                            /* !< NDTB Offset */
+#define MCAN_TXBC_NDTB_MASK                      ((uint32_t)0x003F0000U)         /* !< Number of Dedicated Transmit
+                                                                                    Buffers   0      No Dedicated Tx
+                                                                                    Buffers   1-32  Number of Dedicated
+                                                                                    Tx Buffers   >32   Values greater
+                                                                                    than 32 are interpreted as 32   Note:
+                                                                                    Be aware that the sum of TFQS and
+                                                                                    NDTB may be not greater than 32.
+                                                                                    There is no check for erroneous
+                                                                                    configurations. The Tx Buffers
+                                                                                    section in the Message RAM starts
+                                                                                    with the dedicated Tx Buffers.
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+/* MCAN_TXBC[TFQS] Bits */
+#define MCAN_TXBC_TFQS_OFS                       (24)                            /* !< TFQS Offset */
+#define MCAN_TXBC_TFQS_MASK                      ((uint32_t)0x3F000000U)         /* !< Transmit FIFO/Queue Size   0
+                                                                                    No Tx FIFO/Queue   1-32  Number of Tx
+                                                                                    Buffers used for Tx FIFO/Queue   >32
+                                                                                    Values greater than 32 are
+                                                                                    interpreted as 32   Note: Be aware
+                                                                                    that the sum of TFQS and NDTB may be
+                                                                                    not greater than 32. There is no
+                                                                                    check for erroneous configurations.
+                                                                                    The Tx Buffers section in the Message
+                                                                                    RAM starts with the dedicated Tx
+                                                                                    Buffers.   Qualified Write is
+                                                                                    possible only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+/* MCAN_TXBC[TFQM] Bits */
+#define MCAN_TXBC_TFQM_OFS                       (30)                            /* !< TFQM Offset */
+#define MCAN_TXBC_TFQM_MASK                      ((uint32_t)0x40000000U)         /* !< Tx FIFO/Queue Mode   0  Tx FIFO
+                                                                                    operation   1  Tx Queue operation
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='1' and CCCR.INIT='1'. */
+
+/* MCAN_TXFQS Bits */
+/* MCAN_TXFQS[TFFL] Bits */
+#define MCAN_TXFQS_TFFL_OFS                      (0)                             /* !< TFFL Offset */
+#define MCAN_TXFQS_TFFL_MASK                     ((uint32_t)0x0000003FU)         /* !< Tx FIFO Free Level.  Number of
+                                                                                    consecutive free Tx FIFO elements
+                                                                                    starting from TFGI, range 0 to 32.
+                                                                                    Read as zero when Tx Queue operation
+                                                                                    is configured (TXBC.TFQM = '1'). */
+/* MCAN_TXFQS[TFGI] Bits */
+#define MCAN_TXFQS_TFGI_OFS                      (8)                             /* !< TFGI Offset */
+#define MCAN_TXFQS_TFGI_MASK                     ((uint32_t)0x00001F00U)         /* !< Tx FIFO Get Index. Tx FIFO read
+                                                                                    index pointer, range 0 to 31. Read as
+                                                                                    zero when Tx Queue operation is
+                                                                                    configured (TXBC.TFQM = '1').   Note:
+                                                                                    In case of mixed configurations where
+                                                                                    dedicated Tx Buffers are combined
+                                                                                    with a Tx FIFO or a Tx Queue, the Put
+                                                                                    and Get Indices indicate the number
+                                                                                    of the Tx Buffer starting with the
+                                                                                    first dedicated Tx Buffers. Example:
+                                                                                    For a configuration of 12 dedicated
+                                                                                    Tx Buffers and a Tx FIFO of 20
+                                                                                    Buffers a Put Index of 15 points to
+                                                                                    the fourth buffer of the Tx FIFO. */
+/* MCAN_TXFQS[TFQP] Bits */
+#define MCAN_TXFQS_TFQP_OFS                      (16)                            /* !< TFQP Offset */
+#define MCAN_TXFQS_TFQP_MASK                     ((uint32_t)0x001F0000U)         /* !< Tx FIFO/Queue Put Index. Tx
+                                                                                    FIFO/Queue write index pointer, range
+                                                                                    0 to 31.   Note: In case of mixed
+                                                                                    configurations where dedicated Tx
+                                                                                    Buffers are combined with a Tx FIFO
+                                                                                    or a Tx Queue, the Put and Get
+                                                                                    Indices indicate the number of the Tx
+                                                                                    Buffer starting with the first
+                                                                                    dedicated Tx Buffers. Example: For a
+                                                                                    configuration of 12 dedicated Tx
+                                                                                    Buffers and a Tx FIFO of 20 Buffers a
+                                                                                    Put Index of 15 points to the fourth
+                                                                                    buffer of the Tx FIFO. */
+/* MCAN_TXFQS[TFQF] Bits */
+#define MCAN_TXFQS_TFQF_OFS                      (21)                            /* !< TFQF Offset */
+#define MCAN_TXFQS_TFQF_MASK                     ((uint32_t)0x00200000U)         /* !< Tx FIFO/Queue Full   0  Tx
+                                                                                    FIFO/Queue not full   1  Tx
+                                                                                    FIFO/Queue full */
+
+/* MCAN_TXESC Bits */
+/* MCAN_TXESC[TBDS] Bits */
+#define MCAN_TXESC_TBDS_OFS                      (0)                             /* !< TBDS Offset */
+#define MCAN_TXESC_TBDS_MASK                     ((uint32_t)0x00000007U)         /* !< Tx Buffer Data Field Size   000  8
+                                                                                    byte data field   001  12 byte data
+                                                                                    field   010  16 byte data field   011
+                                                                                    20 byte data field   100  24 byte
+                                                                                    data field   101  32 byte data field
+                                                                                    110  48 byte data field   111  64
+                                                                                    byte data field   Note: In case the
+                                                                                    data length code DLC of a Tx Buffer
+                                                                                    element is configured to a value
+                                                                                    higher than the Tx Buffer data field
+                                                                                    size TXESC.TBDS, the bytes not
+                                                                                    defined by the Tx Buffer are
+                                                                                    transmitted as "0xCC" (padding
+                                                                                    bytes).   Qualified Write is possible
+                                                                                    only with CCCR.CCE='1' and
+                                                                                    CCCR.INIT='1'. */
+
+/* MCAN_TXBRP Bits */
+/* MCAN_TXBRP[TRP0] Bits */
+#define MCAN_TXBRP_TRP0_OFS                      (0)                             /* !< TRP0 Offset */
+#define MCAN_TXBRP_TRP0_MASK                     ((uint32_t)0x00000001U)         /* !< Transmission Request Pending 0.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Request Pending bit. The
+                                                                                    bits are set via register TXBAR. The
+                                                                                    bits are reset after a requested
+                                                                                    transmission has completed or has
+                                                                                    been cancelled via register TXBCR.
+                                                                                    TXBRP bits are set only for those Tx
+                                                                                    Buffers configured via TXBC. After a
+                                                                                    TXBRP bit has been set, a Tx scan is
+                                                                                    started to check for the pending Tx
+                                                                                    request with the highest priority (Tx
+                                                                                    Buffer with lowest Message ID).   A
+                                                                                    cancellation request resets the
+                                                                                    corresponding transmission request
+                                                                                    pending bit of register TXBRP. In
+                                                                                    case a transmission has already been
+                                                                                    started when a cancellation is
+                                                                                    requested, this is done at the end of
+                                                                                    the transmission, regardless whether
+                                                                                    the transmission was successful or
+                                                                                    not. The cancellation request bits
+                                                                                    are reset directly after the
+                                                                                    corresponding TXBRP bit has been
+                                                                                    reset.   After a cancellation has
+                                                                                    been requested, a finished
+                                                                                    cancellation is signalled via TXBCF -
+                                                                                    after successful transmission
+                                                                                    together with the corresponding TXBTO
+                                                                                    bit - when the transmission has not
+                                                                                    yet been started at the point of
+                                                                                    cancellation - when the transmission
+                                                                                    has been aborted due to lost
+                                                                                    arbitration - when an error occurred
+                                                                                    during frame transmission   In DAR
+                                                                                    mode all transmissions are
+                                                                                    automatically cancelled if they are
+                                                                                    not successful. The corresponding
+                                                                                    TXBCF bit is set for all unsuccessful
+                                                                                    transmissions.   0  No transmission
+                                                                                    request pending   1  Transmission
+                                                                                    request pending   Note: TXBRP bits
+                                                                                    which are set while a Tx scan is in
+                                                                                    progress are not considered during
+                                                                                    this particular Tx scan. In case a
+                                                                                    cancellation is requested for such a
+                                                                                    Tx Buffer, this Add Request is
+                                                                                    cancelled immediately, the
+                                                                                    corresponding TXBRP bit is reset. */
+/* MCAN_TXBRP[TRP1] Bits */
+#define MCAN_TXBRP_TRP1_OFS                      (1)                             /* !< TRP1 Offset */
+#define MCAN_TXBRP_TRP1_MASK                     ((uint32_t)0x00000002U)         /* !< Transmission Request Pending 1. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBRP[TRP2] Bits */
+#define MCAN_TXBRP_TRP2_OFS                      (2)                             /* !< TRP2 Offset */
+#define MCAN_TXBRP_TRP2_MASK                     ((uint32_t)0x00000004U)         /* !< Transmission Request Pending 2. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBRP[TRP3] Bits */
+#define MCAN_TXBRP_TRP3_OFS                      (3)                             /* !< TRP3 Offset */
+#define MCAN_TXBRP_TRP3_MASK                     ((uint32_t)0x00000008U)         /* !< Transmission Request Pending 3. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBRP[TRP4] Bits */
+#define MCAN_TXBRP_TRP4_OFS                      (4)                             /* !< TRP4 Offset */
+#define MCAN_TXBRP_TRP4_MASK                     ((uint32_t)0x00000010U)         /* !< Transmission Request Pending 4. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBRP[TRP5] Bits */
+#define MCAN_TXBRP_TRP5_OFS                      (5)                             /* !< TRP5 Offset */
+#define MCAN_TXBRP_TRP5_MASK                     ((uint32_t)0x00000020U)         /* !< Transmission Request Pending 5. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBRP[TRP6] Bits */
+#define MCAN_TXBRP_TRP6_OFS                      (6)                             /* !< TRP6 Offset */
+#define MCAN_TXBRP_TRP6_MASK                     ((uint32_t)0x00000040U)         /* !< Transmission Request Pending 6. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBRP[TRP7] Bits */
+#define MCAN_TXBRP_TRP7_OFS                      (7)                             /* !< TRP7 Offset */
+#define MCAN_TXBRP_TRP7_MASK                     ((uint32_t)0x00000080U)         /* !< Transmission Request Pending 7. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBRP[TRP8] Bits */
+#define MCAN_TXBRP_TRP8_OFS                      (8)                             /* !< TRP8 Offset */
+#define MCAN_TXBRP_TRP8_MASK                     ((uint32_t)0x00000100U)         /* !< Transmission Request Pending 8. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBRP[TRP9] Bits */
+#define MCAN_TXBRP_TRP9_OFS                      (9)                             /* !< TRP9 Offset */
+#define MCAN_TXBRP_TRP9_MASK                     ((uint32_t)0x00000200U)         /* !< Transmission Request Pending 9. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBRP[TRP10] Bits */
+#define MCAN_TXBRP_TRP10_OFS                     (10)                            /* !< TRP10 Offset */
+#define MCAN_TXBRP_TRP10_MASK                    ((uint32_t)0x00000400U)         /* !< Transmission Request Pending 10.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP11] Bits */
+#define MCAN_TXBRP_TRP11_OFS                     (11)                            /* !< TRP11 Offset */
+#define MCAN_TXBRP_TRP11_MASK                    ((uint32_t)0x00000800U)         /* !< Transmission Request Pending 11.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP12] Bits */
+#define MCAN_TXBRP_TRP12_OFS                     (12)                            /* !< TRP12 Offset */
+#define MCAN_TXBRP_TRP12_MASK                    ((uint32_t)0x00001000U)         /* !< Transmission Request Pending 12.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP13] Bits */
+#define MCAN_TXBRP_TRP13_OFS                     (13)                            /* !< TRP13 Offset */
+#define MCAN_TXBRP_TRP13_MASK                    ((uint32_t)0x00002000U)         /* !< Transmission Request Pending 13.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP14] Bits */
+#define MCAN_TXBRP_TRP14_OFS                     (14)                            /* !< TRP14 Offset */
+#define MCAN_TXBRP_TRP14_MASK                    ((uint32_t)0x00004000U)         /* !< Transmission Request Pending 14.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP15] Bits */
+#define MCAN_TXBRP_TRP15_OFS                     (15)                            /* !< TRP15 Offset */
+#define MCAN_TXBRP_TRP15_MASK                    ((uint32_t)0x00008000U)         /* !< Transmission Request Pending 15.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP16] Bits */
+#define MCAN_TXBRP_TRP16_OFS                     (16)                            /* !< TRP16 Offset */
+#define MCAN_TXBRP_TRP16_MASK                    ((uint32_t)0x00010000U)         /* !< Transmission Request Pending 16.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP17] Bits */
+#define MCAN_TXBRP_TRP17_OFS                     (17)                            /* !< TRP17 Offset */
+#define MCAN_TXBRP_TRP17_MASK                    ((uint32_t)0x00020000U)         /* !< Transmission Request Pending 17.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP18] Bits */
+#define MCAN_TXBRP_TRP18_OFS                     (18)                            /* !< TRP18 Offset */
+#define MCAN_TXBRP_TRP18_MASK                    ((uint32_t)0x00040000U)         /* !< Transmission Request Pending 18.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP19] Bits */
+#define MCAN_TXBRP_TRP19_OFS                     (19)                            /* !< TRP19 Offset */
+#define MCAN_TXBRP_TRP19_MASK                    ((uint32_t)0x00080000U)         /* !< Transmission Request Pending 19.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP20] Bits */
+#define MCAN_TXBRP_TRP20_OFS                     (20)                            /* !< TRP20 Offset */
+#define MCAN_TXBRP_TRP20_MASK                    ((uint32_t)0x00100000U)         /* !< Transmission Request Pending 20.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP21] Bits */
+#define MCAN_TXBRP_TRP21_OFS                     (21)                            /* !< TRP21 Offset */
+#define MCAN_TXBRP_TRP21_MASK                    ((uint32_t)0x00200000U)         /* !< Transmission Request Pending 21.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP22] Bits */
+#define MCAN_TXBRP_TRP22_OFS                     (22)                            /* !< TRP22 Offset */
+#define MCAN_TXBRP_TRP22_MASK                    ((uint32_t)0x00400000U)         /* !< Transmission Request Pending 22.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP23] Bits */
+#define MCAN_TXBRP_TRP23_OFS                     (23)                            /* !< TRP23 Offset */
+#define MCAN_TXBRP_TRP23_MASK                    ((uint32_t)0x00800000U)         /* !< Transmission Request Pending 23.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP24] Bits */
+#define MCAN_TXBRP_TRP24_OFS                     (24)                            /* !< TRP24 Offset */
+#define MCAN_TXBRP_TRP24_MASK                    ((uint32_t)0x01000000U)         /* !< Transmission Request Pending 24.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP25] Bits */
+#define MCAN_TXBRP_TRP25_OFS                     (25)                            /* !< TRP25 Offset */
+#define MCAN_TXBRP_TRP25_MASK                    ((uint32_t)0x02000000U)         /* !< Transmission Request Pending 25.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP26] Bits */
+#define MCAN_TXBRP_TRP26_OFS                     (26)                            /* !< TRP26 Offset */
+#define MCAN_TXBRP_TRP26_MASK                    ((uint32_t)0x04000000U)         /* !< Transmission Request Pending 26.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP27] Bits */
+#define MCAN_TXBRP_TRP27_OFS                     (27)                            /* !< TRP27 Offset */
+#define MCAN_TXBRP_TRP27_MASK                    ((uint32_t)0x08000000U)         /* !< Transmission Request Pending 27.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP28] Bits */
+#define MCAN_TXBRP_TRP28_OFS                     (28)                            /* !< TRP28 Offset */
+#define MCAN_TXBRP_TRP28_MASK                    ((uint32_t)0x10000000U)         /* !< Transmission Request Pending 28.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP29] Bits */
+#define MCAN_TXBRP_TRP29_OFS                     (29)                            /* !< TRP29 Offset */
+#define MCAN_TXBRP_TRP29_MASK                    ((uint32_t)0x20000000U)         /* !< Transmission Request Pending 29.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP30] Bits */
+#define MCAN_TXBRP_TRP30_OFS                     (30)                            /* !< TRP30 Offset */
+#define MCAN_TXBRP_TRP30_MASK                    ((uint32_t)0x40000000U)         /* !< Transmission Request Pending 30.
+                                                                                    See description for bit 0. */
+/* MCAN_TXBRP[TRP31] Bits */
+#define MCAN_TXBRP_TRP31_OFS                     (31)                            /* !< TRP31 Offset */
+#define MCAN_TXBRP_TRP31_MASK                    ((uint32_t)0x80000000U)         /* !< Transmission Request Pending 31.
+                                                                                    See description for bit 0. */
+
+/* MCAN_TXBAR Bits */
+/* MCAN_TXBAR[AR0] Bits */
+#define MCAN_TXBAR_AR0_OFS                       (0)                             /* !< AR0 Offset */
+#define MCAN_TXBAR_AR0_MASK                      ((uint32_t)0x00000001U)         /* !< Add Request 0.   Each Tx Buffer has
+                                                                                    its own Add Request bit. Writing a
+                                                                                    '1' will set the corresponding Add
+                                                                                    Request bit; writing a '0' has no
+                                                                                    impact. This enables the Host to set
+                                                                                    transmission requests for multiple Tx
+                                                                                    Buffers with one write to TXBAR.
+                                                                                    TXBAR bits are set only for those Tx
+                                                                                    Buffers configured via TXBC. When no
+                                                                                    Tx scan is running, the bits are
+                                                                                    reset immediately, else the bits
+                                                                                    remain set until the Tx scan process
+                                                                                    has completed.   0  No transmission
+                                                                                    request added   1  Transmission
+                                                                                    requested added   Note: If an add
+                                                                                    request is applied for a Tx Buffer
+                                                                                    with pending transmission request
+                                                                                    (corresponding TXBRP bit already
+                                                                                    set), this add request is ignored.
+                                                                                    Qualified Write is possible only with
+                                                                                    CCCR.CCE='0' */
+/* MCAN_TXBAR[AR1] Bits */
+#define MCAN_TXBAR_AR1_OFS                       (1)                             /* !< AR1 Offset */
+#define MCAN_TXBAR_AR1_MASK                      ((uint32_t)0x00000002U)         /* !< Add Request 1. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR2] Bits */
+#define MCAN_TXBAR_AR2_OFS                       (2)                             /* !< AR2 Offset */
+#define MCAN_TXBAR_AR2_MASK                      ((uint32_t)0x00000004U)         /* !< Add Request 2. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR3] Bits */
+#define MCAN_TXBAR_AR3_OFS                       (3)                             /* !< AR3 Offset */
+#define MCAN_TXBAR_AR3_MASK                      ((uint32_t)0x00000008U)         /* !< Add Request 3. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR4] Bits */
+#define MCAN_TXBAR_AR4_OFS                       (4)                             /* !< AR4 Offset */
+#define MCAN_TXBAR_AR4_MASK                      ((uint32_t)0x00000010U)         /* !< Add Request 4. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR5] Bits */
+#define MCAN_TXBAR_AR5_OFS                       (5)                             /* !< AR5 Offset */
+#define MCAN_TXBAR_AR5_MASK                      ((uint32_t)0x00000020U)         /* !< Add Request 5. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR6] Bits */
+#define MCAN_TXBAR_AR6_OFS                       (6)                             /* !< AR6 Offset */
+#define MCAN_TXBAR_AR6_MASK                      ((uint32_t)0x00000040U)         /* !< Add Request 6. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR7] Bits */
+#define MCAN_TXBAR_AR7_OFS                       (7)                             /* !< AR7 Offset */
+#define MCAN_TXBAR_AR7_MASK                      ((uint32_t)0x00000080U)         /* !< Add Request 7. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR8] Bits */
+#define MCAN_TXBAR_AR8_OFS                       (8)                             /* !< AR8 Offset */
+#define MCAN_TXBAR_AR8_MASK                      ((uint32_t)0x00000100U)         /* !< Add Request 8. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR9] Bits */
+#define MCAN_TXBAR_AR9_OFS                       (9)                             /* !< AR9 Offset */
+#define MCAN_TXBAR_AR9_MASK                      ((uint32_t)0x00000200U)         /* !< Add Request 9. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR10] Bits */
+#define MCAN_TXBAR_AR10_OFS                      (10)                            /* !< AR10 Offset */
+#define MCAN_TXBAR_AR10_MASK                     ((uint32_t)0x00000400U)         /* !< Add Request 10. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR11] Bits */
+#define MCAN_TXBAR_AR11_OFS                      (11)                            /* !< AR11 Offset */
+#define MCAN_TXBAR_AR11_MASK                     ((uint32_t)0x00000800U)         /* !< Add Request 11. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR12] Bits */
+#define MCAN_TXBAR_AR12_OFS                      (12)                            /* !< AR12 Offset */
+#define MCAN_TXBAR_AR12_MASK                     ((uint32_t)0x00001000U)         /* !< Add Request 12. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR13] Bits */
+#define MCAN_TXBAR_AR13_OFS                      (13)                            /* !< AR13 Offset */
+#define MCAN_TXBAR_AR13_MASK                     ((uint32_t)0x00002000U)         /* !< Add Request 13. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR14] Bits */
+#define MCAN_TXBAR_AR14_OFS                      (14)                            /* !< AR14 Offset */
+#define MCAN_TXBAR_AR14_MASK                     ((uint32_t)0x00004000U)         /* !< Add Request 14. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR15] Bits */
+#define MCAN_TXBAR_AR15_OFS                      (15)                            /* !< AR15 Offset */
+#define MCAN_TXBAR_AR15_MASK                     ((uint32_t)0x00008000U)         /* !< Add Request 15. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR16] Bits */
+#define MCAN_TXBAR_AR16_OFS                      (16)                            /* !< AR16 Offset */
+#define MCAN_TXBAR_AR16_MASK                     ((uint32_t)0x00010000U)         /* !< Add Request 16. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR17] Bits */
+#define MCAN_TXBAR_AR17_OFS                      (17)                            /* !< AR17 Offset */
+#define MCAN_TXBAR_AR17_MASK                     ((uint32_t)0x00020000U)         /* !< Add Request 17. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR18] Bits */
+#define MCAN_TXBAR_AR18_OFS                      (18)                            /* !< AR18 Offset */
+#define MCAN_TXBAR_AR18_MASK                     ((uint32_t)0x00040000U)         /* !< Add Request 18. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR19] Bits */
+#define MCAN_TXBAR_AR19_OFS                      (19)                            /* !< AR19 Offset */
+#define MCAN_TXBAR_AR19_MASK                     ((uint32_t)0x00080000U)         /* !< Add Request 19. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR20] Bits */
+#define MCAN_TXBAR_AR20_OFS                      (20)                            /* !< AR20 Offset */
+#define MCAN_TXBAR_AR20_MASK                     ((uint32_t)0x00100000U)         /* !< Add Request 20. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR21] Bits */
+#define MCAN_TXBAR_AR21_OFS                      (21)                            /* !< AR21 Offset */
+#define MCAN_TXBAR_AR21_MASK                     ((uint32_t)0x00200000U)         /* !< Add Request 21. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR22] Bits */
+#define MCAN_TXBAR_AR22_OFS                      (22)                            /* !< AR22 Offset */
+#define MCAN_TXBAR_AR22_MASK                     ((uint32_t)0x00400000U)         /* !< Add Request 22. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR23] Bits */
+#define MCAN_TXBAR_AR23_OFS                      (23)                            /* !< AR23 Offset */
+#define MCAN_TXBAR_AR23_MASK                     ((uint32_t)0x00800000U)         /* !< Add Request 23. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR24] Bits */
+#define MCAN_TXBAR_AR24_OFS                      (24)                            /* !< AR24 Offset */
+#define MCAN_TXBAR_AR24_MASK                     ((uint32_t)0x01000000U)         /* !< Add Request 24. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR25] Bits */
+#define MCAN_TXBAR_AR25_OFS                      (25)                            /* !< AR25 Offset */
+#define MCAN_TXBAR_AR25_MASK                     ((uint32_t)0x02000000U)         /* !< Add Request 25. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR26] Bits */
+#define MCAN_TXBAR_AR26_OFS                      (26)                            /* !< AR26 Offset */
+#define MCAN_TXBAR_AR26_MASK                     ((uint32_t)0x04000000U)         /* !< Add Request 26. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR27] Bits */
+#define MCAN_TXBAR_AR27_OFS                      (27)                            /* !< AR27 Offset */
+#define MCAN_TXBAR_AR27_MASK                     ((uint32_t)0x08000000U)         /* !< Add Request 27. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR28] Bits */
+#define MCAN_TXBAR_AR28_OFS                      (28)                            /* !< AR28 Offset */
+#define MCAN_TXBAR_AR28_MASK                     ((uint32_t)0x10000000U)         /* !< Add Request 28. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR29] Bits */
+#define MCAN_TXBAR_AR29_OFS                      (29)                            /* !< AR29 Offset */
+#define MCAN_TXBAR_AR29_MASK                     ((uint32_t)0x20000000U)         /* !< Add Request 29. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR30] Bits */
+#define MCAN_TXBAR_AR30_OFS                      (30)                            /* !< AR30 Offset */
+#define MCAN_TXBAR_AR30_MASK                     ((uint32_t)0x40000000U)         /* !< Add Request 30. See description for
+                                                                                    bit 0. */
+/* MCAN_TXBAR[AR31] Bits */
+#define MCAN_TXBAR_AR31_OFS                      (31)                            /* !< AR31 Offset */
+#define MCAN_TXBAR_AR31_MASK                     ((uint32_t)0x80000000U)         /* !< Add Request 31. See description for
+                                                                                    bit 0. */
+
+/* MCAN_TXBCR Bits */
+/* MCAN_TXBCR[CR0] Bits */
+#define MCAN_TXBCR_CR0_OFS                       (0)                             /* !< CR0 Offset */
+#define MCAN_TXBCR_CR0_MASK                      ((uint32_t)0x00000001U)         /* !< Cancellation Request 0.   Each Tx
+                                                                                    Buffer has its own Cancellation
+                                                                                    Request bit. Writing a '1' will set
+                                                                                    the corresponding Cancellation
+                                                                                    Request bit; writing a '0' has no
+                                                                                    impact. This enables the Host to set
+                                                                                    cancellation requests for multiple Tx
+                                                                                    Buffers with one write to TXBCR.
+                                                                                    TXBCR bits are set only for those Tx
+                                                                                    Buffers configured via TXBC. The bits
+                                                                                    remain set until the corresponding
+                                                                                    bit of TXBRP is reset.   0  No
+                                                                                    cancellation pending   1
+                                                                                    Cancellation pending   Qualified
+                                                                                    Write is possible only with
+                                                                                    CCCR.CCE='0' */
+/* MCAN_TXBCR[CR1] Bits */
+#define MCAN_TXBCR_CR1_OFS                       (1)                             /* !< CR1 Offset */
+#define MCAN_TXBCR_CR1_MASK                      ((uint32_t)0x00000002U)         /* !< Cancellation Request 1. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR2] Bits */
+#define MCAN_TXBCR_CR2_OFS                       (2)                             /* !< CR2 Offset */
+#define MCAN_TXBCR_CR2_MASK                      ((uint32_t)0x00000004U)         /* !< Cancellation Request 2. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR3] Bits */
+#define MCAN_TXBCR_CR3_OFS                       (3)                             /* !< CR3 Offset */
+#define MCAN_TXBCR_CR3_MASK                      ((uint32_t)0x00000008U)         /* !< Cancellation Request 3. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR4] Bits */
+#define MCAN_TXBCR_CR4_OFS                       (4)                             /* !< CR4 Offset */
+#define MCAN_TXBCR_CR4_MASK                      ((uint32_t)0x00000010U)         /* !< Cancellation Request 4. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR5] Bits */
+#define MCAN_TXBCR_CR5_OFS                       (5)                             /* !< CR5 Offset */
+#define MCAN_TXBCR_CR5_MASK                      ((uint32_t)0x00000020U)         /* !< Cancellation Request 5. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR6] Bits */
+#define MCAN_TXBCR_CR6_OFS                       (6)                             /* !< CR6 Offset */
+#define MCAN_TXBCR_CR6_MASK                      ((uint32_t)0x00000040U)         /* !< Cancellation Request 6. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR7] Bits */
+#define MCAN_TXBCR_CR7_OFS                       (7)                             /* !< CR7 Offset */
+#define MCAN_TXBCR_CR7_MASK                      ((uint32_t)0x00000080U)         /* !< Cancellation Request 7. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR8] Bits */
+#define MCAN_TXBCR_CR8_OFS                       (8)                             /* !< CR8 Offset */
+#define MCAN_TXBCR_CR8_MASK                      ((uint32_t)0x00000100U)         /* !< Cancellation Request 8. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR9] Bits */
+#define MCAN_TXBCR_CR9_OFS                       (9)                             /* !< CR9 Offset */
+#define MCAN_TXBCR_CR9_MASK                      ((uint32_t)0x00000200U)         /* !< Cancellation Request 9. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR10] Bits */
+#define MCAN_TXBCR_CR10_OFS                      (10)                            /* !< CR10 Offset */
+#define MCAN_TXBCR_CR10_MASK                     ((uint32_t)0x00000400U)         /* !< Cancellation Request 10. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR11] Bits */
+#define MCAN_TXBCR_CR11_OFS                      (11)                            /* !< CR11 Offset */
+#define MCAN_TXBCR_CR11_MASK                     ((uint32_t)0x00000800U)         /* !< Cancellation Request 11. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR12] Bits */
+#define MCAN_TXBCR_CR12_OFS                      (12)                            /* !< CR12 Offset */
+#define MCAN_TXBCR_CR12_MASK                     ((uint32_t)0x00001000U)         /* !< Cancellation Request 12. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR13] Bits */
+#define MCAN_TXBCR_CR13_OFS                      (13)                            /* !< CR13 Offset */
+#define MCAN_TXBCR_CR13_MASK                     ((uint32_t)0x00002000U)         /* !< Cancellation Request 13. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR14] Bits */
+#define MCAN_TXBCR_CR14_OFS                      (14)                            /* !< CR14 Offset */
+#define MCAN_TXBCR_CR14_MASK                     ((uint32_t)0x00004000U)         /* !< Cancellation Request 14. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR15] Bits */
+#define MCAN_TXBCR_CR15_OFS                      (15)                            /* !< CR15 Offset */
+#define MCAN_TXBCR_CR15_MASK                     ((uint32_t)0x00008000U)         /* !< Cancellation Request 15. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR16] Bits */
+#define MCAN_TXBCR_CR16_OFS                      (16)                            /* !< CR16 Offset */
+#define MCAN_TXBCR_CR16_MASK                     ((uint32_t)0x00010000U)         /* !< Cancellation Request 16. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR17] Bits */
+#define MCAN_TXBCR_CR17_OFS                      (17)                            /* !< CR17 Offset */
+#define MCAN_TXBCR_CR17_MASK                     ((uint32_t)0x00020000U)         /* !< Cancellation Request 17. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR18] Bits */
+#define MCAN_TXBCR_CR18_OFS                      (18)                            /* !< CR18 Offset */
+#define MCAN_TXBCR_CR18_MASK                     ((uint32_t)0x00040000U)         /* !< Cancellation Request 18. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR19] Bits */
+#define MCAN_TXBCR_CR19_OFS                      (19)                            /* !< CR19 Offset */
+#define MCAN_TXBCR_CR19_MASK                     ((uint32_t)0x00080000U)         /* !< Cancellation Request 19. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR20] Bits */
+#define MCAN_TXBCR_CR20_OFS                      (20)                            /* !< CR20 Offset */
+#define MCAN_TXBCR_CR20_MASK                     ((uint32_t)0x00100000U)         /* !< Cancellation Request 20. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR21] Bits */
+#define MCAN_TXBCR_CR21_OFS                      (21)                            /* !< CR21 Offset */
+#define MCAN_TXBCR_CR21_MASK                     ((uint32_t)0x00200000U)         /* !< Cancellation Request 21. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR22] Bits */
+#define MCAN_TXBCR_CR22_OFS                      (22)                            /* !< CR22 Offset */
+#define MCAN_TXBCR_CR22_MASK                     ((uint32_t)0x00400000U)         /* !< Cancellation Request 22. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR23] Bits */
+#define MCAN_TXBCR_CR23_OFS                      (23)                            /* !< CR23 Offset */
+#define MCAN_TXBCR_CR23_MASK                     ((uint32_t)0x00800000U)         /* !< Cancellation Request 23. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR24] Bits */
+#define MCAN_TXBCR_CR24_OFS                      (24)                            /* !< CR24 Offset */
+#define MCAN_TXBCR_CR24_MASK                     ((uint32_t)0x01000000U)         /* !< Cancellation Request 24. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR25] Bits */
+#define MCAN_TXBCR_CR25_OFS                      (25)                            /* !< CR25 Offset */
+#define MCAN_TXBCR_CR25_MASK                     ((uint32_t)0x02000000U)         /* !< Cancellation Request 25. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR26] Bits */
+#define MCAN_TXBCR_CR26_OFS                      (26)                            /* !< CR26 Offset */
+#define MCAN_TXBCR_CR26_MASK                     ((uint32_t)0x04000000U)         /* !< Cancellation Request 26. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR27] Bits */
+#define MCAN_TXBCR_CR27_OFS                      (27)                            /* !< CR27 Offset */
+#define MCAN_TXBCR_CR27_MASK                     ((uint32_t)0x08000000U)         /* !< Cancellation Request 27. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR28] Bits */
+#define MCAN_TXBCR_CR28_OFS                      (28)                            /* !< CR28 Offset */
+#define MCAN_TXBCR_CR28_MASK                     ((uint32_t)0x10000000U)         /* !< Cancellation Request 28. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR29] Bits */
+#define MCAN_TXBCR_CR29_OFS                      (29)                            /* !< CR29 Offset */
+#define MCAN_TXBCR_CR29_MASK                     ((uint32_t)0x20000000U)         /* !< Cancellation Request 29. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR30] Bits */
+#define MCAN_TXBCR_CR30_OFS                      (30)                            /* !< CR30 Offset */
+#define MCAN_TXBCR_CR30_MASK                     ((uint32_t)0x40000000U)         /* !< Cancellation Request 30. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCR[CR31] Bits */
+#define MCAN_TXBCR_CR31_OFS                      (31)                            /* !< CR31 Offset */
+#define MCAN_TXBCR_CR31_MASK                     ((uint32_t)0x80000000U)         /* !< Cancellation Request 31. See
+                                                                                    description for bit 0. */
+
+/* MCAN_TXBTO Bits */
+/* MCAN_TXBTO[TO0] Bits */
+#define MCAN_TXBTO_TO0_OFS                       (0)                             /* !< TO0 Offset */
+#define MCAN_TXBTO_TO0_MASK                      ((uint32_t)0x00000001U)         /* !< Transmission Occurred 0.   Each Tx
+                                                                                    Buffer has its own Transmission
+                                                                                    Occurred bit. The bits are set when
+                                                                                    the corresponding TXBRP bit is
+                                                                                    cleared after a successful
+                                                                                    transmission. The bits are reset when
+                                                                                    a new transmission is requested by
+                                                                                    writing a '1' to the corresponding
+                                                                                    bit of register TXBAR.   0  No
+                                                                                    transmission occurred   1
+                                                                                    Transmission occurred */
+/* MCAN_TXBTO[TO1] Bits */
+#define MCAN_TXBTO_TO1_OFS                       (1)                             /* !< TO1 Offset */
+#define MCAN_TXBTO_TO1_MASK                      ((uint32_t)0x00000002U)         /* !< Transmission Occurred 1. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO2] Bits */
+#define MCAN_TXBTO_TO2_OFS                       (2)                             /* !< TO2 Offset */
+#define MCAN_TXBTO_TO2_MASK                      ((uint32_t)0x00000004U)         /* !< Transmission Occurred 2. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO3] Bits */
+#define MCAN_TXBTO_TO3_OFS                       (3)                             /* !< TO3 Offset */
+#define MCAN_TXBTO_TO3_MASK                      ((uint32_t)0x00000008U)         /* !< Transmission Occurred 3. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO4] Bits */
+#define MCAN_TXBTO_TO4_OFS                       (4)                             /* !< TO4 Offset */
+#define MCAN_TXBTO_TO4_MASK                      ((uint32_t)0x00000010U)         /* !< Transmission Occurred 4. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO5] Bits */
+#define MCAN_TXBTO_TO5_OFS                       (5)                             /* !< TO5 Offset */
+#define MCAN_TXBTO_TO5_MASK                      ((uint32_t)0x00000020U)         /* !< Transmission Occurred 5. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO6] Bits */
+#define MCAN_TXBTO_TO6_OFS                       (6)                             /* !< TO6 Offset */
+#define MCAN_TXBTO_TO6_MASK                      ((uint32_t)0x00000040U)         /* !< Transmission Occurred 6. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO7] Bits */
+#define MCAN_TXBTO_TO7_OFS                       (7)                             /* !< TO7 Offset */
+#define MCAN_TXBTO_TO7_MASK                      ((uint32_t)0x00000080U)         /* !< Transmission Occurred 7. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO8] Bits */
+#define MCAN_TXBTO_TO8_OFS                       (8)                             /* !< TO8 Offset */
+#define MCAN_TXBTO_TO8_MASK                      ((uint32_t)0x00000100U)         /* !< Transmission Occurred 8. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO9] Bits */
+#define MCAN_TXBTO_TO9_OFS                       (9)                             /* !< TO9 Offset */
+#define MCAN_TXBTO_TO9_MASK                      ((uint32_t)0x00000200U)         /* !< Transmission Occurred 9. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO10] Bits */
+#define MCAN_TXBTO_TO10_OFS                      (10)                            /* !< TO10 Offset */
+#define MCAN_TXBTO_TO10_MASK                     ((uint32_t)0x00000400U)         /* !< Transmission Occurred 10. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO11] Bits */
+#define MCAN_TXBTO_TO11_OFS                      (11)                            /* !< TO11 Offset */
+#define MCAN_TXBTO_TO11_MASK                     ((uint32_t)0x00000800U)         /* !< Transmission Occurred 11. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO12] Bits */
+#define MCAN_TXBTO_TO12_OFS                      (12)                            /* !< TO12 Offset */
+#define MCAN_TXBTO_TO12_MASK                     ((uint32_t)0x00001000U)         /* !< Transmission Occurred 12. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO13] Bits */
+#define MCAN_TXBTO_TO13_OFS                      (13)                            /* !< TO13 Offset */
+#define MCAN_TXBTO_TO13_MASK                     ((uint32_t)0x00002000U)         /* !< Transmission Occurred 13. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO14] Bits */
+#define MCAN_TXBTO_TO14_OFS                      (14)                            /* !< TO14 Offset */
+#define MCAN_TXBTO_TO14_MASK                     ((uint32_t)0x00004000U)         /* !< Transmission Occurred 14. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO15] Bits */
+#define MCAN_TXBTO_TO15_OFS                      (15)                            /* !< TO15 Offset */
+#define MCAN_TXBTO_TO15_MASK                     ((uint32_t)0x00008000U)         /* !< Transmission Occurred 15. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO16] Bits */
+#define MCAN_TXBTO_TO16_OFS                      (16)                            /* !< TO16 Offset */
+#define MCAN_TXBTO_TO16_MASK                     ((uint32_t)0x00010000U)         /* !< Transmission Occurred 16. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO17] Bits */
+#define MCAN_TXBTO_TO17_OFS                      (17)                            /* !< TO17 Offset */
+#define MCAN_TXBTO_TO17_MASK                     ((uint32_t)0x00020000U)         /* !< Transmission Occurred 17. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO18] Bits */
+#define MCAN_TXBTO_TO18_OFS                      (18)                            /* !< TO18 Offset */
+#define MCAN_TXBTO_TO18_MASK                     ((uint32_t)0x00040000U)         /* !< Transmission Occurred 18. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO19] Bits */
+#define MCAN_TXBTO_TO19_OFS                      (19)                            /* !< TO19 Offset */
+#define MCAN_TXBTO_TO19_MASK                     ((uint32_t)0x00080000U)         /* !< Transmission Occurred 19. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO20] Bits */
+#define MCAN_TXBTO_TO20_OFS                      (20)                            /* !< TO20 Offset */
+#define MCAN_TXBTO_TO20_MASK                     ((uint32_t)0x00100000U)         /* !< Transmission Occurred 20. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO21] Bits */
+#define MCAN_TXBTO_TO21_OFS                      (21)                            /* !< TO21 Offset */
+#define MCAN_TXBTO_TO21_MASK                     ((uint32_t)0x00200000U)         /* !< Transmission Occurred 21. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO22] Bits */
+#define MCAN_TXBTO_TO22_OFS                      (22)                            /* !< TO22 Offset */
+#define MCAN_TXBTO_TO22_MASK                     ((uint32_t)0x00400000U)         /* !< Transmission Occurred 22. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO23] Bits */
+#define MCAN_TXBTO_TO23_OFS                      (23)                            /* !< TO23 Offset */
+#define MCAN_TXBTO_TO23_MASK                     ((uint32_t)0x00800000U)         /* !< Transmission Occurred 23. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO24] Bits */
+#define MCAN_TXBTO_TO24_OFS                      (24)                            /* !< TO24 Offset */
+#define MCAN_TXBTO_TO24_MASK                     ((uint32_t)0x01000000U)         /* !< Transmission Occurred 24. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO25] Bits */
+#define MCAN_TXBTO_TO25_OFS                      (25)                            /* !< TO25 Offset */
+#define MCAN_TXBTO_TO25_MASK                     ((uint32_t)0x02000000U)         /* !< Transmission Occurred 25. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO26] Bits */
+#define MCAN_TXBTO_TO26_OFS                      (26)                            /* !< TO26 Offset */
+#define MCAN_TXBTO_TO26_MASK                     ((uint32_t)0x04000000U)         /* !< Transmission Occurred 26. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO27] Bits */
+#define MCAN_TXBTO_TO27_OFS                      (27)                            /* !< TO27 Offset */
+#define MCAN_TXBTO_TO27_MASK                     ((uint32_t)0x08000000U)         /* !< Transmission Occurred 27. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO28] Bits */
+#define MCAN_TXBTO_TO28_OFS                      (28)                            /* !< TO28 Offset */
+#define MCAN_TXBTO_TO28_MASK                     ((uint32_t)0x10000000U)         /* !< Transmission Occurred 28. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO29] Bits */
+#define MCAN_TXBTO_TO29_OFS                      (29)                            /* !< TO29 Offset */
+#define MCAN_TXBTO_TO29_MASK                     ((uint32_t)0x20000000U)         /* !< Transmission Occurred 29. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO30] Bits */
+#define MCAN_TXBTO_TO30_OFS                      (30)                            /* !< TO30 Offset */
+#define MCAN_TXBTO_TO30_MASK                     ((uint32_t)0x40000000U)         /* !< Transmission Occurred 30. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBTO[TO31] Bits */
+#define MCAN_TXBTO_TO31_OFS                      (31)                            /* !< TO31 Offset */
+#define MCAN_TXBTO_TO31_MASK                     ((uint32_t)0x80000000U)         /* !< Transmission Occurred 31. See
+                                                                                    description for bit 0. */
+
+/* MCAN_TXBCF Bits */
+/* MCAN_TXBCF[CF0] Bits */
+#define MCAN_TXBCF_CF0_OFS                       (0)                             /* !< CF0 Offset */
+#define MCAN_TXBCF_CF0_MASK                      ((uint32_t)0x00000001U)         /* !< Cancellation Finished 0.   Each Tx
+                                                                                    Buffer has its own Cancellation
+                                                                                    Finished bit. The bits are set when
+                                                                                    the corresponding TXBRP bit is
+                                                                                    cleared after a cancellation was
+                                                                                    requested via TXBCR. In case the
+                                                                                    corresponding TXBRP bit was not set
+                                                                                    at the point of cancellation, CF is
+                                                                                    set immediately. The bits are reset
+                                                                                    when a new transmission is requested
+                                                                                    by writing a '1' to the corresponding
+                                                                                    bit of register TXBAR.   0  No
+                                                                                    transmit buffer cancellation   1
+                                                                                    Transmit buffer cancellation finished */
+/* MCAN_TXBCF[CF1] Bits */
+#define MCAN_TXBCF_CF1_OFS                       (1)                             /* !< CF1 Offset */
+#define MCAN_TXBCF_CF1_MASK                      ((uint32_t)0x00000002U)         /* !< Cancellation Finished 1. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF2] Bits */
+#define MCAN_TXBCF_CF2_OFS                       (2)                             /* !< CF2 Offset */
+#define MCAN_TXBCF_CF2_MASK                      ((uint32_t)0x00000004U)         /* !< Cancellation Finished 2. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF3] Bits */
+#define MCAN_TXBCF_CF3_OFS                       (3)                             /* !< CF3 Offset */
+#define MCAN_TXBCF_CF3_MASK                      ((uint32_t)0x00000008U)         /* !< Cancellation Finished 3. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF4] Bits */
+#define MCAN_TXBCF_CF4_OFS                       (4)                             /* !< CF4 Offset */
+#define MCAN_TXBCF_CF4_MASK                      ((uint32_t)0x00000010U)         /* !< Cancellation Finished 4. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF5] Bits */
+#define MCAN_TXBCF_CF5_OFS                       (5)                             /* !< CF5 Offset */
+#define MCAN_TXBCF_CF5_MASK                      ((uint32_t)0x00000020U)         /* !< Cancellation Finished 5. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF6] Bits */
+#define MCAN_TXBCF_CF6_OFS                       (6)                             /* !< CF6 Offset */
+#define MCAN_TXBCF_CF6_MASK                      ((uint32_t)0x00000040U)         /* !< Cancellation Finished 6. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF7] Bits */
+#define MCAN_TXBCF_CF7_OFS                       (7)                             /* !< CF7 Offset */
+#define MCAN_TXBCF_CF7_MASK                      ((uint32_t)0x00000080U)         /* !< Cancellation Finished 7. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF8] Bits */
+#define MCAN_TXBCF_CF8_OFS                       (8)                             /* !< CF8 Offset */
+#define MCAN_TXBCF_CF8_MASK                      ((uint32_t)0x00000100U)         /* !< Cancellation Finished 8. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF9] Bits */
+#define MCAN_TXBCF_CF9_OFS                       (9)                             /* !< CF9 Offset */
+#define MCAN_TXBCF_CF9_MASK                      ((uint32_t)0x00000200U)         /* !< Cancellation Finished 9. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF10] Bits */
+#define MCAN_TXBCF_CF10_OFS                      (10)                            /* !< CF10 Offset */
+#define MCAN_TXBCF_CF10_MASK                     ((uint32_t)0x00000400U)         /* !< Cancellation Finished 10. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF11] Bits */
+#define MCAN_TXBCF_CF11_OFS                      (11)                            /* !< CF11 Offset */
+#define MCAN_TXBCF_CF11_MASK                     ((uint32_t)0x00000800U)         /* !< Cancellation Finished 11. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF12] Bits */
+#define MCAN_TXBCF_CF12_OFS                      (12)                            /* !< CF12 Offset */
+#define MCAN_TXBCF_CF12_MASK                     ((uint32_t)0x00001000U)         /* !< Cancellation Finished 12. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF13] Bits */
+#define MCAN_TXBCF_CF13_OFS                      (13)                            /* !< CF13 Offset */
+#define MCAN_TXBCF_CF13_MASK                     ((uint32_t)0x00002000U)         /* !< Cancellation Finished 13. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF14] Bits */
+#define MCAN_TXBCF_CF14_OFS                      (14)                            /* !< CF14 Offset */
+#define MCAN_TXBCF_CF14_MASK                     ((uint32_t)0x00004000U)         /* !< Cancellation Finished 14. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF15] Bits */
+#define MCAN_TXBCF_CF15_OFS                      (15)                            /* !< CF15 Offset */
+#define MCAN_TXBCF_CF15_MASK                     ((uint32_t)0x00008000U)         /* !< Cancellation Finished 15. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF16] Bits */
+#define MCAN_TXBCF_CF16_OFS                      (16)                            /* !< CF16 Offset */
+#define MCAN_TXBCF_CF16_MASK                     ((uint32_t)0x00010000U)         /* !< Cancellation Finished 16. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF17] Bits */
+#define MCAN_TXBCF_CF17_OFS                      (17)                            /* !< CF17 Offset */
+#define MCAN_TXBCF_CF17_MASK                     ((uint32_t)0x00020000U)         /* !< Cancellation Finished 17. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF18] Bits */
+#define MCAN_TXBCF_CF18_OFS                      (18)                            /* !< CF18 Offset */
+#define MCAN_TXBCF_CF18_MASK                     ((uint32_t)0x00040000U)         /* !< Cancellation Finished 18. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF19] Bits */
+#define MCAN_TXBCF_CF19_OFS                      (19)                            /* !< CF19 Offset */
+#define MCAN_TXBCF_CF19_MASK                     ((uint32_t)0x00080000U)         /* !< Cancellation Finished 19. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF20] Bits */
+#define MCAN_TXBCF_CF20_OFS                      (20)                            /* !< CF20 Offset */
+#define MCAN_TXBCF_CF20_MASK                     ((uint32_t)0x00100000U)         /* !< Cancellation Finished 20. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF21] Bits */
+#define MCAN_TXBCF_CF21_OFS                      (21)                            /* !< CF21 Offset */
+#define MCAN_TXBCF_CF21_MASK                     ((uint32_t)0x00200000U)         /* !< Cancellation Finished 21. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF22] Bits */
+#define MCAN_TXBCF_CF22_OFS                      (22)                            /* !< CF22 Offset */
+#define MCAN_TXBCF_CF22_MASK                     ((uint32_t)0x00400000U)         /* !< Cancellation Finished 22. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF23] Bits */
+#define MCAN_TXBCF_CF23_OFS                      (23)                            /* !< CF23 Offset */
+#define MCAN_TXBCF_CF23_MASK                     ((uint32_t)0x00800000U)         /* !< Cancellation Finished 23. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF24] Bits */
+#define MCAN_TXBCF_CF24_OFS                      (24)                            /* !< CF24 Offset */
+#define MCAN_TXBCF_CF24_MASK                     ((uint32_t)0x01000000U)         /* !< Cancellation Finished 24. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF25] Bits */
+#define MCAN_TXBCF_CF25_OFS                      (25)                            /* !< CF25 Offset */
+#define MCAN_TXBCF_CF25_MASK                     ((uint32_t)0x02000000U)         /* !< Cancellation Finished 25. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF26] Bits */
+#define MCAN_TXBCF_CF26_OFS                      (26)                            /* !< CF26 Offset */
+#define MCAN_TXBCF_CF26_MASK                     ((uint32_t)0x04000000U)         /* !< Cancellation Finished 26. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF27] Bits */
+#define MCAN_TXBCF_CF27_OFS                      (27)                            /* !< CF27 Offset */
+#define MCAN_TXBCF_CF27_MASK                     ((uint32_t)0x08000000U)         /* !< Cancellation Finished 27. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF28] Bits */
+#define MCAN_TXBCF_CF28_OFS                      (28)                            /* !< CF28 Offset */
+#define MCAN_TXBCF_CF28_MASK                     ((uint32_t)0x10000000U)         /* !< Cancellation Finished 28. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF29] Bits */
+#define MCAN_TXBCF_CF29_OFS                      (29)                            /* !< CF29 Offset */
+#define MCAN_TXBCF_CF29_MASK                     ((uint32_t)0x20000000U)         /* !< Cancellation Finished 29. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF30] Bits */
+#define MCAN_TXBCF_CF30_OFS                      (30)                            /* !< CF30 Offset */
+#define MCAN_TXBCF_CF30_MASK                     ((uint32_t)0x40000000U)         /* !< Cancellation Finished 30. See
+                                                                                    description for bit 0. */
+/* MCAN_TXBCF[CF31] Bits */
+#define MCAN_TXBCF_CF31_OFS                      (31)                            /* !< CF31 Offset */
+#define MCAN_TXBCF_CF31_MASK                     ((uint32_t)0x80000000U)         /* !< Cancellation Finished 31. See
+                                                                                    description for bit 0. */
+
+/* MCAN_TXBTIE Bits */
+/* MCAN_TXBTIE[TIE0] Bits */
+#define MCAN_TXBTIE_TIE0_OFS                     (0)                             /* !< TIE0 Offset */
+#define MCAN_TXBTIE_TIE0_MASK                    ((uint32_t)0x00000001U)         /* !< Transmission Interrupt Enable 0.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE1] Bits */
+#define MCAN_TXBTIE_TIE1_OFS                     (1)                             /* !< TIE1 Offset */
+#define MCAN_TXBTIE_TIE1_MASK                    ((uint32_t)0x00000002U)         /* !< Transmission Interrupt Enable 1.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE2] Bits */
+#define MCAN_TXBTIE_TIE2_OFS                     (2)                             /* !< TIE2 Offset */
+#define MCAN_TXBTIE_TIE2_MASK                    ((uint32_t)0x00000004U)         /* !< Transmission Interrupt Enable 2.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE3] Bits */
+#define MCAN_TXBTIE_TIE3_OFS                     (3)                             /* !< TIE3 Offset */
+#define MCAN_TXBTIE_TIE3_MASK                    ((uint32_t)0x00000008U)         /* !< Transmission Interrupt Enable 3.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE4] Bits */
+#define MCAN_TXBTIE_TIE4_OFS                     (4)                             /* !< TIE4 Offset */
+#define MCAN_TXBTIE_TIE4_MASK                    ((uint32_t)0x00000010U)         /* !< Transmission Interrupt Enable 4.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE5] Bits */
+#define MCAN_TXBTIE_TIE5_OFS                     (5)                             /* !< TIE5 Offset */
+#define MCAN_TXBTIE_TIE5_MASK                    ((uint32_t)0x00000020U)         /* !< Transmission Interrupt Enable 5.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE6] Bits */
+#define MCAN_TXBTIE_TIE6_OFS                     (6)                             /* !< TIE6 Offset */
+#define MCAN_TXBTIE_TIE6_MASK                    ((uint32_t)0x00000040U)         /* !< Transmission Interrupt Enable 6.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE7] Bits */
+#define MCAN_TXBTIE_TIE7_OFS                     (7)                             /* !< TIE7 Offset */
+#define MCAN_TXBTIE_TIE7_MASK                    ((uint32_t)0x00000080U)         /* !< Transmission Interrupt Enable 7.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE8] Bits */
+#define MCAN_TXBTIE_TIE8_OFS                     (8)                             /* !< TIE8 Offset */
+#define MCAN_TXBTIE_TIE8_MASK                    ((uint32_t)0x00000100U)         /* !< Transmission Interrupt Enable 8.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE9] Bits */
+#define MCAN_TXBTIE_TIE9_OFS                     (9)                             /* !< TIE9 Offset */
+#define MCAN_TXBTIE_TIE9_MASK                    ((uint32_t)0x00000200U)         /* !< Transmission Interrupt Enable 9.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE10] Bits */
+#define MCAN_TXBTIE_TIE10_OFS                    (10)                            /* !< TIE10 Offset */
+#define MCAN_TXBTIE_TIE10_MASK                   ((uint32_t)0x00000400U)         /* !< Transmission Interrupt Enable 10.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE11] Bits */
+#define MCAN_TXBTIE_TIE11_OFS                    (11)                            /* !< TIE11 Offset */
+#define MCAN_TXBTIE_TIE11_MASK                   ((uint32_t)0x00000800U)         /* !< Transmission Interrupt Enable 11.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE12] Bits */
+#define MCAN_TXBTIE_TIE12_OFS                    (12)                            /* !< TIE12 Offset */
+#define MCAN_TXBTIE_TIE12_MASK                   ((uint32_t)0x00001000U)         /* !< Transmission Interrupt Enable 12.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE13] Bits */
+#define MCAN_TXBTIE_TIE13_OFS                    (13)                            /* !< TIE13 Offset */
+#define MCAN_TXBTIE_TIE13_MASK                   ((uint32_t)0x00002000U)         /* !< Transmission Interrupt Enable 13.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE14] Bits */
+#define MCAN_TXBTIE_TIE14_OFS                    (14)                            /* !< TIE14 Offset */
+#define MCAN_TXBTIE_TIE14_MASK                   ((uint32_t)0x00004000U)         /* !< Transmission Interrupt Enable 14.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE15] Bits */
+#define MCAN_TXBTIE_TIE15_OFS                    (15)                            /* !< TIE15 Offset */
+#define MCAN_TXBTIE_TIE15_MASK                   ((uint32_t)0x00008000U)         /* !< Transmission Interrupt Enable 15.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE16] Bits */
+#define MCAN_TXBTIE_TIE16_OFS                    (16)                            /* !< TIE16 Offset */
+#define MCAN_TXBTIE_TIE16_MASK                   ((uint32_t)0x00010000U)         /* !< Transmission Interrupt Enable 16.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE17] Bits */
+#define MCAN_TXBTIE_TIE17_OFS                    (17)                            /* !< TIE17 Offset */
+#define MCAN_TXBTIE_TIE17_MASK                   ((uint32_t)0x00020000U)         /* !< Transmission Interrupt Enable 17.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE18] Bits */
+#define MCAN_TXBTIE_TIE18_OFS                    (18)                            /* !< TIE18 Offset */
+#define MCAN_TXBTIE_TIE18_MASK                   ((uint32_t)0x00040000U)         /* !< Transmission Interrupt Enable 18.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE19] Bits */
+#define MCAN_TXBTIE_TIE19_OFS                    (19)                            /* !< TIE19 Offset */
+#define MCAN_TXBTIE_TIE19_MASK                   ((uint32_t)0x00080000U)         /* !< Transmission Interrupt Enable 19.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE20] Bits */
+#define MCAN_TXBTIE_TIE20_OFS                    (20)                            /* !< TIE20 Offset */
+#define MCAN_TXBTIE_TIE20_MASK                   ((uint32_t)0x00100000U)         /* !< Transmission Interrupt Enable 20.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE21] Bits */
+#define MCAN_TXBTIE_TIE21_OFS                    (21)                            /* !< TIE21 Offset */
+#define MCAN_TXBTIE_TIE21_MASK                   ((uint32_t)0x00200000U)         /* !< Transmission Interrupt Enable 21.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE22] Bits */
+#define MCAN_TXBTIE_TIE22_OFS                    (22)                            /* !< TIE22 Offset */
+#define MCAN_TXBTIE_TIE22_MASK                   ((uint32_t)0x00400000U)         /* !< Transmission Interrupt Enable 22.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE23] Bits */
+#define MCAN_TXBTIE_TIE23_OFS                    (23)                            /* !< TIE23 Offset */
+#define MCAN_TXBTIE_TIE23_MASK                   ((uint32_t)0x00800000U)         /* !< Transmission Interrupt Enable 23.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE24] Bits */
+#define MCAN_TXBTIE_TIE24_OFS                    (24)                            /* !< TIE24 Offset */
+#define MCAN_TXBTIE_TIE24_MASK                   ((uint32_t)0x01000000U)         /* !< Transmission Interrupt Enable 24.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE25] Bits */
+#define MCAN_TXBTIE_TIE25_OFS                    (25)                            /* !< TIE25 Offset */
+#define MCAN_TXBTIE_TIE25_MASK                   ((uint32_t)0x02000000U)         /* !< Transmission Interrupt Enable 25.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE26] Bits */
+#define MCAN_TXBTIE_TIE26_OFS                    (26)                            /* !< TIE26 Offset */
+#define MCAN_TXBTIE_TIE26_MASK                   ((uint32_t)0x04000000U)         /* !< Transmission Interrupt Enable 26.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE27] Bits */
+#define MCAN_TXBTIE_TIE27_OFS                    (27)                            /* !< TIE27 Offset */
+#define MCAN_TXBTIE_TIE27_MASK                   ((uint32_t)0x08000000U)         /* !< Transmission Interrupt Enable 27.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE28] Bits */
+#define MCAN_TXBTIE_TIE28_OFS                    (28)                            /* !< TIE28 Offset */
+#define MCAN_TXBTIE_TIE28_MASK                   ((uint32_t)0x10000000U)         /* !< Transmission Interrupt Enable 28.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE29] Bits */
+#define MCAN_TXBTIE_TIE29_OFS                    (29)                            /* !< TIE29 Offset */
+#define MCAN_TXBTIE_TIE29_MASK                   ((uint32_t)0x20000000U)         /* !< Transmission Interrupt Enable 29.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE30] Bits */
+#define MCAN_TXBTIE_TIE30_OFS                    (30)                            /* !< TIE30 Offset */
+#define MCAN_TXBTIE_TIE30_MASK                   ((uint32_t)0x40000000U)         /* !< Transmission Interrupt Enable 30.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+/* MCAN_TXBTIE[TIE31] Bits */
+#define MCAN_TXBTIE_TIE31_OFS                    (31)                            /* !< TIE31 Offset */
+#define MCAN_TXBTIE_TIE31_MASK                   ((uint32_t)0x80000000U)         /* !< Transmission Interrupt Enable 31.
+                                                                                    Each Tx Buffer has its own
+                                                                                    Transmission Interrupt Enable bit.
+                                                                                    0  Transmission interrupt disabled
+                                                                                    1  Transmission interrupt enable */
+
+/* MCAN_TXBCIE Bits */
+/* MCAN_TXBCIE[CFIE0] Bits */
+#define MCAN_TXBCIE_CFIE0_OFS                    (0)                             /* !< CFIE0 Offset */
+#define MCAN_TXBCIE_CFIE0_MASK                   ((uint32_t)0x00000001U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 0. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE1] Bits */
+#define MCAN_TXBCIE_CFIE1_OFS                    (1)                             /* !< CFIE1 Offset */
+#define MCAN_TXBCIE_CFIE1_MASK                   ((uint32_t)0x00000002U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 1. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE2] Bits */
+#define MCAN_TXBCIE_CFIE2_OFS                    (2)                             /* !< CFIE2 Offset */
+#define MCAN_TXBCIE_CFIE2_MASK                   ((uint32_t)0x00000004U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 2. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE3] Bits */
+#define MCAN_TXBCIE_CFIE3_OFS                    (3)                             /* !< CFIE3 Offset */
+#define MCAN_TXBCIE_CFIE3_MASK                   ((uint32_t)0x00000008U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 3. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE4] Bits */
+#define MCAN_TXBCIE_CFIE4_OFS                    (4)                             /* !< CFIE4 Offset */
+#define MCAN_TXBCIE_CFIE4_MASK                   ((uint32_t)0x00000010U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 4. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE5] Bits */
+#define MCAN_TXBCIE_CFIE5_OFS                    (5)                             /* !< CFIE5 Offset */
+#define MCAN_TXBCIE_CFIE5_MASK                   ((uint32_t)0x00000020U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 5. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE6] Bits */
+#define MCAN_TXBCIE_CFIE6_OFS                    (6)                             /* !< CFIE6 Offset */
+#define MCAN_TXBCIE_CFIE6_MASK                   ((uint32_t)0x00000040U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 6. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE7] Bits */
+#define MCAN_TXBCIE_CFIE7_OFS                    (7)                             /* !< CFIE7 Offset */
+#define MCAN_TXBCIE_CFIE7_MASK                   ((uint32_t)0x00000080U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 7. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE8] Bits */
+#define MCAN_TXBCIE_CFIE8_OFS                    (8)                             /* !< CFIE8 Offset */
+#define MCAN_TXBCIE_CFIE8_MASK                   ((uint32_t)0x00000100U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 8. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE9] Bits */
+#define MCAN_TXBCIE_CFIE9_OFS                    (9)                             /* !< CFIE9 Offset */
+#define MCAN_TXBCIE_CFIE9_MASK                   ((uint32_t)0x00000200U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 9. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE10] Bits */
+#define MCAN_TXBCIE_CFIE10_OFS                   (10)                            /* !< CFIE10 Offset */
+#define MCAN_TXBCIE_CFIE10_MASK                  ((uint32_t)0x00000400U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 10. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE11] Bits */
+#define MCAN_TXBCIE_CFIE11_OFS                   (11)                            /* !< CFIE11 Offset */
+#define MCAN_TXBCIE_CFIE11_MASK                  ((uint32_t)0x00000800U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 11. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE12] Bits */
+#define MCAN_TXBCIE_CFIE12_OFS                   (12)                            /* !< CFIE12 Offset */
+#define MCAN_TXBCIE_CFIE12_MASK                  ((uint32_t)0x00001000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 12. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE13] Bits */
+#define MCAN_TXBCIE_CFIE13_OFS                   (13)                            /* !< CFIE13 Offset */
+#define MCAN_TXBCIE_CFIE13_MASK                  ((uint32_t)0x00002000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 13. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE14] Bits */
+#define MCAN_TXBCIE_CFIE14_OFS                   (14)                            /* !< CFIE14 Offset */
+#define MCAN_TXBCIE_CFIE14_MASK                  ((uint32_t)0x00004000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 14. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE15] Bits */
+#define MCAN_TXBCIE_CFIE15_OFS                   (15)                            /* !< CFIE15 Offset */
+#define MCAN_TXBCIE_CFIE15_MASK                  ((uint32_t)0x00008000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 15. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE16] Bits */
+#define MCAN_TXBCIE_CFIE16_OFS                   (16)                            /* !< CFIE16 Offset */
+#define MCAN_TXBCIE_CFIE16_MASK                  ((uint32_t)0x00010000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 16. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE17] Bits */
+#define MCAN_TXBCIE_CFIE17_OFS                   (17)                            /* !< CFIE17 Offset */
+#define MCAN_TXBCIE_CFIE17_MASK                  ((uint32_t)0x00020000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 17. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE18] Bits */
+#define MCAN_TXBCIE_CFIE18_OFS                   (18)                            /* !< CFIE18 Offset */
+#define MCAN_TXBCIE_CFIE18_MASK                  ((uint32_t)0x00040000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 18. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE19] Bits */
+#define MCAN_TXBCIE_CFIE19_OFS                   (19)                            /* !< CFIE19 Offset */
+#define MCAN_TXBCIE_CFIE19_MASK                  ((uint32_t)0x00080000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 19. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE20] Bits */
+#define MCAN_TXBCIE_CFIE20_OFS                   (20)                            /* !< CFIE20 Offset */
+#define MCAN_TXBCIE_CFIE20_MASK                  ((uint32_t)0x00100000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 20. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE21] Bits */
+#define MCAN_TXBCIE_CFIE21_OFS                   (21)                            /* !< CFIE21 Offset */
+#define MCAN_TXBCIE_CFIE21_MASK                  ((uint32_t)0x00200000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 21. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE22] Bits */
+#define MCAN_TXBCIE_CFIE22_OFS                   (22)                            /* !< CFIE22 Offset */
+#define MCAN_TXBCIE_CFIE22_MASK                  ((uint32_t)0x00400000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 22. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE23] Bits */
+#define MCAN_TXBCIE_CFIE23_OFS                   (23)                            /* !< CFIE23 Offset */
+#define MCAN_TXBCIE_CFIE23_MASK                  ((uint32_t)0x00800000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 23. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE24] Bits */
+#define MCAN_TXBCIE_CFIE24_OFS                   (24)                            /* !< CFIE24 Offset */
+#define MCAN_TXBCIE_CFIE24_MASK                  ((uint32_t)0x01000000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 24. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE25] Bits */
+#define MCAN_TXBCIE_CFIE25_OFS                   (25)                            /* !< CFIE25 Offset */
+#define MCAN_TXBCIE_CFIE25_MASK                  ((uint32_t)0x02000000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 25. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE26] Bits */
+#define MCAN_TXBCIE_CFIE26_OFS                   (26)                            /* !< CFIE26 Offset */
+#define MCAN_TXBCIE_CFIE26_MASK                  ((uint32_t)0x04000000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 26. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE27] Bits */
+#define MCAN_TXBCIE_CFIE27_OFS                   (27)                            /* !< CFIE27 Offset */
+#define MCAN_TXBCIE_CFIE27_MASK                  ((uint32_t)0x08000000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 27. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE28] Bits */
+#define MCAN_TXBCIE_CFIE28_OFS                   (28)                            /* !< CFIE28 Offset */
+#define MCAN_TXBCIE_CFIE28_MASK                  ((uint32_t)0x10000000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 28. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE29] Bits */
+#define MCAN_TXBCIE_CFIE29_OFS                   (29)                            /* !< CFIE29 Offset */
+#define MCAN_TXBCIE_CFIE29_MASK                  ((uint32_t)0x20000000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 29. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE30] Bits */
+#define MCAN_TXBCIE_CFIE30_OFS                   (30)                            /* !< CFIE30 Offset */
+#define MCAN_TXBCIE_CFIE30_MASK                  ((uint32_t)0x40000000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 30. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+/* MCAN_TXBCIE[CFIE31] Bits */
+#define MCAN_TXBCIE_CFIE31_OFS                   (31)                            /* !< CFIE31 Offset */
+#define MCAN_TXBCIE_CFIE31_MASK                  ((uint32_t)0x80000000U)         /* !< Cancellation Finished Interrupt
+                                                                                    Enable 31. Each Tx Buffer has its own
+                                                                                    Cancellation Finished Interrupt
+                                                                                    Enable bit.   0  Cancellation
+                                                                                    finished interrupt disabled   1
+                                                                                    Cancellation finished interrupt
+                                                                                    enabled */
+
+/* MCAN_TXEFC Bits */
+/* MCAN_TXEFC[EFSA] Bits */
+#define MCAN_TXEFC_EFSA_OFS                      (2)                             /* !< EFSA Offset */
+#define MCAN_TXEFC_EFSA_MASK                     ((uint32_t)0x0000FFFCU)         /* !< Event FIFO Start Address. Start
+                                                                                    address of Tx Event FIFO in Message
+                                                                                    RAM (32-bit word address). */
+/* MCAN_TXEFC[EFS] Bits */
+#define MCAN_TXEFC_EFS_OFS                       (16)                            /* !< EFS Offset */
+#define MCAN_TXEFC_EFS_MASK                      ((uint32_t)0x003F0000U)         /* !< Event FIFO Size. The Tx Event FIFO
+                                                                                    elements are indexed from 0 to EFS -
+                                                                                    1.   0      Tx Event FIFO disabled
+                                                                                    1-32  Number of Tx Event FIFO
+                                                                                    elements   >32   Values greater than
+                                                                                    32 are interpreted as 32 */
+/* MCAN_TXEFC[EFWM] Bits */
+#define MCAN_TXEFC_EFWM_OFS                      (24)                            /* !< EFWM Offset */
+#define MCAN_TXEFC_EFWM_MASK                     ((uint32_t)0x3F000000U)         /* !< Event FIFO Watermark   0
+                                                                                    Watermark interrupt disabled   1-32
+                                                                                    Level for Tx Event FIFO watermark
+                                                                                    interrupt (IR.TEFW)   >32   Watermark
+                                                                                    interrupt disabled */
+
+/* MCAN_TXEFS Bits */
+/* MCAN_TXEFS[EFFL] Bits */
+#define MCAN_TXEFS_EFFL_OFS                      (0)                             /* !< EFFL Offset */
+#define MCAN_TXEFS_EFFL_MASK                     ((uint32_t)0x0000003FU)         /* !< Event FIFO Fill Level. Number of
+                                                                                    elements stored in Tx Event FIFO,
+                                                                                    range 0 to 32. */
+/* MCAN_TXEFS[EFGI] Bits */
+#define MCAN_TXEFS_EFGI_OFS                      (8)                             /* !< EFGI Offset */
+#define MCAN_TXEFS_EFGI_MASK                     ((uint32_t)0x00001F00U)         /* !< Event FIFO Get Index. Tx Event FIFO
+                                                                                    read index pointer, range 0 to 31. */
+/* MCAN_TXEFS[EFPI] Bits */
+#define MCAN_TXEFS_EFPI_OFS                      (16)                            /* !< EFPI Offset */
+#define MCAN_TXEFS_EFPI_MASK                     ((uint32_t)0x001F0000U)         /* !< Event FIFO Put Index.Tx Event FIFO
+                                                                                    write index pointer, range 0 to 31. */
+/* MCAN_TXEFS[EFF] Bits */
+#define MCAN_TXEFS_EFF_OFS                       (24)                            /* !< EFF Offset */
+#define MCAN_TXEFS_EFF_MASK                      ((uint32_t)0x01000000U)         /* !< Event FIFO Full   0  Tx Event FIFO
+                                                                                    not full   1  Tx Event FIFO full */
+/* MCAN_TXEFS[TEFL] Bits */
+#define MCAN_TXEFS_TEFL_OFS                      (25)                            /* !< TEFL Offset */
+#define MCAN_TXEFS_TEFL_MASK                     ((uint32_t)0x02000000U)         /* !< Tx Event FIFO Element Lost. This
+                                                                                    bit is a copy of interrupt flag
+                                                                                    IR.TEFL. When IR.TEFL is reset, this
+                                                                                    bit is also reset.   0  No Tx Event
+                                                                                    FIFO element lost   1  Tx Event FIFO
+                                                                                    element lost, also set after write
+                                                                                    attempt to Tx Event FIFO of size
+                                                                                    zero. */
+
+/* MCAN_TXEFA Bits */
+/* MCAN_TXEFA[EFAI] Bits */
+#define MCAN_TXEFA_EFAI_OFS                      (0)                             /* !< EFAI Offset */
+#define MCAN_TXEFA_EFAI_MASK                     ((uint32_t)0x0000001FU)         /* !< Event FIFO Acknowledge Index. After
+                                                                                    the Host has read an element or a
+                                                                                    sequence of elements from the Tx
+                                                                                    Event FIFO it has to write the index
+                                                                                    of the last element read from Tx
+                                                                                    Event FIFO to EFAI. This will set the
+                                                                                    Tx Event FIFO Get Index TXEFS.EFGI to
+                                                                                    EFAI + 1 and update the Event FIFO
+                                                                                    Fill Level TXEFS.EFFL. */
+
+/* MCAN_PWREN Bits */
+/* MCAN_PWREN[ENABLE] Bits */
+#define MCAN_PWREN_ENABLE_OFS                    (0)                             /* !< ENABLE Offset */
+#define MCAN_PWREN_ENABLE_MASK                   ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define MCAN_PWREN_ENABLE_DISABLE                ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define MCAN_PWREN_ENABLE_ENABLE                 ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* MCAN_PWREN[KEY] Bits */
+#define MCAN_PWREN_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define MCAN_PWREN_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define MCAN_PWREN_KEY_UNLOCK_W                  ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* MCAN_RSTCTL Bits */
+/* MCAN_RSTCTL[RESETSTKYCLR] Bits */
+#define MCAN_RSTCTL_RESETSTKYCLR_OFS             (1)                             /* !< RESETSTKYCLR Offset */
+#define MCAN_RSTCTL_RESETSTKYCLR_MASK            ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define MCAN_RSTCTL_RESETSTKYCLR_NOP             ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_RSTCTL_RESETSTKYCLR_CLR             ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* MCAN_RSTCTL[RESETASSERT] Bits */
+#define MCAN_RSTCTL_RESETASSERT_OFS              (0)                             /* !< RESETASSERT Offset */
+#define MCAN_RSTCTL_RESETASSERT_MASK             ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define MCAN_RSTCTL_RESETASSERT_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define MCAN_RSTCTL_RESETASSERT_ASSERT           ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* MCAN_RSTCTL[KEY] Bits */
+#define MCAN_RSTCTL_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define MCAN_RSTCTL_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define MCAN_RSTCTL_KEY_UNLOCK_W                 ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* MCAN_STAT Bits */
+/* MCAN_STAT[RESETSTKY] Bits */
+#define MCAN_STAT_RESETSTKY_OFS                  (16)                            /* !< RESETSTKY Offset */
+#define MCAN_STAT_RESETSTKY_MASK                 ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define MCAN_STAT_RESETSTKY_NORES                ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define MCAN_STAT_RESETSTKY_RESET                ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_mcan__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_oa.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_oa.h
@@ -1,0 +1,292 @@
+/*****************************************************************************
+
+  Copyright (C) 2022 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_oa__include
+#define ti_devices_msp_peripherals_hw_oa__include
+
+/* This preliminary header file does not have a version number */
+/* MMR repo: https://bitbucket.itg.ti.com/projects/cmcu_msp65ip/repos/f65mspoa */
+/* MMR revision: 89377c76ba10fe939dabf3c32948d02a456b2167 */
+/* Generator revision: b581896b67084e57bafba0cd5bf5aa0fc4c1ca1a
+   (MInT: ec7ec7482a60c6871be32db8b378ec27aa4771f6) */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* OA Registers
+******************************************************************************/
+#define OA_GPRCM_OFS                             ((uint32_t)0x00000800U)
+
+
+/** @addtogroup OA_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} OA_GPRCM_Regs;
+
+/*@}*/ /* end of group OA_GPRCM */
+
+/** @addtogroup OA
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  OA_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED1[510];
+  __IO uint32_t CLKOVR;                            /* !< (@ 0x00001010) Clock Override */
+       uint32_t RESERVED2[2];
+  __IO uint32_t PWRCTL;                            /* !< (@ 0x0000101C) Power Control */
+       uint32_t RESERVED3[56];
+  __IO uint32_t CTL;                               /* !< (@ 0x00001100) Control Register */
+  __IO uint32_t CFGBASE;                           /* !< (@ 0x00001104) Configuration Base Register */
+  __IO uint32_t CFG;                               /* !< (@ 0x00001108) Configuration Register */
+       uint32_t RESERVED4[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00001118) Status Register */
+} OA_Regs;
+
+/*@}*/ /* end of group OA */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* OA Register Control Bits
+******************************************************************************/
+
+/* OA_PWREN Bits */
+/* OA_PWREN[ENABLE] Bits */
+#define OA_PWREN_ENABLE_OFS                      (0)                             /* !< ENABLE Offset */
+#define OA_PWREN_ENABLE_MASK                     ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define OA_PWREN_ENABLE_DISABLE                  ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define OA_PWREN_ENABLE_ENABLE                   ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* OA_PWREN[KEY] Bits */
+#define OA_PWREN_KEY_OFS                         (24)                            /* !< KEY Offset */
+#define OA_PWREN_KEY_MASK                        ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define OA_PWREN_KEY_UNLOCK_W                    ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* OA_RSTCTL Bits */
+/* OA_RSTCTL[RESETSTKYCLR] Bits */
+#define OA_RSTCTL_RESETSTKYCLR_OFS               (1)                             /* !< RESETSTKYCLR Offset */
+#define OA_RSTCTL_RESETSTKYCLR_MASK              ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define OA_RSTCTL_RESETSTKYCLR_NOP               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define OA_RSTCTL_RESETSTKYCLR_CLR               ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* OA_RSTCTL[RESETASSERT] Bits */
+#define OA_RSTCTL_RESETASSERT_OFS                (0)                             /* !< RESETASSERT Offset */
+#define OA_RSTCTL_RESETASSERT_MASK               ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define OA_RSTCTL_RESETASSERT_NOP                ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define OA_RSTCTL_RESETASSERT_ASSERT             ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* OA_RSTCTL[KEY] Bits */
+#define OA_RSTCTL_KEY_OFS                        (24)                            /* !< KEY Offset */
+#define OA_RSTCTL_KEY_MASK                       ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define OA_RSTCTL_KEY_UNLOCK_W                   ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* OA_GPRCM_STAT Bits */
+/* OA_GPRCM_STAT[RESETSTKY] Bits */
+#define OA_GPRCM_STAT_RESETSTKY_OFS              (16)                            /* !< RESETSTKY Offset */
+#define OA_GPRCM_STAT_RESETSTKY_MASK             ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define OA_GPRCM_STAT_RESETSTKY_NORES            ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define OA_GPRCM_STAT_RESETSTKY_RESET            ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* OA_CLKOVR Bits */
+/* OA_CLKOVR[OVERRIDE] Bits */
+#define OA_CLKOVR_OVERRIDE_OFS                   (0)                             /* !< OVERRIDE Offset */
+#define OA_CLKOVR_OVERRIDE_MASK                  ((uint32_t)0x00000001U)         /* !< Unlocks the functionality of
+                                                                                    [RUN_STOP] to override the automatic
+                                                                                    peripheral clock request */
+#define OA_CLKOVR_OVERRIDE_DISABLED              ((uint32_t)0x00000000U)         /* !< Override disabled */
+#define OA_CLKOVR_OVERRIDE_ENABLED               ((uint32_t)0x00000001U)         /* !< Override enabled */
+/* OA_CLKOVR[RUN_STOP] Bits */
+#define OA_CLKOVR_RUN_STOP_OFS                   (1)                             /* !< RUN_STOP Offset */
+#define OA_CLKOVR_RUN_STOP_MASK                  ((uint32_t)0x00000002U)         /* !< If [OVERRIDE] is enabled, this
+                                                                                    register is used to manually control
+                                                                                    the peripheral's clock request to the
+                                                                                    system */
+#define OA_CLKOVR_RUN_STOP_RUN                   ((uint32_t)0x00000000U)         /* !< Run/ungate functional clock */
+#define OA_CLKOVR_RUN_STOP_STOP                  ((uint32_t)0x00000002U)         /* !< Stop/gate functional clock */
+
+/* OA_PWRCTL Bits */
+/* OA_PWRCTL[AUTO_OFF] Bits */
+#define OA_PWRCTL_AUTO_OFF_OFS                   (0)                             /* !< AUTO_OFF Offset */
+#define OA_PWRCTL_AUTO_OFF_MASK                  ((uint32_t)0x00000001U)         /* !< When set the peripheral will remove
+                                                                                    its local IP request for enable so
+                                                                                    that it can be disabled if no other
+                                                                                    entities in the system are requesting
+                                                                                    it to be enabled. */
+#define OA_PWRCTL_AUTO_OFF_DISABLE               ((uint32_t)0x00000000U)         /* !< Disable automatic power off
+                                                                                    function */
+#define OA_PWRCTL_AUTO_OFF_ENABLE                ((uint32_t)0x00000001U)         /* !< Enable automatic power off function */
+
+/* OA_CTL Bits */
+/* OA_CTL[ENABLE] Bits */
+#define OA_CTL_ENABLE_OFS                        (0)                             /* !< ENABLE Offset */
+#define OA_CTL_ENABLE_MASK                       ((uint32_t)0x00000001U)         /* !< OAxn Enable. */
+#define OA_CTL_ENABLE_OFF                        ((uint32_t)0x00000000U)         /* !< OAxn OFF */
+#define OA_CTL_ENABLE_ON                         ((uint32_t)0x00000001U)         /* !< OAxn ON */
+
+/* OA_CFGBASE Bits */
+/* OA_CFGBASE[GBW] Bits */
+#define OA_CFGBASE_GBW_OFS                       (0)                             /* !< GBW Offset */
+#define OA_CFGBASE_GBW_MASK                      ((uint32_t)0x00000001U)         /* !< Select gain bandwidth which affects
+                                                                                    current as well the gain bandwidth.
+                                                                                    The lower gain bandwidth has lower
+                                                                                    current. See device specific
+                                                                                    datasheet for values. Can only be
+                                                                                    modified when STAT.BUSY=0. */
+#define OA_CFGBASE_GBW_LOWGAIN                   ((uint32_t)0x00000000U)         /* !< Low gain bandwidth. See device
+                                                                                    specific datasheet for gain
+                                                                                    bandwidth. */
+#define OA_CFGBASE_GBW_HIGHGAIN                  ((uint32_t)0x00000001U)         /* !< High gain bandwidth. See device
+                                                                                    specific datasheet for gain
+                                                                                    bandwidth. */
+/* OA_CFGBASE[RRI] Bits */
+#define OA_CFGBASE_RRI_OFS                       (2)                             /* !< RRI Offset */
+#define OA_CFGBASE_RRI_MASK                      ((uint32_t)0x00000004U)         /* !< Rail-to-rail input enable. Can only
+                                                                                    be modified when STAT.BUSY=0 */
+#define OA_CFGBASE_RRI_OFF                       ((uint32_t)0x00000000U)         /* !< Rail-to-rail input disable. */
+#define OA_CFGBASE_RRI_ON                        ((uint32_t)0x00000004U)         /* !< Rail-to-rail input enable. */
+
+/* OA_CFG Bits */
+/* OA_CFG[CHOP] Bits */
+#define OA_CFG_CHOP_OFS                          (0)                             /* !< CHOP Offset */
+#define OA_CFG_CHOP_MASK                         ((uint32_t)0x00000003U)         /* !< Chopping enable. */
+#define OA_CFG_CHOP_OFF                          ((uint32_t)0x00000000U)         /* !< Chopping disable. */
+#define OA_CFG_CHOP_ON                           ((uint32_t)0x00000001U)         /* !< Standard chopping enable. */
+#define OA_CFG_CHOP_AVGON                        ((uint32_t)0x00000002U)         /* !< Chop with post average on. Requires
+                                                                                    output to be connect to ADC in
+                                                                                    average mode. */
+/* OA_CFG[OUTPIN] Bits */
+#define OA_CFG_OUTPIN_OFS                        (2)                             /* !< OUTPIN Offset */
+#define OA_CFG_OUTPIN_MASK                       ((uint32_t)0x00000004U)         /* !< Enable output pin */
+#define OA_CFG_OUTPIN_DISABLED                   ((uint32_t)0x00000000U)         /* !< Output pin disabled */
+#define OA_CFG_OUTPIN_ENABLED                    ((uint32_t)0x00000004U)         /* !< Output pin enabled */
+/* OA_CFG[PSEL] Bits */
+#define OA_CFG_PSEL_OFS                          (3)                             /* !< PSEL Offset */
+#define OA_CFG_PSEL_MASK                         ((uint32_t)0x00000078U)         /* !< Positive OA input selection.
+                                                                                    Please refer to the device specific
+                                                                                    datasheet for exact channels
+                                                                                    available. */
+#define OA_CFG_PSEL_NC                           ((uint32_t)0x00000000U)         /* !< No connect */
+#define OA_CFG_PSEL_EXTPIN0                      ((uint32_t)0x00000008U)         /* !< external pin OA+0 */
+#define OA_CFG_PSEL_EXTPIN1                      ((uint32_t)0x00000010U)         /* !< external pin OAn+1 */
+#define OA_CFG_PSEL_DAC12OUT                     ((uint32_t)0x00000018U)         /* !< DAC12OUT */
+#define OA_CFG_PSEL_DAC8OUT                      ((uint32_t)0x00000020U)         /* !< DAC8OUT */
+#define OA_CFG_PSEL_VREF                         ((uint32_t)0x00000028U)         /* !< VREF Channel */
+#define OA_CFG_PSEL_OANM1RTOP                    ((uint32_t)0x00000030U)         /* !< OA[n-1]Rtop */
+#define OA_CFG_PSEL_GPAMP_OUT_INT                ((uint32_t)0x00000038U)         /* !< GPAMP_OUT_INT Input */
+#define OA_CFG_PSEL_VSS                          ((uint32_t)0x00000040U)         /* !< Internal Grouund Connection */
+/* OA_CFG[NSEL] Bits */
+#define OA_CFG_NSEL_OFS                          (7)                             /* !< NSEL Offset */
+#define OA_CFG_NSEL_MASK                         ((uint32_t)0x00000380U)         /* !< Negative OA input selection. Please
+                                                                                    refer to the device specific
+                                                                                    datasheet for exact channels
+                                                                                    available. */
+#define OA_CFG_NSEL_NC                           ((uint32_t)0x00000000U)         /* !< no connect */
+#define OA_CFG_NSEL_EXTPIN0                      ((uint32_t)0x00000080U)         /* !< external pin OAn-0 */
+#define OA_CFG_NSEL_EXTPIN1                      ((uint32_t)0x00000100U)         /* !< external pin OAn-1 */
+#define OA_CFG_NSEL_OANP1RBOT                    ((uint32_t)0x00000180U)         /* !< OA[n+1]Rbot */
+#define OA_CFG_NSEL_OANRTAP                      ((uint32_t)0x00000200U)         /* !< OA[n]Rtap */
+#define OA_CFG_NSEL_OANRTOP                      ((uint32_t)0x00000280U)         /* !< OA[n]Rtop */
+#define OA_CFG_NSEL_SPARE                        ((uint32_t)0x00000300U)         /* !< Spare input */
+/* OA_CFG[MSEL] Bits */
+#define OA_CFG_MSEL_OFS                          (10)                            /* !< MSEL Offset */
+#define OA_CFG_MSEL_MASK                         ((uint32_t)0x00001C00U)         /* !< MSEL Mux selection.  Please refer
+                                                                                    to the device specific datasheet for
+                                                                                    exact channels available. */
+#define OA_CFG_MSEL_NC                           ((uint32_t)0x00000000U)         /* !< no connect */
+#define OA_CFG_MSEL_EXTNPIN1                     ((uint32_t)0x00000400U)         /* !< external pin OAn-1 */
+#define OA_CFG_MSEL_VSS                          ((uint32_t)0x00000800U)         /* !< VSS */
+#define OA_CFG_MSEL_DAC12OUT                     ((uint32_t)0x00000C00U)         /* !< DAC12 Output */
+#define OA_CFG_MSEL_OANM1RTOP                    ((uint32_t)0x00001000U)         /* !< OA[n-1]Rtop */
+/* OA_CFG[GAIN] Bits */
+#define OA_CFG_GAIN_OFS                          (13)                            /* !< GAIN Offset */
+#define OA_CFG_GAIN_MASK                         ((uint32_t)0x0000E000U)         /* !< Gain setting. Refer to TRM for
+                                                                                    enumeration information. */
+#define OA_CFG_GAIN_MINIMUM                      ((uint32_t)0x00000000U)         /* !< Minmum gain value */
+#define OA_CFG_GAIN_MAXIMUM                      ((uint32_t)0x0000E000U)         /* !< Maximum gain value. */
+
+/* OA_STAT Bits */
+/* OA_STAT[RDY] Bits */
+#define OA_STAT_RDY_OFS                          (0)                             /* !< RDY Offset */
+#define OA_STAT_RDY_MASK                         ((uint32_t)0x00000001U)         /* !< OA ready status. */
+#define OA_STAT_RDY_FALSE                        ((uint32_t)0x00000000U)         /* !< OAxn is not ready. */
+#define OA_STAT_RDY_TRUE                         ((uint32_t)0x00000001U)         /* !< OAxn is ready. */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_oa__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_rtc.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_rtc.h
@@ -1,0 +1,2750 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/ 
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+   Redistributions of source code must retain the above copyright 
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the   
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_rtc__include
+#define ti_devices_msp_peripherals_hw_rtc__include
+
+/* Filename: hw_rtc.h */
+/* Revised: 2023-11-10 23:33:05 */
+/* Revision: 57bdd406cc3983634d43d73d4088fae123c0b478 */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* RTC Registers
+******************************************************************************/
+#define RTC_GEN_EVENT_OFS                        ((uint32_t)0x00001050U)
+#define RTC_CPU_INT_OFS                          ((uint32_t)0x00001020U)
+#define RTC_GPRCM_OFS                            ((uint32_t)0x00000800U)
+
+
+/** @addtogroup RTC_GEN_EVENT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001050) Interrupt Index Register */
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001054) Interrupt mask */
+  __I  uint32_t RIS;                               /* !< (@ 0x00001058) Raw interrupt status */
+  __I  uint32_t MIS;                               /* !< (@ 0x0000105C) Masked interrupt status */
+  __O  uint32_t ISET;                              /* !< (@ 0x00001060) Interrupt set */
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001064) Interrupt clear */
+} RTC_GEN_EVENT_Regs;
+
+/*@}*/ /* end of group RTC_GEN_EVENT */
+
+/** @addtogroup RTC_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} RTC_CPU_INT_Regs;
+
+/*@}*/ /* end of group RTC_CPU_INT */
+
+/** @addtogroup RTC_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00000808) Peripheral Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} RTC_GPRCM_Regs;
+
+/*@}*/ /* end of group RTC_GPRCM */
+
+/** @addtogroup RTC
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[273];
+  __IO uint32_t FPUB_0;                            /* !< (@ 0x00000444) Publisher Port 0 */
+       uint32_t RESERVED1[238];
+  RTC_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED2[507];
+  __I  uint32_t CLKSEL;                            /* !< (@ 0x00001004) Clock Select for Ultra Low Power peripherals */
+       uint32_t RESERVED3[6];
+  RTC_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED4;
+  RTC_GEN_EVENT_Regs  GEN_EVENT;                         /* !< (@ 0x00001050) */
+       uint32_t RESERVED5[30];
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED6[6];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) RTC Descriptor Register */
+  __IO uint32_t CLKCTL;                            /* !< (@ 0x00001100) RTC Clock Control Register */
+  __IO uint32_t DBGCTL;                            /* !< (@ 0x00001104) RTC Module Debug Control Register */
+  __IO uint32_t CTL;                               /* !< (@ 0x00001108) RTC Control Register */
+  __I  uint32_t STA;                               /* !< (@ 0x0000110C) RTC Status Register */
+  __IO uint32_t CAL;                               /* !< (@ 0x00001110) RTC Clock Offset Calibration Register */
+  __IO uint32_t TCMP;                              /* !< (@ 0x00001114) RTC Temperature Compensation Register */
+  __IO uint32_t SEC;                               /* !< (@ 0x00001118) RTC Seconds Register - Calendar Mode With Binary /
+                                                      BCD Format */
+  __IO uint32_t MIN;                               /* !< (@ 0x0000111C) RTC Minutes Register - Calendar Mode With Binary /
+                                                      BCD Format */
+  __IO uint32_t HOUR;                              /* !< (@ 0x00001120) RTC Hours Register - Calendar Mode With Binary /
+                                                      BCD Format */
+  __IO uint32_t DAY;                               /* !< (@ 0x00001124) RTC Day Of Week / Month Register - Calendar Mode
+                                                      With Binary / BCD Format */
+  __IO uint32_t MON;                               /* !< (@ 0x00001128) RTC Month Register - Calendar Mode With Binary /
+                                                      BCD Format */
+  __IO uint32_t YEAR;                              /* !< (@ 0x0000112C) RTC Year Register - Calendar Mode With Binary /
+                                                      BCD Format */
+  __IO uint32_t A1MIN;                             /* !< (@ 0x00001130) RTC Minute Alarm Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __IO uint32_t A1HOUR;                            /* !< (@ 0x00001134) RTC Hours Alarm Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __IO uint32_t A1DAY;                             /* !< (@ 0x00001138) RTC Alarm Day Of Week / Month Register - Calendar
+                                                      Mode With Binary / BCD Format */
+  __IO uint32_t A2MIN;                             /* !< (@ 0x0000113C) RTC Minute Alarm Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __IO uint32_t A2HOUR;                            /* !< (@ 0x00001140) RTC Hours Alarm Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __IO uint32_t A2DAY;                             /* !< (@ 0x00001144) RTC Alarm Day Of Week / Month Register - Calendar
+                                                      Mode With Binary / BCD Format */
+  __IO uint32_t PSCTL;                             /* !< (@ 0x00001148) RTC Prescale Timer 0/1 Control Register */
+  __IO uint32_t EXTPSCTL;                          /* !< (@ 0x0000114C) RTC Prescale Timer 2 Control Register */
+  __I  uint32_t TSSEC;                             /* !< (@ 0x00001150) Time Stamp Seconds Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __I  uint32_t TSMIN;                             /* !< (@ 0x00001154) Time Stamp Minutes Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __I  uint32_t TSHOUR;                            /* !< (@ 0x00001158) Time Stamp Hours Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __I  uint32_t TSDAY;                             /* !< (@ 0x0000115C) Time Stamp Day Of Week / MonthRegister - Calendar
+                                                      Mode With Binary / BCD Format */
+  __I  uint32_t TSMON;                             /* !< (@ 0x00001160) Time Stamp Month Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __I  uint32_t TSYEAR;                            /* !< (@ 0x00001164) Time Stamp Years Register - Calendar Mode With
+                                                      Binary / BCD Format */
+  __I  uint32_t TSSTAT;                            /* !< (@ 0x00001168) Time Stamp Status Register */
+  __IO uint32_t TSCTL;                             /* !< (@ 0x0000116C) Time Stamp Control Register */
+  __O  uint32_t TSCLR;                             /* !< (@ 0x00001170) Time Stamp Clear Register */
+  __IO uint32_t LFSSRST;                           /* !< (@ 0x00001174) Low frequency sub-system reset request */
+  __IO uint32_t RTCLOCK;                           /* !< (@ 0x00001178) Real time clock lock register */
+} RTC_Regs;
+
+/*@}*/ /* end of group RTC */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* RTC Register Control Bits
+******************************************************************************/
+
+/* RTC_GEN_EVENT_IIDX Bits */
+/* RTC_GEN_EVENT_IIDX[STAT] Bits */
+#define RTC_GEN_EVENT_IIDX_STAT_OFS              (0)                             /* !< STAT Offset */
+#define RTC_GEN_EVENT_IIDX_STAT_MASK             ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define RTC_GEN_EVENT_IIDX_STAT_NO_INTR          ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define RTC_GEN_EVENT_IIDX_STAT_RTCRDY           ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define RTC_GEN_EVENT_IIDX_STAT_RTCTEV           ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define RTC_GEN_EVENT_IIDX_STAT_RTCA1            ((uint32_t)0x00000003U)         /* !< RTC alarm 1 */
+#define RTC_GEN_EVENT_IIDX_STAT_RTCA2            ((uint32_t)0x00000004U)         /* !< RTC alarm 2 */
+#define RTC_GEN_EVENT_IIDX_STAT_RT0PS            ((uint32_t)0x00000005U)         /* !< RTC prescale timer 0 */
+#define RTC_GEN_EVENT_IIDX_STAT_RT1PS            ((uint32_t)0x00000006U)         /* !< RTC prescale timer 1 */
+#define RTC_GEN_EVENT_IIDX_STAT_RT2PS            ((uint32_t)0x00000007U)         /* !< RTC prescale timer 2 */
+#define RTC_GEN_EVENT_IIDX_STAT_TSEVT            ((uint32_t)0x00000008U)         /* !< Time stamp event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO0             ((uint32_t)0x00000009U)         /* !< Tamper I/O 0 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO1             ((uint32_t)0x0000000AU)         /* !< Tamper I/O 1 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO2             ((uint32_t)0x0000000BU)         /* !< Tamper I/O 2 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO3             ((uint32_t)0x0000000CU)         /* !< Tamper I/O 3 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO4             ((uint32_t)0x0000000DU)         /* !< Tamper I/O 4 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO5             ((uint32_t)0x0000000EU)         /* !< Tamper I/O 5 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO6             ((uint32_t)0x0000000FU)         /* !< Tamper I/O 6 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO7             ((uint32_t)0x00000010U)         /* !< Tamper I/O 7 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO8             ((uint32_t)0x00000011U)         /* !< Tamper I/O 8 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO9             ((uint32_t)0x00000012U)         /* !< Tamper I/O 9 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO10            ((uint32_t)0x00000013U)         /* !< Tamper I/O 10 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO11            ((uint32_t)0x00000014U)         /* !< Tamper I/O 11 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO12            ((uint32_t)0x00000015U)         /* !< Tamper I/O 12 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO13            ((uint32_t)0x00000016U)         /* !< Tamper I/O 13 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO14            ((uint32_t)0x00000017U)         /* !< Tamper I/O 14 event */
+#define RTC_GEN_EVENT_IIDX_STAT_TIO15            ((uint32_t)0x00000018U)         /* !< Tamper I/O 15 event */
+
+/* RTC_GEN_EVENT_IMASK Bits */
+/* RTC_GEN_EVENT_IMASK[RTCRDY] Bits */
+#define RTC_GEN_EVENT_IMASK_RTCRDY_OFS           (0)                             /* !< RTCRDY Offset */
+#define RTC_GEN_EVENT_IMASK_RTCRDY_MASK          ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define RTC_GEN_EVENT_IMASK_RTCRDY_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_RTCRDY_SET           ((uint32_t)0x00000001U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[RTCTEV] Bits */
+#define RTC_GEN_EVENT_IMASK_RTCTEV_OFS           (1)                             /* !< RTCTEV Offset */
+#define RTC_GEN_EVENT_IMASK_RTCTEV_MASK          ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define RTC_GEN_EVENT_IMASK_RTCTEV_CLR           ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_RTCTEV_SET           ((uint32_t)0x00000002U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[RTCA1] Bits */
+#define RTC_GEN_EVENT_IMASK_RTCA1_OFS            (2)                             /* !< RTCA1 Offset */
+#define RTC_GEN_EVENT_IMASK_RTCA1_MASK           ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define RTC_GEN_EVENT_IMASK_RTCA1_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_RTCA1_SET            ((uint32_t)0x00000004U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[RTCA2] Bits */
+#define RTC_GEN_EVENT_IMASK_RTCA2_OFS            (3)                             /* !< RTCA2 Offset */
+#define RTC_GEN_EVENT_IMASK_RTCA2_MASK           ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define RTC_GEN_EVENT_IMASK_RTCA2_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_RTCA2_SET            ((uint32_t)0x00000008U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[RT0PS] Bits */
+#define RTC_GEN_EVENT_IMASK_RT0PS_OFS            (4)                             /* !< RT0PS Offset */
+#define RTC_GEN_EVENT_IMASK_RT0PS_MASK           ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define RTC_GEN_EVENT_IMASK_RT0PS_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_RT0PS_SET            ((uint32_t)0x00000010U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[RT1PS] Bits */
+#define RTC_GEN_EVENT_IMASK_RT1PS_OFS            (5)                             /* !< RT1PS Offset */
+#define RTC_GEN_EVENT_IMASK_RT1PS_MASK           ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define RTC_GEN_EVENT_IMASK_RT1PS_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_RT1PS_SET            ((uint32_t)0x00000020U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[RT2PS] Bits */
+#define RTC_GEN_EVENT_IMASK_RT2PS_OFS            (6)                             /* !< RT2PS Offset */
+#define RTC_GEN_EVENT_IMASK_RT2PS_MASK           ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define RTC_GEN_EVENT_IMASK_RT2PS_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_RT2PS_SET            ((uint32_t)0x00000040U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TSEVT] Bits */
+#define RTC_GEN_EVENT_IMASK_TSEVT_OFS            (7)                             /* !< TSEVT Offset */
+#define RTC_GEN_EVENT_IMASK_TSEVT_MASK           ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define RTC_GEN_EVENT_IMASK_TSEVT_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TSEVT_SET            ((uint32_t)0x00000080U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO0] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO0_OFS             (8)                             /* !< TIO0 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO0_MASK            ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define RTC_GEN_EVENT_IMASK_TIO0_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO0_SET             ((uint32_t)0x00000100U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO1] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO1_OFS             (9)                             /* !< TIO1 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO1_MASK            ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define RTC_GEN_EVENT_IMASK_TIO1_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO1_SET             ((uint32_t)0x00000200U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO2] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO2_OFS             (10)                            /* !< TIO2 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO2_MASK            ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define RTC_GEN_EVENT_IMASK_TIO2_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO2_SET             ((uint32_t)0x00000400U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO3] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO3_OFS             (11)                            /* !< TIO3 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO3_MASK            ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define RTC_GEN_EVENT_IMASK_TIO3_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO3_SET             ((uint32_t)0x00000800U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO4] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO4_OFS             (12)                            /* !< TIO4 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO4_MASK            ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define RTC_GEN_EVENT_IMASK_TIO4_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO4_SET             ((uint32_t)0x00001000U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO5] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO5_OFS             (13)                            /* !< TIO5 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO5_MASK            ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define RTC_GEN_EVENT_IMASK_TIO5_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO5_SET             ((uint32_t)0x00002000U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO6] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO6_OFS             (14)                            /* !< TIO6 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO6_MASK            ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define RTC_GEN_EVENT_IMASK_TIO6_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO6_SET             ((uint32_t)0x00004000U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO7] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO7_OFS             (15)                            /* !< TIO7 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO7_MASK            ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define RTC_GEN_EVENT_IMASK_TIO7_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO7_SET             ((uint32_t)0x00008000U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO8] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO8_OFS             (16)                            /* !< TIO8 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO8_MASK            ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define RTC_GEN_EVENT_IMASK_TIO8_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO8_SET             ((uint32_t)0x00010000U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO9] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO9_OFS             (17)                            /* !< TIO9 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO9_MASK            ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define RTC_GEN_EVENT_IMASK_TIO9_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO9_SET             ((uint32_t)0x00020000U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO10] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO10_OFS            (18)                            /* !< TIO10 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO10_MASK           ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define RTC_GEN_EVENT_IMASK_TIO10_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO10_SET            ((uint32_t)0x00040000U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO11] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO11_OFS            (19)                            /* !< TIO11 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO11_MASK           ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define RTC_GEN_EVENT_IMASK_TIO11_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO11_SET            ((uint32_t)0x00080000U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO12] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO12_OFS            (20)                            /* !< TIO12 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO12_MASK           ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define RTC_GEN_EVENT_IMASK_TIO12_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO12_SET            ((uint32_t)0x00100000U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO13] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO13_OFS            (21)                            /* !< TIO13 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO13_MASK           ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define RTC_GEN_EVENT_IMASK_TIO13_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO13_SET            ((uint32_t)0x00200000U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO14] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO14_OFS            (22)                            /* !< TIO14 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO14_MASK           ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define RTC_GEN_EVENT_IMASK_TIO14_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO14_SET            ((uint32_t)0x00400000U)         /* !< Set Interrrupt Mask */
+/* RTC_GEN_EVENT_IMASK[TIO15] Bits */
+#define RTC_GEN_EVENT_IMASK_TIO15_OFS            (23)                            /* !< TIO15 Offset */
+#define RTC_GEN_EVENT_IMASK_TIO15_MASK           ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define RTC_GEN_EVENT_IMASK_TIO15_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_GEN_EVENT_IMASK_TIO15_SET            ((uint32_t)0x00800000U)         /* !< Set Interrrupt Mask */
+
+/* RTC_GEN_EVENT_RIS Bits */
+/* RTC_GEN_EVENT_RIS[RTCRDY] Bits */
+#define RTC_GEN_EVENT_RIS_RTCRDY_OFS             (0)                             /* !< RTCRDY Offset */
+#define RTC_GEN_EVENT_RIS_RTCRDY_MASK            ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define RTC_GEN_EVENT_RIS_RTCRDY_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_RTCRDY_SET             ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[RTCTEV] Bits */
+#define RTC_GEN_EVENT_RIS_RTCTEV_OFS             (1)                             /* !< RTCTEV Offset */
+#define RTC_GEN_EVENT_RIS_RTCTEV_MASK            ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define RTC_GEN_EVENT_RIS_RTCTEV_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_RTCTEV_SET             ((uint32_t)0x00000002U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[RTCA1] Bits */
+#define RTC_GEN_EVENT_RIS_RTCA1_OFS              (2)                             /* !< RTCA1 Offset */
+#define RTC_GEN_EVENT_RIS_RTCA1_MASK             ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define RTC_GEN_EVENT_RIS_RTCA1_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_RTCA1_SET              ((uint32_t)0x00000004U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[RTCA2] Bits */
+#define RTC_GEN_EVENT_RIS_RTCA2_OFS              (3)                             /* !< RTCA2 Offset */
+#define RTC_GEN_EVENT_RIS_RTCA2_MASK             ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define RTC_GEN_EVENT_RIS_RTCA2_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_RTCA2_SET              ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[RT0PS] Bits */
+#define RTC_GEN_EVENT_RIS_RT0PS_OFS              (4)                             /* !< RT0PS Offset */
+#define RTC_GEN_EVENT_RIS_RT0PS_MASK             ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define RTC_GEN_EVENT_RIS_RT0PS_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_RT0PS_SET              ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[RT1PS] Bits */
+#define RTC_GEN_EVENT_RIS_RT1PS_OFS              (5)                             /* !< RT1PS Offset */
+#define RTC_GEN_EVENT_RIS_RT1PS_MASK             ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define RTC_GEN_EVENT_RIS_RT1PS_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_RT1PS_SET              ((uint32_t)0x00000020U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[RT2PS] Bits */
+#define RTC_GEN_EVENT_RIS_RT2PS_OFS              (6)                             /* !< RT2PS Offset */
+#define RTC_GEN_EVENT_RIS_RT2PS_MASK             ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define RTC_GEN_EVENT_RIS_RT2PS_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_RT2PS_SET              ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TSEVT] Bits */
+#define RTC_GEN_EVENT_RIS_TSEVT_OFS              (7)                             /* !< TSEVT Offset */
+#define RTC_GEN_EVENT_RIS_TSEVT_MASK             ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define RTC_GEN_EVENT_RIS_TSEVT_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TSEVT_SET              ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO0] Bits */
+#define RTC_GEN_EVENT_RIS_TIO0_OFS               (8)                             /* !< TIO0 Offset */
+#define RTC_GEN_EVENT_RIS_TIO0_MASK              ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define RTC_GEN_EVENT_RIS_TIO0_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO0_SET               ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO1] Bits */
+#define RTC_GEN_EVENT_RIS_TIO1_OFS               (9)                             /* !< TIO1 Offset */
+#define RTC_GEN_EVENT_RIS_TIO1_MASK              ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define RTC_GEN_EVENT_RIS_TIO1_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO1_SET               ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO2] Bits */
+#define RTC_GEN_EVENT_RIS_TIO2_OFS               (10)                            /* !< TIO2 Offset */
+#define RTC_GEN_EVENT_RIS_TIO2_MASK              ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define RTC_GEN_EVENT_RIS_TIO2_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO2_SET               ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO3] Bits */
+#define RTC_GEN_EVENT_RIS_TIO3_OFS               (11)                            /* !< TIO3 Offset */
+#define RTC_GEN_EVENT_RIS_TIO3_MASK              ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define RTC_GEN_EVENT_RIS_TIO3_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO3_SET               ((uint32_t)0x00000800U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO4] Bits */
+#define RTC_GEN_EVENT_RIS_TIO4_OFS               (12)                            /* !< TIO4 Offset */
+#define RTC_GEN_EVENT_RIS_TIO4_MASK              ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define RTC_GEN_EVENT_RIS_TIO4_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO4_SET               ((uint32_t)0x00001000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO5] Bits */
+#define RTC_GEN_EVENT_RIS_TIO5_OFS               (13)                            /* !< TIO5 Offset */
+#define RTC_GEN_EVENT_RIS_TIO5_MASK              ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define RTC_GEN_EVENT_RIS_TIO5_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO5_SET               ((uint32_t)0x00002000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO6] Bits */
+#define RTC_GEN_EVENT_RIS_TIO6_OFS               (14)                            /* !< TIO6 Offset */
+#define RTC_GEN_EVENT_RIS_TIO6_MASK              ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define RTC_GEN_EVENT_RIS_TIO6_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO6_SET               ((uint32_t)0x00004000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO7] Bits */
+#define RTC_GEN_EVENT_RIS_TIO7_OFS               (15)                            /* !< TIO7 Offset */
+#define RTC_GEN_EVENT_RIS_TIO7_MASK              ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define RTC_GEN_EVENT_RIS_TIO7_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO7_SET               ((uint32_t)0x00008000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO8] Bits */
+#define RTC_GEN_EVENT_RIS_TIO8_OFS               (16)                            /* !< TIO8 Offset */
+#define RTC_GEN_EVENT_RIS_TIO8_MASK              ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define RTC_GEN_EVENT_RIS_TIO8_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO8_SET               ((uint32_t)0x00010000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO9] Bits */
+#define RTC_GEN_EVENT_RIS_TIO9_OFS               (17)                            /* !< TIO9 Offset */
+#define RTC_GEN_EVENT_RIS_TIO9_MASK              ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define RTC_GEN_EVENT_RIS_TIO9_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO9_SET               ((uint32_t)0x00020000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO10] Bits */
+#define RTC_GEN_EVENT_RIS_TIO10_OFS              (18)                            /* !< TIO10 Offset */
+#define RTC_GEN_EVENT_RIS_TIO10_MASK             ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define RTC_GEN_EVENT_RIS_TIO10_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO10_SET              ((uint32_t)0x00040000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO11] Bits */
+#define RTC_GEN_EVENT_RIS_TIO11_OFS              (19)                            /* !< TIO11 Offset */
+#define RTC_GEN_EVENT_RIS_TIO11_MASK             ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define RTC_GEN_EVENT_RIS_TIO11_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO11_SET              ((uint32_t)0x00080000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO12] Bits */
+#define RTC_GEN_EVENT_RIS_TIO12_OFS              (20)                            /* !< TIO12 Offset */
+#define RTC_GEN_EVENT_RIS_TIO12_MASK             ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define RTC_GEN_EVENT_RIS_TIO12_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO12_SET              ((uint32_t)0x00100000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO13] Bits */
+#define RTC_GEN_EVENT_RIS_TIO13_OFS              (21)                            /* !< TIO13 Offset */
+#define RTC_GEN_EVENT_RIS_TIO13_MASK             ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define RTC_GEN_EVENT_RIS_TIO13_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO13_SET              ((uint32_t)0x00200000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO14] Bits */
+#define RTC_GEN_EVENT_RIS_TIO14_OFS              (22)                            /* !< TIO14 Offset */
+#define RTC_GEN_EVENT_RIS_TIO14_MASK             ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define RTC_GEN_EVENT_RIS_TIO14_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO14_SET              ((uint32_t)0x00400000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_RIS[TIO15] Bits */
+#define RTC_GEN_EVENT_RIS_TIO15_OFS              (23)                            /* !< TIO15 Offset */
+#define RTC_GEN_EVENT_RIS_TIO15_MASK             ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define RTC_GEN_EVENT_RIS_TIO15_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_GEN_EVENT_RIS_TIO15_SET              ((uint32_t)0x00800000U)         /* !< Interrupt occurred */
+
+/* RTC_GEN_EVENT_MIS Bits */
+/* RTC_GEN_EVENT_MIS[RTCRDY] Bits */
+#define RTC_GEN_EVENT_MIS_RTCRDY_OFS             (0)                             /* !< RTCRDY Offset */
+#define RTC_GEN_EVENT_MIS_RTCRDY_MASK            ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define RTC_GEN_EVENT_MIS_RTCRDY_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_RTCRDY_SET             ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[RTCTEV] Bits */
+#define RTC_GEN_EVENT_MIS_RTCTEV_OFS             (1)                             /* !< RTCTEV Offset */
+#define RTC_GEN_EVENT_MIS_RTCTEV_MASK            ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define RTC_GEN_EVENT_MIS_RTCTEV_CLR             ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_RTCTEV_SET             ((uint32_t)0x00000002U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[RTCA1] Bits */
+#define RTC_GEN_EVENT_MIS_RTCA1_OFS              (2)                             /* !< RTCA1 Offset */
+#define RTC_GEN_EVENT_MIS_RTCA1_MASK             ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define RTC_GEN_EVENT_MIS_RTCA1_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_RTCA1_SET              ((uint32_t)0x00000004U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[RTCA2] Bits */
+#define RTC_GEN_EVENT_MIS_RTCA2_OFS              (3)                             /* !< RTCA2 Offset */
+#define RTC_GEN_EVENT_MIS_RTCA2_MASK             ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define RTC_GEN_EVENT_MIS_RTCA2_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_RTCA2_SET              ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[RT0PS] Bits */
+#define RTC_GEN_EVENT_MIS_RT0PS_OFS              (4)                             /* !< RT0PS Offset */
+#define RTC_GEN_EVENT_MIS_RT0PS_MASK             ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define RTC_GEN_EVENT_MIS_RT0PS_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_RT0PS_SET              ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[RT1PS] Bits */
+#define RTC_GEN_EVENT_MIS_RT1PS_OFS              (5)                             /* !< RT1PS Offset */
+#define RTC_GEN_EVENT_MIS_RT1PS_MASK             ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define RTC_GEN_EVENT_MIS_RT1PS_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_RT1PS_SET              ((uint32_t)0x00000020U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[RT2PS] Bits */
+#define RTC_GEN_EVENT_MIS_RT2PS_OFS              (6)                             /* !< RT2PS Offset */
+#define RTC_GEN_EVENT_MIS_RT2PS_MASK             ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define RTC_GEN_EVENT_MIS_RT2PS_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_RT2PS_SET              ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TSEVT] Bits */
+#define RTC_GEN_EVENT_MIS_TSEVT_OFS              (7)                             /* !< TSEVT Offset */
+#define RTC_GEN_EVENT_MIS_TSEVT_MASK             ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define RTC_GEN_EVENT_MIS_TSEVT_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TSEVT_SET              ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO0] Bits */
+#define RTC_GEN_EVENT_MIS_TIO0_OFS               (8)                             /* !< TIO0 Offset */
+#define RTC_GEN_EVENT_MIS_TIO0_MASK              ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define RTC_GEN_EVENT_MIS_TIO0_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO0_SET               ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO1] Bits */
+#define RTC_GEN_EVENT_MIS_TIO1_OFS               (9)                             /* !< TIO1 Offset */
+#define RTC_GEN_EVENT_MIS_TIO1_MASK              ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define RTC_GEN_EVENT_MIS_TIO1_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO1_SET               ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO2] Bits */
+#define RTC_GEN_EVENT_MIS_TIO2_OFS               (10)                            /* !< TIO2 Offset */
+#define RTC_GEN_EVENT_MIS_TIO2_MASK              ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define RTC_GEN_EVENT_MIS_TIO2_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO2_SET               ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO3] Bits */
+#define RTC_GEN_EVENT_MIS_TIO3_OFS               (11)                            /* !< TIO3 Offset */
+#define RTC_GEN_EVENT_MIS_TIO3_MASK              ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define RTC_GEN_EVENT_MIS_TIO3_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO3_SET               ((uint32_t)0x00000800U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO4] Bits */
+#define RTC_GEN_EVENT_MIS_TIO4_OFS               (12)                            /* !< TIO4 Offset */
+#define RTC_GEN_EVENT_MIS_TIO4_MASK              ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define RTC_GEN_EVENT_MIS_TIO4_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO4_SET               ((uint32_t)0x00001000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO5] Bits */
+#define RTC_GEN_EVENT_MIS_TIO5_OFS               (13)                            /* !< TIO5 Offset */
+#define RTC_GEN_EVENT_MIS_TIO5_MASK              ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define RTC_GEN_EVENT_MIS_TIO5_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO5_SET               ((uint32_t)0x00002000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO6] Bits */
+#define RTC_GEN_EVENT_MIS_TIO6_OFS               (14)                            /* !< TIO6 Offset */
+#define RTC_GEN_EVENT_MIS_TIO6_MASK              ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define RTC_GEN_EVENT_MIS_TIO6_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO6_SET               ((uint32_t)0x00004000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO7] Bits */
+#define RTC_GEN_EVENT_MIS_TIO7_OFS               (15)                            /* !< TIO7 Offset */
+#define RTC_GEN_EVENT_MIS_TIO7_MASK              ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define RTC_GEN_EVENT_MIS_TIO7_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO7_SET               ((uint32_t)0x00008000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO8] Bits */
+#define RTC_GEN_EVENT_MIS_TIO8_OFS               (16)                            /* !< TIO8 Offset */
+#define RTC_GEN_EVENT_MIS_TIO8_MASK              ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define RTC_GEN_EVENT_MIS_TIO8_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO8_SET               ((uint32_t)0x00010000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO9] Bits */
+#define RTC_GEN_EVENT_MIS_TIO9_OFS               (17)                            /* !< TIO9 Offset */
+#define RTC_GEN_EVENT_MIS_TIO9_MASK              ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define RTC_GEN_EVENT_MIS_TIO9_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO9_SET               ((uint32_t)0x00020000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO10] Bits */
+#define RTC_GEN_EVENT_MIS_TIO10_OFS              (18)                            /* !< TIO10 Offset */
+#define RTC_GEN_EVENT_MIS_TIO10_MASK             ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define RTC_GEN_EVENT_MIS_TIO10_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO10_SET              ((uint32_t)0x00040000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO11] Bits */
+#define RTC_GEN_EVENT_MIS_TIO11_OFS              (19)                            /* !< TIO11 Offset */
+#define RTC_GEN_EVENT_MIS_TIO11_MASK             ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define RTC_GEN_EVENT_MIS_TIO11_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO11_SET              ((uint32_t)0x00080000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO12] Bits */
+#define RTC_GEN_EVENT_MIS_TIO12_OFS              (20)                            /* !< TIO12 Offset */
+#define RTC_GEN_EVENT_MIS_TIO12_MASK             ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define RTC_GEN_EVENT_MIS_TIO12_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO12_SET              ((uint32_t)0x00100000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO13] Bits */
+#define RTC_GEN_EVENT_MIS_TIO13_OFS              (21)                            /* !< TIO13 Offset */
+#define RTC_GEN_EVENT_MIS_TIO13_MASK             ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define RTC_GEN_EVENT_MIS_TIO13_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO13_SET              ((uint32_t)0x00200000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO14] Bits */
+#define RTC_GEN_EVENT_MIS_TIO14_OFS              (22)                            /* !< TIO14 Offset */
+#define RTC_GEN_EVENT_MIS_TIO14_MASK             ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define RTC_GEN_EVENT_MIS_TIO14_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO14_SET              ((uint32_t)0x00400000U)         /* !< Interrupt occurred */
+/* RTC_GEN_EVENT_MIS[TIO15] Bits */
+#define RTC_GEN_EVENT_MIS_TIO15_OFS              (23)                            /* !< TIO15 Offset */
+#define RTC_GEN_EVENT_MIS_TIO15_MASK             ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define RTC_GEN_EVENT_MIS_TIO15_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_GEN_EVENT_MIS_TIO15_SET              ((uint32_t)0x00800000U)         /* !< Interrupt occurred */
+
+/* RTC_GEN_EVENT_ISET Bits */
+/* RTC_GEN_EVENT_ISET[RTCRDY] Bits */
+#define RTC_GEN_EVENT_ISET_RTCRDY_OFS            (0)                             /* !< RTCRDY Offset */
+#define RTC_GEN_EVENT_ISET_RTCRDY_MASK           ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define RTC_GEN_EVENT_ISET_RTCRDY_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_RTCRDY_SET            ((uint32_t)0x00000001U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[RTCTEV] Bits */
+#define RTC_GEN_EVENT_ISET_RTCTEV_OFS            (1)                             /* !< RTCTEV Offset */
+#define RTC_GEN_EVENT_ISET_RTCTEV_MASK           ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define RTC_GEN_EVENT_ISET_RTCTEV_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_RTCTEV_SET            ((uint32_t)0x00000002U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[RTCA1] Bits */
+#define RTC_GEN_EVENT_ISET_RTCA1_OFS             (2)                             /* !< RTCA1 Offset */
+#define RTC_GEN_EVENT_ISET_RTCA1_MASK            ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define RTC_GEN_EVENT_ISET_RTCA1_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_RTCA1_SET             ((uint32_t)0x00000004U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[RTCA2] Bits */
+#define RTC_GEN_EVENT_ISET_RTCA2_OFS             (3)                             /* !< RTCA2 Offset */
+#define RTC_GEN_EVENT_ISET_RTCA2_MASK            ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define RTC_GEN_EVENT_ISET_RTCA2_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_RTCA2_SET             ((uint32_t)0x00000008U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[RT0PS] Bits */
+#define RTC_GEN_EVENT_ISET_RT0PS_OFS             (4)                             /* !< RT0PS Offset */
+#define RTC_GEN_EVENT_ISET_RT0PS_MASK            ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define RTC_GEN_EVENT_ISET_RT0PS_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_RT0PS_SET             ((uint32_t)0x00000010U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[RT1PS] Bits */
+#define RTC_GEN_EVENT_ISET_RT1PS_OFS             (5)                             /* !< RT1PS Offset */
+#define RTC_GEN_EVENT_ISET_RT1PS_MASK            ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define RTC_GEN_EVENT_ISET_RT1PS_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_RT1PS_SET             ((uint32_t)0x00000020U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[RT2PS] Bits */
+#define RTC_GEN_EVENT_ISET_RT2PS_OFS             (6)                             /* !< RT2PS Offset */
+#define RTC_GEN_EVENT_ISET_RT2PS_MASK            ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define RTC_GEN_EVENT_ISET_RT2PS_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_RT2PS_SET             ((uint32_t)0x00000040U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TSEVT] Bits */
+#define RTC_GEN_EVENT_ISET_TSEVT_OFS             (7)                             /* !< TSEVT Offset */
+#define RTC_GEN_EVENT_ISET_TSEVT_MASK            ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define RTC_GEN_EVENT_ISET_TSEVT_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TSEVT_SET             ((uint32_t)0x00000080U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO0] Bits */
+#define RTC_GEN_EVENT_ISET_TIO0_OFS              (8)                             /* !< TIO0 Offset */
+#define RTC_GEN_EVENT_ISET_TIO0_MASK             ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define RTC_GEN_EVENT_ISET_TIO0_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO0_SET              ((uint32_t)0x00000100U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO1] Bits */
+#define RTC_GEN_EVENT_ISET_TIO1_OFS              (9)                             /* !< TIO1 Offset */
+#define RTC_GEN_EVENT_ISET_TIO1_MASK             ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define RTC_GEN_EVENT_ISET_TIO1_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO1_SET              ((uint32_t)0x00000200U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO2] Bits */
+#define RTC_GEN_EVENT_ISET_TIO2_OFS              (10)                            /* !< TIO2 Offset */
+#define RTC_GEN_EVENT_ISET_TIO2_MASK             ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define RTC_GEN_EVENT_ISET_TIO2_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO2_SET              ((uint32_t)0x00000400U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO3] Bits */
+#define RTC_GEN_EVENT_ISET_TIO3_OFS              (11)                            /* !< TIO3 Offset */
+#define RTC_GEN_EVENT_ISET_TIO3_MASK             ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define RTC_GEN_EVENT_ISET_TIO3_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO3_SET              ((uint32_t)0x00000800U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO4] Bits */
+#define RTC_GEN_EVENT_ISET_TIO4_OFS              (12)                            /* !< TIO4 Offset */
+#define RTC_GEN_EVENT_ISET_TIO4_MASK             ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define RTC_GEN_EVENT_ISET_TIO4_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO4_SET              ((uint32_t)0x00001000U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO5] Bits */
+#define RTC_GEN_EVENT_ISET_TIO5_OFS              (13)                            /* !< TIO5 Offset */
+#define RTC_GEN_EVENT_ISET_TIO5_MASK             ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define RTC_GEN_EVENT_ISET_TIO5_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO5_SET              ((uint32_t)0x00002000U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO6] Bits */
+#define RTC_GEN_EVENT_ISET_TIO6_OFS              (14)                            /* !< TIO6 Offset */
+#define RTC_GEN_EVENT_ISET_TIO6_MASK             ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define RTC_GEN_EVENT_ISET_TIO6_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO6_SET              ((uint32_t)0x00004000U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO7] Bits */
+#define RTC_GEN_EVENT_ISET_TIO7_OFS              (15)                            /* !< TIO7 Offset */
+#define RTC_GEN_EVENT_ISET_TIO7_MASK             ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define RTC_GEN_EVENT_ISET_TIO7_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO7_SET              ((uint32_t)0x00008000U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO8] Bits */
+#define RTC_GEN_EVENT_ISET_TIO8_OFS              (16)                            /* !< TIO8 Offset */
+#define RTC_GEN_EVENT_ISET_TIO8_MASK             ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define RTC_GEN_EVENT_ISET_TIO8_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO8_SET              ((uint32_t)0x00010000U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO9] Bits */
+#define RTC_GEN_EVENT_ISET_TIO9_OFS              (17)                            /* !< TIO9 Offset */
+#define RTC_GEN_EVENT_ISET_TIO9_MASK             ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define RTC_GEN_EVENT_ISET_TIO9_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO9_SET              ((uint32_t)0x00020000U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO10] Bits */
+#define RTC_GEN_EVENT_ISET_TIO10_OFS             (18)                            /* !< TIO10 Offset */
+#define RTC_GEN_EVENT_ISET_TIO10_MASK            ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define RTC_GEN_EVENT_ISET_TIO10_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO10_SET             ((uint32_t)0x00040000U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO11] Bits */
+#define RTC_GEN_EVENT_ISET_TIO11_OFS             (19)                            /* !< TIO11 Offset */
+#define RTC_GEN_EVENT_ISET_TIO11_MASK            ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define RTC_GEN_EVENT_ISET_TIO11_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO11_SET             ((uint32_t)0x00080000U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO12] Bits */
+#define RTC_GEN_EVENT_ISET_TIO12_OFS             (20)                            /* !< TIO12 Offset */
+#define RTC_GEN_EVENT_ISET_TIO12_MASK            ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define RTC_GEN_EVENT_ISET_TIO12_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO12_SET             ((uint32_t)0x00100000U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO13] Bits */
+#define RTC_GEN_EVENT_ISET_TIO13_OFS             (21)                            /* !< TIO13 Offset */
+#define RTC_GEN_EVENT_ISET_TIO13_MASK            ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define RTC_GEN_EVENT_ISET_TIO13_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO13_SET             ((uint32_t)0x00200000U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO14] Bits */
+#define RTC_GEN_EVENT_ISET_TIO14_OFS             (22)                            /* !< TIO14 Offset */
+#define RTC_GEN_EVENT_ISET_TIO14_MASK            ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define RTC_GEN_EVENT_ISET_TIO14_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO14_SET             ((uint32_t)0x00400000U)         /* !< Set interrupt */
+/* RTC_GEN_EVENT_ISET[TIO15] Bits */
+#define RTC_GEN_EVENT_ISET_TIO15_OFS             (23)                            /* !< TIO15 Offset */
+#define RTC_GEN_EVENT_ISET_TIO15_MASK            ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define RTC_GEN_EVENT_ISET_TIO15_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ISET_TIO15_SET             ((uint32_t)0x00800000U)         /* !< Set interrupt */
+
+/* RTC_GEN_EVENT_ICLR Bits */
+/* RTC_GEN_EVENT_ICLR[RTCRDY] Bits */
+#define RTC_GEN_EVENT_ICLR_RTCRDY_OFS            (0)                             /* !< RTCRDY Offset */
+#define RTC_GEN_EVENT_ICLR_RTCRDY_MASK           ((uint32_t)0x00000001U)         /* !< RTC ready */
+#define RTC_GEN_EVENT_ICLR_RTCRDY_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_RTCRDY_CLR            ((uint32_t)0x00000001U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[RTCTEV] Bits */
+#define RTC_GEN_EVENT_ICLR_RTCTEV_OFS            (1)                             /* !< RTCTEV Offset */
+#define RTC_GEN_EVENT_ICLR_RTCTEV_MASK           ((uint32_t)0x00000002U)         /* !< RTC time event */
+#define RTC_GEN_EVENT_ICLR_RTCTEV_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_RTCTEV_CLR            ((uint32_t)0x00000002U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[RTCA1] Bits */
+#define RTC_GEN_EVENT_ICLR_RTCA1_OFS             (2)                             /* !< RTCA1 Offset */
+#define RTC_GEN_EVENT_ICLR_RTCA1_MASK            ((uint32_t)0x00000004U)         /* !< RTC alarm 1 */
+#define RTC_GEN_EVENT_ICLR_RTCA1_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_RTCA1_CLR             ((uint32_t)0x00000004U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[RTCA2] Bits */
+#define RTC_GEN_EVENT_ICLR_RTCA2_OFS             (3)                             /* !< RTCA2 Offset */
+#define RTC_GEN_EVENT_ICLR_RTCA2_MASK            ((uint32_t)0x00000008U)         /* !< RTC alarm 2 */
+#define RTC_GEN_EVENT_ICLR_RTCA2_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_RTCA2_CLR             ((uint32_t)0x00000008U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[RT0PS] Bits */
+#define RTC_GEN_EVENT_ICLR_RT0PS_OFS             (4)                             /* !< RT0PS Offset */
+#define RTC_GEN_EVENT_ICLR_RT0PS_MASK            ((uint32_t)0x00000010U)         /* !< RTC prescale timer 0 */
+#define RTC_GEN_EVENT_ICLR_RT0PS_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_RT0PS_CLR             ((uint32_t)0x00000010U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[RT1PS] Bits */
+#define RTC_GEN_EVENT_ICLR_RT1PS_OFS             (5)                             /* !< RT1PS Offset */
+#define RTC_GEN_EVENT_ICLR_RT1PS_MASK            ((uint32_t)0x00000020U)         /* !< RTC prescale timer 1 */
+#define RTC_GEN_EVENT_ICLR_RT1PS_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_RT1PS_CLR             ((uint32_t)0x00000020U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[RT2PS] Bits */
+#define RTC_GEN_EVENT_ICLR_RT2PS_OFS             (6)                             /* !< RT2PS Offset */
+#define RTC_GEN_EVENT_ICLR_RT2PS_MASK            ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define RTC_GEN_EVENT_ICLR_RT2PS_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_RT2PS_CLR             ((uint32_t)0x00000040U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TSEVT] Bits */
+#define RTC_GEN_EVENT_ICLR_TSEVT_OFS             (7)                             /* !< TSEVT Offset */
+#define RTC_GEN_EVENT_ICLR_TSEVT_MASK            ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define RTC_GEN_EVENT_ICLR_TSEVT_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TSEVT_CLR             ((uint32_t)0x00000080U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO0] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO0_OFS              (8)                             /* !< TIO0 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO0_MASK             ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define RTC_GEN_EVENT_ICLR_TIO0_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO0_CLR              ((uint32_t)0x00000100U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO1] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO1_OFS              (9)                             /* !< TIO1 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO1_MASK             ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define RTC_GEN_EVENT_ICLR_TIO1_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO1_CLR              ((uint32_t)0x00000200U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO2] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO2_OFS              (10)                            /* !< TIO2 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO2_MASK             ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define RTC_GEN_EVENT_ICLR_TIO2_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO2_CLR              ((uint32_t)0x00000400U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO3] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO3_OFS              (11)                            /* !< TIO3 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO3_MASK             ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define RTC_GEN_EVENT_ICLR_TIO3_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO3_CLR              ((uint32_t)0x00000800U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO4] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO4_OFS              (12)                            /* !< TIO4 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO4_MASK             ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define RTC_GEN_EVENT_ICLR_TIO4_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO4_CLR              ((uint32_t)0x00001000U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO5] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO5_OFS              (13)                            /* !< TIO5 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO5_MASK             ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define RTC_GEN_EVENT_ICLR_TIO5_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO5_CLR              ((uint32_t)0x00002000U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO6] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO6_OFS              (14)                            /* !< TIO6 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO6_MASK             ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define RTC_GEN_EVENT_ICLR_TIO6_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO6_CLR              ((uint32_t)0x00004000U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO7] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO7_OFS              (15)                            /* !< TIO7 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO7_MASK             ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define RTC_GEN_EVENT_ICLR_TIO7_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO7_CLR              ((uint32_t)0x00008000U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO8] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO8_OFS              (16)                            /* !< TIO8 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO8_MASK             ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define RTC_GEN_EVENT_ICLR_TIO8_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO8_CLR              ((uint32_t)0x00010000U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO9] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO9_OFS              (17)                            /* !< TIO9 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO9_MASK             ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define RTC_GEN_EVENT_ICLR_TIO9_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO9_CLR              ((uint32_t)0x00020000U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO10] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO10_OFS             (18)                            /* !< TIO10 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO10_MASK            ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define RTC_GEN_EVENT_ICLR_TIO10_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO10_CLR             ((uint32_t)0x00040000U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO11] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO11_OFS             (19)                            /* !< TIO11 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO11_MASK            ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define RTC_GEN_EVENT_ICLR_TIO11_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO11_CLR             ((uint32_t)0x00080000U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO12] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO12_OFS             (20)                            /* !< TIO12 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO12_MASK            ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define RTC_GEN_EVENT_ICLR_TIO12_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO12_CLR             ((uint32_t)0x00100000U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO13] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO13_OFS             (21)                            /* !< TIO13 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO13_MASK            ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define RTC_GEN_EVENT_ICLR_TIO13_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO13_CLR             ((uint32_t)0x00200000U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO14] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO14_OFS             (22)                            /* !< TIO14 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO14_MASK            ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define RTC_GEN_EVENT_ICLR_TIO14_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO14_CLR             ((uint32_t)0x00400000U)         /* !< Clear interrupt */
+/* RTC_GEN_EVENT_ICLR[TIO15] Bits */
+#define RTC_GEN_EVENT_ICLR_TIO15_OFS             (23)                            /* !< TIO15 Offset */
+#define RTC_GEN_EVENT_ICLR_TIO15_MASK            ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define RTC_GEN_EVENT_ICLR_TIO15_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_GEN_EVENT_ICLR_TIO15_CLR             ((uint32_t)0x00800000U)         /* !< Clear interrupt */
+
+/* RTC_CPU_INT_IIDX Bits */
+/* RTC_CPU_INT_IIDX[STAT] Bits */
+#define RTC_CPU_INT_IIDX_STAT_OFS                (0)                             /* !< STAT Offset */
+#define RTC_CPU_INT_IIDX_STAT_MASK               ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define RTC_CPU_INT_IIDX_STAT_NO_INTR            ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define RTC_CPU_INT_IIDX_STAT_RTCRDY             ((uint32_t)0x00000001U)         /* !< RTC-Ready interrupt; Interrupt
+                                                                                    flag: RTCRDY */
+#define RTC_CPU_INT_IIDX_STAT_RTCTEV             ((uint32_t)0x00000002U)         /* !< Time-Event interrupt; Interrupt
+                                                                                    flag: RTCTEV */
+#define RTC_CPU_INT_IIDX_STAT_RTCA1              ((uint32_t)0x00000003U)         /* !< Alarm-1 interrupt; Interrupt flag:
+                                                                                    RTCA1 */
+#define RTC_CPU_INT_IIDX_STAT_RTCA2              ((uint32_t)0x00000004U)         /* !< Alarm-2 interrupt; Interrupt flag:
+                                                                                    RTCA2 */
+#define RTC_CPU_INT_IIDX_STAT_RT0PS              ((uint32_t)0x00000005U)         /* !< Prescaler-0 interrupt; Interrupt
+                                                                                    flag: RT0PS */
+#define RTC_CPU_INT_IIDX_STAT_RT1PS              ((uint32_t)0x00000006U)         /* !< Prescaler-1 interrupt; Interrupt
+                                                                                    flag: RT1PS */
+#define RTC_CPU_INT_IIDX_STAT_RT2PS              ((uint32_t)0x00000007U)         /* !< RTC prescale timer 2 */
+#define RTC_CPU_INT_IIDX_STAT_TSEVT              ((uint32_t)0x00000008U)         /* !< Time stamp event */
+#define RTC_CPU_INT_IIDX_STAT_TIO0               ((uint32_t)0x00000009U)         /* !< Tamper I/O 0 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO1               ((uint32_t)0x0000000AU)         /* !< Tamper I/O 1 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO2               ((uint32_t)0x0000000BU)         /* !< Tamper I/O 2 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO3               ((uint32_t)0x0000000CU)         /* !< Tamper I/O 3 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO4               ((uint32_t)0x0000000DU)         /* !< Tamper I/O 4 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO5               ((uint32_t)0x0000000EU)         /* !< Tamper I/O 5 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO6               ((uint32_t)0x0000000FU)         /* !< Tamper I/O 6 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO7               ((uint32_t)0x00000010U)         /* !< Tamper I/O 7 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO8               ((uint32_t)0x00000011U)         /* !< Tamper I/O 8 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO9               ((uint32_t)0x00000012U)         /* !< Tamper I/O 9 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO10              ((uint32_t)0x00000013U)         /* !< Tamper I/O 10 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO11              ((uint32_t)0x00000014U)         /* !< Tamper I/O 11 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO12              ((uint32_t)0x00000015U)         /* !< Tamper I/O 12 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO13              ((uint32_t)0x00000016U)         /* !< Tamper I/O 13 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO14              ((uint32_t)0x00000017U)         /* !< Tamper I/O 14 event */
+#define RTC_CPU_INT_IIDX_STAT_TIO15              ((uint32_t)0x00000018U)         /* !< Tamper I/O 15 event */
+
+/* RTC_CPU_INT_IMASK Bits */
+/* RTC_CPU_INT_IMASK[RTCA2] Bits */
+#define RTC_CPU_INT_IMASK_RTCA2_OFS              (3)                             /* !< RTCA2 Offset */
+#define RTC_CPU_INT_IMASK_RTCA2_MASK             ((uint32_t)0x00000008U)         /* !< Enable Alarm-2 interrupt */
+#define RTC_CPU_INT_IMASK_RTCA2_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_RTCA2_SET              ((uint32_t)0x00000008U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[RT0PS] Bits */
+#define RTC_CPU_INT_IMASK_RT0PS_OFS              (4)                             /* !< RT0PS Offset */
+#define RTC_CPU_INT_IMASK_RT0PS_MASK             ((uint32_t)0x00000010U)         /* !< Enable Prescaler-0 interrupt */
+#define RTC_CPU_INT_IMASK_RT0PS_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_RT0PS_SET              ((uint32_t)0x00000010U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[RT1PS] Bits */
+#define RTC_CPU_INT_IMASK_RT1PS_OFS              (5)                             /* !< RT1PS Offset */
+#define RTC_CPU_INT_IMASK_RT1PS_MASK             ((uint32_t)0x00000020U)         /* !< Enable Prescaler-1 interrupt */
+#define RTC_CPU_INT_IMASK_RT1PS_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_RT1PS_SET              ((uint32_t)0x00000020U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[RTCTEV] Bits */
+#define RTC_CPU_INT_IMASK_RTCTEV_OFS             (1)                             /* !< RTCTEV Offset */
+#define RTC_CPU_INT_IMASK_RTCTEV_MASK            ((uint32_t)0x00000002U)         /* !< Enable Time-Event interrupt */
+#define RTC_CPU_INT_IMASK_RTCTEV_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_RTCTEV_SET             ((uint32_t)0x00000002U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[RTCRDY] Bits */
+#define RTC_CPU_INT_IMASK_RTCRDY_OFS             (0)                             /* !< RTCRDY Offset */
+#define RTC_CPU_INT_IMASK_RTCRDY_MASK            ((uint32_t)0x00000001U)         /* !< Enable RTC-Ready interrupt */
+#define RTC_CPU_INT_IMASK_RTCRDY_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_RTCRDY_SET             ((uint32_t)0x00000001U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[RTCA1] Bits */
+#define RTC_CPU_INT_IMASK_RTCA1_OFS              (2)                             /* !< RTCA1 Offset */
+#define RTC_CPU_INT_IMASK_RTCA1_MASK             ((uint32_t)0x00000004U)         /* !< Enable Alarm-1 interrupt */
+#define RTC_CPU_INT_IMASK_RTCA1_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_RTCA1_SET              ((uint32_t)0x00000004U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[RT2PS] Bits */
+#define RTC_CPU_INT_IMASK_RT2PS_OFS              (6)                             /* !< RT2PS Offset */
+#define RTC_CPU_INT_IMASK_RT2PS_MASK             ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define RTC_CPU_INT_IMASK_RT2PS_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_RT2PS_SET              ((uint32_t)0x00000040U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TSEVT] Bits */
+#define RTC_CPU_INT_IMASK_TSEVT_OFS              (7)                             /* !< TSEVT Offset */
+#define RTC_CPU_INT_IMASK_TSEVT_MASK             ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define RTC_CPU_INT_IMASK_TSEVT_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TSEVT_SET              ((uint32_t)0x00000080U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO0] Bits */
+#define RTC_CPU_INT_IMASK_TIO0_OFS               (8)                             /* !< TIO0 Offset */
+#define RTC_CPU_INT_IMASK_TIO0_MASK              ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define RTC_CPU_INT_IMASK_TIO0_CLR               ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO0_SET               ((uint32_t)0x00000100U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO1] Bits */
+#define RTC_CPU_INT_IMASK_TIO1_OFS               (9)                             /* !< TIO1 Offset */
+#define RTC_CPU_INT_IMASK_TIO1_MASK              ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define RTC_CPU_INT_IMASK_TIO1_CLR               ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO1_SET               ((uint32_t)0x00000200U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO2] Bits */
+#define RTC_CPU_INT_IMASK_TIO2_OFS               (10)                            /* !< TIO2 Offset */
+#define RTC_CPU_INT_IMASK_TIO2_MASK              ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define RTC_CPU_INT_IMASK_TIO2_CLR               ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO2_SET               ((uint32_t)0x00000400U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO3] Bits */
+#define RTC_CPU_INT_IMASK_TIO3_OFS               (11)                            /* !< TIO3 Offset */
+#define RTC_CPU_INT_IMASK_TIO3_MASK              ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define RTC_CPU_INT_IMASK_TIO3_CLR               ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO3_SET               ((uint32_t)0x00000800U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO4] Bits */
+#define RTC_CPU_INT_IMASK_TIO4_OFS               (12)                            /* !< TIO4 Offset */
+#define RTC_CPU_INT_IMASK_TIO4_MASK              ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define RTC_CPU_INT_IMASK_TIO4_CLR               ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO4_SET               ((uint32_t)0x00001000U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO5] Bits */
+#define RTC_CPU_INT_IMASK_TIO5_OFS               (13)                            /* !< TIO5 Offset */
+#define RTC_CPU_INT_IMASK_TIO5_MASK              ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define RTC_CPU_INT_IMASK_TIO5_CLR               ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO5_SET               ((uint32_t)0x00002000U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO6] Bits */
+#define RTC_CPU_INT_IMASK_TIO6_OFS               (14)                            /* !< TIO6 Offset */
+#define RTC_CPU_INT_IMASK_TIO6_MASK              ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define RTC_CPU_INT_IMASK_TIO6_CLR               ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO6_SET               ((uint32_t)0x00004000U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO7] Bits */
+#define RTC_CPU_INT_IMASK_TIO7_OFS               (15)                            /* !< TIO7 Offset */
+#define RTC_CPU_INT_IMASK_TIO7_MASK              ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define RTC_CPU_INT_IMASK_TIO7_CLR               ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO7_SET               ((uint32_t)0x00008000U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO8] Bits */
+#define RTC_CPU_INT_IMASK_TIO8_OFS               (16)                            /* !< TIO8 Offset */
+#define RTC_CPU_INT_IMASK_TIO8_MASK              ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define RTC_CPU_INT_IMASK_TIO8_CLR               ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO8_SET               ((uint32_t)0x00010000U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO9] Bits */
+#define RTC_CPU_INT_IMASK_TIO9_OFS               (17)                            /* !< TIO9 Offset */
+#define RTC_CPU_INT_IMASK_TIO9_MASK              ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define RTC_CPU_INT_IMASK_TIO9_CLR               ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO9_SET               ((uint32_t)0x00020000U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO10] Bits */
+#define RTC_CPU_INT_IMASK_TIO10_OFS              (18)                            /* !< TIO10 Offset */
+#define RTC_CPU_INT_IMASK_TIO10_MASK             ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define RTC_CPU_INT_IMASK_TIO10_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO10_SET              ((uint32_t)0x00040000U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO11] Bits */
+#define RTC_CPU_INT_IMASK_TIO11_OFS              (19)                            /* !< TIO11 Offset */
+#define RTC_CPU_INT_IMASK_TIO11_MASK             ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define RTC_CPU_INT_IMASK_TIO11_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO11_SET              ((uint32_t)0x00080000U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO12] Bits */
+#define RTC_CPU_INT_IMASK_TIO12_OFS              (20)                            /* !< TIO12 Offset */
+#define RTC_CPU_INT_IMASK_TIO12_MASK             ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define RTC_CPU_INT_IMASK_TIO12_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO12_SET              ((uint32_t)0x00100000U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO13] Bits */
+#define RTC_CPU_INT_IMASK_TIO13_OFS              (21)                            /* !< TIO13 Offset */
+#define RTC_CPU_INT_IMASK_TIO13_MASK             ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define RTC_CPU_INT_IMASK_TIO13_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO13_SET              ((uint32_t)0x00200000U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO14] Bits */
+#define RTC_CPU_INT_IMASK_TIO14_OFS              (22)                            /* !< TIO14 Offset */
+#define RTC_CPU_INT_IMASK_TIO14_MASK             ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define RTC_CPU_INT_IMASK_TIO14_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO14_SET              ((uint32_t)0x00400000U)         /* !< Set Interrrupt Mask */
+/* RTC_CPU_INT_IMASK[TIO15] Bits */
+#define RTC_CPU_INT_IMASK_TIO15_OFS              (23)                            /* !< TIO15 Offset */
+#define RTC_CPU_INT_IMASK_TIO15_MASK             ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define RTC_CPU_INT_IMASK_TIO15_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define RTC_CPU_INT_IMASK_TIO15_SET              ((uint32_t)0x00800000U)         /* !< Set Interrrupt Mask */
+
+/* RTC_CPU_INT_RIS Bits */
+/* RTC_CPU_INT_RIS[RTCRDY] Bits */
+#define RTC_CPU_INT_RIS_RTCRDY_OFS               (0)                             /* !< RTCRDY Offset */
+#define RTC_CPU_INT_RIS_RTCRDY_MASK              ((uint32_t)0x00000001U)         /* !< Raw RTC-Ready interrupts status */
+#define RTC_CPU_INT_RIS_RTCRDY_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_RTCRDY_SET               ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+/* RTC_CPU_INT_RIS[RTCTEV] Bits */
+#define RTC_CPU_INT_RIS_RTCTEV_OFS               (1)                             /* !< RTCTEV Offset */
+#define RTC_CPU_INT_RIS_RTCTEV_MASK              ((uint32_t)0x00000002U)         /* !< Raw Time-Event interrupt status */
+#define RTC_CPU_INT_RIS_RTCTEV_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_RTCTEV_SET               ((uint32_t)0x00000002U)         /* !< Interrupt occured */
+/* RTC_CPU_INT_RIS[RTCA1] Bits */
+#define RTC_CPU_INT_RIS_RTCA1_OFS                (2)                             /* !< RTCA1 Offset */
+#define RTC_CPU_INT_RIS_RTCA1_MASK               ((uint32_t)0x00000004U)         /* !< Raw Alarm-1 interrupt status */
+#define RTC_CPU_INT_RIS_RTCA1_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_RTCA1_SET                ((uint32_t)0x00000004U)         /* !< Interrupt occured */
+/* RTC_CPU_INT_RIS[RTCA2] Bits */
+#define RTC_CPU_INT_RIS_RTCA2_OFS                (3)                             /* !< RTCA2 Offset */
+#define RTC_CPU_INT_RIS_RTCA2_MASK               ((uint32_t)0x00000008U)         /* !< Raw Alarm-2 interrupts status */
+#define RTC_CPU_INT_RIS_RTCA2_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_RTCA2_SET                ((uint32_t)0x00000008U)         /* !< Interrupt occured */
+/* RTC_CPU_INT_RIS[RT0PS] Bits */
+#define RTC_CPU_INT_RIS_RT0PS_OFS                (4)                             /* !< RT0PS Offset */
+#define RTC_CPU_INT_RIS_RT0PS_MASK               ((uint32_t)0x00000010U)         /* !< Raw Prescaler-0 interrupt status */
+#define RTC_CPU_INT_RIS_RT0PS_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_RT0PS_SET                ((uint32_t)0x00000010U)         /* !< Interrupt occured */
+/* RTC_CPU_INT_RIS[RT1PS] Bits */
+#define RTC_CPU_INT_RIS_RT1PS_OFS                (5)                             /* !< RT1PS Offset */
+#define RTC_CPU_INT_RIS_RT1PS_MASK               ((uint32_t)0x00000020U)         /* !< Raw Prescaler-1 interrupt status */
+#define RTC_CPU_INT_RIS_RT1PS_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_RT1PS_SET                ((uint32_t)0x00000020U)         /* !< Interrupt occured */
+/* RTC_CPU_INT_RIS[RT2PS] Bits */
+#define RTC_CPU_INT_RIS_RT2PS_OFS                (6)                             /* !< RT2PS Offset */
+#define RTC_CPU_INT_RIS_RT2PS_MASK               ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define RTC_CPU_INT_RIS_RT2PS_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_RT2PS_SET                ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TSEVT] Bits */
+#define RTC_CPU_INT_RIS_TSEVT_OFS                (7)                             /* !< TSEVT Offset */
+#define RTC_CPU_INT_RIS_TSEVT_MASK               ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define RTC_CPU_INT_RIS_TSEVT_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TSEVT_SET                ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO0] Bits */
+#define RTC_CPU_INT_RIS_TIO0_OFS                 (8)                             /* !< TIO0 Offset */
+#define RTC_CPU_INT_RIS_TIO0_MASK                ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define RTC_CPU_INT_RIS_TIO0_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO0_SET                 ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO1] Bits */
+#define RTC_CPU_INT_RIS_TIO1_OFS                 (9)                             /* !< TIO1 Offset */
+#define RTC_CPU_INT_RIS_TIO1_MASK                ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define RTC_CPU_INT_RIS_TIO1_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO1_SET                 ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO2] Bits */
+#define RTC_CPU_INT_RIS_TIO2_OFS                 (10)                            /* !< TIO2 Offset */
+#define RTC_CPU_INT_RIS_TIO2_MASK                ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define RTC_CPU_INT_RIS_TIO2_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO2_SET                 ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO3] Bits */
+#define RTC_CPU_INT_RIS_TIO3_OFS                 (11)                            /* !< TIO3 Offset */
+#define RTC_CPU_INT_RIS_TIO3_MASK                ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define RTC_CPU_INT_RIS_TIO3_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO3_SET                 ((uint32_t)0x00000800U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO4] Bits */
+#define RTC_CPU_INT_RIS_TIO4_OFS                 (12)                            /* !< TIO4 Offset */
+#define RTC_CPU_INT_RIS_TIO4_MASK                ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define RTC_CPU_INT_RIS_TIO4_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO4_SET                 ((uint32_t)0x00001000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO5] Bits */
+#define RTC_CPU_INT_RIS_TIO5_OFS                 (13)                            /* !< TIO5 Offset */
+#define RTC_CPU_INT_RIS_TIO5_MASK                ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define RTC_CPU_INT_RIS_TIO5_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO5_SET                 ((uint32_t)0x00002000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO6] Bits */
+#define RTC_CPU_INT_RIS_TIO6_OFS                 (14)                            /* !< TIO6 Offset */
+#define RTC_CPU_INT_RIS_TIO6_MASK                ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define RTC_CPU_INT_RIS_TIO6_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO6_SET                 ((uint32_t)0x00004000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO7] Bits */
+#define RTC_CPU_INT_RIS_TIO7_OFS                 (15)                            /* !< TIO7 Offset */
+#define RTC_CPU_INT_RIS_TIO7_MASK                ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define RTC_CPU_INT_RIS_TIO7_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO7_SET                 ((uint32_t)0x00008000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO8] Bits */
+#define RTC_CPU_INT_RIS_TIO8_OFS                 (16)                            /* !< TIO8 Offset */
+#define RTC_CPU_INT_RIS_TIO8_MASK                ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define RTC_CPU_INT_RIS_TIO8_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO8_SET                 ((uint32_t)0x00010000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO9] Bits */
+#define RTC_CPU_INT_RIS_TIO9_OFS                 (17)                            /* !< TIO9 Offset */
+#define RTC_CPU_INT_RIS_TIO9_MASK                ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define RTC_CPU_INT_RIS_TIO9_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO9_SET                 ((uint32_t)0x00020000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO10] Bits */
+#define RTC_CPU_INT_RIS_TIO10_OFS                (18)                            /* !< TIO10 Offset */
+#define RTC_CPU_INT_RIS_TIO10_MASK               ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define RTC_CPU_INT_RIS_TIO10_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO10_SET                ((uint32_t)0x00040000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO11] Bits */
+#define RTC_CPU_INT_RIS_TIO11_OFS                (19)                            /* !< TIO11 Offset */
+#define RTC_CPU_INT_RIS_TIO11_MASK               ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define RTC_CPU_INT_RIS_TIO11_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO11_SET                ((uint32_t)0x00080000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO12] Bits */
+#define RTC_CPU_INT_RIS_TIO12_OFS                (20)                            /* !< TIO12 Offset */
+#define RTC_CPU_INT_RIS_TIO12_MASK               ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define RTC_CPU_INT_RIS_TIO12_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO12_SET                ((uint32_t)0x00100000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO13] Bits */
+#define RTC_CPU_INT_RIS_TIO13_OFS                (21)                            /* !< TIO13 Offset */
+#define RTC_CPU_INT_RIS_TIO13_MASK               ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define RTC_CPU_INT_RIS_TIO13_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO13_SET                ((uint32_t)0x00200000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO14] Bits */
+#define RTC_CPU_INT_RIS_TIO14_OFS                (22)                            /* !< TIO14 Offset */
+#define RTC_CPU_INT_RIS_TIO14_MASK               ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define RTC_CPU_INT_RIS_TIO14_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO14_SET                ((uint32_t)0x00400000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_RIS[TIO15] Bits */
+#define RTC_CPU_INT_RIS_TIO15_OFS                (23)                            /* !< TIO15 Offset */
+#define RTC_CPU_INT_RIS_TIO15_MASK               ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define RTC_CPU_INT_RIS_TIO15_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_RIS_TIO15_SET                ((uint32_t)0x00800000U)         /* !< Interrupt occurred */
+
+/* RTC_CPU_INT_MIS Bits */
+/* RTC_CPU_INT_MIS[RTCRDY] Bits */
+#define RTC_CPU_INT_MIS_RTCRDY_OFS               (0)                             /* !< RTCRDY Offset */
+#define RTC_CPU_INT_MIS_RTCRDY_MASK              ((uint32_t)0x00000001U)         /* !< Masked RTC-Ready interrupt status */
+#define RTC_CPU_INT_MIS_RTCRDY_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_MIS_RTCRDY_SET               ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+/* RTC_CPU_INT_MIS[RTCTEV] Bits */
+#define RTC_CPU_INT_MIS_RTCTEV_OFS               (1)                             /* !< RTCTEV Offset */
+#define RTC_CPU_INT_MIS_RTCTEV_MASK              ((uint32_t)0x00000002U)         /* !< Masked Time-Event interrupt status */
+#define RTC_CPU_INT_MIS_RTCTEV_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_MIS_RTCTEV_SET               ((uint32_t)0x00000002U)         /* !< Interrupt occured */
+/* RTC_CPU_INT_MIS[RTCA1] Bits */
+#define RTC_CPU_INT_MIS_RTCA1_OFS                (2)                             /* !< RTCA1 Offset */
+#define RTC_CPU_INT_MIS_RTCA1_MASK               ((uint32_t)0x00000004U)         /* !< Masked Alarm-1 interrupt status */
+#define RTC_CPU_INT_MIS_RTCA1_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_MIS_RTCA1_SET                ((uint32_t)0x00000004U)         /* !< Interrupt occured */
+/* RTC_CPU_INT_MIS[RTCA2] Bits */
+#define RTC_CPU_INT_MIS_RTCA2_OFS                (3)                             /* !< RTCA2 Offset */
+#define RTC_CPU_INT_MIS_RTCA2_MASK               ((uint32_t)0x00000008U)         /* !< Masked Alarm-2 interrupt status */
+#define RTC_CPU_INT_MIS_RTCA2_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_MIS_RTCA2_SET                ((uint32_t)0x00000008U)         /* !< Interrupt occured */
+/* RTC_CPU_INT_MIS[RT0PS] Bits */
+#define RTC_CPU_INT_MIS_RT0PS_OFS                (4)                             /* !< RT0PS Offset */
+#define RTC_CPU_INT_MIS_RT0PS_MASK               ((uint32_t)0x00000010U)         /* !< Masked Prescaler-0 interrupt status */
+#define RTC_CPU_INT_MIS_RT0PS_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_MIS_RT0PS_SET                ((uint32_t)0x00000010U)         /* !< Interrupt occured */
+/* RTC_CPU_INT_MIS[RT1PS] Bits */
+#define RTC_CPU_INT_MIS_RT1PS_OFS                (5)                             /* !< RT1PS Offset */
+#define RTC_CPU_INT_MIS_RT1PS_MASK               ((uint32_t)0x00000020U)         /* !< Masked Prescaler-1 interrupt status */
+#define RTC_CPU_INT_MIS_RT1PS_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define RTC_CPU_INT_MIS_RT1PS_SET                ((uint32_t)0x00000020U)         /* !< Interrupt occured */
+/* RTC_CPU_INT_MIS[RT2PS] Bits */
+#define RTC_CPU_INT_MIS_RT2PS_OFS                (6)                             /* !< RT2PS Offset */
+#define RTC_CPU_INT_MIS_RT2PS_MASK               ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define RTC_CPU_INT_MIS_RT2PS_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_RT2PS_SET                ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TSEVT] Bits */
+#define RTC_CPU_INT_MIS_TSEVT_OFS                (7)                             /* !< TSEVT Offset */
+#define RTC_CPU_INT_MIS_TSEVT_MASK               ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define RTC_CPU_INT_MIS_TSEVT_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TSEVT_SET                ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO0] Bits */
+#define RTC_CPU_INT_MIS_TIO0_OFS                 (8)                             /* !< TIO0 Offset */
+#define RTC_CPU_INT_MIS_TIO0_MASK                ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define RTC_CPU_INT_MIS_TIO0_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO0_SET                 ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO1] Bits */
+#define RTC_CPU_INT_MIS_TIO1_OFS                 (9)                             /* !< TIO1 Offset */
+#define RTC_CPU_INT_MIS_TIO1_MASK                ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define RTC_CPU_INT_MIS_TIO1_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO1_SET                 ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO2] Bits */
+#define RTC_CPU_INT_MIS_TIO2_OFS                 (10)                            /* !< TIO2 Offset */
+#define RTC_CPU_INT_MIS_TIO2_MASK                ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define RTC_CPU_INT_MIS_TIO2_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO2_SET                 ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO3] Bits */
+#define RTC_CPU_INT_MIS_TIO3_OFS                 (11)                            /* !< TIO3 Offset */
+#define RTC_CPU_INT_MIS_TIO3_MASK                ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define RTC_CPU_INT_MIS_TIO3_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO3_SET                 ((uint32_t)0x00000800U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO4] Bits */
+#define RTC_CPU_INT_MIS_TIO4_OFS                 (12)                            /* !< TIO4 Offset */
+#define RTC_CPU_INT_MIS_TIO4_MASK                ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define RTC_CPU_INT_MIS_TIO4_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO4_SET                 ((uint32_t)0x00001000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO5] Bits */
+#define RTC_CPU_INT_MIS_TIO5_OFS                 (13)                            /* !< TIO5 Offset */
+#define RTC_CPU_INT_MIS_TIO5_MASK                ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define RTC_CPU_INT_MIS_TIO5_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO5_SET                 ((uint32_t)0x00002000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO6] Bits */
+#define RTC_CPU_INT_MIS_TIO6_OFS                 (14)                            /* !< TIO6 Offset */
+#define RTC_CPU_INT_MIS_TIO6_MASK                ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define RTC_CPU_INT_MIS_TIO6_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO6_SET                 ((uint32_t)0x00004000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO7] Bits */
+#define RTC_CPU_INT_MIS_TIO7_OFS                 (15)                            /* !< TIO7 Offset */
+#define RTC_CPU_INT_MIS_TIO7_MASK                ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define RTC_CPU_INT_MIS_TIO7_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO7_SET                 ((uint32_t)0x00008000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO8] Bits */
+#define RTC_CPU_INT_MIS_TIO8_OFS                 (16)                            /* !< TIO8 Offset */
+#define RTC_CPU_INT_MIS_TIO8_MASK                ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define RTC_CPU_INT_MIS_TIO8_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO8_SET                 ((uint32_t)0x00010000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO9] Bits */
+#define RTC_CPU_INT_MIS_TIO9_OFS                 (17)                            /* !< TIO9 Offset */
+#define RTC_CPU_INT_MIS_TIO9_MASK                ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define RTC_CPU_INT_MIS_TIO9_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO9_SET                 ((uint32_t)0x00020000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO10] Bits */
+#define RTC_CPU_INT_MIS_TIO10_OFS                (18)                            /* !< TIO10 Offset */
+#define RTC_CPU_INT_MIS_TIO10_MASK               ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define RTC_CPU_INT_MIS_TIO10_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO10_SET                ((uint32_t)0x00040000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO11] Bits */
+#define RTC_CPU_INT_MIS_TIO11_OFS                (19)                            /* !< TIO11 Offset */
+#define RTC_CPU_INT_MIS_TIO11_MASK               ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define RTC_CPU_INT_MIS_TIO11_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO11_SET                ((uint32_t)0x00080000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO12] Bits */
+#define RTC_CPU_INT_MIS_TIO12_OFS                (20)                            /* !< TIO12 Offset */
+#define RTC_CPU_INT_MIS_TIO12_MASK               ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define RTC_CPU_INT_MIS_TIO12_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO12_SET                ((uint32_t)0x00100000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO13] Bits */
+#define RTC_CPU_INT_MIS_TIO13_OFS                (21)                            /* !< TIO13 Offset */
+#define RTC_CPU_INT_MIS_TIO13_MASK               ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define RTC_CPU_INT_MIS_TIO13_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO13_SET                ((uint32_t)0x00200000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO14] Bits */
+#define RTC_CPU_INT_MIS_TIO14_OFS                (22)                            /* !< TIO14 Offset */
+#define RTC_CPU_INT_MIS_TIO14_MASK               ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define RTC_CPU_INT_MIS_TIO14_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO14_SET                ((uint32_t)0x00400000U)         /* !< Interrupt occurred */
+/* RTC_CPU_INT_MIS[TIO15] Bits */
+#define RTC_CPU_INT_MIS_TIO15_OFS                (23)                            /* !< TIO15 Offset */
+#define RTC_CPU_INT_MIS_TIO15_MASK               ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define RTC_CPU_INT_MIS_TIO15_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur or is
+                                                                                    masked out */
+#define RTC_CPU_INT_MIS_TIO15_SET                ((uint32_t)0x00800000U)         /* !< Interrupt occurred */
+
+/* RTC_CPU_INT_ISET Bits */
+/* RTC_CPU_INT_ISET[RTCRDY] Bits */
+#define RTC_CPU_INT_ISET_RTCRDY_OFS              (0)                             /* !< RTCRDY Offset */
+#define RTC_CPU_INT_ISET_RTCRDY_MASK             ((uint32_t)0x00000001U)         /* !< Set RTC-Ready interrupt */
+#define RTC_CPU_INT_ISET_RTCRDY_CLR              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_RTCRDY_SET              ((uint32_t)0x00000001U)         /* !< Set Interrupt */
+/* RTC_CPU_INT_ISET[RTCTEV] Bits */
+#define RTC_CPU_INT_ISET_RTCTEV_OFS              (1)                             /* !< RTCTEV Offset */
+#define RTC_CPU_INT_ISET_RTCTEV_MASK             ((uint32_t)0x00000002U)         /* !< Set Time-Event interrupt */
+#define RTC_CPU_INT_ISET_RTCTEV_CLR              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_RTCTEV_SET              ((uint32_t)0x00000002U)         /* !< Set Interrupt */
+/* RTC_CPU_INT_ISET[RTCA1] Bits */
+#define RTC_CPU_INT_ISET_RTCA1_OFS               (2)                             /* !< RTCA1 Offset */
+#define RTC_CPU_INT_ISET_RTCA1_MASK              ((uint32_t)0x00000004U)         /* !< Set Alarm-1 interrupt */
+#define RTC_CPU_INT_ISET_RTCA1_CLR               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_RTCA1_SET               ((uint32_t)0x00000004U)         /* !< Set Interrupt */
+/* RTC_CPU_INT_ISET[RTCA2] Bits */
+#define RTC_CPU_INT_ISET_RTCA2_OFS               (3)                             /* !< RTCA2 Offset */
+#define RTC_CPU_INT_ISET_RTCA2_MASK              ((uint32_t)0x00000008U)         /* !< Set Alarm-2 interrupt */
+#define RTC_CPU_INT_ISET_RTCA2_CLR               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_RTCA2_SET               ((uint32_t)0x00000008U)         /* !< Set Interrupt */
+/* RTC_CPU_INT_ISET[RT0PS] Bits */
+#define RTC_CPU_INT_ISET_RT0PS_OFS               (4)                             /* !< RT0PS Offset */
+#define RTC_CPU_INT_ISET_RT0PS_MASK              ((uint32_t)0x00000010U)         /* !< Set Prescaler-0 interrupt */
+#define RTC_CPU_INT_ISET_RT0PS_CLR               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_RT0PS_SET               ((uint32_t)0x00000010U)         /* !< Set Interrupt */
+/* RTC_CPU_INT_ISET[RT1PS] Bits */
+#define RTC_CPU_INT_ISET_RT1PS_OFS               (5)                             /* !< RT1PS Offset */
+#define RTC_CPU_INT_ISET_RT1PS_MASK              ((uint32_t)0x00000020U)         /* !< Set Prescaler-1 interrupt */
+#define RTC_CPU_INT_ISET_RT1PS_CLR               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_RT1PS_SET               ((uint32_t)0x00000020U)         /* !< Set Interrupt */
+/* RTC_CPU_INT_ISET[RT2PS] Bits */
+#define RTC_CPU_INT_ISET_RT2PS_OFS               (6)                             /* !< RT2PS Offset */
+#define RTC_CPU_INT_ISET_RT2PS_MASK              ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define RTC_CPU_INT_ISET_RT2PS_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_RT2PS_SET               ((uint32_t)0x00000040U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TSEVT] Bits */
+#define RTC_CPU_INT_ISET_TSEVT_OFS               (7)                             /* !< TSEVT Offset */
+#define RTC_CPU_INT_ISET_TSEVT_MASK              ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define RTC_CPU_INT_ISET_TSEVT_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TSEVT_SET               ((uint32_t)0x00000080U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO0] Bits */
+#define RTC_CPU_INT_ISET_TIO0_OFS                (8)                             /* !< TIO0 Offset */
+#define RTC_CPU_INT_ISET_TIO0_MASK               ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define RTC_CPU_INT_ISET_TIO0_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO0_SET                ((uint32_t)0x00000100U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO1] Bits */
+#define RTC_CPU_INT_ISET_TIO1_OFS                (9)                             /* !< TIO1 Offset */
+#define RTC_CPU_INT_ISET_TIO1_MASK               ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define RTC_CPU_INT_ISET_TIO1_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO1_SET                ((uint32_t)0x00000200U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO2] Bits */
+#define RTC_CPU_INT_ISET_TIO2_OFS                (10)                            /* !< TIO2 Offset */
+#define RTC_CPU_INT_ISET_TIO2_MASK               ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define RTC_CPU_INT_ISET_TIO2_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO2_SET                ((uint32_t)0x00000400U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO3] Bits */
+#define RTC_CPU_INT_ISET_TIO3_OFS                (11)                            /* !< TIO3 Offset */
+#define RTC_CPU_INT_ISET_TIO3_MASK               ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define RTC_CPU_INT_ISET_TIO3_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO3_SET                ((uint32_t)0x00000800U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO4] Bits */
+#define RTC_CPU_INT_ISET_TIO4_OFS                (12)                            /* !< TIO4 Offset */
+#define RTC_CPU_INT_ISET_TIO4_MASK               ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define RTC_CPU_INT_ISET_TIO4_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO4_SET                ((uint32_t)0x00001000U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO5] Bits */
+#define RTC_CPU_INT_ISET_TIO5_OFS                (13)                            /* !< TIO5 Offset */
+#define RTC_CPU_INT_ISET_TIO5_MASK               ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define RTC_CPU_INT_ISET_TIO5_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO5_SET                ((uint32_t)0x00002000U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO6] Bits */
+#define RTC_CPU_INT_ISET_TIO6_OFS                (14)                            /* !< TIO6 Offset */
+#define RTC_CPU_INT_ISET_TIO6_MASK               ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define RTC_CPU_INT_ISET_TIO6_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO6_SET                ((uint32_t)0x00004000U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO7] Bits */
+#define RTC_CPU_INT_ISET_TIO7_OFS                (15)                            /* !< TIO7 Offset */
+#define RTC_CPU_INT_ISET_TIO7_MASK               ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define RTC_CPU_INT_ISET_TIO7_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO7_SET                ((uint32_t)0x00008000U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO8] Bits */
+#define RTC_CPU_INT_ISET_TIO8_OFS                (16)                            /* !< TIO8 Offset */
+#define RTC_CPU_INT_ISET_TIO8_MASK               ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define RTC_CPU_INT_ISET_TIO8_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO8_SET                ((uint32_t)0x00010000U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO9] Bits */
+#define RTC_CPU_INT_ISET_TIO9_OFS                (17)                            /* !< TIO9 Offset */
+#define RTC_CPU_INT_ISET_TIO9_MASK               ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define RTC_CPU_INT_ISET_TIO9_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO9_SET                ((uint32_t)0x00020000U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO10] Bits */
+#define RTC_CPU_INT_ISET_TIO10_OFS               (18)                            /* !< TIO10 Offset */
+#define RTC_CPU_INT_ISET_TIO10_MASK              ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define RTC_CPU_INT_ISET_TIO10_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO10_SET               ((uint32_t)0x00040000U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO11] Bits */
+#define RTC_CPU_INT_ISET_TIO11_OFS               (19)                            /* !< TIO11 Offset */
+#define RTC_CPU_INT_ISET_TIO11_MASK              ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define RTC_CPU_INT_ISET_TIO11_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO11_SET               ((uint32_t)0x00080000U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO12] Bits */
+#define RTC_CPU_INT_ISET_TIO12_OFS               (20)                            /* !< TIO12 Offset */
+#define RTC_CPU_INT_ISET_TIO12_MASK              ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define RTC_CPU_INT_ISET_TIO12_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO12_SET               ((uint32_t)0x00100000U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO13] Bits */
+#define RTC_CPU_INT_ISET_TIO13_OFS               (21)                            /* !< TIO13 Offset */
+#define RTC_CPU_INT_ISET_TIO13_MASK              ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define RTC_CPU_INT_ISET_TIO13_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO13_SET               ((uint32_t)0x00200000U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO14] Bits */
+#define RTC_CPU_INT_ISET_TIO14_OFS               (22)                            /* !< TIO14 Offset */
+#define RTC_CPU_INT_ISET_TIO14_MASK              ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define RTC_CPU_INT_ISET_TIO14_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO14_SET               ((uint32_t)0x00400000U)         /* !< Set interrupt */
+/* RTC_CPU_INT_ISET[TIO15] Bits */
+#define RTC_CPU_INT_ISET_TIO15_OFS               (23)                            /* !< TIO15 Offset */
+#define RTC_CPU_INT_ISET_TIO15_MASK              ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define RTC_CPU_INT_ISET_TIO15_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ISET_TIO15_SET               ((uint32_t)0x00800000U)         /* !< Set interrupt */
+
+/* RTC_CPU_INT_ICLR Bits */
+/* RTC_CPU_INT_ICLR[RTCRDY] Bits */
+#define RTC_CPU_INT_ICLR_RTCRDY_OFS              (0)                             /* !< RTCRDY Offset */
+#define RTC_CPU_INT_ICLR_RTCRDY_MASK             ((uint32_t)0x00000001U)         /* !< Clear RTC-Ready interrupt */
+#define RTC_CPU_INT_ICLR_RTCRDY_CLR              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_RTCRDY_SET              ((uint32_t)0x00000001U)         /* !< Clear Interrupt */
+/* RTC_CPU_INT_ICLR[RTCTEV] Bits */
+#define RTC_CPU_INT_ICLR_RTCTEV_OFS              (1)                             /* !< RTCTEV Offset */
+#define RTC_CPU_INT_ICLR_RTCTEV_MASK             ((uint32_t)0x00000002U)         /* !< Clear Time-Event interrupt */
+#define RTC_CPU_INT_ICLR_RTCTEV_CLR              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_RTCTEV_SET              ((uint32_t)0x00000002U)         /* !< Clear Interrupt */
+/* RTC_CPU_INT_ICLR[RTCA1] Bits */
+#define RTC_CPU_INT_ICLR_RTCA1_OFS               (2)                             /* !< RTCA1 Offset */
+#define RTC_CPU_INT_ICLR_RTCA1_MASK              ((uint32_t)0x00000004U)         /* !< Clear Alarm-1 interrupt */
+#define RTC_CPU_INT_ICLR_RTCA1_CLR               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_RTCA1_SET               ((uint32_t)0x00000004U)         /* !< Clear Interrupt */
+/* RTC_CPU_INT_ICLR[RTCA2] Bits */
+#define RTC_CPU_INT_ICLR_RTCA2_OFS               (3)                             /* !< RTCA2 Offset */
+#define RTC_CPU_INT_ICLR_RTCA2_MASK              ((uint32_t)0x00000008U)         /* !< Clear Alarm-2 interrupt */
+#define RTC_CPU_INT_ICLR_RTCA2_CLR               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_RTCA2_SET               ((uint32_t)0x00000008U)         /* !< Clear Interrupt */
+/* RTC_CPU_INT_ICLR[RT0PS] Bits */
+#define RTC_CPU_INT_ICLR_RT0PS_OFS               (4)                             /* !< RT0PS Offset */
+#define RTC_CPU_INT_ICLR_RT0PS_MASK              ((uint32_t)0x00000010U)         /* !< Clear Prescaler-0 interrupt */
+#define RTC_CPU_INT_ICLR_RT0PS_CLR               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_RT0PS_SET               ((uint32_t)0x00000010U)         /* !< Clear Interrupt */
+/* RTC_CPU_INT_ICLR[RT1PS] Bits */
+#define RTC_CPU_INT_ICLR_RT1PS_OFS               (5)                             /* !< RT1PS Offset */
+#define RTC_CPU_INT_ICLR_RT1PS_MASK              ((uint32_t)0x00000020U)         /* !< Clear Prescaler-1 interrupt */
+#define RTC_CPU_INT_ICLR_RT1PS_CLR               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_RT1PS_SET               ((uint32_t)0x00000020U)         /* !< Clear Interrupt */
+/* RTC_CPU_INT_ICLR[RT2PS] Bits */
+#define RTC_CPU_INT_ICLR_RT2PS_OFS               (6)                             /* !< RT2PS Offset */
+#define RTC_CPU_INT_ICLR_RT2PS_MASK              ((uint32_t)0x00000040U)         /* !< RTC prescale timer 2 */
+#define RTC_CPU_INT_ICLR_RT2PS_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_RT2PS_CLR               ((uint32_t)0x00000040U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TSEVT] Bits */
+#define RTC_CPU_INT_ICLR_TSEVT_OFS               (7)                             /* !< TSEVT Offset */
+#define RTC_CPU_INT_ICLR_TSEVT_MASK              ((uint32_t)0x00000080U)         /* !< Time stamp event */
+#define RTC_CPU_INT_ICLR_TSEVT_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TSEVT_CLR               ((uint32_t)0x00000080U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO0] Bits */
+#define RTC_CPU_INT_ICLR_TIO0_OFS                (8)                             /* !< TIO0 Offset */
+#define RTC_CPU_INT_ICLR_TIO0_MASK               ((uint32_t)0x00000100U)         /* !< Tamper I/O 0 event */
+#define RTC_CPU_INT_ICLR_TIO0_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO0_CLR                ((uint32_t)0x00000100U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO1] Bits */
+#define RTC_CPU_INT_ICLR_TIO1_OFS                (9)                             /* !< TIO1 Offset */
+#define RTC_CPU_INT_ICLR_TIO1_MASK               ((uint32_t)0x00000200U)         /* !< Tamper I/O 1 event */
+#define RTC_CPU_INT_ICLR_TIO1_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO1_CLR                ((uint32_t)0x00000200U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO2] Bits */
+#define RTC_CPU_INT_ICLR_TIO2_OFS                (10)                            /* !< TIO2 Offset */
+#define RTC_CPU_INT_ICLR_TIO2_MASK               ((uint32_t)0x00000400U)         /* !< Tamper I/O 2 event */
+#define RTC_CPU_INT_ICLR_TIO2_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO2_CLR                ((uint32_t)0x00000400U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO3] Bits */
+#define RTC_CPU_INT_ICLR_TIO3_OFS                (11)                            /* !< TIO3 Offset */
+#define RTC_CPU_INT_ICLR_TIO3_MASK               ((uint32_t)0x00000800U)         /* !< Tamper I/O 3 event */
+#define RTC_CPU_INT_ICLR_TIO3_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO3_CLR                ((uint32_t)0x00000800U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO4] Bits */
+#define RTC_CPU_INT_ICLR_TIO4_OFS                (12)                            /* !< TIO4 Offset */
+#define RTC_CPU_INT_ICLR_TIO4_MASK               ((uint32_t)0x00001000U)         /* !< Tamper I/O 4 event */
+#define RTC_CPU_INT_ICLR_TIO4_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO4_CLR                ((uint32_t)0x00001000U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO5] Bits */
+#define RTC_CPU_INT_ICLR_TIO5_OFS                (13)                            /* !< TIO5 Offset */
+#define RTC_CPU_INT_ICLR_TIO5_MASK               ((uint32_t)0x00002000U)         /* !< Tamper I/O 5 event */
+#define RTC_CPU_INT_ICLR_TIO5_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO5_CLR                ((uint32_t)0x00002000U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO6] Bits */
+#define RTC_CPU_INT_ICLR_TIO6_OFS                (14)                            /* !< TIO6 Offset */
+#define RTC_CPU_INT_ICLR_TIO6_MASK               ((uint32_t)0x00004000U)         /* !< Tamper I/O 6 event */
+#define RTC_CPU_INT_ICLR_TIO6_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO6_CLR                ((uint32_t)0x00004000U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO7] Bits */
+#define RTC_CPU_INT_ICLR_TIO7_OFS                (15)                            /* !< TIO7 Offset */
+#define RTC_CPU_INT_ICLR_TIO7_MASK               ((uint32_t)0x00008000U)         /* !< Tamper I/O 7 event */
+#define RTC_CPU_INT_ICLR_TIO7_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO7_CLR                ((uint32_t)0x00008000U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO8] Bits */
+#define RTC_CPU_INT_ICLR_TIO8_OFS                (16)                            /* !< TIO8 Offset */
+#define RTC_CPU_INT_ICLR_TIO8_MASK               ((uint32_t)0x00010000U)         /* !< Tamper I/O 8 event */
+#define RTC_CPU_INT_ICLR_TIO8_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO8_CLR                ((uint32_t)0x00010000U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO9] Bits */
+#define RTC_CPU_INT_ICLR_TIO9_OFS                (17)                            /* !< TIO9 Offset */
+#define RTC_CPU_INT_ICLR_TIO9_MASK               ((uint32_t)0x00020000U)         /* !< Tamper I/O 9 event */
+#define RTC_CPU_INT_ICLR_TIO9_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO9_CLR                ((uint32_t)0x00020000U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO10] Bits */
+#define RTC_CPU_INT_ICLR_TIO10_OFS               (18)                            /* !< TIO10 Offset */
+#define RTC_CPU_INT_ICLR_TIO10_MASK              ((uint32_t)0x00040000U)         /* !< Tamper I/O 10 event */
+#define RTC_CPU_INT_ICLR_TIO10_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO10_CLR               ((uint32_t)0x00040000U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO11] Bits */
+#define RTC_CPU_INT_ICLR_TIO11_OFS               (19)                            /* !< TIO11 Offset */
+#define RTC_CPU_INT_ICLR_TIO11_MASK              ((uint32_t)0x00080000U)         /* !< Tamper I/O 11 event */
+#define RTC_CPU_INT_ICLR_TIO11_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO11_CLR               ((uint32_t)0x00080000U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO12] Bits */
+#define RTC_CPU_INT_ICLR_TIO12_OFS               (20)                            /* !< TIO12 Offset */
+#define RTC_CPU_INT_ICLR_TIO12_MASK              ((uint32_t)0x00100000U)         /* !< Tamper I/O 12 event */
+#define RTC_CPU_INT_ICLR_TIO12_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO12_CLR               ((uint32_t)0x00100000U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO13] Bits */
+#define RTC_CPU_INT_ICLR_TIO13_OFS               (21)                            /* !< TIO13 Offset */
+#define RTC_CPU_INT_ICLR_TIO13_MASK              ((uint32_t)0x00200000U)         /* !< Tamper I/O 13 event */
+#define RTC_CPU_INT_ICLR_TIO13_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO13_CLR               ((uint32_t)0x00200000U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO14] Bits */
+#define RTC_CPU_INT_ICLR_TIO14_OFS               (22)                            /* !< TIO14 Offset */
+#define RTC_CPU_INT_ICLR_TIO14_MASK              ((uint32_t)0x00400000U)         /* !< Tamper I/O 14 event */
+#define RTC_CPU_INT_ICLR_TIO14_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO14_CLR               ((uint32_t)0x00400000U)         /* !< Clear interrupt */
+/* RTC_CPU_INT_ICLR[TIO15] Bits */
+#define RTC_CPU_INT_ICLR_TIO15_OFS               (23)                            /* !< TIO15 Offset */
+#define RTC_CPU_INT_ICLR_TIO15_MASK              ((uint32_t)0x00800000U)         /* !< Tamper I/O 15 event */
+#define RTC_CPU_INT_ICLR_TIO15_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_CPU_INT_ICLR_TIO15_CLR               ((uint32_t)0x00800000U)         /* !< Clear interrupt */
+
+/* RTC_PWREN Bits */
+/* RTC_PWREN[ENABLE] Bits */
+#define RTC_PWREN_ENABLE_OFS                     (0)                             /* !< ENABLE Offset */
+#define RTC_PWREN_ENABLE_MASK                    ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define RTC_PWREN_ENABLE_DISABLE                 ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define RTC_PWREN_ENABLE_ENABLE                  ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* RTC_PWREN[KEY] Bits */
+#define RTC_PWREN_KEY_OFS                        (24)                            /* !< KEY Offset */
+#define RTC_PWREN_KEY_MASK                       ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define RTC_PWREN_KEY_UNLOCK_W                   ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* RTC_RSTCTL Bits */
+/* RTC_RSTCTL[RESETSTKYCLR] Bits */
+#define RTC_RSTCTL_RESETSTKYCLR_OFS              (1)                             /* !< RESETSTKYCLR Offset */
+#define RTC_RSTCTL_RESETSTKYCLR_MASK             ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define RTC_RSTCTL_RESETSTKYCLR_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_RSTCTL_RESETSTKYCLR_CLR              ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* RTC_RSTCTL[RESETASSERT] Bits */
+#define RTC_RSTCTL_RESETASSERT_OFS               (0)                             /* !< RESETASSERT Offset */
+#define RTC_RSTCTL_RESETASSERT_MASK              ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define RTC_RSTCTL_RESETASSERT_NOP               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_RSTCTL_RESETASSERT_ASSERT            ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* RTC_RSTCTL[KEY] Bits */
+#define RTC_RSTCTL_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define RTC_RSTCTL_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define RTC_RSTCTL_KEY_UNLOCK_W                  ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* RTC_CLKCFG Bits */
+/* RTC_CLKCFG[KEY] Bits */
+#define RTC_CLKCFG_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define RTC_CLKCFG_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define RTC_CLKCFG_KEY_UNLOCK_W                  ((uint32_t)0xA9000000U)         /* !< key value to allow change field of
+                                                                                    GPRCM */
+/* RTC_CLKCFG[BLOCKASYNC] Bits */
+#define RTC_CLKCFG_BLOCKASYNC_OFS                (8)                             /* !< BLOCKASYNC Offset */
+#define RTC_CLKCFG_BLOCKASYNC_MASK               ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define RTC_CLKCFG_BLOCKASYNC_DISABLE            ((uint32_t)0x00000000U)         /* !< Not block async clock request */
+#define RTC_CLKCFG_BLOCKASYNC_ENABLE             ((uint32_t)0x00000100U)         /* !< Block async clock request */
+
+/* RTC_STAT Bits */
+/* RTC_STAT[RESETSTKY] Bits */
+#define RTC_STAT_RESETSTKY_OFS                   (16)                            /* !< RESETSTKY Offset */
+#define RTC_STAT_RESETSTKY_MASK                  ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define RTC_STAT_RESETSTKY_NORES                 ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define RTC_STAT_RESETSTKY_RESET                 ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* RTC_FPUB_0 Bits */
+/* RTC_FPUB_0[CHANID] Bits */
+#define RTC_FPUB_0_CHANID_OFS                    (0)                             /* !< CHANID Offset */
+#define RTC_FPUB_0_CHANID_MASK                   ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define RTC_FPUB_0_CHANID_MNIMUM                 ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define RTC_FPUB_0_CHANID_UNCONNECTED            ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define RTC_FPUB_0_CHANID_MAXIMUM                ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* RTC_CLKSEL Bits */
+/* RTC_CLKSEL[LFCLK_SEL] Bits */
+#define RTC_CLKSEL_LFCLK_SEL_OFS                 (1)                             /* !< LFCLK_SEL Offset */
+#define RTC_CLKSEL_LFCLK_SEL_MASK                ((uint32_t)0x00000002U)         /* !< Selects LFCLK as clock source if
+                                                                                    enabled */
+#define RTC_CLKSEL_LFCLK_SEL_DISABLE             ((uint32_t)0x00000000U)         /* !< LFCLK is disabled as clock source */
+#define RTC_CLKSEL_LFCLK_SEL_ENABLE              ((uint32_t)0x00000002U)         /* !< LFCLK is enabled as clock source */
+
+/* RTC_EVT_MODE Bits */
+/* RTC_EVT_MODE[EVT0_CFG] Bits */
+#define RTC_EVT_MODE_EVT0_CFG_OFS                (0)                             /* !< EVT0_CFG Offset */
+#define RTC_EVT_MODE_EVT0_CFG_MASK               ((uint32_t)0x00000003U)         /* !< Event line mode 0 select */
+#define RTC_EVT_MODE_EVT0_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define RTC_EVT_MODE_EVT0_CFG_SOFTWARE           ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. The software ISR
+                                                                                    clears the associated RIS flag. */
+#define RTC_EVT_MODE_EVT0_CFG_HARDWARE           ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* RTC_EVT_MODE[EVT1_CFG] Bits */
+#define RTC_EVT_MODE_EVT1_CFG_OFS                (2)                             /* !< EVT1_CFG Offset */
+#define RTC_EVT_MODE_EVT1_CFG_MASK               ((uint32_t)0x0000000CU)         /* !< Event line mode 1 select */
+#define RTC_EVT_MODE_EVT1_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define RTC_EVT_MODE_EVT1_CFG_SOFTWARE           ((uint32_t)0x00000004U)         /* !< The interrupt or event line is in
+                                                                                    software mode. The software ISR
+                                                                                    clears the associated RIS flag. */
+#define RTC_EVT_MODE_EVT1_CFG_HARDWARE           ((uint32_t)0x00000008U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* RTC_DESC Bits */
+/* RTC_DESC[MINREV] Bits */
+#define RTC_DESC_MINREV_OFS                      (0)                             /* !< MINREV Offset */
+#define RTC_DESC_MINREV_MASK                     ((uint32_t)0x0000000FU)         /* !< Minor revision. This number holds
+                                                                                    the module revision and is
+                                                                                    incremented by the module developers.
+                                                                                    n = Minor module revision (see
+                                                                                    device-specific data sheet) */
+#define RTC_DESC_MINREV_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_DESC_MINREV_MAXIMUM                  ((uint32_t)0x0000000FU)         /* !< Maximum value */
+/* RTC_DESC[MAJREV] Bits */
+#define RTC_DESC_MAJREV_OFS                      (4)                             /* !< MAJREV Offset */
+#define RTC_DESC_MAJREV_MASK                     ((uint32_t)0x000000F0U)         /* !< Major revision. This number holds
+                                                                                    the module revision and is
+                                                                                    incremented by the module developers.
+                                                                                    n = Major version (see
+                                                                                    device-specific data sheet) */
+#define RTC_DESC_MAJREV_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_DESC_MAJREV_MAXIMUM                  ((uint32_t)0x000000F0U)         /* !< Maximum value */
+/* RTC_DESC[INSTNUM] Bits */
+#define RTC_DESC_INSTNUM_OFS                     (8)                             /* !< INSTNUM Offset */
+#define RTC_DESC_INSTNUM_MASK                    ((uint32_t)0x00000F00U)         /* !< Instantiated version. Describes
+                                                                                    which instance of the module
+                                                                                    accessed. */
+#define RTC_DESC_INSTNUM_INST0                   ((uint32_t)0x00000000U)         /* !< This is the default, if there is
+                                                                                    only one instance - like for SSIM */
+/* RTC_DESC[FEATUREVER] Bits */
+#define RTC_DESC_FEATUREVER_OFS                  (12)                            /* !< FEATUREVER Offset */
+#define RTC_DESC_FEATUREVER_MASK                 ((uint32_t)0x0000F000U)         /* !< Feature set of this module.
+                                                                                    Differentiates the complexity of the
+                                                                                    actually instantiated module if there
+                                                                                    are differences. */
+#define RTC_DESC_FEATUREVER_MINIMUM              ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_DESC_FEATUREVER_MAXIMUM              ((uint32_t)0x0000F000U)         /* !< Maximum value */
+/* RTC_DESC[MODULEID] Bits */
+#define RTC_DESC_MODULEID_OFS                    (16)                            /* !< MODULEID Offset */
+#define RTC_DESC_MODULEID_MASK                   ((uint32_t)0xFFFF0000U)         /* !< Module identifier. This ID is
+                                                                                    unique for each module. 0x0911 =
+                                                                                    Module ID of the RTC Module */
+#define RTC_DESC_MODULEID_MINIMUM                ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_DESC_MODULEID_MAXIMUM                ((uint32_t)0xFFFF0000U)         /* !< Maximum value */
+
+/* RTC_CLKCTL Bits */
+/* RTC_CLKCTL[MODCLKEN] Bits */
+#define RTC_CLKCTL_MODCLKEN_OFS                  (31)                            /* !< MODCLKEN Offset */
+#define RTC_CLKCTL_MODCLKEN_MASK                 ((uint32_t)0x80000000U)         /* !< This bit enables the supply of the
+                                                                                    32kHz clock to the RTC. It will not
+                                                                                    power-up the 32kHz crystal oscillator
+                                                                                    this needs to be done in the Clock
+                                                                                    System Module. */
+#define RTC_CLKCTL_MODCLKEN_DISABLE              ((uint32_t)0x00000000U)         /* !< 32kHz clock is not supplied to the
+                                                                                    RTC. */
+#define RTC_CLKCTL_MODCLKEN_ENABLE               ((uint32_t)0x80000000U)         /* !< 32kHz clock is supplied to the RTC. */
+
+/* RTC_DBGCTL Bits */
+/* RTC_DBGCTL[DBGRUN] Bits */
+#define RTC_DBGCTL_DBGRUN_OFS                    (0)                             /* !< DBGRUN Offset */
+#define RTC_DBGCTL_DBGRUN_MASK                   ((uint32_t)0x00000001U)         /* !< Debug Run. */
+#define RTC_DBGCTL_DBGRUN_HALT                   ((uint32_t)0x00000000U)         /* !< Counter is halted if CPU is in
+                                                                                    debug state. */
+#define RTC_DBGCTL_DBGRUN_RUN                    ((uint32_t)0x00000001U)         /* !< Continue to operate normally
+                                                                                    ignoring the debug state of the CPU. */
+/* RTC_DBGCTL[DBGINT] Bits */
+#define RTC_DBGCTL_DBGINT_OFS                    (1)                             /* !< DBGINT Offset */
+#define RTC_DBGCTL_DBGINT_MASK                   ((uint32_t)0x00000002U)         /* !< Debug Interrupt Enable. */
+#define RTC_DBGCTL_DBGINT_OFF                    ((uint32_t)0x00000000U)         /* !< Interrupts of the module will not
+                                                                                    be captured anymore if CPU is in
+                                                                                    debug state. Which means no update to
+                                                                                    the RTCRIS, RTCMISC and RTCIIDX
+                                                                                    register. */
+#define RTC_DBGCTL_DBGINT_ON                     ((uint32_t)0x00000002U)         /* !< Interrupts are enabled in debug
+                                                                                    mode. Interrupt requests are signaled
+                                                                                    to the interrupt controller. If the
+                                                                                    flags are required by software
+                                                                                    (polling mode) the DGBINT bit need to
+                                                                                    be set to 1. */
+
+/* RTC_CTL Bits */
+/* RTC_CTL[RTCTEVTX] Bits */
+#define RTC_CTL_RTCTEVTX_OFS                     (0)                             /* !< RTCTEVTX Offset */
+#define RTC_CTL_RTCTEVTX_MASK                    ((uint32_t)0x00000003U)         /* !< Real-time clock time event. */
+#define RTC_CTL_RTCTEVTX_MINUTE                  ((uint32_t)0x00000000U)         /* !< Minute changed. */
+#define RTC_CTL_RTCTEVTX_HOUR                    ((uint32_t)0x00000001U)         /* !< Hour changed. */
+#define RTC_CTL_RTCTEVTX_MIDNIGHT                ((uint32_t)0x00000002U)         /* !< Every day at midnight (00:00). */
+#define RTC_CTL_RTCTEVTX_NOON                    ((uint32_t)0x00000003U)         /* !< Every day at noon (12:00). */
+/* RTC_CTL[RTCBCD] Bits */
+#define RTC_CTL_RTCBCD_OFS                       (7)                             /* !< RTCBCD Offset */
+#define RTC_CTL_RTCBCD_MASK                      ((uint32_t)0x00000080U)         /* !< Real-time clock BCD select. Selects
+                                                                                    BCD counting for real-time clock. */
+#define RTC_CTL_RTCBCD_BINARY                    ((uint32_t)0x00000000U)         /* !< Binary code selected */
+#define RTC_CTL_RTCBCD_BCD                       ((uint32_t)0x00000080U)         /* !< Binary coded decimal (BCD) code
+                                                                                    selected */
+
+/* RTC_STA Bits */
+/* RTC_STA[RTCRDY] Bits */
+#define RTC_STA_RTCRDY_OFS                       (0)                             /* !< RTCRDY Offset */
+#define RTC_STA_RTCRDY_MASK                      ((uint32_t)0x00000001U)         /* !< Real-time clock ready. This bit
+                                                                                    indicates when the real-time clock
+                                                                                    time values are safe for reading. */
+#define RTC_STA_RTCRDY_NOT_READY                 ((uint32_t)0x00000000U)         /* !< RTC time values in transition */
+#define RTC_STA_RTCRDY_READY                     ((uint32_t)0x00000001U)         /* !< RTC time values safe for reading */
+/* RTC_STA[RTCTCRDY] Bits */
+#define RTC_STA_RTCTCRDY_OFS                     (1)                             /* !< RTCTCRDY Offset */
+#define RTC_STA_RTCTCRDY_MASK                    ((uint32_t)0x00000002U)         /* !< Real-time clock temperature
+                                                                                    compensation ready. This is a read
+                                                                                    only bit that indicates when the
+                                                                                    RTCTCMPx can be written. Write to
+                                                                                    RTCTCMPx should be avoided when
+                                                                                    RTCTCRDY is reset. */
+#define RTC_STA_RTCTCRDY_NOT_READY               ((uint32_t)0x00000000U)         /* !< Real-time clock temperature
+                                                                                    compensation not ready */
+#define RTC_STA_RTCTCRDY_READY                   ((uint32_t)0x00000002U)         /* !< Real-time clock temperature
+                                                                                    compensation ready */
+/* RTC_STA[RTCTCOK] Bits */
+#define RTC_STA_RTCTCOK_OFS                      (2)                             /* !< RTCTCOK Offset */
+#define RTC_STA_RTCTCOK_MASK                     ((uint32_t)0x00000004U)         /* !< Real-time clock temperature
+                                                                                    compensation write OK. This is a
+                                                                                    read-only bit that indicates if the
+                                                                                    write to RTCTCMP is successful or
+                                                                                    not. */
+#define RTC_STA_RTCTCOK_NOT_OK                   ((uint32_t)0x00000000U)         /* !< Write to RTCTCMPx is unsuccessful */
+#define RTC_STA_RTCTCOK_OK                       ((uint32_t)0x00000004U)         /* !< Write to RTCTCMPx is successful */
+
+/* RTC_CAL Bits */
+/* RTC_CAL[RTCOCALX] Bits */
+#define RTC_CAL_RTCOCALX_OFS                     (0)                             /* !< RTCOCALX Offset */
+#define RTC_CAL_RTCOCALX_MASK                    ((uint32_t)0x000000FFU)         /* !< Real-time clock offset error
+                                                                                    calibration. Each LSB represents
+                                                                                    approximately +1ppm (RTCOCALXS = 1)
+                                                                                    or -1ppm (RTCOCALXS = 0) adjustment
+                                                                                    in frequency. Maximum effective
+                                                                                    calibration value is +/-240ppm.
+                                                                                    Excess values written above +/-240ppm
+                                                                                    will be ignored by hardware. */
+#define RTC_CAL_RTCOCALX_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Minimum effective calibration
+                                                                                    value. */
+#define RTC_CAL_RTCOCALX_MAXIMUM                 ((uint32_t)0x000000FFU)         /* !< Maximum effective calibration value
+                                                                                    is +/-240ppm. Excess values written
+                                                                                    above +/-240ppm will be ignored by
+                                                                                    hardware. */
+/* RTC_CAL[RTCOCALS] Bits */
+#define RTC_CAL_RTCOCALS_OFS                     (15)                            /* !< RTCOCALS Offset */
+#define RTC_CAL_RTCOCALS_MASK                    ((uint32_t)0x00008000U)         /* !< Real-time clock offset error
+                                                                                    calibration sign. This bit decides
+                                                                                    the sign of offset error calibration. */
+#define RTC_CAL_RTCOCALS_DOWN                    ((uint32_t)0x00000000U)         /* !< Down calibration. Frequency
+                                                                                    adjusted down. */
+#define RTC_CAL_RTCOCALS_UP                      ((uint32_t)0x00008000U)         /* !< Up calibration. Frequency adjusted
+                                                                                    up. */
+/* RTC_CAL[RTCCALFX] Bits */
+#define RTC_CAL_RTCCALFX_OFS                     (16)                            /* !< RTCCALFX Offset */
+#define RTC_CAL_RTCCALFX_MASK                    ((uint32_t)0x00030000U)         /* !< Real-time clock calibration
+                                                                                    frequency. Selects frequency output
+                                                                                    to RTC_OUT pin for calibration
+                                                                                    measurement. The corresponding port
+                                                                                    must be configured for the peripheral
+                                                                                    module function. */
+#define RTC_CAL_RTCCALFX_OFF                     ((uint32_t)0x00000000U)         /* !< No frequency output to RTC_OUT pin */
+#define RTC_CAL_RTCCALFX_F512HZ                  ((uint32_t)0x00010000U)         /* !< 512 Hz */
+#define RTC_CAL_RTCCALFX_F256HZ                  ((uint32_t)0x00020000U)         /* !< 256 Hz */
+#define RTC_CAL_RTCCALFX_F1HZ                    ((uint32_t)0x00030000U)         /* !< 1 Hz */
+
+/* RTC_TCMP Bits */
+/* RTC_TCMP[RTCTCMPX] Bits */
+#define RTC_TCMP_RTCTCMPX_OFS                    (0)                             /* !< RTCTCMPX Offset */
+#define RTC_TCMP_RTCTCMPX_MASK                   ((uint32_t)0x000000FFU)         /* !< Real-time clock temperature
+                                                                                    compensation. Value written into this
+                                                                                    register is used for temperature
+                                                                                    compensation of RTC. Each LSB
+                                                                                    represents approximately +1ppm
+                                                                                    (RTCTCMPS = 1) or -1ppm (RTCTCMPS =
+                                                                                    0) adjustment in frequency. Maximum
+                                                                                    effective calibration value is
+                                                                                    +/-240ppm. Excess values written
+                                                                                    above +/-240ppm are ignored by
+                                                                                    hardware. Reading from RTCTCMP
+                                                                                    register at any time returns the
+                                                                                    cumulative value which is the signed
+                                                                                    addition of RTCOCALx and RTCTCMPX
+                                                                                    values, and the updated sign bit
+                                                                                    (RTCTCMPS) of the addition result. */
+#define RTC_TCMP_RTCTCMPX_MINIMUM                ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_TCMP_RTCTCMPX_MAXIMUM                ((uint32_t)0x000000FFU)         /* !< Maximum value */
+/* RTC_TCMP[RTCTCMPS] Bits */
+#define RTC_TCMP_RTCTCMPS_OFS                    (15)                            /* !< RTCTCMPS Offset */
+#define RTC_TCMP_RTCTCMPS_MASK                   ((uint32_t)0x00008000U)         /* !< Real-time clock temperature
+                                                                                    compensation sign. This bit decides
+                                                                                    the sign of temperature compensation. */
+#define RTC_TCMP_RTCTCMPS_DOWN                   ((uint32_t)0x00000000U)         /* !< Down calibration. Frequency
+                                                                                    adjusted down. */
+#define RTC_TCMP_RTCTCMPS_UP                     ((uint32_t)0x00008000U)         /* !< Up calibration. Frequency adjusted
+                                                                                    up. */
+
+/* RTC_SEC Bits */
+/* RTC_SEC[SECBIN] Bits */
+#define RTC_SEC_SECBIN_OFS                       (0)                             /* !< SECBIN Offset */
+#define RTC_SEC_SECBIN_MASK                      ((uint32_t)0x0000003FU)         /* !< Seconds Binary (0 to 59). If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_SEC_SECBIN_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_SEC_SECBIN_MAXIMUM                   ((uint32_t)0x0000003BU)         /* !< Maximum value */
+/* RTC_SEC[SECLOWBCD] Bits */
+#define RTC_SEC_SECLOWBCD_OFS                    (8)                             /* !< SECLOWBCD Offset */
+#define RTC_SEC_SECLOWBCD_MASK                   ((uint32_t)0x00000F00U)         /* !< Seconds BCD  low digit (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_SEC_SECLOWBCD_MINIMUM                ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_SEC_SECLOWBCD_MAXIMUM                ((uint32_t)0x00000900U)         /* !< Maximum value */
+/* RTC_SEC[SECHIGHBCD] Bits */
+#define RTC_SEC_SECHIGHBCD_OFS                   (12)                            /* !< SECHIGHBCD Offset */
+#define RTC_SEC_SECHIGHBCD_MASK                  ((uint32_t)0x00007000U)         /* !< Seconds BCD  high digit (0 to 5).
+                                                                                    If RTCBCD=0 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define RTC_SEC_SECHIGHBCD_MINIMUM               ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_SEC_SECHIGHBCD_MAXIMUM               ((uint32_t)0x00005000U)         /* !< Maximum value */
+
+/* RTC_MIN Bits */
+/* RTC_MIN[MINBIN] Bits */
+#define RTC_MIN_MINBIN_OFS                       (0)                             /* !< MINBIN Offset */
+#define RTC_MIN_MINBIN_MASK                      ((uint32_t)0x0000003FU)         /* !< Minutes Binary (0 to 59). If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_MIN_MINBIN_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_MIN_MINBIN_MAXIMUM                   ((uint32_t)0x0000003BU)         /* !< Maximum value */
+/* RTC_MIN[MINLOWBCD] Bits */
+#define RTC_MIN_MINLOWBCD_OFS                    (8)                             /* !< MINLOWBCD Offset */
+#define RTC_MIN_MINLOWBCD_MASK                   ((uint32_t)0x00000F00U)         /* !< Minutes BCD  low digit (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_MIN_MINLOWBCD_MINIMUM                ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_MIN_MINLOWBCD_MAXIMUM                ((uint32_t)0x00000900U)         /* !< Maximum value */
+/* RTC_MIN[MINHIGHBCD] Bits */
+#define RTC_MIN_MINHIGHBCD_OFS                   (12)                            /* !< MINHIGHBCD Offset */
+#define RTC_MIN_MINHIGHBCD_MASK                  ((uint32_t)0x00007000U)         /* !< Minutes BCD  high digit (0 to 5).
+                                                                                    If RTCBCD=0 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define RTC_MIN_MINHIGHBCD_MINIMUM               ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_MIN_MINHIGHBCD_MAXIMUM               ((uint32_t)0x00005000U)         /* !< Maximum value */
+
+/* RTC_HOUR Bits */
+/* RTC_HOUR[HOURBIN] Bits */
+#define RTC_HOUR_HOURBIN_OFS                     (0)                             /* !< HOURBIN Offset */
+#define RTC_HOUR_HOURBIN_MASK                    ((uint32_t)0x0000001FU)         /* !< Hours Binary (0 to 23). If RTCBCD=1
+                                                                                    write to these bits will be ignored
+                                                                                    and read give the value 0. */
+#define RTC_HOUR_HOURBIN_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Minimum value. */
+#define RTC_HOUR_HOURBIN_MAXIMUM                 ((uint32_t)0x00000017U)         /* !< Maximum value. */
+/* RTC_HOUR[HOURLOWBCD] Bits */
+#define RTC_HOUR_HOURLOWBCD_OFS                  (8)                             /* !< HOURLOWBCD Offset */
+#define RTC_HOUR_HOURLOWBCD_MASK                 ((uint32_t)0x00000F00U)         /* !< Hours BCD  low digit (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_HOUR_HOURLOWBCD_MINIMUM              ((uint32_t)0x00000000U)         /* !< Minimum value. */
+#define RTC_HOUR_HOURLOWBCD_MAXIMUM              ((uint32_t)0x00000900U)         /* !< Maximum value. */
+/* RTC_HOUR[HOURHIGHBCD] Bits */
+#define RTC_HOUR_HOURHIGHBCD_OFS                 (12)                            /* !< HOURHIGHBCD Offset */
+#define RTC_HOUR_HOURHIGHBCD_MASK                ((uint32_t)0x00003000U)         /* !< Hours BCD  high digit (0 to 2). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_HOUR_HOURHIGHBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Minimum value. */
+#define RTC_HOUR_HOURHIGHBCD_MAXIMUM             ((uint32_t)0x00002000U)         /* !< Maximum value. */
+
+/* RTC_DAY Bits */
+/* RTC_DAY[DOW] Bits */
+#define RTC_DAY_DOW_OFS                          (0)                             /* !< DOW Offset */
+#define RTC_DAY_DOW_MASK                         ((uint32_t)0x00000007U)         /* !< Day of week (0 to 6). These bits
+                                                                                    are valid if RTCBCD=1 or RTCBCD=0. */
+#define RTC_DAY_DOW_MINIMUM                      ((uint32_t)0x00000000U)         /* !< Mimimum value */
+#define RTC_DAY_DOW_MAXIMUM                      ((uint32_t)0x00000006U)         /* !< Maximum value */
+/* RTC_DAY[DOMBIN] Bits */
+#define RTC_DAY_DOMBIN_OFS                       (8)                             /* !< DOMBIN Offset */
+#define RTC_DAY_DOMBIN_MASK                      ((uint32_t)0x00001F00U)         /* !< Day of month Binary (1 to 28, 29,
+                                                                                    30, 31). If RTCBCD=1 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_DAY_DOMBIN_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Mimimum value */
+#define RTC_DAY_DOMBIN_MAXIMUM                   ((uint32_t)0x00001F00U)         /* !< Maximum value */
+/* RTC_DAY[DOMLOWBCD] Bits */
+#define RTC_DAY_DOMLOWBCD_OFS                    (16)                            /* !< DOMLOWBCD Offset */
+#define RTC_DAY_DOMLOWBCD_MASK                   ((uint32_t)0x000F0000U)         /* !< Day of month BCD  low digit (0 to
+                                                                                    9). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define RTC_DAY_DOMLOWBCD_MINIMUM                ((uint32_t)0x00000000U)         /* !< Mimimum value */
+#define RTC_DAY_DOMLOWBCD_MAXIMUM                ((uint32_t)0x00090000U)         /* !< Maximum value */
+/* RTC_DAY[DOMHIGHBCD] Bits */
+#define RTC_DAY_DOMHIGHBCD_OFS                   (20)                            /* !< DOMHIGHBCD Offset */
+#define RTC_DAY_DOMHIGHBCD_MASK                  ((uint32_t)0x00300000U)         /* !< Day of month BCD  high digit (0 to
+                                                                                    3). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define RTC_DAY_DOMHIGHBCD_MINIMUM               ((uint32_t)0x00000000U)         /* !< Mimimum value */
+#define RTC_DAY_DOMHIGHBCD_MAXIMUM               ((uint32_t)0x00300000U)         /* !< Maximum value */
+
+/* RTC_MON Bits */
+/* RTC_MON[MONBIN] Bits */
+#define RTC_MON_MONBIN_OFS                       (0)                             /* !< MONBIN Offset */
+#define RTC_MON_MONBIN_MASK                      ((uint32_t)0x0000000FU)         /* !< Month Binary (1 to 12). If RTCBCD=1
+                                                                                    write to these bits will be ignored
+                                                                                    and read give the value 0. */
+#define RTC_MON_MONBIN_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Mimimum value */
+#define RTC_MON_MONBIN_MAXIMUM                   ((uint32_t)0x0000000CU)         /* !< Maximum value */
+/* RTC_MON[MONLOWBCD] Bits */
+#define RTC_MON_MONLOWBCD_OFS                    (8)                             /* !< MONLOWBCD Offset */
+#define RTC_MON_MONLOWBCD_MASK                   ((uint32_t)0x00000F00U)         /* !< Month BCD  low digit (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_MON_MONLOWBCD_MINIMUM                ((uint32_t)0x00000000U)         /* !< Mimimum value */
+#define RTC_MON_MONLOWBCD_MAXIMUM                ((uint32_t)0x00000900U)         /* !< Maximum value */
+/* RTC_MON[MONHIGHBCD] Bits */
+#define RTC_MON_MONHIGHBCD_OFS                   (12)                            /* !< MONHIGHBCD Offset */
+#define RTC_MON_MONHIGHBCD_MASK                  ((uint32_t)0x00001000U)         /* !< Month BCD  high digit (0 or 1). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_MON_MONHIGHBCD_MINIMUM               ((uint32_t)0x00000000U)         /* !< Mimimum value */
+#define RTC_MON_MONHIGHBCD_MAXIMUM               ((uint32_t)0x00001000U)         /* !< Maximum value */
+
+/* RTC_YEAR Bits */
+/* RTC_YEAR[YEARLOWBIN] Bits */
+#define RTC_YEAR_YEARLOWBIN_OFS                  (0)                             /* !< YEARLOWBIN Offset */
+#define RTC_YEAR_YEARLOWBIN_MASK                 ((uint32_t)0x000000FFU)         /* !< Year Binary  low byte. Valid values
+                                                                                    for Year are 0 to 4095. If RTCBCD=1
+                                                                                    write to these bits will be ignored
+                                                                                    and read give the value 0. */
+#define RTC_YEAR_YEARLOWBIN_MINIMUM              ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_YEAR_YEARLOWBIN_MAXIMUM              ((uint32_t)0x000000FFU)         /* !< Maximum value */
+/* RTC_YEAR[YEARHIGHBIN] Bits */
+#define RTC_YEAR_YEARHIGHBIN_OFS                 (8)                             /* !< YEARHIGHBIN Offset */
+#define RTC_YEAR_YEARHIGHBIN_MASK                ((uint32_t)0x00000F00U)         /* !< Year Binary  high byte. Valid
+                                                                                    values for Year are 0 to 4095. If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_YEAR_YEARHIGHBIN_MINIMUM             ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_YEAR_YEARHIGHBIN_MAXIMUM             ((uint32_t)0x00000F00U)         /* !< Maximum value */
+/* RTC_YEAR[YEARLOWESTBCD] Bits */
+#define RTC_YEAR_YEARLOWESTBCD_OFS               (16)                            /* !< YEARLOWESTBCD Offset */
+#define RTC_YEAR_YEARLOWESTBCD_MASK              ((uint32_t)0x000F0000U)         /* !< Year BCD  lowest digit (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_YEAR_YEARLOWESTBCD_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_YEAR_YEARLOWESTBCD_MAXIMUM           ((uint32_t)0x00090000U)         /* !< Maximum value */
+/* RTC_YEAR[DECADEBCD] Bits */
+#define RTC_YEAR_DECADEBCD_OFS                   (20)                            /* !< DECADEBCD Offset */
+#define RTC_YEAR_DECADEBCD_MASK                  ((uint32_t)0x00F00000U)         /* !< Decade BCD (0 to 9). If RTCBCD=0
+                                                                                    write to these bits will be ignored
+                                                                                    and read give the value 0. */
+#define RTC_YEAR_DECADEBCD_MINIMUM               ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_YEAR_DECADEBCD_MAXIMUM               ((uint32_t)0x00900000U)         /* !< Maximum value */
+/* RTC_YEAR[CENTLOWBCD] Bits */
+#define RTC_YEAR_CENTLOWBCD_OFS                  (24)                            /* !< CENTLOWBCD Offset */
+#define RTC_YEAR_CENTLOWBCD_MASK                 ((uint32_t)0x0F000000U)         /* !< Century BCD  low digit (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_YEAR_CENTLOWBCD_MINIMUM              ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_YEAR_CENTLOWBCD_MAXIMUM              ((uint32_t)0x09000000U)         /* !< Maximum value */
+/* RTC_YEAR[CENTHIGHBCD] Bits */
+#define RTC_YEAR_CENTHIGHBCD_OFS                 (28)                            /* !< CENTHIGHBCD Offset */
+#define RTC_YEAR_CENTHIGHBCD_MASK                ((uint32_t)0x70000000U)         /* !< Century BCD  high digit (0 to 4).
+                                                                                    If RTCBCD=0 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define RTC_YEAR_CENTHIGHBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_YEAR_CENTHIGHBCD_MAXIMUM             ((uint32_t)0x40000000U)         /* !< Maximum value */
+
+/* RTC_A1MIN Bits */
+/* RTC_A1MIN[AMINBIN] Bits */
+#define RTC_A1MIN_AMINBIN_OFS                    (0)                             /* !< AMINBIN Offset */
+#define RTC_A1MIN_AMINBIN_MASK                   ((uint32_t)0x0000003FU)         /* !< Alarm Minutes Binary (0 to 59). If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_A1MIN_AMINBIN_MINIMUM                ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A1MIN_AMINBIN_MAXIMUM                ((uint32_t)0x0000003BU)         /* !< Maximum value */
+/* RTC_A1MIN[AMINAEBIN] Bits */
+#define RTC_A1MIN_AMINAEBIN_OFS                  (7)                             /* !< AMINAEBIN Offset */
+#define RTC_A1MIN_AMINAEBIN_MASK                 ((uint32_t)0x00000080U)         /* !< Alarm Minutes Binary enable. If
+                                                                                    RTCBCD=1 this bit is always 0. Write
+                                                                                    to this bit will be ignored. */
+#define RTC_A1MIN_AMINAEBIN_DISABLE              ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A1MIN_AMINAEBIN_ENABLE               ((uint32_t)0x00000080U)         /* !< Alarm enabled */
+/* RTC_A1MIN[AMINLOWBCD] Bits */
+#define RTC_A1MIN_AMINLOWBCD_OFS                 (8)                             /* !< AMINLOWBCD Offset */
+#define RTC_A1MIN_AMINLOWBCD_MASK                ((uint32_t)0x00000F00U)         /* !< Alarm Minutes BCD  low digit (0 to
+                                                                                    9). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define RTC_A1MIN_AMINLOWBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A1MIN_AMINLOWBCD_MAXIMUM             ((uint32_t)0x00000900U)         /* !< Maximum value */
+/* RTC_A1MIN[AMINHIGHBCD] Bits */
+#define RTC_A1MIN_AMINHIGHBCD_OFS                (12)                            /* !< AMINHIGHBCD Offset */
+#define RTC_A1MIN_AMINHIGHBCD_MASK               ((uint32_t)0x00007000U)         /* !< Alarm Minutes BCD  high digit (0 to
+                                                                                    5). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define RTC_A1MIN_AMINHIGHBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A1MIN_AMINHIGHBCD_MAXIMUM            ((uint32_t)0x00005000U)         /* !< Maximum value */
+/* RTC_A1MIN[AMINAEBCD] Bits */
+#define RTC_A1MIN_AMINAEBCD_OFS                  (15)                            /* !< AMINAEBCD Offset */
+#define RTC_A1MIN_AMINAEBCD_MASK                 ((uint32_t)0x00008000U)         /* !< Alarm Minutes BCD enable. If
+                                                                                    RTCBCD=0 this bit is always 0. Write
+                                                                                    to this bit will be ignored. */
+#define RTC_A1MIN_AMINAEBCD_DISABLE              ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A1MIN_AMINAEBCD_ENABLE               ((uint32_t)0x00008000U)         /* !< Alarm enabled */
+
+/* RTC_A1HOUR Bits */
+/* RTC_A1HOUR[AHOURBIN] Bits */
+#define RTC_A1HOUR_AHOURBIN_OFS                  (0)                             /* !< AHOURBIN Offset */
+#define RTC_A1HOUR_AHOURBIN_MASK                 ((uint32_t)0x0000001FU)         /* !< Alarm Hours Binary (0 to 23). If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_A1HOUR_AHOURBIN_MINIMUM              ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A1HOUR_AHOURBIN_MAXIMUM              ((uint32_t)0x00000017U)         /* !< Maximum value */
+/* RTC_A1HOUR[AHOURAEBIN] Bits */
+#define RTC_A1HOUR_AHOURAEBIN_OFS                (7)                             /* !< AHOURAEBIN Offset */
+#define RTC_A1HOUR_AHOURAEBIN_MASK               ((uint32_t)0x00000080U)         /* !< Alarm Hours Binary enable. If
+                                                                                    RTCBCD=1 this bit is always 0. Write
+                                                                                    to this bit will be ignored. */
+#define RTC_A1HOUR_AHOURAEBIN_DISABLE            ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A1HOUR_AHOURAEBIN_ENABLE             ((uint32_t)0x00000080U)         /* !< Alarm enabled */
+/* RTC_A1HOUR[AHOURLOWBCD] Bits */
+#define RTC_A1HOUR_AHOURLOWBCD_OFS               (8)                             /* !< AHOURLOWBCD Offset */
+#define RTC_A1HOUR_AHOURLOWBCD_MASK              ((uint32_t)0x00000F00U)         /* !< Alarm Hours BCD  low digit (0 to
+                                                                                    9). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define RTC_A1HOUR_AHOURLOWBCD_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A1HOUR_AHOURLOWBCD_MAXIMUM           ((uint32_t)0x00000900U)         /* !< Maximum value */
+/* RTC_A1HOUR[AHOURHIGHBCD] Bits */
+#define RTC_A1HOUR_AHOURHIGHBCD_OFS              (12)                            /* !< AHOURHIGHBCD Offset */
+#define RTC_A1HOUR_AHOURHIGHBCD_MASK             ((uint32_t)0x00003000U)         /* !< Alarm Hours BCD  high digit (0 to
+                                                                                    2). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0.. */
+#define RTC_A1HOUR_AHOURHIGHBCD_MINIMUM          ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A1HOUR_AHOURHIGHBCD_MAXIMUM          ((uint32_t)0x00002000U)         /* !< Maximum value */
+/* RTC_A1HOUR[AHOURAEBCD] Bits */
+#define RTC_A1HOUR_AHOURAEBCD_OFS                (15)                            /* !< AHOURAEBCD Offset */
+#define RTC_A1HOUR_AHOURAEBCD_MASK               ((uint32_t)0x00008000U)         /* !< Alarm Hours BCD enable. If RTCBCD=0
+                                                                                    this bit is always 0. Write to this
+                                                                                    bit will be ignored. */
+#define RTC_A1HOUR_AHOURAEBCD_DISABLE            ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A1HOUR_AHOURAEBCD_ENABLE             ((uint32_t)0x00008000U)         /* !< Alarm enabled */
+
+/* RTC_A1DAY Bits */
+/* RTC_A1DAY[ADOW] Bits */
+#define RTC_A1DAY_ADOW_OFS                       (0)                             /* !< ADOW Offset */
+#define RTC_A1DAY_ADOW_MASK                      ((uint32_t)0x00000007U)         /* !< Alarm Day of week (0 to 6). These
+                                                                                    bits are valid if RTCBCD=1 or
+                                                                                    RTCBCD=0. */
+#define RTC_A1DAY_ADOW_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A1DAY_ADOW_MAXIMUM                   ((uint32_t)0x00000006U)         /* !< Maximum value */
+/* RTC_A1DAY[ADOWAE] Bits */
+#define RTC_A1DAY_ADOWAE_OFS                     (7)                             /* !< ADOWAE Offset */
+#define RTC_A1DAY_ADOWAE_MASK                    ((uint32_t)0x00000080U)         /* !< Alarm Day of week enable. This bit
+                                                                                    are valid if RTCBCD=1 or RTCBCD=0. */
+#define RTC_A1DAY_ADOWAE_DISABLE                 ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A1DAY_ADOWAE_ENABLE                  ((uint32_t)0x00000080U)         /* !< Alarm enabled */
+/* RTC_A1DAY[ADOMBIN] Bits */
+#define RTC_A1DAY_ADOMBIN_OFS                    (8)                             /* !< ADOMBIN Offset */
+#define RTC_A1DAY_ADOMBIN_MASK                   ((uint32_t)0x00001F00U)         /* !< Alarm Day of month Binary (1 to 28,
+                                                                                    29, 30, 31) If RTCBCD=1 write to
+                                                                                    these bits will be ignored and read
+                                                                                    give the value 0. */
+#define RTC_A1DAY_ADOMBIN_MINIMUM                ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A1DAY_ADOMBIN_MAXIMUM                ((uint32_t)0x00001F00U)         /* !< Maximum value */
+/* RTC_A1DAY[ADOMAEBIN] Bits */
+#define RTC_A1DAY_ADOMAEBIN_OFS                  (15)                            /* !< ADOMAEBIN Offset */
+#define RTC_A1DAY_ADOMAEBIN_MASK                 ((uint32_t)0x00008000U)         /* !< Alarm Day of month Binary enable.
+                                                                                    If RTCBCD=1 this bit is always 0.
+                                                                                    Write to this bit will be ignored. */
+#define RTC_A1DAY_ADOMAEBIN_DISABLE              ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A1DAY_ADOMAEBIN_ENABLE               ((uint32_t)0x00008000U)         /* !< Alarm enabled */
+/* RTC_A1DAY[ADOMLOWBCD] Bits */
+#define RTC_A1DAY_ADOMLOWBCD_OFS                 (16)                            /* !< ADOMLOWBCD Offset */
+#define RTC_A1DAY_ADOMLOWBCD_MASK                ((uint32_t)0x000F0000U)         /* !< Alarm Day of month BCD  low digit
+                                                                                    (0 to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_A1DAY_ADOMLOWBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A1DAY_ADOMLOWBCD_MAXIMUM             ((uint32_t)0x00090000U)         /* !< Maximum value */
+/* RTC_A1DAY[ADOMHIGHBCD] Bits */
+#define RTC_A1DAY_ADOMHIGHBCD_OFS                (20)                            /* !< ADOMHIGHBCD Offset */
+#define RTC_A1DAY_ADOMHIGHBCD_MASK               ((uint32_t)0x00300000U)         /* !< Alarm Day of month BCD  high digit
+                                                                                    (0 to 3). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_A1DAY_ADOMHIGHBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A1DAY_ADOMHIGHBCD_MAXIMUM            ((uint32_t)0x00300000U)         /* !< Maximum value */
+/* RTC_A1DAY[ADOMAEBCD] Bits */
+#define RTC_A1DAY_ADOMAEBCD_OFS                  (23)                            /* !< ADOMAEBCD Offset */
+#define RTC_A1DAY_ADOMAEBCD_MASK                 ((uint32_t)0x00800000U)         /* !< Alarm Day of month BCD enable. If
+                                                                                    RTCBCD=0 this bit is always 0. Write
+                                                                                    to this bit will be ignored. */
+#define RTC_A1DAY_ADOMAEBCD_DISABLE              ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A1DAY_ADOMAEBCD_ENABLE               ((uint32_t)0x00800000U)         /* !< Alarm enabled */
+
+/* RTC_A2MIN Bits */
+/* RTC_A2MIN[AMINBIN] Bits */
+#define RTC_A2MIN_AMINBIN_OFS                    (0)                             /* !< AMINBIN Offset */
+#define RTC_A2MIN_AMINBIN_MASK                   ((uint32_t)0x0000003FU)         /* !< Alarm Minutes Binary (0 to 59). If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_A2MIN_AMINBIN_MINIMUM                ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A2MIN_AMINBIN_MAXIMUM                ((uint32_t)0x0000003BU)         /* !< Maximum value */
+/* RTC_A2MIN[AMINAEBIN] Bits */
+#define RTC_A2MIN_AMINAEBIN_OFS                  (7)                             /* !< AMINAEBIN Offset */
+#define RTC_A2MIN_AMINAEBIN_MASK                 ((uint32_t)0x00000080U)         /* !< Alarm Minutes Binary enable. If
+                                                                                    RTCBCD=1 this bit is always 0. Write
+                                                                                    to this bit will be ignored. */
+#define RTC_A2MIN_AMINAEBIN_DISABLE              ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A2MIN_AMINAEBIN_ENABLE               ((uint32_t)0x00000080U)         /* !< Alarm enabled */
+/* RTC_A2MIN[AMINLOWBCD] Bits */
+#define RTC_A2MIN_AMINLOWBCD_OFS                 (8)                             /* !< AMINLOWBCD Offset */
+#define RTC_A2MIN_AMINLOWBCD_MASK                ((uint32_t)0x00000F00U)         /* !< Alarm Minutes BCD  low digit (0 to
+                                                                                    9). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define RTC_A2MIN_AMINLOWBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A2MIN_AMINLOWBCD_MAXIMUM             ((uint32_t)0x00000900U)         /* !< Maximum value */
+/* RTC_A2MIN[AMINHIGHBCD] Bits */
+#define RTC_A2MIN_AMINHIGHBCD_OFS                (12)                            /* !< AMINHIGHBCD Offset */
+#define RTC_A2MIN_AMINHIGHBCD_MASK               ((uint32_t)0x00007000U)         /* !< Alarm Minutes BCD  high digit (0 to
+                                                                                    5). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define RTC_A2MIN_AMINHIGHBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A2MIN_AMINHIGHBCD_MAXIMUM            ((uint32_t)0x00005000U)         /* !< Maximum value */
+/* RTC_A2MIN[AMINAEBCD] Bits */
+#define RTC_A2MIN_AMINAEBCD_OFS                  (15)                            /* !< AMINAEBCD Offset */
+#define RTC_A2MIN_AMINAEBCD_MASK                 ((uint32_t)0x00008000U)         /* !< Alarm Minutes BCD enable. If
+                                                                                    RTCBCD=0 this bit is always 0. Write
+                                                                                    to this bit will be ignored. */
+#define RTC_A2MIN_AMINAEBCD_DISABLE              ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A2MIN_AMINAEBCD_ENABLE               ((uint32_t)0x00008000U)         /* !< Alarm enabled */
+
+/* RTC_A2HOUR Bits */
+/* RTC_A2HOUR[AHOURBIN] Bits */
+#define RTC_A2HOUR_AHOURBIN_OFS                  (0)                             /* !< AHOURBIN Offset */
+#define RTC_A2HOUR_AHOURBIN_MASK                 ((uint32_t)0x0000001FU)         /* !< Alarm Hours Binary (0 to 23). If
+                                                                                    RTCBCD=1 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_A2HOUR_AHOURBIN_MINIMUM              ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A2HOUR_AHOURBIN_MAXIMUM              ((uint32_t)0x00000017U)         /* !< Maximum value */
+/* RTC_A2HOUR[AHOURAEBIN] Bits */
+#define RTC_A2HOUR_AHOURAEBIN_OFS                (7)                             /* !< AHOURAEBIN Offset */
+#define RTC_A2HOUR_AHOURAEBIN_MASK               ((uint32_t)0x00000080U)         /* !< Alarm Hours Binary enable. If
+                                                                                    RTCBCD=1 this bit is always 0. Write
+                                                                                    to this bit will be ignored. */
+#define RTC_A2HOUR_AHOURAEBIN_DISABLE            ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A2HOUR_AHOURAEBIN_ENABLE             ((uint32_t)0x00000080U)         /* !< Alarm enabled */
+/* RTC_A2HOUR[AHOURLOWBCD] Bits */
+#define RTC_A2HOUR_AHOURLOWBCD_OFS               (8)                             /* !< AHOURLOWBCD Offset */
+#define RTC_A2HOUR_AHOURLOWBCD_MASK              ((uint32_t)0x00000F00U)         /* !< Alarm Hours BCD  low digit (0 to
+                                                                                    9). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define RTC_A2HOUR_AHOURLOWBCD_MINIMUM           ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A2HOUR_AHOURLOWBCD_MAXIMUM           ((uint32_t)0x00000900U)         /* !< Maximum value */
+/* RTC_A2HOUR[AHOURHIGHBCD] Bits */
+#define RTC_A2HOUR_AHOURHIGHBCD_OFS              (12)                            /* !< AHOURHIGHBCD Offset */
+#define RTC_A2HOUR_AHOURHIGHBCD_MASK             ((uint32_t)0x00003000U)         /* !< Alarm Hours BCD  high digit (0 to
+                                                                                    2). If RTCBCD=0 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0.. */
+#define RTC_A2HOUR_AHOURHIGHBCD_MINIMUM          ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A2HOUR_AHOURHIGHBCD_MAXIMUM          ((uint32_t)0x00002000U)         /* !< Maximum value */
+/* RTC_A2HOUR[AHOURAEBCD] Bits */
+#define RTC_A2HOUR_AHOURAEBCD_OFS                (15)                            /* !< AHOURAEBCD Offset */
+#define RTC_A2HOUR_AHOURAEBCD_MASK               ((uint32_t)0x00008000U)         /* !< Alarm Hours BCD enable. If RTCBCD=0
+                                                                                    this bit is always 0. Write to this
+                                                                                    bit will be ignored. */
+#define RTC_A2HOUR_AHOURAEBCD_DISABLE            ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A2HOUR_AHOURAEBCD_ENABLE             ((uint32_t)0x00008000U)         /* !< Alarm enabled */
+
+/* RTC_A2DAY Bits */
+/* RTC_A2DAY[ADOW] Bits */
+#define RTC_A2DAY_ADOW_OFS                       (0)                             /* !< ADOW Offset */
+#define RTC_A2DAY_ADOW_MASK                      ((uint32_t)0x00000007U)         /* !< Alarm Day of week (0 to 6). These
+                                                                                    bits are valid if RTCBCD=1 or
+                                                                                    RTCBCD=0. */
+#define RTC_A2DAY_ADOW_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A2DAY_ADOW_MAXIMUM                   ((uint32_t)0x00000006U)         /* !< Maximum value */
+/* RTC_A2DAY[ADOWAE] Bits */
+#define RTC_A2DAY_ADOWAE_OFS                     (7)                             /* !< ADOWAE Offset */
+#define RTC_A2DAY_ADOWAE_MASK                    ((uint32_t)0x00000080U)         /* !< Alarm Day of week enable. This bit
+                                                                                    are valid if RTCBCD=1 or RTCBCD=0. */
+#define RTC_A2DAY_ADOWAE_DISABLE                 ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A2DAY_ADOWAE_ENABLE                  ((uint32_t)0x00000080U)         /* !< Alarm enabled */
+/* RTC_A2DAY[ADOMBIN] Bits */
+#define RTC_A2DAY_ADOMBIN_OFS                    (8)                             /* !< ADOMBIN Offset */
+#define RTC_A2DAY_ADOMBIN_MASK                   ((uint32_t)0x00001F00U)         /* !< Alarm Day of month Binary (1 to 28,
+                                                                                    29, 30, 31) If RTCBCD=1 write to
+                                                                                    these bits will be ignored and read
+                                                                                    give the value 0. */
+#define RTC_A2DAY_ADOMBIN_MINIMUM                ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A2DAY_ADOMBIN_MAXIMUM                ((uint32_t)0x00001F00U)         /* !< Maximum value */
+/* RTC_A2DAY[ADOMAEBIN] Bits */
+#define RTC_A2DAY_ADOMAEBIN_OFS                  (15)                            /* !< ADOMAEBIN Offset */
+#define RTC_A2DAY_ADOMAEBIN_MASK                 ((uint32_t)0x00008000U)         /* !< Alarm Day of month Binary enable.
+                                                                                    If RTCBCD=1 this bit is always 0.
+                                                                                    Write to this bit will be ignored. */
+#define RTC_A2DAY_ADOMAEBIN_DISABLE              ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A2DAY_ADOMAEBIN_ENABLE               ((uint32_t)0x00008000U)         /* !< Alarm enabled */
+/* RTC_A2DAY[ADOMLOWBCD] Bits */
+#define RTC_A2DAY_ADOMLOWBCD_OFS                 (16)                            /* !< ADOMLOWBCD Offset */
+#define RTC_A2DAY_ADOMLOWBCD_MASK                ((uint32_t)0x000F0000U)         /* !< Alarm Day of month BCD  low digit
+                                                                                    (0 to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_A2DAY_ADOMLOWBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A2DAY_ADOMLOWBCD_MAXIMUM             ((uint32_t)0x00090000U)         /* !< Maximum value */
+/* RTC_A2DAY[ADOMHIGHBCD] Bits */
+#define RTC_A2DAY_ADOMHIGHBCD_OFS                (20)                            /* !< ADOMHIGHBCD Offset */
+#define RTC_A2DAY_ADOMHIGHBCD_MASK               ((uint32_t)0x00300000U)         /* !< Alarm Day of month BCD  high digit
+                                                                                    (0 to 3). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_A2DAY_ADOMHIGHBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define RTC_A2DAY_ADOMHIGHBCD_MAXIMUM            ((uint32_t)0x00300000U)         /* !< Maximum value */
+/* RTC_A2DAY[ADOMAEBCD] Bits */
+#define RTC_A2DAY_ADOMAEBCD_OFS                  (23)                            /* !< ADOMAEBCD Offset */
+#define RTC_A2DAY_ADOMAEBCD_MASK                 ((uint32_t)0x00800000U)         /* !< Alarm Day of month BCD enable. If
+                                                                                    RTCBCD=0 this bit is always 0. Write
+                                                                                    to this bit will be ignored. */
+#define RTC_A2DAY_ADOMAEBCD_DISABLE              ((uint32_t)0x00000000U)         /* !< Alarm disabled */
+#define RTC_A2DAY_ADOMAEBCD_ENABLE               ((uint32_t)0x00800000U)         /* !< Alarm enabled */
+
+/* RTC_PSCTL Bits */
+/* RTC_PSCTL[RT0IP] Bits */
+#define RTC_PSCTL_RT0IP_OFS                      (2)                             /* !< RT0IP Offset */
+#define RTC_PSCTL_RT0IP_MASK                     ((uint32_t)0x0000001CU)         /* !< Prescale timer 0 interrupt interval */
+#define RTC_PSCTL_RT0IP_DIV8                     ((uint32_t)0x00000008U)         /* !< Divide by 8 - 244 microsecond
+                                                                                    interval */
+#define RTC_PSCTL_RT0IP_DIV16                    ((uint32_t)0x0000000CU)         /* !< Divide by 16  - 488 microsecond
+                                                                                    interval */
+#define RTC_PSCTL_RT0IP_DIV32                    ((uint32_t)0x00000010U)         /* !< Divide by 32 - 976 microsecond
+                                                                                    interval */
+#define RTC_PSCTL_RT0IP_DIV64                    ((uint32_t)0x00000014U)         /* !< Divide by 64 - 1.95 millisecond
+                                                                                    interval */
+#define RTC_PSCTL_RT0IP_DIV128                   ((uint32_t)0x00000018U)         /* !< Divide by 128 - 3.90 millisecond
+                                                                                    interval */
+#define RTC_PSCTL_RT0IP_DIV256                   ((uint32_t)0x0000001CU)         /* !< Divide by 256 - 7.81 millisecond
+                                                                                    interval */
+/* RTC_PSCTL[RT1IP] Bits */
+#define RTC_PSCTL_RT1IP_OFS                      (18)                            /* !< RT1IP Offset */
+#define RTC_PSCTL_RT1IP_MASK                     ((uint32_t)0x001C0000U)         /* !< Prescale timer 1 interrupt interval */
+#define RTC_PSCTL_RT1IP_DIV2                     ((uint32_t)0x00000000U)         /* !< Divide by 2 - 15.6 millisecond
+                                                                                    interval */
+#define RTC_PSCTL_RT1IP_DIV4                     ((uint32_t)0x00040000U)         /* !< Divide by 4 - 31.2 millisecond
+                                                                                    interval */
+#define RTC_PSCTL_RT1IP_DIV8                     ((uint32_t)0x00080000U)         /* !< Divide by 8 - 62.5 millisecond
+                                                                                    interval */
+#define RTC_PSCTL_RT1IP_DIV16                    ((uint32_t)0x000C0000U)         /* !< Divide by 16 - 125 millisecond
+                                                                                    interval */
+#define RTC_PSCTL_RT1IP_DIV32                    ((uint32_t)0x00100000U)         /* !< Divide by 32 - 250 millisecond
+                                                                                    interval */
+#define RTC_PSCTL_RT1IP_DIV64                    ((uint32_t)0x00140000U)         /* !< Divide by 64 - 500 millisecond
+                                                                                    interval */
+#define RTC_PSCTL_RT1IP_DIV128                   ((uint32_t)0x00180000U)         /* !< Divide by 128 - 1 second interval */
+#define RTC_PSCTL_RT1IP_DIV256                   ((uint32_t)0x001C0000U)         /* !< Divide by 256 - 2 second interval */
+
+/* RTC_EXTPSCTL Bits */
+/* RTC_EXTPSCTL[RT2PS] Bits */
+#define RTC_EXTPSCTL_RT2PS_OFS                   (2)                             /* !< RT2PS Offset */
+#define RTC_EXTPSCTL_RT2PS_MASK                  ((uint32_t)0x0000000CU)         /* !< Prescale timer 2 interrupt interval */
+#define RTC_EXTPSCTL_RT2PS_INT4S                 ((uint32_t)0x00000000U)         /* !< Interval every 4 second */
+#define RTC_EXTPSCTL_RT2PS_INT8S                 ((uint32_t)0x00000004U)         /* !< Interval every 8 second */
+#define RTC_EXTPSCTL_RT2PS_INT16S                ((uint32_t)0x00000008U)         /* !< Interval every 16 second */
+
+/* RTC_TSSEC Bits */
+/* RTC_TSSEC[SECBIN] Bits */
+#define RTC_TSSEC_SECBIN_OFS                     (0)                             /* !< SECBIN Offset */
+#define RTC_TSSEC_SECBIN_MASK                    ((uint32_t)0x0000003FU)         /* !< Time Stamp Second Binary (0 to 59).
+                                                                                    If RTCBCD=1 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define RTC_TSSEC_SECBIN_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSSEC_SECBIN_MAXIMUM                 ((uint32_t)0x0000003BU)         /* !< Highest possible value */
+/* RTC_TSSEC[SECLOWBCD] Bits */
+#define RTC_TSSEC_SECLOWBCD_OFS                  (8)                             /* !< SECLOWBCD Offset */
+#define RTC_TSSEC_SECLOWBCD_MASK                 ((uint32_t)0x00000F00U)         /* !< Time Stamp Seconds BCD  low digit
+                                                                                    (0 to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_TSSEC_SECLOWBCD_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSSEC_SECLOWBCD_MAXIMUM              ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* RTC_TSSEC[SECHIGHBCD] Bits */
+#define RTC_TSSEC_SECHIGHBCD_OFS                 (12)                            /* !< SECHIGHBCD Offset */
+#define RTC_TSSEC_SECHIGHBCD_MASK                ((uint32_t)0x00007000U)         /* !< Time Stamp Seconds BCD  high digit
+                                                                                    (0 to 5). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_TSSEC_SECHIGHBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSSEC_SECHIGHBCD_MAXIMUM             ((uint32_t)0x00005000U)         /* !< Highest possible value */
+
+/* RTC_TSMIN Bits */
+/* RTC_TSMIN[MINBIN] Bits */
+#define RTC_TSMIN_MINBIN_OFS                     (0)                             /* !< MINBIN Offset */
+#define RTC_TSMIN_MINBIN_MASK                    ((uint32_t)0x0000003FU)         /* !< Time Stamp Minutes Binary (0 to
+                                                                                    59). If RTCBCD=1 write to these bits
+                                                                                    will be ignored and read give the
+                                                                                    value 0. */
+#define RTC_TSMIN_MINBIN_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSMIN_MINBIN_MAXIMUM                 ((uint32_t)0x0000003BU)         /* !< Highest possible value */
+/* RTC_TSMIN[MINLOWBCD] Bits */
+#define RTC_TSMIN_MINLOWBCD_OFS                  (8)                             /* !< MINLOWBCD Offset */
+#define RTC_TSMIN_MINLOWBCD_MASK                 ((uint32_t)0x00000F00U)         /* !< Time Stamp Minutes BCD  low digit
+                                                                                    (0 to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_TSMIN_MINLOWBCD_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSMIN_MINLOWBCD_MAXIMUM              ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* RTC_TSMIN[MINHIGHBCD] Bits */
+#define RTC_TSMIN_MINHIGHBCD_OFS                 (12)                            /* !< MINHIGHBCD Offset */
+#define RTC_TSMIN_MINHIGHBCD_MASK                ((uint32_t)0x00007000U)         /* !< Time Stamp Minutes BCD  high digit
+                                                                                    (0 to 5). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_TSMIN_MINHIGHBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSMIN_MINHIGHBCD_MAXIMUM             ((uint32_t)0x00005000U)         /* !< Highest possible value */
+
+/* RTC_TSHOUR Bits */
+/* RTC_TSHOUR[HOURBIN] Bits */
+#define RTC_TSHOUR_HOURBIN_OFS                   (0)                             /* !< HOURBIN Offset */
+#define RTC_TSHOUR_HOURBIN_MASK                  ((uint32_t)0x0000001FU)         /* !< Time Stamp Hours Binary (0 to 23).
+                                                                                    If RTCBCD=1 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define RTC_TSHOUR_HOURBIN_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSHOUR_HOURBIN_MAXIMUM               ((uint32_t)0x00000017U)         /* !< Highest possible value */
+/* RTC_TSHOUR[HOURLOWBCD] Bits */
+#define RTC_TSHOUR_HOURLOWBCD_OFS                (8)                             /* !< HOURLOWBCD Offset */
+#define RTC_TSHOUR_HOURLOWBCD_MASK               ((uint32_t)0x00000F00U)         /* !< Time Stamp Hours BCD  low digit (0
+                                                                                    to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_TSHOUR_HOURLOWBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSHOUR_HOURLOWBCD_MAXIMUM            ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* RTC_TSHOUR[HOURHIGHBCD] Bits */
+#define RTC_TSHOUR_HOURHIGHBCD_OFS               (12)                            /* !< HOURHIGHBCD Offset */
+#define RTC_TSHOUR_HOURHIGHBCD_MASK              ((uint32_t)0x00003000U)         /* !< Time Stamp Hours BCD  high digit (0
+                                                                                    to 2). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_TSHOUR_HOURHIGHBCD_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSHOUR_HOURHIGHBCD_MAXIMUM           ((uint32_t)0x00002000U)         /* !< Highest possible value */
+
+/* RTC_TSDAY Bits */
+/* RTC_TSDAY[DOW] Bits */
+#define RTC_TSDAY_DOW_OFS                        (0)                             /* !< DOW Offset */
+#define RTC_TSDAY_DOW_MASK                       ((uint32_t)0x00000007U)         /* !< Time Stamp Day of week (0 to 6).
+                                                                                    These bits are valid if RTCBCD=1 or
+                                                                                    RTCBCD=0. */
+#define RTC_TSDAY_DOW_MINIMUM                    ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSDAY_DOW_MAXIMUM                    ((uint32_t)0x00000006U)         /* !< Highest possible value */
+/* RTC_TSDAY[DOMBIN] Bits */
+#define RTC_TSDAY_DOMBIN_OFS                     (8)                             /* !< DOMBIN Offset */
+#define RTC_TSDAY_DOMBIN_MASK                    ((uint32_t)0x00001F00U)         /* !< Time Stamp Day of month Binary (1
+                                                                                    to 28, 29, 30, 31) If RTCBCD=1 write
+                                                                                    to these bits will be ignored and
+                                                                                    read give the value 0. */
+#define RTC_TSDAY_DOMBIN_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSDAY_DOMBIN_MAXIMUM                 ((uint32_t)0x00001F00U)         /* !< Highest possible value */
+/* RTC_TSDAY[DOMLOWBCD] Bits */
+#define RTC_TSDAY_DOMLOWBCD_OFS                  (16)                            /* !< DOMLOWBCD Offset */
+#define RTC_TSDAY_DOMLOWBCD_MASK                 ((uint32_t)0x000F0000U)         /* !< Time Stamp Day of month BCD  low
+                                                                                    digit (0 to 9). If RTCBCD=0 write to
+                                                                                    these bits will be ignored and read
+                                                                                    give the value 0. */
+#define RTC_TSDAY_DOMLOWBCD_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSDAY_DOMLOWBCD_MAXIMUM              ((uint32_t)0x00090000U)         /* !< Highest possible value */
+/* RTC_TSDAY[DOMHIGHBCD] Bits */
+#define RTC_TSDAY_DOMHIGHBCD_OFS                 (20)                            /* !< DOMHIGHBCD Offset */
+#define RTC_TSDAY_DOMHIGHBCD_MASK                ((uint32_t)0x00300000U)         /* !< Time Stamp Day of month BCD  high
+                                                                                    digit (0 to 3). If RTCBCD=0 write to
+                                                                                    these bits will be ignored and read
+                                                                                    give the value 0. */
+#define RTC_TSDAY_DOMHIGHBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSDAY_DOMHIGHBCD_MAXIMUM             ((uint32_t)0x00300000U)         /* !< Highest possible value */
+
+/* RTC_TSMON Bits */
+/* RTC_TSMON[MONBIN] Bits */
+#define RTC_TSMON_MONBIN_OFS                     (0)                             /* !< MONBIN Offset */
+#define RTC_TSMON_MONBIN_MASK                    ((uint32_t)0x0000000FU)         /* !< Time Stamp Month Binary (1 to 12).
+                                                                                    If RTCBCD=1 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define RTC_TSMON_MONBIN_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSMON_MONBIN_MAXIMUM                 ((uint32_t)0x0000000CU)         /* !< Highest possible value */
+/* RTC_TSMON[MONLOWBCD] Bits */
+#define RTC_TSMON_MONLOWBCD_OFS                  (8)                             /* !< MONLOWBCD Offset */
+#define RTC_TSMON_MONLOWBCD_MASK                 ((uint32_t)0x00000F00U)         /* !< Time Stamp Month BCD  low digit (0
+                                                                                    to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_TSMON_MONLOWBCD_MINIMUM              ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSMON_MONLOWBCD_MAXIMUM              ((uint32_t)0x00000900U)         /* !< Highest possible value */
+/* RTC_TSMON[MONHIGHBCD] Bits */
+#define RTC_TSMON_MONHIGHBCD_OFS                 (12)                            /* !< MONHIGHBCD Offset */
+#define RTC_TSMON_MONHIGHBCD_MASK                ((uint32_t)0x00001000U)         /* !< Time Stamp Month BCD  high digit (0
+                                                                                    or 1). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_TSMON_MONHIGHBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSMON_MONHIGHBCD_MAXIMUM             ((uint32_t)0x00001000U)         /* !< Highest possible value */
+
+/* RTC_TSYEAR Bits */
+/* RTC_TSYEAR[YEARLOWBIN] Bits */
+#define RTC_TSYEAR_YEARLOWBIN_OFS                (0)                             /* !< YEARLOWBIN Offset */
+#define RTC_TSYEAR_YEARLOWBIN_MASK               ((uint32_t)0x000000FFU)         /* !< Time Stamp Year Binary  low byte.
+                                                                                    Valid values for Year are 0 to 4095.
+                                                                                    If RTCBCD=1 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define RTC_TSYEAR_YEARLOWBIN_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSYEAR_YEARLOWBIN_MAXIMUM            ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+/* RTC_TSYEAR[YEARHIGHBIN] Bits */
+#define RTC_TSYEAR_YEARHIGHBIN_OFS               (8)                             /* !< YEARHIGHBIN Offset */
+#define RTC_TSYEAR_YEARHIGHBIN_MASK              ((uint32_t)0x00000F00U)         /* !< Time Stamp Year Binary  high byte.
+                                                                                    Valid values for Year are 0 to 4095.
+                                                                                    If RTCBCD=1 write to these bits will
+                                                                                    be ignored and read give the value 0. */
+#define RTC_TSYEAR_YEARHIGHBIN_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSYEAR_YEARHIGHBIN_MAXIMUM           ((uint32_t)0x00000F00U)         /* !< Highest possible value */
+/* RTC_TSYEAR[YERARLOWESTBCD] Bits */
+#define RTC_TSYEAR_YERARLOWESTBCD_OFS            (16)                            /* !< YERARLOWESTBCD Offset */
+#define RTC_TSYEAR_YERARLOWESTBCD_MASK           ((uint32_t)0x000F0000U)         /* !< Time Stamp Year BCD  lowest digit
+                                                                                    (0 to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_TSYEAR_YERARLOWESTBCD_MINIMUM        ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSYEAR_YERARLOWESTBCD_MAXIMUM        ((uint32_t)0x00090000U)         /* !< Highest possible value */
+/* RTC_TSYEAR[DECADEBCD] Bits */
+#define RTC_TSYEAR_DECADEBCD_OFS                 (20)                            /* !< DECADEBCD Offset */
+#define RTC_TSYEAR_DECADEBCD_MASK                ((uint32_t)0x00F00000U)         /* !< Time Stamp Decade BCD (0 to 9). If
+                                                                                    RTCBCD=0 write to these bits will be
+                                                                                    ignored and read give the value 0. */
+#define RTC_TSYEAR_DECADEBCD_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSYEAR_DECADEBCD_MAXIMUM             ((uint32_t)0x00900000U)         /* !< Highest possible value */
+/* RTC_TSYEAR[CENTLOWBCD] Bits */
+#define RTC_TSYEAR_CENTLOWBCD_OFS                (24)                            /* !< CENTLOWBCD Offset */
+#define RTC_TSYEAR_CENTLOWBCD_MASK               ((uint32_t)0x0F000000U)         /* !< Time Stamp Century BCD  low digit
+                                                                                    (0 to 9). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_TSYEAR_CENTLOWBCD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSYEAR_CENTLOWBCD_MAXIMUM            ((uint32_t)0x09000000U)         /* !< Highest possible value */
+/* RTC_TSYEAR[CENTHIGHBCD] Bits */
+#define RTC_TSYEAR_CENTHIGHBCD_OFS               (28)                            /* !< CENTHIGHBCD Offset */
+#define RTC_TSYEAR_CENTHIGHBCD_MASK              ((uint32_t)0x70000000U)         /* !< Time Stamp Century BCD  high digit
+                                                                                    (0 to 4). If RTCBCD=0 write to these
+                                                                                    bits will be ignored and read give
+                                                                                    the value 0. */
+#define RTC_TSYEAR_CENTHIGHBCD_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define RTC_TSYEAR_CENTHIGHBCD_MAXIMUM           ((uint32_t)0x40000000U)         /* !< Highest possible value */
+
+/* RTC_TSSTAT Bits */
+/* RTC_TSSTAT[TSTIOEVT0] Bits */
+#define RTC_TSSTAT_TSTIOEVT0_OFS                 (0)                             /* !< TSTIOEVT0 Offset */
+#define RTC_TSSTAT_TSTIOEVT0_MASK                ((uint32_t)0x00000001U)         /* !< Tamper I/O 0 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT0_CLR                 ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT0_SET                 ((uint32_t)0x00000001U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT1] Bits */
+#define RTC_TSSTAT_TSTIOEVT1_OFS                 (1)                             /* !< TSTIOEVT1 Offset */
+#define RTC_TSSTAT_TSTIOEVT1_MASK                ((uint32_t)0x00000002U)         /* !< Tamper I/O 1 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT1_CLR                 ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT1_SET                 ((uint32_t)0x00000002U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT2] Bits */
+#define RTC_TSSTAT_TSTIOEVT2_OFS                 (2)                             /* !< TSTIOEVT2 Offset */
+#define RTC_TSSTAT_TSTIOEVT2_MASK                ((uint32_t)0x00000004U)         /* !< Tamper I/O 2 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT2_CLR                 ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT2_SET                 ((uint32_t)0x00000004U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT3] Bits */
+#define RTC_TSSTAT_TSTIOEVT3_OFS                 (3)                             /* !< TSTIOEVT3 Offset */
+#define RTC_TSSTAT_TSTIOEVT3_MASK                ((uint32_t)0x00000008U)         /* !< Tamper I/O 3 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT3_CLR                 ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT3_SET                 ((uint32_t)0x00000008U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT4] Bits */
+#define RTC_TSSTAT_TSTIOEVT4_OFS                 (4)                             /* !< TSTIOEVT4 Offset */
+#define RTC_TSSTAT_TSTIOEVT4_MASK                ((uint32_t)0x00000010U)         /* !< Tamper I/O 4 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT4_CLR                 ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT4_SET                 ((uint32_t)0x00000010U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT5] Bits */
+#define RTC_TSSTAT_TSTIOEVT5_OFS                 (5)                             /* !< TSTIOEVT5 Offset */
+#define RTC_TSSTAT_TSTIOEVT5_MASK                ((uint32_t)0x00000020U)         /* !< Tamper I/O 5 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT5_CLR                 ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT5_SET                 ((uint32_t)0x00000020U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT6] Bits */
+#define RTC_TSSTAT_TSTIOEVT6_OFS                 (6)                             /* !< TSTIOEVT6 Offset */
+#define RTC_TSSTAT_TSTIOEVT6_MASK                ((uint32_t)0x00000040U)         /* !< Tamper I/O 6 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT6_CLR                 ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT6_SET                 ((uint32_t)0x00000040U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT7] Bits */
+#define RTC_TSSTAT_TSTIOEVT7_OFS                 (7)                             /* !< TSTIOEVT7 Offset */
+#define RTC_TSSTAT_TSTIOEVT7_MASK                ((uint32_t)0x00000080U)         /* !< Tamper I/O 7 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT7_CLR                 ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT7_SET                 ((uint32_t)0x00000080U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT8] Bits */
+#define RTC_TSSTAT_TSTIOEVT8_OFS                 (8)                             /* !< TSTIOEVT8 Offset */
+#define RTC_TSSTAT_TSTIOEVT8_MASK                ((uint32_t)0x00000100U)         /* !< Tamper I/O 8 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT8_CLR                 ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT8_SET                 ((uint32_t)0x00000100U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT9] Bits */
+#define RTC_TSSTAT_TSTIOEVT9_OFS                 (9)                             /* !< TSTIOEVT9 Offset */
+#define RTC_TSSTAT_TSTIOEVT9_MASK                ((uint32_t)0x00000200U)         /* !< Tamper I/O 9 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT9_CLR                 ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT9_SET                 ((uint32_t)0x00000200U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT10] Bits */
+#define RTC_TSSTAT_TSTIOEVT10_OFS                (10)                            /* !< TSTIOEVT10 Offset */
+#define RTC_TSSTAT_TSTIOEVT10_MASK               ((uint32_t)0x00000400U)         /* !< Tamper I/O 10 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT10_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT10_SET                ((uint32_t)0x00000400U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT11] Bits */
+#define RTC_TSSTAT_TSTIOEVT11_OFS                (11)                            /* !< TSTIOEVT11 Offset */
+#define RTC_TSSTAT_TSTIOEVT11_MASK               ((uint32_t)0x00000800U)         /* !< Tamper I/O 11 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT11_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT11_SET                ((uint32_t)0x00000800U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT12] Bits */
+#define RTC_TSSTAT_TSTIOEVT12_OFS                (12)                            /* !< TSTIOEVT12 Offset */
+#define RTC_TSSTAT_TSTIOEVT12_MASK               ((uint32_t)0x00001000U)         /* !< Tamper I/O 12 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT12_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT12_SET                ((uint32_t)0x00001000U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT13] Bits */
+#define RTC_TSSTAT_TSTIOEVT13_OFS                (13)                            /* !< TSTIOEVT13 Offset */
+#define RTC_TSSTAT_TSTIOEVT13_MASK               ((uint32_t)0x00002000U)         /* !< Tamper I/O 13 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT13_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT13_SET                ((uint32_t)0x00002000U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT14] Bits */
+#define RTC_TSSTAT_TSTIOEVT14_OFS                (14)                            /* !< TSTIOEVT14 Offset */
+#define RTC_TSSTAT_TSTIOEVT14_MASK               ((uint32_t)0x00004000U)         /* !< Tamper I/O 14 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT14_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT14_SET                ((uint32_t)0x00004000U)         /* !< event detected */
+/* RTC_TSSTAT[TSTIOEVT15] Bits */
+#define RTC_TSSTAT_TSTIOEVT15_OFS                (15)                            /* !< TSTIOEVT15 Offset */
+#define RTC_TSSTAT_TSTIOEVT15_MASK               ((uint32_t)0x00008000U)         /* !< Tamper I/O 15 caused time stamp
+                                                                                    event */
+#define RTC_TSSTAT_TSTIOEVT15_CLR                ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSTIOEVT15_SET                ((uint32_t)0x00008000U)         /* !< event detected */
+/* RTC_TSSTAT[TSVDDEVT] Bits */
+#define RTC_TSSTAT_TSVDDEVT_OFS                  (16)                            /* !< TSVDDEVT Offset */
+#define RTC_TSSTAT_TSVDDEVT_MASK                 ((uint32_t)0x00010000U)         /* !< Loss of VDD caused time stamp event */
+#define RTC_TSSTAT_TSVDDEVT_CLR                  ((uint32_t)0x00000000U)         /* !< no event detected */
+#define RTC_TSSTAT_TSVDDEVT_SET                  ((uint32_t)0x00010000U)         /* !< event detected */
+
+/* RTC_TSCTL Bits */
+/* RTC_TSCTL[TSTIOEN0] Bits */
+#define RTC_TSCTL_TSTIOEN0_OFS                   (0)                             /* !< TSTIOEN0 Offset */
+#define RTC_TSCTL_TSTIOEN0_MASK                  ((uint32_t)0x00000001U)         /* !< Time Stamp by Tamper I/O 0 enable */
+#define RTC_TSCTL_TSTIOEN0_DISABLE               ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN0_ENABLE                ((uint32_t)0x00000001U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN1] Bits */
+#define RTC_TSCTL_TSTIOEN1_OFS                   (1)                             /* !< TSTIOEN1 Offset */
+#define RTC_TSCTL_TSTIOEN1_MASK                  ((uint32_t)0x00000002U)         /* !< Time Stamp by Tamper I/O 1 enable */
+#define RTC_TSCTL_TSTIOEN1_DISABLE               ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN1_ENABLE                ((uint32_t)0x00000002U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN2] Bits */
+#define RTC_TSCTL_TSTIOEN2_OFS                   (2)                             /* !< TSTIOEN2 Offset */
+#define RTC_TSCTL_TSTIOEN2_MASK                  ((uint32_t)0x00000004U)         /* !< Time Stamp by Tamper I/O 2 enable */
+#define RTC_TSCTL_TSTIOEN2_DISABLE               ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN2_ENABLE                ((uint32_t)0x00000004U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN3] Bits */
+#define RTC_TSCTL_TSTIOEN3_OFS                   (3)                             /* !< TSTIOEN3 Offset */
+#define RTC_TSCTL_TSTIOEN3_MASK                  ((uint32_t)0x00000008U)         /* !< Time Stamp by Tamper I/O 3 enable */
+#define RTC_TSCTL_TSTIOEN3_DISABLE               ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN3_ENABLE                ((uint32_t)0x00000008U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN4] Bits */
+#define RTC_TSCTL_TSTIOEN4_OFS                   (4)                             /* !< TSTIOEN4 Offset */
+#define RTC_TSCTL_TSTIOEN4_MASK                  ((uint32_t)0x00000010U)         /* !< Time Stamp by Tamper I/O 4 enable */
+#define RTC_TSCTL_TSTIOEN4_DISABLE               ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN4_ENABLE                ((uint32_t)0x00000010U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN5] Bits */
+#define RTC_TSCTL_TSTIOEN5_OFS                   (5)                             /* !< TSTIOEN5 Offset */
+#define RTC_TSCTL_TSTIOEN5_MASK                  ((uint32_t)0x00000020U)         /* !< Time Stamp by Tamper I/O 5 enable */
+#define RTC_TSCTL_TSTIOEN5_DISABLE               ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN5_ENABLE                ((uint32_t)0x00000020U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN6] Bits */
+#define RTC_TSCTL_TSTIOEN6_OFS                   (6)                             /* !< TSTIOEN6 Offset */
+#define RTC_TSCTL_TSTIOEN6_MASK                  ((uint32_t)0x00000040U)         /* !< Time Stamp by Tamper I/O 6 enable */
+#define RTC_TSCTL_TSTIOEN6_DISABLE               ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN6_ENABLE                ((uint32_t)0x00000040U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN7] Bits */
+#define RTC_TSCTL_TSTIOEN7_OFS                   (7)                             /* !< TSTIOEN7 Offset */
+#define RTC_TSCTL_TSTIOEN7_MASK                  ((uint32_t)0x00000080U)         /* !< Time Stamp by Tamper I/O 7 enable */
+#define RTC_TSCTL_TSTIOEN7_DISABLE               ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN7_ENABLE                ((uint32_t)0x00000080U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN8] Bits */
+#define RTC_TSCTL_TSTIOEN8_OFS                   (8)                             /* !< TSTIOEN8 Offset */
+#define RTC_TSCTL_TSTIOEN8_MASK                  ((uint32_t)0x00000100U)         /* !< Time Stamp by Tamper I/O 8 enable */
+#define RTC_TSCTL_TSTIOEN8_DISABLE               ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN8_ENABLE                ((uint32_t)0x00000100U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN9] Bits */
+#define RTC_TSCTL_TSTIOEN9_OFS                   (9)                             /* !< TSTIOEN9 Offset */
+#define RTC_TSCTL_TSTIOEN9_MASK                  ((uint32_t)0x00000200U)         /* !< Time Stamp by Tamper I/O 9 enable */
+#define RTC_TSCTL_TSTIOEN9_DISABLE               ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN9_ENABLE                ((uint32_t)0x00000200U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN10] Bits */
+#define RTC_TSCTL_TSTIOEN10_OFS                  (10)                            /* !< TSTIOEN10 Offset */
+#define RTC_TSCTL_TSTIOEN10_MASK                 ((uint32_t)0x00000400U)         /* !< Time Stamp by Tamper I/O 10 enable */
+#define RTC_TSCTL_TSTIOEN10_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN10_ENABLE               ((uint32_t)0x00000400U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN11] Bits */
+#define RTC_TSCTL_TSTIOEN11_OFS                  (11)                            /* !< TSTIOEN11 Offset */
+#define RTC_TSCTL_TSTIOEN11_MASK                 ((uint32_t)0x00000800U)         /* !< Time Stamp by Tamper I/O 11 enable */
+#define RTC_TSCTL_TSTIOEN11_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN11_ENABLE               ((uint32_t)0x00000800U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN12] Bits */
+#define RTC_TSCTL_TSTIOEN12_OFS                  (12)                            /* !< TSTIOEN12 Offset */
+#define RTC_TSCTL_TSTIOEN12_MASK                 ((uint32_t)0x00001000U)         /* !< Time Stamp by Tamper I/O 12 enable */
+#define RTC_TSCTL_TSTIOEN12_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN12_ENABLE               ((uint32_t)0x00001000U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN13] Bits */
+#define RTC_TSCTL_TSTIOEN13_OFS                  (13)                            /* !< TSTIOEN13 Offset */
+#define RTC_TSCTL_TSTIOEN13_MASK                 ((uint32_t)0x00002000U)         /* !< Time Stamp by Tamper I/O 13 enable */
+#define RTC_TSCTL_TSTIOEN13_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN13_ENABLE               ((uint32_t)0x00002000U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN14] Bits */
+#define RTC_TSCTL_TSTIOEN14_OFS                  (14)                            /* !< TSTIOEN14 Offset */
+#define RTC_TSCTL_TSTIOEN14_MASK                 ((uint32_t)0x00004000U)         /* !< Time Stamp by Tamper I/O 14 enable */
+#define RTC_TSCTL_TSTIOEN14_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN14_ENABLE               ((uint32_t)0x00004000U)         /* !< function enabled */
+/* RTC_TSCTL[TSTIOEN15] Bits */
+#define RTC_TSCTL_TSTIOEN15_OFS                  (15)                            /* !< TSTIOEN15 Offset */
+#define RTC_TSCTL_TSTIOEN15_MASK                 ((uint32_t)0x00008000U)         /* !< Time Stamp by Tamper I/O 15 enable */
+#define RTC_TSCTL_TSTIOEN15_DISABLE              ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSTIOEN15_ENABLE               ((uint32_t)0x00008000U)         /* !< function enabled */
+/* RTC_TSCTL[TSVDDEN] Bits */
+#define RTC_TSCTL_TSVDDEN_OFS                    (16)                            /* !< TSVDDEN Offset */
+#define RTC_TSCTL_TSVDDEN_MASK                   ((uint32_t)0x00010000U)         /* !< Time Stamp by VDD Loss detection
+                                                                                    enable */
+#define RTC_TSCTL_TSVDDEN_DISABLE                ((uint32_t)0x00000000U)         /* !< function disabled */
+#define RTC_TSCTL_TSVDDEN_ENABLE                 ((uint32_t)0x00010000U)         /* !< function enabled */
+/* RTC_TSCTL[TSCAPTURE] Bits */
+#define RTC_TSCTL_TSCAPTURE_OFS                  (20)                            /* !< TSCAPTURE Offset */
+#define RTC_TSCTL_TSCAPTURE_MASK                 ((uint32_t)0x00100000U)         /* !< Defines the capture method of the
+                                                                                    RTC timestamp when a time stamp event
+                                                                                    occurens. */
+#define RTC_TSCTL_TSCAPTURE_FIRST                ((uint32_t)0x00000000U)         /* !< Time stamp holds RTC capture at
+                                                                                    first occurrence of time stamp event. */
+#define RTC_TSCTL_TSCAPTURE_LAST                 ((uint32_t)0x00100000U)         /* !< Time stamp holds RTC capture at
+                                                                                    last occurrence of time stamp event. */
+/* RTC_TSCTL[KEY] Bits */
+#define RTC_TSCTL_KEY_OFS                        (24)                            /* !< KEY Offset */
+#define RTC_TSCTL_KEY_MASK                       ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xC5) to update
+                                                                                    this register */
+#define RTC_TSCTL_KEY_UNLOCK_W                   ((uint32_t)0xC5000000U)         /* !< This field must be written with
+                                                                                    0xC5 to be able to clear any of the
+                                                                                    enable bits */
+
+/* RTC_TSCLR Bits */
+/* RTC_TSCLR[CLR] Bits */
+#define RTC_TSCLR_CLR_OFS                        (0)                             /* !< CLR Offset */
+#define RTC_TSCLR_CLR_MASK                       ((uint32_t)0x00000001U)         /* !< Clear time stamp and status
+                                                                                    register. */
+#define RTC_TSCLR_CLR_NO_EFFECT                  ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define RTC_TSCLR_CLR_CLR                        ((uint32_t)0x00000001U)         /* !< clear time stamp event */
+/* RTC_TSCLR[KEY] Bits */
+#define RTC_TSCLR_KEY_OFS                        (24)                            /* !< KEY Offset */
+#define RTC_TSCLR_KEY_MASK                       ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0xE2) to update
+                                                                                    this register */
+#define RTC_TSCLR_KEY_UNLOCK_W                   ((uint32_t)0xE2000000U)         /* !< This field must be written with
+                                                                                    0xE2 to be able to clear any of the
+                                                                                    enable bits */
+
+/* RTC_LFSSRST Bits */
+/* RTC_LFSSRST[VBATPOR] Bits */
+#define RTC_LFSSRST_VBATPOR_OFS                  (0)                             /* !< VBATPOR Offset */
+#define RTC_LFSSRST_VBATPOR_MASK                 ((uint32_t)0x00000001U)         /* !< If set, the register bit will
+                                                                                    request a power on reset to the PMU
+                                                                                    of the LFSS. */
+#define RTC_LFSSRST_VBATPOR_NO_EFFECT            ((uint32_t)0x00000000U)         /* !< Writing this value has no effect. */
+#define RTC_LFSSRST_VBATPOR_SET                  ((uint32_t)0x00000001U)         /* !< Request power on reset to the LFSS. */
+/* RTC_LFSSRST[KEY] Bits */
+#define RTC_LFSSRST_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define RTC_LFSSRST_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0x12) to update
+                                                                                    this register */
+#define RTC_LFSSRST_KEY_UNLOCK_W                 ((uint32_t)0x12000000U)         /* !< This field must be written with
+                                                                                    0x12 to be able to request the power
+                                                                                    on reset. */
+
+/* RTC_RTCLOCK Bits */
+/* RTC_RTCLOCK[PROTECT] Bits */
+#define RTC_RTCLOCK_PROTECT_OFS                  (0)                             /* !< PROTECT Offset */
+#define RTC_RTCLOCK_PROTECT_MASK                 ((uint32_t)0x00000001U)         /* !< If set, the register bit will
+                                                                                    protect the CLKCTL, SEC, MIN, HOUR,
+                                                                                    DAY, MON, YEAR and LFSSRST from
+                                                                                    accidental writes. */
+#define RTC_RTCLOCK_PROTECT_CLR                  ((uint32_t)0x00000000U)         /* !< RTC counter is writable. */
+#define RTC_RTCLOCK_PROTECT_SET                  ((uint32_t)0x00000001U)         /* !< RTC counter is read only access. */
+/* RTC_RTCLOCK[KEY] Bits */
+#define RTC_RTCLOCK_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define RTC_RTCLOCK_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< need to write (KEY=0x22) to update
+                                                                                    this register */
+#define RTC_RTCLOCK_KEY_UNLOCK_W                 ((uint32_t)0x22000000U)         /* !< This field must be written with
+                                                                                    0x22 to be able to update any of the
+                                                                                    bits. */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_rtc__include */
+

--- a/mspm0/source/ti/devices/msp/peripherals/hw_spi.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_spi.h
@@ -1,0 +1,1173 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_spi__include
+#define ti_devices_msp_peripherals_hw_spi__include
+
+/* Filename: hw_spi.h */
+/* Revised: 2023-05-01 11:44:28 */
+/* Revision: e59cc9a0a7fab62c1b5a05a01c0efbbc96c33ec7 */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* SPI Registers
+******************************************************************************/
+#define SPI_DMA_TRIG_TX_OFS                      ((uint32_t)0x00001080U)
+#define SPI_DMA_TRIG_RX_OFS                      ((uint32_t)0x00001050U)
+#define SPI_CPU_INT_OFS                          ((uint32_t)0x00001020U)
+#define SPI_GPRCM_OFS                            ((uint32_t)0x00000800U)
+
+
+/** @addtogroup SPI_DMA_TRIG_TX
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001080) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001088) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001090) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001098) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x000010A0) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x000010A8) Interrupt clear */
+} SPI_DMA_TRIG_TX_Regs;
+
+/*@}*/ /* end of group SPI_DMA_TRIG_TX */
+
+/** @addtogroup SPI_DMA_TRIG_RX
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001050) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001058) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001060) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001068) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001070) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001078) Interrupt clear */
+} SPI_DMA_TRIG_RX_Regs;
+
+/*@}*/ /* end of group SPI_DMA_TRIG_RX */
+
+/** @addtogroup SPI_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt Index Register */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} SPI_CPU_INT_Regs;
+
+/*@}*/ /* end of group SPI_CPU_INT */
+
+/** @addtogroup SPI_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00000808) Peripheral Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} SPI_GPRCM_Regs;
+
+/*@}*/ /* end of group SPI_GPRCM */
+
+/** @addtogroup SPI
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  SPI_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED1[506];
+  __IO uint32_t CLKDIV;                            /* !< (@ 0x00001000) Clock Divider */
+  __IO uint32_t CLKSEL;                            /* !< (@ 0x00001004) Clock Select for Ultra Low Power peripherals */
+       uint32_t RESERVED2[4];
+  __IO uint32_t PDBGCTL;                           /* !< (@ 0x00001018) Peripheral Debug Control */
+       uint32_t RESERVED3;
+  SPI_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED4;
+  SPI_DMA_TRIG_RX_Regs  DMA_TRIG_RX;                       /* !< (@ 0x00001050) */
+       uint32_t RESERVED5;
+  SPI_DMA_TRIG_TX_Regs  DMA_TRIG_TX;                       /* !< (@ 0x00001080) */
+       uint32_t RESERVED6[13];
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+  __IO uint32_t INTCTL;                            /* !< (@ 0x000010E4) Interrupt control register */
+       uint32_t RESERVED7[6];
+  __IO uint32_t CTL0;                              /* !< (@ 0x00001100) SPI control register 0 */
+  __IO uint32_t CTL1;                              /* !< (@ 0x00001104) SPI control register 1 */
+  __IO uint32_t CLKCTL;                            /* !< (@ 0x00001108) Clock prescaler and divider register. */
+  __IO uint32_t IFLS;                              /* !< (@ 0x0000110C) Interrupt FIFO Level Select Register */
+  __I  uint32_t STAT;                              /* !< (@ 0x00001110) Status Register */
+       uint32_t RESERVED8[7];
+  __I  uint32_t RXDATA;                            /* !< (@ 0x00001130) RXDATA Register */
+       uint32_t RESERVED9[3];
+  __IO uint32_t TXDATA;                            /* !< (@ 0x00001140) TXDATA Register */
+} SPI_Regs;
+
+/*@}*/ /* end of group SPI */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* SPI Register Control Bits
+******************************************************************************/
+
+/* SPI_DMA_TRIG_TX_IIDX Bits */
+/* SPI_DMA_TRIG_TX_IIDX[STAT] Bits */
+#define SPI_DMA_TRIG_TX_IIDX_STAT_OFS            (0)                             /* !< STAT Offset */
+#define SPI_DMA_TRIG_TX_IIDX_STAT_MASK           ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define SPI_DMA_TRIG_TX_IIDX_STAT_NO_INTR        ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define SPI_DMA_TRIG_TX_IIDX_STAT_TX_EVT         ((uint32_t)0x00000005U)         /* !< Transmit Event/interrupt pending */
+
+/* SPI_DMA_TRIG_TX_IMASK Bits */
+/* SPI_DMA_TRIG_TX_IMASK[TX] Bits */
+#define SPI_DMA_TRIG_TX_IMASK_TX_OFS             (4)                             /* !< TX Offset */
+#define SPI_DMA_TRIG_TX_IMASK_TX_MASK            ((uint32_t)0x00000010U)         /* !< Transmit FIFO event mask. */
+#define SPI_DMA_TRIG_TX_IMASK_TX_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_DMA_TRIG_TX_IMASK_TX_SET             ((uint32_t)0x00000010U)         /* !< Set Interrupt Mask */
+
+/* SPI_DMA_TRIG_TX_RIS Bits */
+/* SPI_DMA_TRIG_TX_RIS[TX] Bits */
+#define SPI_DMA_TRIG_TX_RIS_TX_OFS               (4)                             /* !< TX Offset */
+#define SPI_DMA_TRIG_TX_RIS_TX_MASK              ((uint32_t)0x00000010U)         /* !< Transmit FIFO event: A read returns
+                                                                                    the current mask for transmit FIFO
+                                                                                    interrupt. On a write of 1, the mask
+                                                                                    for transmit FIFO interrupt is set
+                                                                                    which means the interrupt state will
+                                                                                    be reflected in MIS.TXMIS. A write of
+                                                                                    0 clears the mask which means
+                                                                                    MIS.TXMIS will not reflect the
+                                                                                    interrupt. */
+#define SPI_DMA_TRIG_TX_RIS_TX_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_DMA_TRIG_TX_RIS_TX_SET               ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+
+/* SPI_DMA_TRIG_TX_MIS Bits */
+/* SPI_DMA_TRIG_TX_MIS[TX] Bits */
+#define SPI_DMA_TRIG_TX_MIS_TX_OFS               (4)                             /* !< TX Offset */
+#define SPI_DMA_TRIG_TX_MIS_TX_MASK              ((uint32_t)0x00000010U)         /* !< Masked Transmit FIFO event */
+#define SPI_DMA_TRIG_TX_MIS_TX_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_DMA_TRIG_TX_MIS_TX_SET               ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+
+/* SPI_DMA_TRIG_TX_ISET Bits */
+/* SPI_DMA_TRIG_TX_ISET[TX] Bits */
+#define SPI_DMA_TRIG_TX_ISET_TX_OFS              (4)                             /* !< TX Offset */
+#define SPI_DMA_TRIG_TX_ISET_TX_MASK             ((uint32_t)0x00000010U)         /* !< Set Transmit FIFO event. */
+#define SPI_DMA_TRIG_TX_ISET_TX_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_DMA_TRIG_TX_ISET_TX_SET              ((uint32_t)0x00000010U)         /* !< Set Interrupt */
+
+/* SPI_DMA_TRIG_TX_ICLR Bits */
+/* SPI_DMA_TRIG_TX_ICLR[TX] Bits */
+#define SPI_DMA_TRIG_TX_ICLR_TX_OFS              (4)                             /* !< TX Offset */
+#define SPI_DMA_TRIG_TX_ICLR_TX_MASK             ((uint32_t)0x00000010U)         /* !< Clear Transmit FIFO event. */
+#define SPI_DMA_TRIG_TX_ICLR_TX_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_DMA_TRIG_TX_ICLR_TX_CLR              ((uint32_t)0x00000010U)         /* !< Clear Interrupt */
+
+/* SPI_DMA_TRIG_RX_IIDX Bits */
+/* SPI_DMA_TRIG_RX_IIDX[STAT] Bits */
+#define SPI_DMA_TRIG_RX_IIDX_STAT_OFS            (0)                             /* !< STAT Offset */
+#define SPI_DMA_TRIG_RX_IIDX_STAT_MASK           ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define SPI_DMA_TRIG_RX_IIDX_STAT_NO_INTR        ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define SPI_DMA_TRIG_RX_IIDX_STAT_RTOUT_EVT      ((uint32_t)0x00000003U)         /* !< SPI receive time-out interrupt */
+#define SPI_DMA_TRIG_RX_IIDX_STAT_RX_EVT         ((uint32_t)0x00000004U)         /* !< Receive Event/interrupt pending */
+
+/* SPI_DMA_TRIG_RX_IMASK Bits */
+/* SPI_DMA_TRIG_RX_IMASK[RX] Bits */
+#define SPI_DMA_TRIG_RX_IMASK_RX_OFS             (3)                             /* !< RX Offset */
+#define SPI_DMA_TRIG_RX_IMASK_RX_MASK            ((uint32_t)0x00000008U)         /* !< Receive FIFO event mask. */
+#define SPI_DMA_TRIG_RX_IMASK_RX_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_DMA_TRIG_RX_IMASK_RX_SET             ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+/* SPI_DMA_TRIG_RX_IMASK[RTOUT] Bits */
+#define SPI_DMA_TRIG_RX_IMASK_RTOUT_OFS          (2)                             /* !< RTOUT Offset */
+#define SPI_DMA_TRIG_RX_IMASK_RTOUT_MASK         ((uint32_t)0x00000004U)         /* !< SPI Receive Time-Out event mask. */
+#define SPI_DMA_TRIG_RX_IMASK_RTOUT_CLR          ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_DMA_TRIG_RX_IMASK_RTOUT_SET          ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+
+/* SPI_DMA_TRIG_RX_RIS Bits */
+/* SPI_DMA_TRIG_RX_RIS[RX] Bits */
+#define SPI_DMA_TRIG_RX_RIS_RX_OFS               (3)                             /* !< RX Offset */
+#define SPI_DMA_TRIG_RX_RIS_RX_MASK              ((uint32_t)0x00000008U)         /* !< Receive FIFO event.This interrupt
+                                                                                    is set if the selected Receive FIFO
+                                                                                    level has been reached */
+#define SPI_DMA_TRIG_RX_RIS_RX_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_DMA_TRIG_RX_RIS_RX_SET               ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* SPI_DMA_TRIG_RX_RIS[RTOUT] Bits */
+#define SPI_DMA_TRIG_RX_RIS_RTOUT_OFS            (2)                             /* !< RTOUT Offset */
+#define SPI_DMA_TRIG_RX_RIS_RTOUT_MASK           ((uint32_t)0x00000004U)         /* !< SPI Receive Time-Out Event. */
+#define SPI_DMA_TRIG_RX_RIS_RTOUT_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_DMA_TRIG_RX_RIS_RTOUT_SET            ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+
+/* SPI_DMA_TRIG_RX_MIS Bits */
+/* SPI_DMA_TRIG_RX_MIS[RX] Bits */
+#define SPI_DMA_TRIG_RX_MIS_RX_OFS               (3)                             /* !< RX Offset */
+#define SPI_DMA_TRIG_RX_MIS_RX_MASK              ((uint32_t)0x00000008U)         /* !< Receive FIFO event mask. */
+#define SPI_DMA_TRIG_RX_MIS_RX_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_DMA_TRIG_RX_MIS_RX_SET               ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* SPI_DMA_TRIG_RX_MIS[RTOUT] Bits */
+#define SPI_DMA_TRIG_RX_MIS_RTOUT_OFS            (2)                             /* !< RTOUT Offset */
+#define SPI_DMA_TRIG_RX_MIS_RTOUT_MASK           ((uint32_t)0x00000004U)         /* !< SPI Receive Time-Out event mask. */
+#define SPI_DMA_TRIG_RX_MIS_RTOUT_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_DMA_TRIG_RX_MIS_RTOUT_SET            ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+
+/* SPI_DMA_TRIG_RX_ISET Bits */
+/* SPI_DMA_TRIG_RX_ISET[RX] Bits */
+#define SPI_DMA_TRIG_RX_ISET_RX_OFS              (3)                             /* !< RX Offset */
+#define SPI_DMA_TRIG_RX_ISET_RX_MASK             ((uint32_t)0x00000008U)         /* !< Set Receive FIFO event. */
+#define SPI_DMA_TRIG_RX_ISET_RX_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_DMA_TRIG_RX_ISET_RX_SET              ((uint32_t)0x00000008U)         /* !< Set Interrupt */
+/* SPI_DMA_TRIG_RX_ISET[RTOUT] Bits */
+#define SPI_DMA_TRIG_RX_ISET_RTOUT_OFS           (2)                             /* !< RTOUT Offset */
+#define SPI_DMA_TRIG_RX_ISET_RTOUT_MASK          ((uint32_t)0x00000004U)         /* !< Set SPI Receive Time-Out event. */
+#define SPI_DMA_TRIG_RX_ISET_RTOUT_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_DMA_TRIG_RX_ISET_RTOUT_SET           ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+
+/* SPI_DMA_TRIG_RX_ICLR Bits */
+/* SPI_DMA_TRIG_RX_ICLR[RX] Bits */
+#define SPI_DMA_TRIG_RX_ICLR_RX_OFS              (3)                             /* !< RX Offset */
+#define SPI_DMA_TRIG_RX_ICLR_RX_MASK             ((uint32_t)0x00000008U)         /* !< Clear Receive FIFO event. */
+#define SPI_DMA_TRIG_RX_ICLR_RX_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_DMA_TRIG_RX_ICLR_RX_CLR              ((uint32_t)0x00000008U)         /* !< Clear Interrupt */
+/* SPI_DMA_TRIG_RX_ICLR[RTOUT] Bits */
+#define SPI_DMA_TRIG_RX_ICLR_RTOUT_OFS           (2)                             /* !< RTOUT Offset */
+#define SPI_DMA_TRIG_RX_ICLR_RTOUT_MASK          ((uint32_t)0x00000004U)         /* !< Clear SPI Receive Time-Out event. */
+#define SPI_DMA_TRIG_RX_ICLR_RTOUT_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_DMA_TRIG_RX_ICLR_RTOUT_CLR           ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+
+/* SPI_CPU_INT_IIDX Bits */
+/* SPI_CPU_INT_IIDX[STAT] Bits */
+#define SPI_CPU_INT_IIDX_STAT_OFS                (0)                             /* !< STAT Offset */
+#define SPI_CPU_INT_IIDX_STAT_MASK               ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define SPI_CPU_INT_IIDX_STAT_NO_INTR            ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define SPI_CPU_INT_IIDX_STAT_RXFIFO_OFV_EVT     ((uint32_t)0x00000001U)         /* !< RX FIFO Overflow Event/interrupt
+                                                                                    pending */
+#define SPI_CPU_INT_IIDX_STAT_PER_EVT            ((uint32_t)0x00000002U)         /* !< Transmit Parity Event/interrupt
+                                                                                    pending */
+#define SPI_CPU_INT_IIDX_STAT_RTOUT_EVT          ((uint32_t)0x00000003U)         /* !< SPI receive time-out interrupt */
+#define SPI_CPU_INT_IIDX_STAT_RX_EVT             ((uint32_t)0x00000004U)         /* !< Receive Event/interrupt pending */
+#define SPI_CPU_INT_IIDX_STAT_TX_EVT             ((uint32_t)0x00000005U)         /* !< Transmit Event/interrupt pending */
+#define SPI_CPU_INT_IIDX_STAT_TX_EMPTY           ((uint32_t)0x00000006U)         /* !< Transmit Buffer Empty
+                                                                                    Event/interrupt pending */
+#define SPI_CPU_INT_IIDX_STAT_IDLE_EVT           ((uint32_t)0x00000007U)         /* !< End of Transmit Event/interrupt
+                                                                                    pending */
+#define SPI_CPU_INT_IIDX_STAT_DMA_DONE_RX_EVT    ((uint32_t)0x00000008U)         /* !< DMA Done for Receive
+                                                                                    Event/interrupt pending */
+#define SPI_CPU_INT_IIDX_STAT_DMA_DONE_TX_EVT    ((uint32_t)0x00000009U)         /* !< DMA Done for Transmit
+                                                                                    Event/interrupt pending */
+#define SPI_CPU_INT_IIDX_STAT_TXFIFO_UNF_EVT     ((uint32_t)0x0000000AU)         /* !< TX FIFO underflow interrupt */
+#define SPI_CPU_INT_IIDX_STAT_RXFULL_EVT         ((uint32_t)0x0000000BU)         /* !< RX FIFO Full Interrupt */
+
+/* SPI_CPU_INT_IMASK Bits */
+/* SPI_CPU_INT_IMASK[RX] Bits */
+#define SPI_CPU_INT_IMASK_RX_OFS                 (3)                             /* !< RX Offset */
+#define SPI_CPU_INT_IMASK_RX_MASK                ((uint32_t)0x00000008U)         /* !< Receive FIFO event.This interrupt
+                                                                                    is set if the selected Receive FIFO
+                                                                                    level has been reached */
+#define SPI_CPU_INT_IMASK_RX_CLR                 ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_CPU_INT_IMASK_RX_SET                 ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+/* SPI_CPU_INT_IMASK[TX] Bits */
+#define SPI_CPU_INT_IMASK_TX_OFS                 (4)                             /* !< TX Offset */
+#define SPI_CPU_INT_IMASK_TX_MASK                ((uint32_t)0x00000010U)         /* !< Transmit FIFO event mask. */
+#define SPI_CPU_INT_IMASK_TX_CLR                 ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_CPU_INT_IMASK_TX_SET                 ((uint32_t)0x00000010U)         /* !< Set Interrupt Mask */
+/* SPI_CPU_INT_IMASK[TXEMPTY] Bits */
+#define SPI_CPU_INT_IMASK_TXEMPTY_OFS            (5)                             /* !< TXEMPTY Offset */
+#define SPI_CPU_INT_IMASK_TXEMPTY_MASK           ((uint32_t)0x00000020U)         /* !< Transmit FIFO Empty event mask. */
+#define SPI_CPU_INT_IMASK_TXEMPTY_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_CPU_INT_IMASK_TXEMPTY_SET            ((uint32_t)0x00000020U)         /* !< Set Interrupt Mask */
+/* SPI_CPU_INT_IMASK[PER] Bits */
+#define SPI_CPU_INT_IMASK_PER_OFS                (1)                             /* !< PER Offset */
+#define SPI_CPU_INT_IMASK_PER_MASK               ((uint32_t)0x00000002U)         /* !< Parity error event mask. */
+#define SPI_CPU_INT_IMASK_PER_CLR                ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_CPU_INT_IMASK_PER_SET                ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* SPI_CPU_INT_IMASK[DMA_DONE_RX] Bits */
+#define SPI_CPU_INT_IMASK_DMA_DONE_RX_OFS        (7)                             /* !< DMA_DONE_RX Offset */
+#define SPI_CPU_INT_IMASK_DMA_DONE_RX_MASK       ((uint32_t)0x00000080U)         /* !< DMA Done 1 event for RX event mask. */
+#define SPI_CPU_INT_IMASK_DMA_DONE_RX_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_CPU_INT_IMASK_DMA_DONE_RX_SET        ((uint32_t)0x00000080U)         /* !< Set Interrupt Mask */
+/* SPI_CPU_INT_IMASK[RXFIFO_OVF] Bits */
+#define SPI_CPU_INT_IMASK_RXFIFO_OVF_OFS         (0)                             /* !< RXFIFO_OVF Offset */
+#define SPI_CPU_INT_IMASK_RXFIFO_OVF_MASK        ((uint32_t)0x00000001U)         /* !< RXFIFO overflow event mask. */
+#define SPI_CPU_INT_IMASK_RXFIFO_OVF_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_CPU_INT_IMASK_RXFIFO_OVF_SET         ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* SPI_CPU_INT_IMASK[DMA_DONE_TX] Bits */
+#define SPI_CPU_INT_IMASK_DMA_DONE_TX_OFS        (8)                             /* !< DMA_DONE_TX Offset */
+#define SPI_CPU_INT_IMASK_DMA_DONE_TX_MASK       ((uint32_t)0x00000100U)         /* !< DMA Done 1 event for TX event mask. */
+#define SPI_CPU_INT_IMASK_DMA_DONE_TX_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_CPU_INT_IMASK_DMA_DONE_TX_SET        ((uint32_t)0x00000100U)         /* !< Set Interrupt Mask */
+/* SPI_CPU_INT_IMASK[IDLE] Bits */
+#define SPI_CPU_INT_IMASK_IDLE_OFS               (6)                             /* !< IDLE Offset */
+#define SPI_CPU_INT_IMASK_IDLE_MASK              ((uint32_t)0x00000040U)         /* !< SPI Idle event mask. */
+#define SPI_CPU_INT_IMASK_IDLE_CLR               ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_CPU_INT_IMASK_IDLE_SET               ((uint32_t)0x00000040U)         /* !< Set Interrupt Mask */
+/* SPI_CPU_INT_IMASK[RTOUT] Bits */
+#define SPI_CPU_INT_IMASK_RTOUT_OFS              (2)                             /* !< RTOUT Offset */
+#define SPI_CPU_INT_IMASK_RTOUT_MASK             ((uint32_t)0x00000004U)         /* !< Enable SPI Receive Time-Out event
+                                                                                    mask. */
+#define SPI_CPU_INT_IMASK_RTOUT_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_CPU_INT_IMASK_RTOUT_SET              ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* SPI_CPU_INT_IMASK[RXFULL] Bits */
+#define SPI_CPU_INT_IMASK_RXFULL_OFS             (10)                            /* !< RXFULL Offset */
+#define SPI_CPU_INT_IMASK_RXFULL_MASK            ((uint32_t)0x00000400U)         /* !< RX FIFO Full Interrupt Mask */
+#define SPI_CPU_INT_IMASK_RXFULL_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_CPU_INT_IMASK_RXFULL_SET             ((uint32_t)0x00000400U)         /* !< Set Interrupt Mask */
+/* SPI_CPU_INT_IMASK[TXFIFO_UNF] Bits */
+#define SPI_CPU_INT_IMASK_TXFIFO_UNF_OFS         (9)                             /* !< TXFIFO_UNF Offset */
+#define SPI_CPU_INT_IMASK_TXFIFO_UNF_MASK        ((uint32_t)0x00000200U)         /* !< TX FIFO underflow interrupt mask */
+#define SPI_CPU_INT_IMASK_TXFIFO_UNF_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_CPU_INT_IMASK_TXFIFO_UNF_SET         ((uint32_t)0x00000200U)         /* !< Set Interrupt Mask */
+
+/* SPI_CPU_INT_RIS Bits */
+/* SPI_CPU_INT_RIS[RX] Bits */
+#define SPI_CPU_INT_RIS_RX_OFS                   (3)                             /* !< RX Offset */
+#define SPI_CPU_INT_RIS_RX_MASK                  ((uint32_t)0x00000008U)         /* !< Receive FIFO event.This interrupt
+                                                                                    is set if the selected Receive FIFO
+                                                                                    level has been reached */
+#define SPI_CPU_INT_RIS_RX_CLR                   ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_RIS_RX_SET                   ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_RIS[TX] Bits */
+#define SPI_CPU_INT_RIS_TX_OFS                   (4)                             /* !< TX Offset */
+#define SPI_CPU_INT_RIS_TX_MASK                  ((uint32_t)0x00000010U)         /* !< Transmit FIFO event..This interrupt
+                                                                                    is set if the selected Transmit FIFO
+                                                                                    level has been reached. */
+#define SPI_CPU_INT_RIS_TX_CLR                   ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_RIS_TX_SET                   ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_RIS[TXEMPTY] Bits */
+#define SPI_CPU_INT_RIS_TXEMPTY_OFS              (5)                             /* !< TXEMPTY Offset */
+#define SPI_CPU_INT_RIS_TXEMPTY_MASK             ((uint32_t)0x00000020U)         /* !< Transmit FIFO Empty interrupt mask.
+                                                                                    This interrupt is set if all data in
+                                                                                    the Transmit FIFO have been move to
+                                                                                    the shift register. */
+#define SPI_CPU_INT_RIS_TXEMPTY_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_RIS_TXEMPTY_SET              ((uint32_t)0x00000020U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_RIS[PER] Bits */
+#define SPI_CPU_INT_RIS_PER_OFS                  (1)                             /* !< PER Offset */
+#define SPI_CPU_INT_RIS_PER_MASK                 ((uint32_t)0x00000002U)         /* !< Parity error event: this bit is set
+                                                                                    if a Parity error has been detected */
+#define SPI_CPU_INT_RIS_PER_CLR                  ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_RIS_PER_SET                  ((uint32_t)0x00000002U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_RIS[DMA_DONE_RX] Bits */
+#define SPI_CPU_INT_RIS_DMA_DONE_RX_OFS          (7)                             /* !< DMA_DONE_RX Offset */
+#define SPI_CPU_INT_RIS_DMA_DONE_RX_MASK         ((uint32_t)0x00000080U)         /* !< DMA Done 1 event for RX. This
+                                                                                    interrupt is set if the RX DMA
+                                                                                    channel sends the DONE signal. This
+                                                                                    allows the handling of the DMA event
+                                                                                    inside the mapped peripheral. */
+#define SPI_CPU_INT_RIS_DMA_DONE_RX_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_RIS_DMA_DONE_RX_SET          ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_RIS[RXFIFO_OVF] Bits */
+#define SPI_CPU_INT_RIS_RXFIFO_OVF_OFS           (0)                             /* !< RXFIFO_OVF Offset */
+#define SPI_CPU_INT_RIS_RXFIFO_OVF_MASK          ((uint32_t)0x00000001U)         /* !< RXFIFO overflow event. This
+                                                                                    interrupt is set if an RX FIFO
+                                                                                    overflow has been detected. */
+#define SPI_CPU_INT_RIS_RXFIFO_OVF_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_RIS_RXFIFO_OVF_SET           ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_RIS[DMA_DONE_TX] Bits */
+#define SPI_CPU_INT_RIS_DMA_DONE_TX_OFS          (8)                             /* !< DMA_DONE_TX Offset */
+#define SPI_CPU_INT_RIS_DMA_DONE_TX_MASK         ((uint32_t)0x00000100U)         /* !< DMA Done 1 event for TX. This
+                                                                                    interrupt is set if the TX DMA
+                                                                                    channel sends the DONE signal. This
+                                                                                    allows the handling of the DMA event
+                                                                                    inside the mapped peripheral. */
+#define SPI_CPU_INT_RIS_DMA_DONE_TX_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_RIS_DMA_DONE_TX_SET          ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_RIS[IDLE] Bits */
+#define SPI_CPU_INT_RIS_IDLE_OFS                 (6)                             /* !< IDLE Offset */
+#define SPI_CPU_INT_RIS_IDLE_MASK                ((uint32_t)0x00000040U)         /* !< SPI has done finished transfers and
+                                                                                    changed into IDLE mode. This bit is
+                                                                                    set when BUSY goes low. */
+#define SPI_CPU_INT_RIS_IDLE_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_RIS_IDLE_SET                 ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_RIS[RTOUT] Bits */
+#define SPI_CPU_INT_RIS_RTOUT_OFS                (2)                             /* !< RTOUT Offset */
+#define SPI_CPU_INT_RIS_RTOUT_MASK               ((uint32_t)0x00000004U)         /* !< SPI Receive Time-Out event. */
+#define SPI_CPU_INT_RIS_RTOUT_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_RIS_RTOUT_SET                ((uint32_t)0x00000004U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_RIS[TXFIFO_UNF] Bits */
+#define SPI_CPU_INT_RIS_TXFIFO_UNF_OFS           (9)                             /* !< TXFIFO_UNF Offset */
+#define SPI_CPU_INT_RIS_TXFIFO_UNF_MASK          ((uint32_t)0x00000200U)         /* !< TX FIFO Underflow Interrupt */
+#define SPI_CPU_INT_RIS_TXFIFO_UNF_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_RIS_TXFIFO_UNF_SET           ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_RIS[RXFULL] Bits */
+#define SPI_CPU_INT_RIS_RXFULL_OFS               (10)                            /* !< RXFULL Offset */
+#define SPI_CPU_INT_RIS_RXFULL_MASK              ((uint32_t)0x00000400U)         /* !< RX FIFO Full Interrupt */
+#define SPI_CPU_INT_RIS_RXFULL_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_RIS_RXFULL_SET               ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+
+/* SPI_CPU_INT_MIS Bits */
+/* SPI_CPU_INT_MIS[RX] Bits */
+#define SPI_CPU_INT_MIS_RX_OFS                   (3)                             /* !< RX Offset */
+#define SPI_CPU_INT_MIS_RX_MASK                  ((uint32_t)0x00000008U)         /* !< Masked receive FIFO event.This
+                                                                                    interrupt is set if the selected
+                                                                                    Receive FIFO level has been reached */
+#define SPI_CPU_INT_MIS_RX_CLR                   ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_MIS_RX_SET                   ((uint32_t)0x00000008U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_MIS[TX] Bits */
+#define SPI_CPU_INT_MIS_TX_OFS                   (4)                             /* !< TX Offset */
+#define SPI_CPU_INT_MIS_TX_MASK                  ((uint32_t)0x00000010U)         /* !< Masked Transmit FIFO event. This
+                                                                                    interrupt is set if the selected
+                                                                                    Transmit FIFO level has been reached. */
+#define SPI_CPU_INT_MIS_TX_CLR                   ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_MIS_TX_SET                   ((uint32_t)0x00000010U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_MIS[TXEMPTY] Bits */
+#define SPI_CPU_INT_MIS_TXEMPTY_OFS              (5)                             /* !< TXEMPTY Offset */
+#define SPI_CPU_INT_MIS_TXEMPTY_MASK             ((uint32_t)0x00000020U)         /* !< Masked Transmit FIFO Empty event. */
+#define SPI_CPU_INT_MIS_TXEMPTY_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_MIS_TXEMPTY_SET              ((uint32_t)0x00000020U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_MIS[PER] Bits */
+#define SPI_CPU_INT_MIS_PER_OFS                  (1)                             /* !< PER Offset */
+#define SPI_CPU_INT_MIS_PER_MASK                 ((uint32_t)0x00000002U)         /* !< Masked Parity error event: this bit
+                                                                                    if a Parity error has been detected */
+#define SPI_CPU_INT_MIS_PER_CLR                  ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_MIS_PER_SET                  ((uint32_t)0x00000002U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_MIS[DMA_DONE_RX] Bits */
+#define SPI_CPU_INT_MIS_DMA_DONE_RX_OFS          (7)                             /* !< DMA_DONE_RX Offset */
+#define SPI_CPU_INT_MIS_DMA_DONE_RX_MASK         ((uint32_t)0x00000080U)         /* !< Masked DMA Done 1 event for RX. */
+#define SPI_CPU_INT_MIS_DMA_DONE_RX_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_MIS_DMA_DONE_RX_SET          ((uint32_t)0x00000080U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_MIS[RXFIFO_OVF] Bits */
+#define SPI_CPU_INT_MIS_RXFIFO_OVF_OFS           (0)                             /* !< RXFIFO_OVF Offset */
+#define SPI_CPU_INT_MIS_RXFIFO_OVF_MASK          ((uint32_t)0x00000001U)         /* !< Masked RXFIFO overflow event. This
+                                                                                    interrupt is set if an RX FIFO
+                                                                                    overflow has been detected. */
+#define SPI_CPU_INT_MIS_RXFIFO_OVF_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_MIS_RXFIFO_OVF_SET           ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_MIS[DMA_DONE_TX] Bits */
+#define SPI_CPU_INT_MIS_DMA_DONE_TX_OFS          (8)                             /* !< DMA_DONE_TX Offset */
+#define SPI_CPU_INT_MIS_DMA_DONE_TX_MASK         ((uint32_t)0x00000100U)         /* !< Masked DMA Done 1 event for TX. */
+#define SPI_CPU_INT_MIS_DMA_DONE_TX_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_MIS_DMA_DONE_TX_SET          ((uint32_t)0x00000100U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_MIS[IDLE] Bits */
+#define SPI_CPU_INT_MIS_IDLE_OFS                 (6)                             /* !< IDLE Offset */
+#define SPI_CPU_INT_MIS_IDLE_MASK                ((uint32_t)0x00000040U)         /* !< Masked SPI IDLE mode event. */
+#define SPI_CPU_INT_MIS_IDLE_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_MIS_IDLE_SET                 ((uint32_t)0x00000040U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_MIS[RTOUT] Bits */
+#define SPI_CPU_INT_MIS_RTOUT_OFS                (2)                             /* !< RTOUT Offset */
+#define SPI_CPU_INT_MIS_RTOUT_MASK               ((uint32_t)0x00000004U)         /* !< Masked SPI Receive Time-Out
+                                                                                    Interrupt. */
+#define SPI_CPU_INT_MIS_RTOUT_CLR                ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define SPI_CPU_INT_MIS_RTOUT_SET                ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* SPI_CPU_INT_MIS[RXFULL] Bits */
+#define SPI_CPU_INT_MIS_RXFULL_OFS               (10)                            /* !< RXFULL Offset */
+#define SPI_CPU_INT_MIS_RXFULL_MASK              ((uint32_t)0x00000400U)         /* !< RX FIFO Full Interrupt */
+#define SPI_CPU_INT_MIS_RXFULL_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_MIS_RXFULL_SET               ((uint32_t)0x00000400U)         /* !< Interrupt occurred */
+/* SPI_CPU_INT_MIS[TXFIFO_UNF] Bits */
+#define SPI_CPU_INT_MIS_TXFIFO_UNF_OFS           (9)                             /* !< TXFIFO_UNF Offset */
+#define SPI_CPU_INT_MIS_TXFIFO_UNF_MASK          ((uint32_t)0x00000200U)         /* !< TX FIFO underflow interrupt */
+#define SPI_CPU_INT_MIS_TXFIFO_UNF_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define SPI_CPU_INT_MIS_TXFIFO_UNF_SET           ((uint32_t)0x00000200U)         /* !< Interrupt occurred */
+
+/* SPI_CPU_INT_ISET Bits */
+/* SPI_CPU_INT_ISET[RX] Bits */
+#define SPI_CPU_INT_ISET_RX_OFS                  (3)                             /* !< RX Offset */
+#define SPI_CPU_INT_ISET_RX_MASK                 ((uint32_t)0x00000008U)         /* !< Set Receive FIFO event. */
+#define SPI_CPU_INT_ISET_RX_NO_EFFECT            ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ISET_RX_SET                  ((uint32_t)0x00000008U)         /* !< Set Interrupt */
+/* SPI_CPU_INT_ISET[TX] Bits */
+#define SPI_CPU_INT_ISET_TX_OFS                  (4)                             /* !< TX Offset */
+#define SPI_CPU_INT_ISET_TX_MASK                 ((uint32_t)0x00000010U)         /* !< Set Transmit FIFO event. */
+#define SPI_CPU_INT_ISET_TX_NO_EFFECT            ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ISET_TX_SET                  ((uint32_t)0x00000010U)         /* !< Set Interrupt */
+/* SPI_CPU_INT_ISET[TXEMPTY] Bits */
+#define SPI_CPU_INT_ISET_TXEMPTY_OFS             (5)                             /* !< TXEMPTY Offset */
+#define SPI_CPU_INT_ISET_TXEMPTY_MASK            ((uint32_t)0x00000020U)         /* !< Set Transmit FIFO Empty event. */
+#define SPI_CPU_INT_ISET_TXEMPTY_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ISET_TXEMPTY_SET             ((uint32_t)0x00000020U)         /* !< Set Interrupt */
+/* SPI_CPU_INT_ISET[PER] Bits */
+#define SPI_CPU_INT_ISET_PER_OFS                 (1)                             /* !< PER Offset */
+#define SPI_CPU_INT_ISET_PER_MASK                ((uint32_t)0x00000002U)         /* !< Set Parity error event. */
+#define SPI_CPU_INT_ISET_PER_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ISET_PER_SET                 ((uint32_t)0x00000002U)         /* !< Set Interrupt */
+/* SPI_CPU_INT_ISET[DMA_DONE_RX] Bits */
+#define SPI_CPU_INT_ISET_DMA_DONE_RX_OFS         (7)                             /* !< DMA_DONE_RX Offset */
+#define SPI_CPU_INT_ISET_DMA_DONE_RX_MASK        ((uint32_t)0x00000080U)         /* !< Set DMA Done 1 event for RX. */
+#define SPI_CPU_INT_ISET_DMA_DONE_RX_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ISET_DMA_DONE_RX_SET         ((uint32_t)0x00000080U)         /* !< Set Interrupt */
+/* SPI_CPU_INT_ISET[RXFIFO_OVF] Bits */
+#define SPI_CPU_INT_ISET_RXFIFO_OVF_OFS          (0)                             /* !< RXFIFO_OVF Offset */
+#define SPI_CPU_INT_ISET_RXFIFO_OVF_MASK         ((uint32_t)0x00000001U)         /* !< Set RXFIFO overflow event. */
+#define SPI_CPU_INT_ISET_RXFIFO_OVF_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ISET_RXFIFO_OVF_SET          ((uint32_t)0x00000001U)         /* !< Set Interrupt */
+/* SPI_CPU_INT_ISET[DMA_DONE_TX] Bits */
+#define SPI_CPU_INT_ISET_DMA_DONE_TX_OFS         (8)                             /* !< DMA_DONE_TX Offset */
+#define SPI_CPU_INT_ISET_DMA_DONE_TX_MASK        ((uint32_t)0x00000100U)         /* !< Set DMA Done 1 event for TX. */
+#define SPI_CPU_INT_ISET_DMA_DONE_TX_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ISET_DMA_DONE_TX_SET         ((uint32_t)0x00000100U)         /* !< Set Interrupt */
+/* SPI_CPU_INT_ISET[IDLE] Bits */
+#define SPI_CPU_INT_ISET_IDLE_OFS                (6)                             /* !< IDLE Offset */
+#define SPI_CPU_INT_ISET_IDLE_MASK               ((uint32_t)0x00000040U)         /* !< Set SPI IDLE mode event. */
+#define SPI_CPU_INT_ISET_IDLE_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ISET_IDLE_SET                ((uint32_t)0x00000040U)         /* !< Set Interrupt */
+/* SPI_CPU_INT_ISET[RTOUT] Bits */
+#define SPI_CPU_INT_ISET_RTOUT_OFS               (2)                             /* !< RTOUT Offset */
+#define SPI_CPU_INT_ISET_RTOUT_MASK              ((uint32_t)0x00000004U)         /* !< Set SPI Receive Time-Out Event. */
+#define SPI_CPU_INT_ISET_RTOUT_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ISET_RTOUT_SET               ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* SPI_CPU_INT_ISET[TXFIFO_UNF] Bits */
+#define SPI_CPU_INT_ISET_TXFIFO_UNF_OFS          (9)                             /* !< TXFIFO_UNF Offset */
+#define SPI_CPU_INT_ISET_TXFIFO_UNF_MASK         ((uint32_t)0x00000200U)         /* !< Set TX FIFO Underflow Event */
+#define SPI_CPU_INT_ISET_TXFIFO_UNF_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing has no effect */
+#define SPI_CPU_INT_ISET_TXFIFO_UNF_SET          ((uint32_t)0x00000200U)         /* !< Set interrupt */
+/* SPI_CPU_INT_ISET[RXFULL] Bits */
+#define SPI_CPU_INT_ISET_RXFULL_OFS              (10)                            /* !< RXFULL Offset */
+#define SPI_CPU_INT_ISET_RXFULL_MASK             ((uint32_t)0x00000400U)         /* !< Set RX FIFO Full Event */
+#define SPI_CPU_INT_ISET_RXFULL_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing has no effect */
+#define SPI_CPU_INT_ISET_RXFULL_SET              ((uint32_t)0x00000400U)         /* !< Set Interrupt */
+
+/* SPI_CPU_INT_ICLR Bits */
+/* SPI_CPU_INT_ICLR[RX] Bits */
+#define SPI_CPU_INT_ICLR_RX_OFS                  (3)                             /* !< RX Offset */
+#define SPI_CPU_INT_ICLR_RX_MASK                 ((uint32_t)0x00000008U)         /* !< Clear Receive FIFO event. */
+#define SPI_CPU_INT_ICLR_RX_NO_EFFECT            ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ICLR_RX_CLR                  ((uint32_t)0x00000008U)         /* !< Clear Interrupt */
+/* SPI_CPU_INT_ICLR[TX] Bits */
+#define SPI_CPU_INT_ICLR_TX_OFS                  (4)                             /* !< TX Offset */
+#define SPI_CPU_INT_ICLR_TX_MASK                 ((uint32_t)0x00000010U)         /* !< Clear Transmit FIFO event. */
+#define SPI_CPU_INT_ICLR_TX_NO_EFFECT            ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ICLR_TX_CLR                  ((uint32_t)0x00000010U)         /* !< Clear Interrupt */
+/* SPI_CPU_INT_ICLR[TXEMPTY] Bits */
+#define SPI_CPU_INT_ICLR_TXEMPTY_OFS             (5)                             /* !< TXEMPTY Offset */
+#define SPI_CPU_INT_ICLR_TXEMPTY_MASK            ((uint32_t)0x00000020U)         /* !< Clear Transmit FIFO Empty event. */
+#define SPI_CPU_INT_ICLR_TXEMPTY_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ICLR_TXEMPTY_CLR             ((uint32_t)0x00000020U)         /* !< Clear Interrupt */
+/* SPI_CPU_INT_ICLR[PER] Bits */
+#define SPI_CPU_INT_ICLR_PER_OFS                 (1)                             /* !< PER Offset */
+#define SPI_CPU_INT_ICLR_PER_MASK                ((uint32_t)0x00000002U)         /* !< Clear Parity error event. */
+#define SPI_CPU_INT_ICLR_PER_NO_EFFECT           ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ICLR_PER_CLR                 ((uint32_t)0x00000002U)         /* !< Clear Interrupt */
+/* SPI_CPU_INT_ICLR[DMA_DONE_RX] Bits */
+#define SPI_CPU_INT_ICLR_DMA_DONE_RX_OFS         (7)                             /* !< DMA_DONE_RX Offset */
+#define SPI_CPU_INT_ICLR_DMA_DONE_RX_MASK        ((uint32_t)0x00000080U)         /* !< Clear DMA Done 1 event for RX. */
+#define SPI_CPU_INT_ICLR_DMA_DONE_RX_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ICLR_DMA_DONE_RX_CLR         ((uint32_t)0x00000080U)         /* !< Clear Interrupt */
+/* SPI_CPU_INT_ICLR[RXFIFO_OVF] Bits */
+#define SPI_CPU_INT_ICLR_RXFIFO_OVF_OFS          (0)                             /* !< RXFIFO_OVF Offset */
+#define SPI_CPU_INT_ICLR_RXFIFO_OVF_MASK         ((uint32_t)0x00000001U)         /* !< Clear RXFIFO overflow event. */
+#define SPI_CPU_INT_ICLR_RXFIFO_OVF_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ICLR_RXFIFO_OVF_CLR          ((uint32_t)0x00000001U)         /* !< Clear Interrupt */
+/* SPI_CPU_INT_ICLR[DMA_DONE_TX] Bits */
+#define SPI_CPU_INT_ICLR_DMA_DONE_TX_OFS         (8)                             /* !< DMA_DONE_TX Offset */
+#define SPI_CPU_INT_ICLR_DMA_DONE_TX_MASK        ((uint32_t)0x00000100U)         /* !< Clear DMA Done 1 event for TX. */
+#define SPI_CPU_INT_ICLR_DMA_DONE_TX_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ICLR_DMA_DONE_TX_CLR         ((uint32_t)0x00000100U)         /* !< Clear Interrupt */
+/* SPI_CPU_INT_ICLR[IDLE] Bits */
+#define SPI_CPU_INT_ICLR_IDLE_OFS                (6)                             /* !< IDLE Offset */
+#define SPI_CPU_INT_ICLR_IDLE_MASK               ((uint32_t)0x00000040U)         /* !< Clear SPI IDLE mode event. */
+#define SPI_CPU_INT_ICLR_IDLE_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ICLR_IDLE_CLR                ((uint32_t)0x00000040U)         /* !< Clear Interrupt */
+/* SPI_CPU_INT_ICLR[RTOUT] Bits */
+#define SPI_CPU_INT_ICLR_RTOUT_OFS               (2)                             /* !< RTOUT Offset */
+#define SPI_CPU_INT_ICLR_RTOUT_MASK              ((uint32_t)0x00000004U)         /* !< Clear SPI Receive Time-Out Event. */
+#define SPI_CPU_INT_ICLR_RTOUT_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_CPU_INT_ICLR_RTOUT_CLR               ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* SPI_CPU_INT_ICLR[TXFIFO_UNF] Bits */
+#define SPI_CPU_INT_ICLR_TXFIFO_UNF_OFS          (9)                             /* !< TXFIFO_UNF Offset */
+#define SPI_CPU_INT_ICLR_TXFIFO_UNF_MASK         ((uint32_t)0x00000200U)         /* !< Clear TXFIFO underflow event */
+#define SPI_CPU_INT_ICLR_TXFIFO_UNF_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing has no effect */
+#define SPI_CPU_INT_ICLR_TXFIFO_UNF_CLR          ((uint32_t)0x00000200U)         /* !< Clear interrupt */
+/* SPI_CPU_INT_ICLR[RXFULL] Bits */
+#define SPI_CPU_INT_ICLR_RXFULL_OFS              (10)                            /* !< RXFULL Offset */
+#define SPI_CPU_INT_ICLR_RXFULL_MASK             ((uint32_t)0x00000400U)         /* !< Clear RX FIFO underflow event */
+#define SPI_CPU_INT_ICLR_RXFULL_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing has no effect */
+#define SPI_CPU_INT_ICLR_RXFULL_CLR              ((uint32_t)0x00000400U)         /* !< Clear interrupt */
+
+/* SPI_PWREN Bits */
+/* SPI_PWREN[ENABLE] Bits */
+#define SPI_PWREN_ENABLE_OFS                     (0)                             /* !< ENABLE Offset */
+#define SPI_PWREN_ENABLE_MASK                    ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define SPI_PWREN_ENABLE_DISABLE                 ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define SPI_PWREN_ENABLE_ENABLE                  ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* SPI_PWREN[KEY] Bits */
+#define SPI_PWREN_KEY_OFS                        (24)                            /* !< KEY Offset */
+#define SPI_PWREN_KEY_MASK                       ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define SPI_PWREN_KEY_UNLOCK_W                   ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* SPI_RSTCTL Bits */
+/* SPI_RSTCTL[RESETSTKYCLR] Bits */
+#define SPI_RSTCTL_RESETSTKYCLR_OFS              (1)                             /* !< RESETSTKYCLR Offset */
+#define SPI_RSTCTL_RESETSTKYCLR_MASK             ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define SPI_RSTCTL_RESETSTKYCLR_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_RSTCTL_RESETSTKYCLR_CLR              ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* SPI_RSTCTL[RESETASSERT] Bits */
+#define SPI_RSTCTL_RESETASSERT_OFS               (0)                             /* !< RESETASSERT Offset */
+#define SPI_RSTCTL_RESETASSERT_MASK              ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define SPI_RSTCTL_RESETASSERT_NOP               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define SPI_RSTCTL_RESETASSERT_ASSERT            ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* SPI_RSTCTL[KEY] Bits */
+#define SPI_RSTCTL_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define SPI_RSTCTL_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define SPI_RSTCTL_KEY_UNLOCK_W                  ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* SPI_CLKCFG Bits */
+/* SPI_CLKCFG[KEY] Bits */
+#define SPI_CLKCFG_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define SPI_CLKCFG_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SPI_CLKCFG_KEY_UNLOCK                    ((uint32_t)0xA9000000U)         /* !< key value to allow change field of
+                                                                                    GPRCM */
+/* SPI_CLKCFG[BLOCKASYNC] Bits */
+#define SPI_CLKCFG_BLOCKASYNC_OFS                (8)                             /* !< BLOCKASYNC Offset */
+#define SPI_CLKCFG_BLOCKASYNC_MASK               ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SPI_CLKCFG_BLOCKASYNC_DISABLE            ((uint32_t)0x00000000U)         /* !< Not block async clock request */
+#define SPI_CLKCFG_BLOCKASYNC_ENABLE             ((uint32_t)0x00000100U)         /* !< Block async clock request */
+
+/* SPI_GPRCM_STAT Bits */
+/* SPI_GPRCM_STAT[RESETSTKY] Bits */
+#define SPI_GPRCM_STAT_RESETSTKY_OFS             (16)                            /* !< RESETSTKY Offset */
+#define SPI_GPRCM_STAT_RESETSTKY_MASK            ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define SPI_GPRCM_STAT_RESETSTKY_NORES           ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define SPI_GPRCM_STAT_RESETSTKY_RESET           ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* SPI_CLKDIV Bits */
+/* SPI_CLKDIV[RATIO] Bits */
+#define SPI_CLKDIV_RATIO_OFS                     (0)                             /* !< RATIO Offset */
+#define SPI_CLKDIV_RATIO_MASK                    ((uint32_t)0x00000007U)         /* !< Selects divide ratio of module
+                                                                                    clock */
+#define SPI_CLKDIV_RATIO_DIV_BY_1                ((uint32_t)0x00000000U)         /* !< Do not divide clock source */
+#define SPI_CLKDIV_RATIO_DIV_BY_2                ((uint32_t)0x00000001U)         /* !< Divide clock source by 2 */
+#define SPI_CLKDIV_RATIO_DIV_BY_3                ((uint32_t)0x00000002U)         /* !< Divide clock source by 3 */
+#define SPI_CLKDIV_RATIO_DIV_BY_4                ((uint32_t)0x00000003U)         /* !< Divide clock source by 4 */
+#define SPI_CLKDIV_RATIO_DIV_BY_5                ((uint32_t)0x00000004U)         /* !< Divide clock source by 5 */
+#define SPI_CLKDIV_RATIO_DIV_BY_6                ((uint32_t)0x00000005U)         /* !< Divide clock source by 6 */
+#define SPI_CLKDIV_RATIO_DIV_BY_7                ((uint32_t)0x00000006U)         /* !< Divide clock source by 7 */
+#define SPI_CLKDIV_RATIO_DIV_BY_8                ((uint32_t)0x00000007U)         /* !< Divide clock source by 8 */
+
+/* SPI_CLKSEL Bits */
+/* SPI_CLKSEL[LFCLK_SEL] Bits */
+#define SPI_CLKSEL_LFCLK_SEL_OFS                 (1)                             /* !< LFCLK_SEL Offset */
+#define SPI_CLKSEL_LFCLK_SEL_MASK                ((uint32_t)0x00000002U)         /* !< Selects LFCLK as clock source if
+                                                                                    enabled */
+#define SPI_CLKSEL_LFCLK_SEL_DISABLE             ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define SPI_CLKSEL_LFCLK_SEL_ENABLE              ((uint32_t)0x00000002U)         /* !< Select this clock as a source */
+/* SPI_CLKSEL[MFCLK_SEL] Bits */
+#define SPI_CLKSEL_MFCLK_SEL_OFS                 (2)                             /* !< MFCLK_SEL Offset */
+#define SPI_CLKSEL_MFCLK_SEL_MASK                ((uint32_t)0x00000004U)         /* !< Selects MFCLK as clock source if
+                                                                                    enabled */
+#define SPI_CLKSEL_MFCLK_SEL_DISABLE             ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define SPI_CLKSEL_MFCLK_SEL_ENABLE              ((uint32_t)0x00000004U)         /* !< Select this clock as a source */
+/* SPI_CLKSEL[SYSCLK_SEL] Bits */
+#define SPI_CLKSEL_SYSCLK_SEL_OFS                (3)                             /* !< SYSCLK_SEL Offset */
+#define SPI_CLKSEL_SYSCLK_SEL_MASK               ((uint32_t)0x00000008U)         /* !< Selects SYSCLK as clock source if
+                                                                                    enabled */
+#define SPI_CLKSEL_SYSCLK_SEL_DISABLE            ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define SPI_CLKSEL_SYSCLK_SEL_ENABLE             ((uint32_t)0x00000008U)         /* !< Select this clock as a source */
+
+/* SPI_PDBGCTL Bits */
+/* SPI_PDBGCTL[FREE] Bits */
+#define SPI_PDBGCTL_FREE_OFS                     (0)                             /* !< FREE Offset */
+#define SPI_PDBGCTL_FREE_MASK                    ((uint32_t)0x00000001U)         /* !< Free run control */
+#define SPI_PDBGCTL_FREE_STOP                    ((uint32_t)0x00000000U)         /* !< The peripheral freezes
+                                                                                    functionality while the Core Halted
+                                                                                    input is asserted and resumes when it
+                                                                                    is deasserted. */
+#define SPI_PDBGCTL_FREE_RUN                     ((uint32_t)0x00000001U)         /* !< The peripheral ignores the state of
+                                                                                    the Core Halted input */
+/* SPI_PDBGCTL[SOFT] Bits */
+#define SPI_PDBGCTL_SOFT_OFS                     (1)                             /* !< SOFT Offset */
+#define SPI_PDBGCTL_SOFT_MASK                    ((uint32_t)0x00000002U)         /* !< Soft halt boundary control. This
+                                                                                    function is only available, if [FREE]
+                                                                                    is set to 'STOP' */
+#define SPI_PDBGCTL_SOFT_IMMEDIATE               ((uint32_t)0x00000000U)         /* !< The peripheral will halt
+                                                                                    immediately, even if the resultant
+                                                                                    state will result in corruption if
+                                                                                    the system is restarted */
+#define SPI_PDBGCTL_SOFT_DELAYED                 ((uint32_t)0x00000002U)         /* !< The peripheral blocks the debug
+                                                                                    freeze until it has reached a
+                                                                                    boundary where it can resume without
+                                                                                    corruption */
+
+/* SPI_EVT_MODE Bits */
+/* SPI_EVT_MODE[INT0_CFG] Bits */
+#define SPI_EVT_MODE_INT0_CFG_OFS                (0)                             /* !< INT0_CFG Offset */
+#define SPI_EVT_MODE_INT0_CFG_MASK               ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT0] */
+#define SPI_EVT_MODE_INT0_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define SPI_EVT_MODE_INT0_CFG_SOFTWARE           ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define SPI_EVT_MODE_INT0_CFG_HARDWARE           ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* SPI_EVT_MODE[INT1_CFG] Bits */
+#define SPI_EVT_MODE_INT1_CFG_OFS                (2)                             /* !< INT1_CFG Offset */
+#define SPI_EVT_MODE_INT1_CFG_MASK               ((uint32_t)0x0000000CU)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT1] */
+#define SPI_EVT_MODE_INT1_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define SPI_EVT_MODE_INT1_CFG_SOFTWARE           ((uint32_t)0x00000004U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define SPI_EVT_MODE_INT1_CFG_HARDWARE           ((uint32_t)0x00000008U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* SPI_EVT_MODE[INT2_CFG] Bits */
+#define SPI_EVT_MODE_INT2_CFG_OFS                (4)                             /* !< INT2_CFG Offset */
+#define SPI_EVT_MODE_INT2_CFG_MASK               ((uint32_t)0x00000030U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT2] */
+#define SPI_EVT_MODE_INT2_CFG_DISABLE            ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define SPI_EVT_MODE_INT2_CFG_SOFTWARE           ((uint32_t)0x00000010U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define SPI_EVT_MODE_INT2_CFG_HARDWARE           ((uint32_t)0x00000020U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* SPI_INTCTL Bits */
+/* SPI_INTCTL[INTEVAL] Bits */
+#define SPI_INTCTL_INTEVAL_OFS                   (0)                             /* !< INTEVAL Offset */
+#define SPI_INTCTL_INTEVAL_MASK                  ((uint32_t)0x00000001U)         /* !< Writing a 1 to this field
+                                                                                    re-evaluates the interrupt sources. */
+#define SPI_INTCTL_INTEVAL_DISABLE               ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define SPI_INTCTL_INTEVAL_EVAL                  ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+
+/* SPI_CTL0 Bits */
+/* SPI_CTL0[DSS] Bits */
+#define SPI_CTL0_DSS_OFS                         (0)                             /* !< DSS Offset */
+#define SPI_CTL0_DSS_MASK                        ((uint32_t)0x0000001FU)         /* !< Data Size Select. Values 0 - 2 are
+                                                                                    reserved and shall not be used. 3h =
+                                                                                    4_BIT : 4-bit data SPI allows only
+                                                                                    values up to 16 Bit */
+#define SPI_CTL0_DSS_DSS_4                       ((uint32_t)0x00000003U)         /* !< Data Size Select bits: 4 */
+#define SPI_CTL0_DSS_DSS_5                       ((uint32_t)0x00000004U)         /* !< Data Size Select bits: 5 */
+#define SPI_CTL0_DSS_DSS_6                       ((uint32_t)0x00000005U)         /* !< Data Size Select bits: 6 */
+#define SPI_CTL0_DSS_DSS_7                       ((uint32_t)0x00000006U)         /* !< Data Size Select bits: 7 */
+#define SPI_CTL0_DSS_DSS_8                       ((uint32_t)0x00000007U)         /* !< Data Size Select bits: 8 */
+#define SPI_CTL0_DSS_DSS_9                       ((uint32_t)0x00000008U)         /* !< Data Size Select bits: 9 */
+#define SPI_CTL0_DSS_DSS_10                      ((uint32_t)0x00000009U)         /* !< Data Size Select bits: 10 */
+#define SPI_CTL0_DSS_DSS_11                      ((uint32_t)0x0000000AU)         /* !< Data Size Select bits: 11 */
+#define SPI_CTL0_DSS_DSS_12                      ((uint32_t)0x0000000BU)         /* !< Data Size Select bits: 12 */
+#define SPI_CTL0_DSS_DSS_13                      ((uint32_t)0x0000000CU)         /* !< Data Size Select bits: 13 */
+#define SPI_CTL0_DSS_DSS_14                      ((uint32_t)0x0000000DU)         /* !< Data Size Select bits: 14 */
+#define SPI_CTL0_DSS_DSS_15                      ((uint32_t)0x0000000EU)         /* !< Data Size Select bits: 15 */
+#define SPI_CTL0_DSS_DSS_16                      ((uint32_t)0x0000000FU)         /* !< Data Size Select bits: 16 */
+/* SPI_CTL0[FRF] Bits */
+#define SPI_CTL0_FRF_OFS                         (5)                             /* !< FRF Offset */
+#define SPI_CTL0_FRF_MASK                        ((uint32_t)0x00000060U)         /* !< Frame format Select */
+#define SPI_CTL0_FRF_MOTOROLA_3WIRE              ((uint32_t)0x00000000U)         /* !< Motorola SPI frame format (3 wire
+                                                                                    mode) */
+#define SPI_CTL0_FRF_MOTOROLA_4WIRE              ((uint32_t)0x00000020U)         /* !< Motorola SPI frame format (4 wire
+                                                                                    mode) */
+#define SPI_CTL0_FRF_TI_SYNC                     ((uint32_t)0x00000040U)         /* !< TI synchronous serial frame format */
+#define SPI_CTL0_FRF_MIRCOWIRE                   ((uint32_t)0x00000060U)         /* !< National Microwire frame format */
+/* SPI_CTL0[SPO] Bits */
+#define SPI_CTL0_SPO_OFS                         (8)                             /* !< SPO Offset */
+#define SPI_CTL0_SPO_MASK                        ((uint32_t)0x00000100U)         /* !< CLKOUT polarity (Motorola SPI frame
+                                                                                    format only) */
+#define SPI_CTL0_SPO_LOW                         ((uint32_t)0x00000000U)         /* !< SPI produces a steady state LOW
+                                                                                    value on the CLKOUT */
+#define SPI_CTL0_SPO_HIGH                        ((uint32_t)0x00000100U)         /* !< SPI produces a steady state HIGH
+                                                                                    value on the CLKOUT */
+/* SPI_CTL0[SPH] Bits */
+#define SPI_CTL0_SPH_OFS                         (9)                             /* !< SPH Offset */
+#define SPI_CTL0_SPH_MASK                        ((uint32_t)0x00000200U)         /* !< CLKOUT phase (Motorola SPI frame
+                                                                                    format only) This bit selects the
+                                                                                    clock edge that captures data and
+                                                                                    enables it to change state. It has
+                                                                                    the most impact on the first bit
+                                                                                    transmitted by either permitting or
+                                                                                    not permitting a clock transition
+                                                                                    before the first data capture edge. */
+#define SPI_CTL0_SPH_FIRST                       ((uint32_t)0x00000000U)         /* !< Data is captured on the first clock
+                                                                                    edge transition. */
+#define SPI_CTL0_SPH_SECOND                      ((uint32_t)0x00000200U)         /* !< Data is captured on the second
+                                                                                    clock edge transition. */
+/* SPI_CTL0[CSSEL] Bits */
+#define SPI_CTL0_CSSEL_OFS                       (12)                            /* !< CSSEL Offset */
+#define SPI_CTL0_CSSEL_MASK                      ((uint32_t)0x00003000U)         /* !< Select the CS line to control on
+                                                                                    data transfer This bit is applicable
+                                                                                    for both controller/target mode */
+#define SPI_CTL0_CSSEL_CSSEL_0                   ((uint32_t)0x00000000U)         /* !< CS line select: 0 */
+#define SPI_CTL0_CSSEL_CSSEL_1                   ((uint32_t)0x00001000U)         /* !< CS line select: 1 */
+#define SPI_CTL0_CSSEL_CSSEL_2                   ((uint32_t)0x00002000U)         /* !< CS line select: 2 */
+#define SPI_CTL0_CSSEL_CSSEL_3                   ((uint32_t)0x00003000U)         /* !< CS line select: 3 */
+/* SPI_CTL0[CSCLR] Bits */
+#define SPI_CTL0_CSCLR_OFS                       (14)                            /* !< CSCLR Offset */
+#define SPI_CTL0_CSCLR_MASK                      ((uint32_t)0x00004000U)         /* !< Clear shift register counter on CS
+                                                                                    inactive This bit is relevant only in
+                                                                                    the peripheral, CTL1.CP=0. */
+#define SPI_CTL0_CSCLR_DISABLE                   ((uint32_t)0x00000000U)         /* !< Disable automatic clear of shift
+                                                                                    register when CS goes to disable. */
+#define SPI_CTL0_CSCLR_ENABLE                    ((uint32_t)0x00004000U)         /* !< Enable automatic clear of shift
+                                                                                    register when CS goes to disable. */
+/* SPI_CTL0[PACKEN] Bits */
+#define SPI_CTL0_PACKEN_OFS                      (7)                             /* !< PACKEN Offset */
+#define SPI_CTL0_PACKEN_MASK                     ((uint32_t)0x00000080U)         /* !< Packing Enable. When 1, packing
+                                                                                    feature is enabled inside the IP When
+                                                                                    0, packing feature is disabled inside
+                                                                                    the IP */
+#define SPI_CTL0_PACKEN_DISABLED                 ((uint32_t)0x00000000U)         /* !< Packing feature disabled */
+#define SPI_CTL0_PACKEN_ENABLED                  ((uint32_t)0x00000080U)         /* !< Packing feature enabled */
+
+/* SPI_CTL1 Bits */
+/* SPI_CTL1[LBM] Bits */
+#define SPI_CTL1_LBM_OFS                         (1)                             /* !< LBM Offset */
+#define SPI_CTL1_LBM_MASK                        ((uint32_t)0x00000002U)         /* !< Loop back mode */
+#define SPI_CTL1_LBM_DISABLE                     ((uint32_t)0x00000000U)         /* !< Disable loopback mode */
+#define SPI_CTL1_LBM_ENABLE                      ((uint32_t)0x00000002U)         /* !< Enable loopback mode */
+/* SPI_CTL1[CP] Bits */
+#define SPI_CTL1_CP_OFS                          (2)                             /* !< CP Offset */
+#define SPI_CTL1_CP_MASK                         ((uint32_t)0x00000004U)         /* !< Controller or peripheral mode
+                                                                                    select. This bit can be modified only
+                                                                                    when SPI is disabled, CTL1.ENABLE=0. */
+#define SPI_CTL1_CP_DISABLE                      ((uint32_t)0x00000000U)         /* !< Select Peripheral mode */
+#define SPI_CTL1_CP_ENABLE                       ((uint32_t)0x00000004U)         /* !< Select Controller Mode */
+/* SPI_CTL1[POD] Bits */
+#define SPI_CTL1_POD_OFS                         (3)                             /* !< POD Offset */
+#define SPI_CTL1_POD_MASK                        ((uint32_t)0x00000008U)         /* !< Peripheral-mode: Data output
+                                                                                    disabled This bit is relevant only in
+                                                                                    Peripheral mode. In
+                                                                                    multiple-peripheral system
+                                                                                    topologies, SPI controller can
+                                                                                    broadcast a message to all
+                                                                                    peripherals, while only one
+                                                                                    peripheral drives the line.  POD can
+                                                                                    be used by the SPI peripheral to
+                                                                                    disable driving data on the line. */
+#define SPI_CTL1_POD_DISABLE                     ((uint32_t)0x00000000U)         /* !< SPI can drive the MISO output in
+                                                                                    peripheral mode. */
+#define SPI_CTL1_POD_ENABLE                      ((uint32_t)0x00000008U)         /* !< SPI cannot drive the MISO output in
+                                                                                    peripheral mode. */
+/* SPI_CTL1[MSB] Bits */
+#define SPI_CTL1_MSB_OFS                         (4)                             /* !< MSB Offset */
+#define SPI_CTL1_MSB_MASK                        ((uint32_t)0x00000010U)         /* !< MSB first select. Controls the
+                                                                                    direction of the receive and transmit
+                                                                                    shift register. */
+#define SPI_CTL1_MSB_DISABLE                     ((uint32_t)0x00000000U)         /* !< LSB first */
+#define SPI_CTL1_MSB_ENABLE                      ((uint32_t)0x00000010U)         /* !< MSB first */
+/* SPI_CTL1[PREN] Bits */
+#define SPI_CTL1_PREN_OFS                        (5)                             /* !< PREN Offset */
+#define SPI_CTL1_PREN_MASK                       ((uint32_t)0x00000020U)         /* !< Parity receive enable If enabled,
+                                                                                    parity reception check will be done
+                                                                                    for both controller and peripheral
+                                                                                    modes In case of a parity miss-match
+                                                                                    the parity error flag RIS.PER will be
+                                                                                    set. */
+#define SPI_CTL1_PREN_DISABLE                    ((uint32_t)0x00000000U)         /* !< Disable Parity receive function */
+#define SPI_CTL1_PREN_ENABLE                     ((uint32_t)0x00000020U)         /* !< Enable Parity receive function */
+/* SPI_CTL1[REPEATTX] Bits */
+#define SPI_CTL1_REPEATTX_OFS                    (16)                            /* !< REPEATTX Offset */
+#define SPI_CTL1_REPEATTX_MASK                   ((uint32_t)0x00FF0000U)         /* !< Counter to repeat last transfer 0:
+                                                                                    repeat last transfer is disabled. x:
+                                                                                    repeat the last transfer with the
+                                                                                    given number. The transfer will be
+                                                                                    started with writing a data into the
+                                                                                    TX Buffer. Sending the data will be
+                                                                                    repeated with the given value, so the
+                                                                                    data will be transferred X+1 times in
+                                                                                    total. The behavior is identical as
+                                                                                    if the data would be written into the
+                                                                                    TX Buffer that many times as defined
+                                                                                    by the value here. It can be used to
+                                                                                    clean a transfer or to pull a certain
+                                                                                    amount of data by a peripheral. */
+#define SPI_CTL1_REPEATTX_DISABLE                ((uint32_t)0x00000000U)         /* !< REPEATTX disable */
+#define SPI_CTL1_REPEATTX_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define SPI_CTL1_REPEATTX_MAXIMUM                ((uint32_t)0x00FF0000U)         /* !< Highest possible value */
+/* SPI_CTL1[PES] Bits */
+#define SPI_CTL1_PES_OFS                         (6)                             /* !< PES Offset */
+#define SPI_CTL1_PES_MASK                        ((uint32_t)0x00000040U)         /* !< Even Parity Select */
+#define SPI_CTL1_PES_DISABLE                     ((uint32_t)0x00000000U)         /* !< Odd Parity mode */
+#define SPI_CTL1_PES_ENABLE                      ((uint32_t)0x00000040U)         /* !< Even Parity mode */
+/* SPI_CTL1[CDMODE] Bits */
+#define SPI_CTL1_CDMODE_OFS                      (12)                            /* !< CDMODE Offset */
+#define SPI_CTL1_CDMODE_MASK                     ((uint32_t)0x0000F000U)         /* !< Command/Data Mode Value  When
+                                                                                    CTL1.CDENABLE is 1, CS3 line is used
+                                                                                    as C/D signal to distinguish between
+                                                                                    Command (C/D low) and Data (C/D high)
+                                                                                    information.  When a value is written
+                                                                                    into the CTL1.CDMODE bits, the C/D
+                                                                                    (CS3) line will go low for the given
+                                                                                    numbers of byte which are sent by the
+                                                                                    SPI, starting with the next value to
+                                                                                    be transmitted after which, C/D line
+                                                                                    will go high automatically  0: Manual
+                                                                                    mode with C/D signal as High 1-14:
+                                                                                    C/D is low while this number of bytes
+                                                                                    are being sent after which, this
+                                                                                    field sets to 0 and C/D goes high.
+                                                                                    Reading this field at any time
+                                                                                    returns the remaining number of
+                                                                                    command bytes. 15: Manual mode with
+                                                                                    C/D signal as Low. */
+#define SPI_CTL1_CDMODE_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define SPI_CTL1_CDMODE_DATA                     ((uint32_t)0x00000000U)         /* !< Manual mode: Data */
+#define SPI_CTL1_CDMODE_MAXIMUM                  ((uint32_t)0x0000F000U)         /* !< Highest possible value */
+#define SPI_CTL1_CDMODE_COMMAND                  ((uint32_t)0x0000F000U)         /* !< Manual mode: Command */
+/* SPI_CTL1[ENABLE] Bits */
+#define SPI_CTL1_ENABLE_OFS                      (0)                             /* !< ENABLE Offset */
+#define SPI_CTL1_ENABLE_MASK                     ((uint32_t)0x00000001U)         /* !< SPI enable */
+#define SPI_CTL1_ENABLE_DISABLE                  ((uint32_t)0x00000000U)         /* !< Disable module function */
+#define SPI_CTL1_ENABLE_ENABLE                   ((uint32_t)0x00000001U)         /* !< Enable module function */
+/* SPI_CTL1[RXTIMEOUT] Bits */
+#define SPI_CTL1_RXTIMEOUT_OFS                   (24)                            /* !< RXTIMEOUT Offset */
+#define SPI_CTL1_RXTIMEOUT_MASK                  ((uint32_t)0x3F000000U)         /* !< Receive Timeout (only for
+                                                                                    Peripheral mode) Defines the number
+                                                                                    of Clock Cycles before after which
+                                                                                    the Receive Timeout flag RTOUT is
+                                                                                    set. The time is calculated using the
+                                                                                    control register for the clock
+                                                                                    selection and divider in the
+                                                                                    Controller mode configuration. A
+                                                                                    value of 0 disables this function. */
+#define SPI_CTL1_RXTIMEOUT_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define SPI_CTL1_RXTIMEOUT_MAXIMUM               ((uint32_t)0x3F000000U)         /* !< Highest possible value */
+/* SPI_CTL1[CDENABLE] Bits */
+#define SPI_CTL1_CDENABLE_OFS                    (11)                            /* !< CDENABLE Offset */
+#define SPI_CTL1_CDENABLE_MASK                   ((uint32_t)0x00000800U)         /* !< Command/Data Mode enable */
+#define SPI_CTL1_CDENABLE_DISABLE                ((uint32_t)0x00000000U)         /* !< CS3 is used for Chip Select */
+#define SPI_CTL1_CDENABLE_ENABLE                 ((uint32_t)0x00000800U)         /* !< CS3 is used as CD signal */
+/* SPI_CTL1[PTEN] Bits */
+#define SPI_CTL1_PTEN_OFS                        (8)                             /* !< PTEN Offset */
+#define SPI_CTL1_PTEN_MASK                       ((uint32_t)0x00000100U)         /* !< Parity transmit enable If enabled,
+                                                                                    parity transmission will be done for
+                                                                                    both controller and peripheral modes. */
+#define SPI_CTL1_PTEN_DISABLE                    ((uint32_t)0x00000000U)         /* !< Parity transmission is disabled */
+#define SPI_CTL1_PTEN_ENABLE                     ((uint32_t)0x00000100U)         /* !< Parity transmission is enabled */
+
+/* SPI_CLKCTL Bits */
+/* SPI_CLKCTL[SCR] Bits */
+#define SPI_CLKCTL_SCR_OFS                       (0)                             /* !< SCR Offset */
+#define SPI_CLKCTL_SCR_MASK                      ((uint32_t)0x000003FFU)         /* !< Serial clock divider: This is used
+                                                                                    to generate the transmit and receive
+                                                                                    bit rate of the SPI. The SPI bit rate
+                                                                                    is (SPI's functional clock
+                                                                                    frequency)/((SCR+1)*2). SCR is a
+                                                                                    value from 0-1023. */
+#define SPI_CLKCTL_SCR_MINIMUM                   ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define SPI_CLKCTL_SCR_MAXIMUM                   ((uint32_t)0x000003FFU)         /* !< Highest possible value */
+/* SPI_CLKCTL[DSAMPLE] Bits */
+#define SPI_CLKCTL_DSAMPLE_OFS                   (28)                            /* !< DSAMPLE Offset */
+#define SPI_CLKCTL_DSAMPLE_MASK                  ((uint32_t)0xF0000000U)         /* !< Delayed sampling value.  In
+                                                                                    controller mode the data on the input
+                                                                                    pin will be delayed sampled by the
+                                                                                    defined clock cycles of internal
+                                                                                    functional clock hence relaxing the
+                                                                                    setup time of input data. This
+                                                                                    setting is useful in systems where
+                                                                                    the board delays and external
+                                                                                    peripheral delays are more than the
+                                                                                    input setup time of the controller.
+                                                                                    Please refer to the datasheet for
+                                                                                    values of controller input setup time
+                                                                                    and assess what DSAMPLE value meets
+                                                                                    the requirement of the system. Note:
+                                                                                    High values of DSAMPLE can cause HOLD
+                                                                                    time violations and must be factored
+                                                                                    in the calculations. */
+#define SPI_CLKCTL_DSAMPLE_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define SPI_CLKCTL_DSAMPLE_MAXIMUM               ((uint32_t)0xF0000000U)         /* !< Highest possible value */
+
+/* SPI_IFLS Bits */
+/* SPI_IFLS[TXIFLSEL] Bits */
+#define SPI_IFLS_TXIFLSEL_OFS                    (0)                             /* !< TXIFLSEL Offset */
+#define SPI_IFLS_TXIFLSEL_MASK                   ((uint32_t)0x00000007U)         /* !< SPI Transmit Interrupt FIFO Level
+                                                                                    Select  The trigger points for the
+                                                                                    transmit interrupt are as follows: */
+#define SPI_IFLS_TXIFLSEL_LVL_OFF                ((uint32_t)0x00000000U)         /* !< Reserved */
+#define SPI_IFLS_TXIFLSEL_LVL_3_4                ((uint32_t)0x00000001U)         /* !< TX FIFO <= 3/4 empty */
+#define SPI_IFLS_TXIFLSEL_LVL_1_2                ((uint32_t)0x00000002U)         /* !< TX FIFO <= 1/2 empty (default) */
+#define SPI_IFLS_TXIFLSEL_LVL_1_4                ((uint32_t)0x00000003U)         /* !< TX FIFO <= 1/4 empty */
+#define SPI_IFLS_TXIFLSEL_LVL_RES4               ((uint32_t)0x00000004U)         /* !< Reserved */
+#define SPI_IFLS_TXIFLSEL_LVL_EMPTY              ((uint32_t)0x00000005U)         /* !< TX FIFO is empty */
+#define SPI_IFLS_TXIFLSEL_LVL_RES6               ((uint32_t)0x00000006U)         /* !< Reserved */
+#define SPI_IFLS_TXIFLSEL_LEVEL_1                ((uint32_t)0x00000007U)         /* !< Trigger when TX FIFO has >= 1 frame
+                                                                                    free Should be used with DMA */
+/* SPI_IFLS[RXIFLSEL] Bits */
+#define SPI_IFLS_RXIFLSEL_OFS                    (3)                             /* !< RXIFLSEL Offset */
+#define SPI_IFLS_RXIFLSEL_MASK                   ((uint32_t)0x00000038U)         /* !< SPI Receive Interrupt FIFO Level
+                                                                                    Select  The trigger points for the
+                                                                                    receive interrupt are as follows: */
+#define SPI_IFLS_RXIFLSEL_LVL_OFF                ((uint32_t)0x00000000U)         /* !< Reserved */
+#define SPI_IFLS_RXIFLSEL_LVL_1_4                ((uint32_t)0x00000008U)         /* !< RX FIFO >= 1/4 full */
+#define SPI_IFLS_RXIFLSEL_LVL_1_2                ((uint32_t)0x00000010U)         /* !< RX FIFO >= 1/2 full (default) */
+#define SPI_IFLS_RXIFLSEL_LVL_3_4                ((uint32_t)0x00000018U)         /* !< RX FIFO >= 3/4 full */
+#define SPI_IFLS_RXIFLSEL_LVL_RES4               ((uint32_t)0x00000020U)         /* !< Reserved */
+#define SPI_IFLS_RXIFLSEL_LVL_FULL               ((uint32_t)0x00000028U)         /* !< RX FIFO is full */
+#define SPI_IFLS_RXIFLSEL_LVL_RES6               ((uint32_t)0x00000030U)         /* !< Reserved */
+#define SPI_IFLS_RXIFLSEL_LEVEL_1                ((uint32_t)0x00000038U)         /* !< Trigger when RX FIFO contains >= 1
+                                                                                    frame */
+
+/* SPI_STAT Bits */
+/* SPI_STAT[TFE] Bits */
+#define SPI_STAT_TFE_OFS                         (0)                             /* !< TFE Offset */
+#define SPI_STAT_TFE_MASK                        ((uint32_t)0x00000001U)         /* !< Transmit FIFO empty. */
+#define SPI_STAT_TFE_NOT_EMPTY                   ((uint32_t)0x00000000U)         /* !< Transmit FIFO is not empty. */
+#define SPI_STAT_TFE_EMPTY                       ((uint32_t)0x00000001U)         /* !< Transmit FIFO is empty. */
+/* SPI_STAT[TNF] Bits */
+#define SPI_STAT_TNF_OFS                         (1)                             /* !< TNF Offset */
+#define SPI_STAT_TNF_MASK                        ((uint32_t)0x00000002U)         /* !< Transmit FIFO not full */
+#define SPI_STAT_TNF_FULL                        ((uint32_t)0x00000000U)         /* !< Transmit FIFO is full. */
+#define SPI_STAT_TNF_NOT_FULL                    ((uint32_t)0x00000002U)         /* !< Transmit FIFO is not full. */
+/* SPI_STAT[RFE] Bits */
+#define SPI_STAT_RFE_OFS                         (2)                             /* !< RFE Offset */
+#define SPI_STAT_RFE_MASK                        ((uint32_t)0x00000004U)         /* !< Receive FIFO empty. */
+#define SPI_STAT_RFE_NOT_EMPTY                   ((uint32_t)0x00000000U)         /* !< Receive FIFO is not empty. */
+#define SPI_STAT_RFE_EMPTY                       ((uint32_t)0x00000004U)         /* !< Receive FIFO is empty. */
+/* SPI_STAT[RNF] Bits */
+#define SPI_STAT_RNF_OFS                         (3)                             /* !< RNF Offset */
+#define SPI_STAT_RNF_MASK                        ((uint32_t)0x00000008U)         /* !< Receive FIFO not full */
+#define SPI_STAT_RNF_FULL                        ((uint32_t)0x00000000U)         /* !< Receive FIFO is full. */
+#define SPI_STAT_RNF_NOT_FULL                    ((uint32_t)0x00000008U)         /* !< Receive FIFO is not full. */
+/* SPI_STAT[BUSY] Bits */
+#define SPI_STAT_BUSY_OFS                        (4)                             /* !< BUSY Offset */
+#define SPI_STAT_BUSY_MASK                       ((uint32_t)0x00000010U)         /* !< Busy */
+#define SPI_STAT_BUSY_IDLE                       ((uint32_t)0x00000000U)         /* !< SPI is in idle mode. */
+#define SPI_STAT_BUSY_ACTIVE                     ((uint32_t)0x00000010U)         /* !< SPI is currently transmitting
+                                                                                    and/or receiving data, or transmit
+                                                                                    FIFO is not empty. */
+
+/* SPI_RXDATA Bits */
+/* SPI_RXDATA[DATA] Bits */
+#define SPI_RXDATA_DATA_OFS                      (0)                             /* !< DATA Offset */
+#define SPI_RXDATA_DATA_MASK                     ((uint32_t)0x0000FFFFU)         /* !< Received Data When PACKEN=1,two
+                                                                                    entries of the FIFO are returned as a
+                                                                                    32-bit value. When PACKEN=0, 1 entry
+                                                                                    of FIFO is returned as 16-bit value.
+                                                                                    As data values are removed by the
+                                                                                    receive logic from the incoming data
+                                                                                    frame, they are placed into the entry
+                                                                                    in the receive FIFO, pointed to by
+                                                                                    the current FIFO write pointer.
+                                                                                    Received data less than 16 bits is
+                                                                                    automatically right justified in the
+                                                                                    receive buffer. */
+#define SPI_RXDATA_DATA_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define SPI_RXDATA_DATA_MAXIMUM                  ((uint32_t)0xFFFFFFFFU)         /* !< Highest possible value */
+
+/* SPI_TXDATA Bits */
+/* SPI_TXDATA[DATA] Bits */
+#define SPI_TXDATA_DATA_OFS                      (0)                             /* !< DATA Offset */
+#define SPI_TXDATA_DATA_MASK                     ((uint32_t)0x0000FFFFU)         /* !< Transmit Data  When read, last
+                                                                                    written value will be returned. If
+                                                                                    the last write to this field was a
+                                                                                    32-bit write (with PACKEN=1), 32-bits
+                                                                                    will be returned and if the last
+                                                                                    write was a 16-bit write (PACKEN=0),
+                                                                                    those 16-bits will be returned.
+                                                                                    When written, one or two FIFO entries
+                                                                                    will be written depending on PACKEN
+                                                                                    value. Data values are removed from
+                                                                                    the transmit FIFO one value at a time
+                                                                                    by the transmit logic. It is loaded
+                                                                                    into the transmit serial shifter,
+                                                                                    then serially shifted out onto the
+                                                                                    TXD output pin at the programmed bit
+                                                                                    rate.   When a data size of less than
+                                                                                    16 bits is selected, the user must
+                                                                                    right-justify data written to the
+                                                                                    transmit FIFO. The transmit logic
+                                                                                    ignores the unused bits. */
+#define SPI_TXDATA_DATA_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define SPI_TXDATA_DATA_MAXIMUM                  ((uint32_t)0xFFFFFFFFU)         /* !< Highest possible value */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_spi__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_trng.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_trng.h
@@ -1,0 +1,551 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_trng__include
+#define ti_devices_msp_peripherals_hw_trng__include
+
+/* Filename: hw_trng.h */
+/* Revised: 2023-06-13 16:12:38 */
+/* Revision: f9b237fa1b82e8166ce3ead25b505b784578352a */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* TRNG Registers
+******************************************************************************/
+#define TRNG_CPU_INT_OFS                         ((uint32_t)0x00001020U)
+#define TRNG_GPRCM_OFS                           ((uint32_t)0x00000800U)
+
+
+/** @addtogroup TRNG_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} TRNG_CPU_INT_Regs;
+
+/*@}*/ /* end of group TRNG_CPU_INT */
+
+/** @addtogroup TRNG_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} TRNG_GPRCM_Regs;
+
+/*@}*/ /* end of group TRNG_GPRCM */
+
+/** @addtogroup TRNG
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  TRNG_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED1[514];
+  TRNG_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED2[44];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Module descriptions */
+  __IO uint32_t CTL;                               /* !< (@ 0x00001100) Controls the command and decimation rate */
+  __I  uint32_t STAT;                              /* !< (@ 0x00001104) Status register that informs health test results
+                                                      and last issued command */
+  __I  uint32_t DATA_CAPTURE;                      /* !< (@ 0x00001108) Captured word buffer of RNG data */
+  __I  uint32_t TEST_RESULTS;                      /* !< (@ 0x0000110C) Test results from TEST_ANA and TEST_DIG */
+  __IO uint32_t CLKDIVIDE;                         /* !< (@ 0x00001110) Clock Divider */
+} TRNG_Regs;
+
+/*@}*/ /* end of group TRNG */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* TRNG Register Control Bits
+******************************************************************************/
+
+/* TRNG_IIDX Bits */
+/* TRNG_IIDX[STAT] Bits */
+#define TRNG_IIDX_STAT_OFS                       (0)                             /* !< STAT Offset */
+#define TRNG_IIDX_STAT_MASK                      ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define TRNG_IIDX_STAT_NO_INTR                   ((uint32_t)0x00000000U)         /* !< No bit is set means there is no
+                                                                                    pending interrupt request */
+#define TRNG_IIDX_STAT_IRQ_HEALTH_FAIL           ((uint32_t)0x00000001U)         /* !< Indicates that a health test has
+                                                                                    failed. The TRNG is in an error state
+                                                                                    until the interrupt is cleared. */
+#define TRNG_IIDX_STAT_IRQ_CMD_FAIL              ((uint32_t)0x00000002U)         /* !< Indicates that the just issued
+                                                                                    command was rejected and is not being
+                                                                                    performed. */
+#define TRNG_IIDX_STAT_IRQ_CMD_DONE              ((uint32_t)0x00000003U)         /* !< Indicates that the current
+                                                                                    command/mode is done. This may have
+                                                                                    different meanings based on the mode:
+                                                                                    OFF --> Power has been turned off
+                                                                                    PWRUP_DIG --> Digital powerup tests
+                                                                                    are done PWRUP_ANA --> Analog powerup
+                                                                                    tests are done NORM_FUNC --> No IRQ,
+                                                                                    since mode runs indefinitely until a
+                                                                                    new command is issued */
+#define TRNG_IIDX_STAT_IRQ_CAPTURED_RDY          ((uint32_t)0x00000004U)         /* !< Indicates that the captured word
+                                                                                    buffer is ready to be copied to
+                                                                                    memory */
+
+/* TRNG_IMASK Bits */
+/* TRNG_IMASK[IRQ_HEALTH_FAIL] Bits */
+#define TRNG_IMASK_IRQ_HEALTH_FAIL_OFS           (0)                             /* !< IRQ_HEALTH_FAIL Offset */
+#define TRNG_IMASK_IRQ_HEALTH_FAIL_MASK          ((uint32_t)0x00000001U)         /* !< Mask for IRQ_HEALTH_FAIL. Indicates
+                                                                                    that a health test has failed. */
+#define TRNG_IMASK_IRQ_HEALTH_FAIL_DISABLED      ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define TRNG_IMASK_IRQ_HEALTH_FAIL_ENABLED       ((uint32_t)0x00000001U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* TRNG_IMASK[IRQ_CAPTURED_RDY] Bits */
+#define TRNG_IMASK_IRQ_CAPTURED_RDY_OFS          (3)                             /* !< IRQ_CAPTURED_RDY Offset */
+#define TRNG_IMASK_IRQ_CAPTURED_RDY_MASK         ((uint32_t)0x00000008U)         /* !< Mask for IRQ_CAPTURED_RDY.
+                                                                                    Indicates to the CPU that the
+                                                                                    Captured Word is ready to be read. */
+#define TRNG_IMASK_IRQ_CAPTURED_RDY_DISABLED     ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define TRNG_IMASK_IRQ_CAPTURED_RDY_ENABLED      ((uint32_t)0x00000008U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* TRNG_IMASK[IRQ_CMD_DONE] Bits */
+#define TRNG_IMASK_IRQ_CMD_DONE_OFS              (2)                             /* !< IRQ_CMD_DONE Offset */
+#define TRNG_IMASK_IRQ_CMD_DONE_MASK             ((uint32_t)0x00000004U)         /* !< Mask for IRQ_CMD_DONE. Indicates
+                                                                                    that a command has finished */
+#define TRNG_IMASK_IRQ_CMD_DONE_DISABLED         ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define TRNG_IMASK_IRQ_CMD_DONE_ENABLED          ((uint32_t)0x00000004U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* TRNG_IMASK[IRQ_CMD_FAIL] Bits */
+#define TRNG_IMASK_IRQ_CMD_FAIL_OFS              (1)                             /* !< IRQ_CMD_FAIL Offset */
+#define TRNG_IMASK_IRQ_CMD_FAIL_MASK             ((uint32_t)0x00000002U)         /* !< Masked interrupt source for
+                                                                                    IRQ_CMD_FAIL. Indicates that the just
+                                                                                    issued command/mode has been
+                                                                                    rejected. */
+#define TRNG_IMASK_IRQ_CMD_FAIL_DISABLED         ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define TRNG_IMASK_IRQ_CMD_FAIL_ENABLED          ((uint32_t)0x00000002U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+
+/* TRNG_RIS Bits */
+/* TRNG_RIS[IRQ_CAPTURED_RDY] Bits */
+#define TRNG_RIS_IRQ_CAPTURED_RDY_OFS            (3)                             /* !< IRQ_CAPTURED_RDY Offset */
+#define TRNG_RIS_IRQ_CAPTURED_RDY_MASK           ((uint32_t)0x00000008U)         /* !< Indicates to the CPU that the
+                                                                                    Captured Word is ready to be read.
+                                                                                    Reading the IIDX will clear this
+                                                                                    interrupt. */
+#define TRNG_RIS_IRQ_CAPTURED_RDY_CLR            ((uint32_t)0x00000000U)         /* !< IRQ_CAPTURED_READY did not occur */
+#define TRNG_RIS_IRQ_CAPTURED_RDY_SET            ((uint32_t)0x00000008U)         /* !< IRQ_CAPTURED_READY occurred */
+/* TRNG_RIS[IRQ_HEALTH_FAIL] Bits */
+#define TRNG_RIS_IRQ_HEALTH_FAIL_OFS             (0)                             /* !< IRQ_HEALTH_FAIL Offset */
+#define TRNG_RIS_IRQ_HEALTH_FAIL_MASK            ((uint32_t)0x00000001U)         /* !< Indicates to the CPU that any of
+                                                                                    the health tests have failed. Reading
+                                                                                    the IIDX  will clear this interrupt. */
+#define TRNG_RIS_IRQ_HEALTH_FAIL_CLR             ((uint32_t)0x00000000U)         /* !< IRQ_CAPTURED_READY did not occur */
+#define TRNG_RIS_IRQ_HEALTH_FAIL_SET             ((uint32_t)0x00000001U)         /* !< IRQ_CAPTURED_READY occurred */
+/* TRNG_RIS[IRQ_CMD_DONE] Bits */
+#define TRNG_RIS_IRQ_CMD_DONE_OFS                (2)                             /* !< IRQ_CMD_DONE Offset */
+#define TRNG_RIS_IRQ_CMD_DONE_MASK               ((uint32_t)0x00000004U)         /* !< Raw interrupt source for
+                                                                                    IRQ_CMD_DONE. Indicates that the
+                                                                                    issued command/mode has completed. */
+#define TRNG_RIS_IRQ_CMD_DONE_CLR                ((uint32_t)0x00000000U)         /* !< IRQ_CMD_DONE did not occur */
+#define TRNG_RIS_IRQ_CMD_DONE_SET                ((uint32_t)0x00000004U)         /* !< IRQ_CMD_DONE occurred */
+/* TRNG_RIS[IRQ_CMD_FAIL] Bits */
+#define TRNG_RIS_IRQ_CMD_FAIL_OFS                (1)                             /* !< IRQ_CMD_FAIL Offset */
+#define TRNG_RIS_IRQ_CMD_FAIL_MASK               ((uint32_t)0x00000002U)         /* !< Masked interrupt source for
+                                                                                    IRQ_CMD_FAIL. Indicates that the just
+                                                                                    issued command/mode has been
+                                                                                    rejected. */
+#define TRNG_RIS_IRQ_CMD_FAIL_CLR                ((uint32_t)0x00000000U)         /* !< IRQ_CMD_FAIL did not occur */
+#define TRNG_RIS_IRQ_CMD_FAIL_SET                ((uint32_t)0x00000002U)         /* !< IRQ_CMD_FAIL occurred */
+
+/* TRNG_MIS Bits */
+/* TRNG_MIS[IRQ_CAPTURED_RDY] Bits */
+#define TRNG_MIS_IRQ_CAPTURED_RDY_OFS            (3)                             /* !< IRQ_CAPTURED_RDY Offset */
+#define TRNG_MIS_IRQ_CAPTURED_RDY_MASK           ((uint32_t)0x00000008U)         /* !< Masked interrupt result for
+                                                                                    CAPTURED_READY. Indicates to the CPU
+                                                                                    that the Captured Word is ready to be
+                                                                                    read. Reading the IIDX  will clear
+                                                                                    this interrupt. */
+#define TRNG_MIS_IRQ_CAPTURED_RDY_CLR            ((uint32_t)0x00000000U)         /* !< IRQ_CAPTURED_READY did not request
+                                                                                    an interrupt service routine */
+#define TRNG_MIS_IRQ_CAPTURED_RDY_SET            ((uint32_t)0x00000008U)         /* !< IRQ_CAPTURED_READY requests an
+                                                                                    interrupt service routine */
+/* TRNG_MIS[IRQ_HEALTH_FAIL] Bits */
+#define TRNG_MIS_IRQ_HEALTH_FAIL_OFS             (0)                             /* !< IRQ_HEALTH_FAIL Offset */
+#define TRNG_MIS_IRQ_HEALTH_FAIL_MASK            ((uint32_t)0x00000001U)         /* !< Masked interrupt result for
+                                                                                    HEALTH_FAIL. Indicates to the CPU
+                                                                                    that any of the health tests have
+                                                                                    failed for the latest 1024-bit
+                                                                                    window. */
+#define TRNG_MIS_IRQ_HEALTH_FAIL_CLR             ((uint32_t)0x00000000U)         /* !< IRQ_CAPTURED_READY did not request
+                                                                                    an interrupt service routine */
+#define TRNG_MIS_IRQ_HEALTH_FAIL_SET             ((uint32_t)0x00000001U)         /* !< IRQ_CAPTURED_READY requests an
+                                                                                    interrupt service routine */
+/* TRNG_MIS[IRQ_CMD_DONE] Bits */
+#define TRNG_MIS_IRQ_CMD_DONE_OFS                (2)                             /* !< IRQ_CMD_DONE Offset */
+#define TRNG_MIS_IRQ_CMD_DONE_MASK               ((uint32_t)0x00000004U)         /* !< Masked interrupt source for
+                                                                                    IRQ_CMD_DONE. Indicates that the
+                                                                                    issued command/mode has completed. */
+#define TRNG_MIS_IRQ_CMD_DONE_CLR                ((uint32_t)0x00000000U)         /* !< IRQ_CAPTURED_READY did not request
+                                                                                    an interrupt service routine */
+#define TRNG_MIS_IRQ_CMD_DONE_SET                ((uint32_t)0x00000004U)         /* !< IRQ_CMD_DONE requests an interrupt
+                                                                                    service routine */
+/* TRNG_MIS[IRQ_CMD_FAIL] Bits */
+#define TRNG_MIS_IRQ_CMD_FAIL_OFS                (1)                             /* !< IRQ_CMD_FAIL Offset */
+#define TRNG_MIS_IRQ_CMD_FAIL_MASK               ((uint32_t)0x00000002U)         /* !< Masked interrupt source for
+                                                                                    IRQ_CMD_FAIL. Indicates that the just
+                                                                                    issued command/mode has been
+                                                                                    rejected. */
+#define TRNG_MIS_IRQ_CMD_FAIL_CLR                ((uint32_t)0x00000000U)         /* !< IRQ_CMD_FAIL did not request an
+                                                                                    interrupt service routine */
+#define TRNG_MIS_IRQ_CMD_FAIL_SET                ((uint32_t)0x00000002U)         /* !< IRQ_CMD_FAIL requests an interrupt
+                                                                                    service routine */
+
+/* TRNG_ISET Bits */
+/* TRNG_ISET[IRQ_CAPTURED_RDY] Bits */
+#define TRNG_ISET_IRQ_CAPTURED_RDY_OFS           (3)                             /* !< IRQ_CAPTURED_RDY Offset */
+#define TRNG_ISET_IRQ_CAPTURED_RDY_MASK          ((uint32_t)0x00000008U)         /* !< Indicates to the CPU that the
+                                                                                    Captured Word is ready to be read.
+                                                                                    Reading the IIDX or DATA_CAPTURE
+                                                                                    registers will clear this interrupt. */
+#define TRNG_ISET_IRQ_CAPTURED_RDY_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define TRNG_ISET_IRQ_CAPTURED_RDY_SET           ((uint32_t)0x00000008U)         /* !< RIS bit corresponding to
+                                                                                    CAPTURED_READY is set */
+/* TRNG_ISET[IRQ_HEALTH_FAIL] Bits */
+#define TRNG_ISET_IRQ_HEALTH_FAIL_OFS            (0)                             /* !< IRQ_HEALTH_FAIL Offset */
+#define TRNG_ISET_IRQ_HEALTH_FAIL_MASK           ((uint32_t)0x00000001U)         /* !< Indicates to the CPU that any of
+                                                                                    the health tests have failed. Reading
+                                                                                    the IIDX or DATA_CAPTURE registers
+                                                                                    will clear this interrupt. */
+#define TRNG_ISET_IRQ_HEALTH_FAIL_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define TRNG_ISET_IRQ_HEALTH_FAIL_SET            ((uint32_t)0x00000001U)         /* !< RIS bit corresponding to
+                                                                                    HEALTH_FAIL is set */
+/* TRNG_ISET[IRQ_CMD_DONE] Bits */
+#define TRNG_ISET_IRQ_CMD_DONE_OFS               (2)                             /* !< IRQ_CMD_DONE Offset */
+#define TRNG_ISET_IRQ_CMD_DONE_MASK              ((uint32_t)0x00000004U)         /* !< Write to turn on CMD_DONE IRQ.
+                                                                                    Indicates that the last issued TRNG
+                                                                                    command has finished. */
+#define TRNG_ISET_IRQ_CMD_DONE_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect. */
+#define TRNG_ISET_IRQ_CMD_DONE_SET               ((uint32_t)0x00000004U)         /* !< RIS bit corresponding to CMD_DONE
+                                                                                    is set */
+/* TRNG_ISET[IRQ_CMD_FAIL] Bits */
+#define TRNG_ISET_IRQ_CMD_FAIL_OFS               (1)                             /* !< IRQ_CMD_FAIL Offset */
+#define TRNG_ISET_IRQ_CMD_FAIL_MASK              ((uint32_t)0x00000002U)         /* !< Masked interrupt source for
+                                                                                    IRQ_CMD_FAIL. Indicates that the just
+                                                                                    issued command/mode has been
+                                                                                    rejected. */
+#define TRNG_ISET_IRQ_CMD_FAIL_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect. */
+#define TRNG_ISET_IRQ_CMD_FAIL_SET               ((uint32_t)0x00000002U)         /* !< RIS bit corresponding to CMD_FAIL
+                                                                                    is set */
+
+/* TRNG_ICLR Bits */
+/* TRNG_ICLR[IRQ_CAPTURED_RDY] Bits */
+#define TRNG_ICLR_IRQ_CAPTURED_RDY_OFS           (3)                             /* !< IRQ_CAPTURED_RDY Offset */
+#define TRNG_ICLR_IRQ_CAPTURED_RDY_MASK          ((uint32_t)0x00000008U)         /* !< Indicates to the CPU that the
+                                                                                    Captured Word is ready to be read.
+                                                                                    Reading the IIDX or DATA_CAPTURE
+                                                                                    registers will clear this interrupt. */
+#define TRNG_ICLR_IRQ_CAPTURED_RDY_NO_EFFECT     ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define TRNG_ICLR_IRQ_CAPTURED_RDY_CLR           ((uint32_t)0x00000008U)         /* !< RIS bit corresponding to
+                                                                                    CAPTURED_READY is cleared */
+/* TRNG_ICLR[IRQ_HEALTH_FAIL] Bits */
+#define TRNG_ICLR_IRQ_HEALTH_FAIL_OFS            (0)                             /* !< IRQ_HEALTH_FAIL Offset */
+#define TRNG_ICLR_IRQ_HEALTH_FAIL_MASK           ((uint32_t)0x00000001U)         /* !< Indicates to the CPU that any of
+                                                                                    the health tests have failed. Reading
+                                                                                    the IIDX or DATA_CAPTURE registers
+                                                                                    will clear this interrupt. */
+#define TRNG_ICLR_IRQ_HEALTH_FAIL_NO_EFFECT      ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define TRNG_ICLR_IRQ_HEALTH_FAIL_CLR            ((uint32_t)0x00000001U)         /* !< RIS bit corresponding to
+                                                                                    CAPTURED_READY is cleared */
+/* TRNG_ICLR[IRQ_CMD_DONE] Bits */
+#define TRNG_ICLR_IRQ_CMD_DONE_OFS               (2)                             /* !< IRQ_CMD_DONE Offset */
+#define TRNG_ICLR_IRQ_CMD_DONE_MASK              ((uint32_t)0x00000004U)         /* !< Write to turn off CMD_DONE IRQ.
+                                                                                    Indicates that the last issued TRNG
+                                                                                    command has finished. */
+#define TRNG_ICLR_IRQ_CMD_DONE_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect. */
+#define TRNG_ICLR_IRQ_CMD_DONE_CLR               ((uint32_t)0x00000004U)         /* !< RIS bit corresponding to CMD_DONE
+                                                                                    is cleared */
+/* TRNG_ICLR[IRQ_CMD_FAIL] Bits */
+#define TRNG_ICLR_IRQ_CMD_FAIL_OFS               (1)                             /* !< IRQ_CMD_FAIL Offset */
+#define TRNG_ICLR_IRQ_CMD_FAIL_MASK              ((uint32_t)0x00000002U)         /* !< Masked interrupt source for
+                                                                                    IRQ_CMD_FAIL. Indicates that the just
+                                                                                    issued command/mode has been
+                                                                                    rejected. */
+#define TRNG_ICLR_IRQ_CMD_FAIL_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect. */
+#define TRNG_ICLR_IRQ_CMD_FAIL_CLR               ((uint32_t)0x00000002U)         /* !< RIS bit corresponding to CMD_FAIL
+                                                                                    is cleared */
+
+/* TRNG_PWREN Bits */
+/* TRNG_PWREN[ENABLE] Bits */
+#define TRNG_PWREN_ENABLE_OFS                    (0)                             /* !< ENABLE Offset */
+#define TRNG_PWREN_ENABLE_MASK                   ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define TRNG_PWREN_ENABLE_DISABLE                ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define TRNG_PWREN_ENABLE_ENABLE                 ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* TRNG_PWREN[KEY] Bits */
+#define TRNG_PWREN_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define TRNG_PWREN_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define TRNG_PWREN_KEY_UNLOCK_W                  ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* TRNG_RSTCTL Bits */
+/* TRNG_RSTCTL[RESETSTKYCLR] Bits */
+#define TRNG_RSTCTL_RESETSTKYCLR_OFS             (1)                             /* !< RESETSTKYCLR Offset */
+#define TRNG_RSTCTL_RESETSTKYCLR_MASK            ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define TRNG_RSTCTL_RESETSTKYCLR_NOP             ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define TRNG_RSTCTL_RESETSTKYCLR_CLR             ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* TRNG_RSTCTL[RESETASSERT] Bits */
+#define TRNG_RSTCTL_RESETASSERT_OFS              (0)                             /* !< RESETASSERT Offset */
+#define TRNG_RSTCTL_RESETASSERT_MASK             ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define TRNG_RSTCTL_RESETASSERT_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define TRNG_RSTCTL_RESETASSERT_ASSERT           ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* TRNG_RSTCTL[KEY] Bits */
+#define TRNG_RSTCTL_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define TRNG_RSTCTL_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define TRNG_RSTCTL_KEY_UNLOCK_W                 ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* TRNG_GPRCM_STAT Bits */
+/* TRNG_GPRCM_STAT[RESETSTKY] Bits */
+#define TRNG_GPRCM_STAT_RESETSTKY_OFS            (16)                            /* !< RESETSTKY Offset */
+#define TRNG_GPRCM_STAT_RESETSTKY_MASK           ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define TRNG_GPRCM_STAT_RESETSTKY_NORES          ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define TRNG_GPRCM_STAT_RESETSTKY_RESET          ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* TRNG_DESC Bits */
+/* TRNG_DESC[MINREV] Bits */
+#define TRNG_DESC_MINREV_OFS                     (0)                             /* !< MINREV Offset */
+#define TRNG_DESC_MINREV_MASK                    ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+/* TRNG_DESC[MAJREV] Bits */
+#define TRNG_DESC_MAJREV_OFS                     (4)                             /* !< MAJREV Offset */
+#define TRNG_DESC_MAJREV_MASK                    ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+/* TRNG_DESC[INSTNUM] Bits */
+#define TRNG_DESC_INSTNUM_OFS                    (8)                             /* !< INSTNUM Offset */
+#define TRNG_DESC_INSTNUM_MASK                   ((uint32_t)0x00000F00U)         /* !< Instance Number within the device.
+                                                                                    This will be a parameter to the RTL
+                                                                                    for modules that can have multiple
+                                                                                    instances */
+/* TRNG_DESC[FEATUREVER] Bits */
+#define TRNG_DESC_FEATUREVER_OFS                 (12)                            /* !< FEATUREVER Offset */
+#define TRNG_DESC_FEATUREVER_MASK                ((uint32_t)0x0000F000U)         /* !< Feature Set for the module
+                                                                                    *instance* */
+/* TRNG_DESC[MODULEID] Bits */
+#define TRNG_DESC_MODULEID_OFS                   (16)                            /* !< MODULEID Offset */
+#define TRNG_DESC_MODULEID_MASK                  ((uint32_t)0xFFFF0000U)         /* !< Module Identifier - An internal TI
+                                                                                    page has been created to request
+                                                                                    unique module IDs */
+
+/* TRNG_CTL Bits */
+/* TRNG_CTL[DECIM_RATE] Bits */
+#define TRNG_CTL_DECIM_RATE_OFS                  (8)                             /* !< DECIM_RATE Offset */
+#define TRNG_CTL_DECIM_RATE_MASK                 ((uint32_t)0x00000700U)         /* !< Set decimation rate. Decimate by n
+                                                                                    0x0 = Decimation by 1 (no decimation)
+                                                                                    0x1 = Decimation by 2 (Skip every
+                                                                                    other sample)  0x7 = Decimation by 8
+                                                                                    (Take every 8th sample) */
+/* TRNG_CTL[PWRUP_CLKDIV] Bits */
+#define TRNG_CTL_PWRUP_CLKDIV_OFS                (16)                            /* !< PWRUP_CLKDIV Offset */
+#define TRNG_CTL_PWRUP_CLKDIV_MASK               ((uint32_t)0x00010000U)         /* !< When '1', the powerup sequence will
+                                                                                    take twice as long (i.e., clock
+                                                                                    frequency halved) */
+/* TRNG_CTL[PWRUP_PCHRG_CFG] Bits */
+#define TRNG_CTL_PWRUP_PCHRG_CFG_OFS             (17)                            /* !< PWRUP_PCHRG_CFG Offset */
+#define TRNG_CTL_PWRUP_PCHRG_CFG_MASK            ((uint32_t)0x00060000U)         /* !< Configure PCHARGE sequence length
+                                                                                    b00 = Disabled b01 = 20 us PCHARGE
+                                                                                    b10 = 30 us PCHARGE (default) b11 =
+                                                                                    40 us PCHARGE */
+/* TRNG_CTL[PWRUP_PSTART_CFG] Bits */
+#define TRNG_CTL_PWRUP_PSTART_CFG_OFS            (19)                            /* !< PWRUP_PSTART_CFG Offset */
+#define TRNG_CTL_PWRUP_PSTART_CFG_MASK           ((uint32_t)0x00180000U)         /* !< Configure pusle startup sequence
+                                                                                    length  b00 = Disabled b01 = rise at
+                                                                                    10us, fall at 50us b10 = rise at
+                                                                                    10us, fall at 70us (default) b11 =
+                                                                                    rise at 10us, fall at 90us */
+/* TRNG_CTL[CMD] Bits */
+#define TRNG_CTL_CMD_OFS                         (0)                             /* !< CMD Offset */
+#define TRNG_CTL_CMD_MASK                        ((uint32_t)0x00000003U)         /* !< Sets the TRNG mode through a
+                                                                                    command. The mode will not be updated
+                                                                                    until the previous command is done,
+                                                                                    as indicated by IRQ_CMD_DONE. 00 -->
+                                                                                    OFF 01 --> PWRUP_DIG 10 --> PWRUP_ANA
+                                                                                    11 --> NORM_FUNC */
+#define TRNG_CTL_CMD_PWR_OFF                     ((uint32_t)0x00000000U)         /* !< Turns the power off of the analog
+                                                                                    source and clocks the digital
+                                                                                    interface */
+#define TRNG_CTL_CMD_PWRUP_DIG                   ((uint32_t)0x00000001U)         /* !< Initiates the powerup test sequence
+                                                                                    for the digital components. This
+                                                                                    verifies that the digital components
+                                                                                    are properly working. IRQ_CMD_DONE
+                                                                                    indicates that the test is done. The
+                                                                                    results of this test are in bits 0:6
+                                                                                    in TEST_RESULTS register */
+#define TRNG_CTL_CMD_PWRUP_ANA                   ((uint32_t)0x00000002U)         /* !< Initiates the powerup test sequence
+                                                                                    for the analog TRNG. This verifies
+                                                                                    that the analog component is
+                                                                                    generating sequences with enough
+                                                                                    entropy. IRQ_CMD_DONE indicates that
+                                                                                    the test is done. The results of this
+                                                                                    test are in bit 7 in TEST_RESULTS
+                                                                                    register */
+#define TRNG_CTL_CMD_NORM_FUNC                   ((uint32_t)0x00000003U)         /* !< Normal operating mode for TRNG. All
+                                                                                    components are turned on. */
+
+/* TRNG_STAT Bits */
+/* TRNG_STAT[ADAP_FAIL] Bits */
+#define TRNG_STAT_ADAP_FAIL_OFS                  (0)                             /* !< ADAP_FAIL Offset */
+#define TRNG_STAT_ADAP_FAIL_MASK                 ((uint32_t)0x00000001U)         /* !< Indicates that the Adaptive
+                                                                                    Proportion Test (1,2,3, or 4-bit
+                                                                                    counters) failed by having too many
+                                                                                    or too few counted samples in the
+                                                                                    last 1024 bit window. */
+/* TRNG_STAT[ISSUED_CMD] Bits */
+#define TRNG_STAT_ISSUED_CMD_OFS                 (8)                             /* !< ISSUED_CMD Offset */
+#define TRNG_STAT_ISSUED_CMD_MASK                ((uint32_t)0x00000300U)         /* !< Indicates the last accepted command
+                                                                                    that is issued to the TRNG interface.
+                                                                                    Upon writing a valid command, this
+                                                                                    register will update and the command
+                                                                                    will be in progress until
+                                                                                    CMD_DONE_IRQ is set. CMD_DONE_IRQ
+                                                                                    indicates that the state is in
+                                                                                    PWROFF, NORM_FUNC, or ERROR. These
+                                                                                    states will accept new commands. 00
+                                                                                    --> OFF 01 --> PWRUP_DIG 10 -->
+                                                                                    PWRUP_ANA 11 --> NORM_FUNC */
+/* TRNG_STAT[FSM_STATE] Bits */
+#define TRNG_STAT_FSM_STATE_OFS                  (16)                            /* !< FSM_STATE Offset */
+#define TRNG_STAT_FSM_STATE_MASK                 ((uint32_t)0x000F0000U)         /* !< Current state of the front end FSM
+                                                                                    (behind a clock domain crossing). 2
+                                                                                    reads are REQUIRED as there is a
+                                                                                    chance of metastability when reading
+                                                                                    this States: 0000: OFF 0001: PWRUP_ES
+                                                                                    0011: NORM_FUNC 0111: TEST_DIG 1011:
+                                                                                    TEST_ANA 1010: ERROR 0010: PWRDOWN_ES */
+/* TRNG_STAT[REP_FAIL] Bits */
+#define TRNG_STAT_REP_FAIL_OFS                   (1)                             /* !< REP_FAIL Offset */
+#define TRNG_STAT_REP_FAIL_MASK                  ((uint32_t)0x00000002U)         /* !< Indicates that the repetition
+                                                                                    counter test caused the most recent
+                                                                                    failure. Thus, the health count
+                                                                                    numbers are most likely not for a
+                                                                                    complete 1024-bit window. */
+
+/* TRNG_DATA_CAPTURE Bits */
+/* TRNG_DATA_CAPTURE[BUFFER] Bits */
+#define TRNG_DATA_CAPTURE_BUFFER_OFS             (0)                             /* !< BUFFER Offset */
+#define TRNG_DATA_CAPTURE_BUFFER_MASK            ((uint32_t)0xFFFFFFFFU)         /* !< Captured Data from the Decimation
+                                                                                    Block */
+
+/* TRNG_TEST_RESULTS Bits */
+/* TRNG_TEST_RESULTS[DIG_TEST] Bits */
+#define TRNG_TEST_RESULTS_DIG_TEST_OFS           (0)                             /* !< DIG_TEST Offset */
+#define TRNG_TEST_RESULTS_DIG_TEST_MASK          ((uint32_t)0x000000FFU)         /* !< Bit 0 indicates if the first
+                                                                                    decimation rate test and health
+                                                                                    test(verifies conditioning,
+                                                                                    decimation, and captured buffer)
+                                                                                    fails and Bit 1 indicates if the
+                                                                                    second decimation test and health
+                                                                                    test fails Bit 0 - decim_test0 (decim
+                                                                                    = 0x0) Bit 1 - decim_test1 (decim =
+                                                                                    0x1) ... */
+/* TRNG_TEST_RESULTS[ANA_TEST] Bits */
+#define TRNG_TEST_RESULTS_ANA_TEST_OFS           (8)                             /* !< ANA_TEST Offset */
+#define TRNG_TEST_RESULTS_ANA_TEST_MASK          ((uint32_t)0x00000100U)         /* !< Runs through 4096 samples from an
+                                                                                    enabled entropy source and verifies
+                                                                                    that none of the health tests failed,
+                                                                                    indicating sufficient entropy was
+                                                                                    produced by the analog components */
+
+/* TRNG_CLKDIVIDE Bits */
+/* TRNG_CLKDIVIDE[RATIO] Bits */
+#define TRNG_CLKDIVIDE_RATIO_OFS                 (0)                             /* !< RATIO Offset */
+#define TRNG_CLKDIVIDE_RATIO_MASK                ((uint32_t)0x00000007U)         /* !< Selects divide ratio of module
+                                                                                    clock */
+#define TRNG_CLKDIVIDE_RATIO_DIV_BY_1            ((uint32_t)0x00000000U)         /* !< Do not divide clock source */
+#define TRNG_CLKDIVIDE_RATIO_DIV_BY_2            ((uint32_t)0x00000001U)         /* !< Divide clock source by 2 */
+#define TRNG_CLKDIVIDE_RATIO_DIV_BY_4            ((uint32_t)0x00000003U)         /* !< Divide clock source by 4 */
+#define TRNG_CLKDIVIDE_RATIO_DIV_BY_6            ((uint32_t)0x00000005U)         /* !< Divide clock source by 6 */
+#define TRNG_CLKDIVIDE_RATIO_DIV_BY_8            ((uint32_t)0x00000007U)         /* !< Divide clock source by 8 */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_trng__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_uart.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_uart.h
@@ -1,0 +1,1841 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_uart__include
+#define ti_devices_msp_peripherals_hw_uart__include
+
+/* Filename: hw_uart.h */
+/* Revised: 2023-05-01 11:26:08 */
+/* Revision: 04a99860157777ec8b82069fbacd72235a1fb09e */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* UART Registers
+******************************************************************************/
+#define UART_DMA_TRIG_TX_OFS                     ((uint32_t)0x00001080U)
+#define UART_DMA_TRIG_RX_OFS                     ((uint32_t)0x00001050U)
+#define UART_CPU_INT_OFS                         ((uint32_t)0x00001020U)
+#define UART_GPRCM_OFS                           ((uint32_t)0x00000800U)
+
+
+/** @addtogroup UART_DMA_TRIG_TX
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001080) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001088) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001090) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001098) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x000010A0) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x000010A8) Interrupt clear */
+} UART_DMA_TRIG_TX_Regs;
+
+/*@}*/ /* end of group UART_DMA_TRIG_TX */
+
+/** @addtogroup UART_DMA_TRIG_RX
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001050) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001058) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001060) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001068) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001070) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001078) Interrupt clear */
+} UART_DMA_TRIG_RX_Regs;
+
+/*@}*/ /* end of group UART_DMA_TRIG_RX */
+
+/** @addtogroup UART_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} UART_CPU_INT_Regs;
+
+/*@}*/ /* end of group UART_CPU_INT */
+
+/** @addtogroup UART_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00000808) Peripheral Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} UART_GPRCM_Regs;
+
+/*@}*/ /* end of group UART_GPRCM */
+
+/** @addtogroup UART
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  UART_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED1[506];
+  __IO uint32_t CLKDIV;                            /* !< (@ 0x00001000) Clock Divider */
+       uint32_t RESERVED2;
+  __IO uint32_t CLKSEL;                            /* !< (@ 0x00001008) Clock Select for Ultra Low Power peripherals */
+       uint32_t RESERVED3[3];
+  __IO uint32_t PDBGCTL;                           /* !< (@ 0x00001018) Peripheral Debug Control */
+       uint32_t RESERVED4;
+  UART_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED5;
+  UART_DMA_TRIG_RX_Regs  DMA_TRIG_RX;                       /* !< (@ 0x00001050) */
+       uint32_t RESERVED6;
+  UART_DMA_TRIG_TX_Regs  DMA_TRIG_TX;                       /* !< (@ 0x00001080) */
+       uint32_t RESERVED7[13];
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+  __IO uint32_t INTCTL;                            /* !< (@ 0x000010E4) Interrupt control register */
+       uint32_t RESERVED8[6];
+  __IO uint32_t CTL0;                              /* !< (@ 0x00001100) UART Control Register 0 */
+  __IO uint32_t LCRH;                              /* !< (@ 0x00001104) UART Line Control Register */
+  __I  uint32_t STAT;                              /* !< (@ 0x00001108) UART Status Register */
+  __IO uint32_t IFLS;                              /* !< (@ 0x0000110C) UART Interrupt FIFO Level Select Register */
+  __IO uint32_t IBRD;                              /* !< (@ 0x00001110) UART Integer Baud-Rate Divisor Register */
+  __IO uint32_t FBRD;                              /* !< (@ 0x00001114) UART Fractional Baud-Rate Divisor Register */
+  __IO uint32_t GFCTL;                             /* !< (@ 0x00001118) Glitch Filter Control */
+       uint32_t RESERVED9;
+  __IO uint32_t TXDATA;                            /* !< (@ 0x00001120) UART Transmit Data Register */
+  __I  uint32_t RXDATA;                            /* !< (@ 0x00001124) UART Receive Data Register */
+       uint32_t RESERVED10[2];
+  __IO uint32_t LINCNT;                            /* !< (@ 0x00001130) UART LIN Mode Counter Register */
+  __IO uint32_t LINCTL;                            /* !< (@ 0x00001134) UART LIN Mode Control Register */
+  __IO uint32_t LINC0;                             /* !< (@ 0x00001138) UART LIN Mode Capture 0 Register */
+  __IO uint32_t LINC1;                             /* !< (@ 0x0000113C) UART LIN Mode Capture 1 Register */
+  __IO uint32_t IRCTL;                             /* !< (@ 0x00001140) eUSCI_Ax IrDA Control Word Register */
+       uint32_t RESERVED11;
+  __IO uint32_t AMASK;                             /* !< (@ 0x00001148) Self Address Mask Register */
+  __IO uint32_t ADDR;                              /* !< (@ 0x0000114C) Self Address Register */
+       uint32_t RESERVED12[4];
+  __IO uint32_t CLKDIV2;                           /* !< (@ 0x00001160) Clock Divider */
+} UART_Regs;
+
+/*@}*/ /* end of group UART */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* UART Register Control Bits
+******************************************************************************/
+
+/* UART_DMA_TRIG_TX_IIDX Bits */
+/* UART_DMA_TRIG_TX_IIDX[STAT] Bits */
+#define UART_DMA_TRIG_TX_IIDX_STAT_OFS           (0)                             /* !< STAT Offset */
+#define UART_DMA_TRIG_TX_IIDX_STAT_MASK          ((uint32_t)0x000000FFU)         /* !< UART Module Interrupt Vector Value.
+                                                                                    This register provides the highes
+                                                                                    priority interrupt index. A read
+                                                                                    clears the corresponding interrupt
+                                                                                    flag in UARTRIS and UARTMISC. 15h-1Fh
+                                                                                    = Reserved */
+#define UART_DMA_TRIG_TX_IIDX_STAT_NO_INTR       ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define UART_DMA_TRIG_TX_IIDX_STAT_TXIFG         ((uint32_t)0x0000000CU)         /* !< UART transmit interrupt; Interrupt
+                                                                                    Flag: TX */
+
+/* UART_DMA_TRIG_TX_IMASK Bits */
+/* UART_DMA_TRIG_TX_IMASK[TXINT] Bits */
+#define UART_DMA_TRIG_TX_IMASK_TXINT_OFS         (11)                            /* !< TXINT Offset */
+#define UART_DMA_TRIG_TX_IMASK_TXINT_MASK        ((uint32_t)0x00000800U)         /* !< Enable UART Transmit Interrupt. */
+#define UART_DMA_TRIG_TX_IMASK_TXINT_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_DMA_TRIG_TX_IMASK_TXINT_SET         ((uint32_t)0x00000800U)         /* !< Set Interrupt Mask */
+
+/* UART_DMA_TRIG_TX_RIS Bits */
+/* UART_DMA_TRIG_TX_RIS[TXINT] Bits */
+#define UART_DMA_TRIG_TX_RIS_TXINT_OFS           (11)                            /* !< TXINT Offset */
+#define UART_DMA_TRIG_TX_RIS_TXINT_MASK          ((uint32_t)0x00000800U)         /* !< UART Transmit Interrupt. */
+#define UART_DMA_TRIG_TX_RIS_TXINT_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_DMA_TRIG_TX_RIS_TXINT_SET           ((uint32_t)0x00000800U)         /* !< Interrupt occured */
+
+/* UART_DMA_TRIG_TX_MIS Bits */
+/* UART_DMA_TRIG_TX_MIS[TXINT] Bits */
+#define UART_DMA_TRIG_TX_MIS_TXINT_OFS           (11)                            /* !< TXINT Offset */
+#define UART_DMA_TRIG_TX_MIS_TXINT_MASK          ((uint32_t)0x00000800U)         /* !< Masked UART Transmit Interrupt. */
+#define UART_DMA_TRIG_TX_MIS_TXINT_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_DMA_TRIG_TX_MIS_TXINT_SET           ((uint32_t)0x00000800U)         /* !< Interrupt occured */
+
+/* UART_DMA_TRIG_TX_ISET Bits */
+/* UART_DMA_TRIG_TX_ISET[TXINT] Bits */
+#define UART_DMA_TRIG_TX_ISET_TXINT_OFS          (11)                            /* !< TXINT Offset */
+#define UART_DMA_TRIG_TX_ISET_TXINT_MASK         ((uint32_t)0x00000800U)         /* !< Set UART Transmit Interrupt. */
+#define UART_DMA_TRIG_TX_ISET_TXINT_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_DMA_TRIG_TX_ISET_TXINT_SET          ((uint32_t)0x00000800U)         /* !< Set Interrupt */
+
+/* UART_DMA_TRIG_TX_ICLR Bits */
+/* UART_DMA_TRIG_TX_ICLR[TXINT] Bits */
+#define UART_DMA_TRIG_TX_ICLR_TXINT_OFS          (11)                            /* !< TXINT Offset */
+#define UART_DMA_TRIG_TX_ICLR_TXINT_MASK         ((uint32_t)0x00000800U)         /* !< Clear UART Transmit Interrupt. */
+#define UART_DMA_TRIG_TX_ICLR_TXINT_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_DMA_TRIG_TX_ICLR_TXINT_CLR          ((uint32_t)0x00000800U)         /* !< Clear Interrupt */
+
+/* UART_DMA_TRIG_RX_IIDX Bits */
+/* UART_DMA_TRIG_RX_IIDX[STAT] Bits */
+#define UART_DMA_TRIG_RX_IIDX_STAT_OFS           (0)                             /* !< STAT Offset */
+#define UART_DMA_TRIG_RX_IIDX_STAT_MASK          ((uint32_t)0x000000FFU)         /* !< UART Module Interrupt Vector Value.
+                                                                                    This register provides the highes
+                                                                                    priority interrupt index. A read
+                                                                                    clears the corresponding interrupt
+                                                                                    flag in UARTRIS and UARTMISC. 15h-1Fh
+                                                                                    = Reserved */
+#define UART_DMA_TRIG_RX_IIDX_STAT_NO_INTR       ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define UART_DMA_TRIG_RX_IIDX_STAT_RTFG          ((uint32_t)0x00000001U)         /* !< UART receive time-out interrupt;
+                                                                                    Interrupt Flag: RT; Interrupt
+                                                                                    Priority: Highest */
+#define UART_DMA_TRIG_RX_IIDX_STAT_RXIFG         ((uint32_t)0x0000000BU)         /* !< UART receive interrupt; Interrupt
+                                                                                    Flag: RX */
+
+/* UART_DMA_TRIG_RX_IMASK Bits */
+/* UART_DMA_TRIG_RX_IMASK[RTOUT] Bits */
+#define UART_DMA_TRIG_RX_IMASK_RTOUT_OFS         (0)                             /* !< RTOUT Offset */
+#define UART_DMA_TRIG_RX_IMASK_RTOUT_MASK        ((uint32_t)0x00000001U)         /* !< Enable UARTOUT Receive Time-Out
+                                                                                    Interrupt. */
+#define UART_DMA_TRIG_RX_IMASK_RTOUT_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_DMA_TRIG_RX_IMASK_RTOUT_SET         ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* UART_DMA_TRIG_RX_IMASK[RXINT] Bits */
+#define UART_DMA_TRIG_RX_IMASK_RXINT_OFS         (10)                            /* !< RXINT Offset */
+#define UART_DMA_TRIG_RX_IMASK_RXINT_MASK        ((uint32_t)0x00000400U)         /* !< Enable UART Receive Interrupt. */
+#define UART_DMA_TRIG_RX_IMASK_RXINT_CLR         ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_DMA_TRIG_RX_IMASK_RXINT_SET         ((uint32_t)0x00000400U)         /* !< Set Interrupt Mask */
+
+/* UART_DMA_TRIG_RX_RIS Bits */
+/* UART_DMA_TRIG_RX_RIS[RTOUT] Bits */
+#define UART_DMA_TRIG_RX_RIS_RTOUT_OFS           (0)                             /* !< RTOUT Offset */
+#define UART_DMA_TRIG_RX_RIS_RTOUT_MASK          ((uint32_t)0x00000001U)         /* !< UARTOUT Receive Time-Out Interrupt. */
+#define UART_DMA_TRIG_RX_RIS_RTOUT_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_DMA_TRIG_RX_RIS_RTOUT_SET           ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+/* UART_DMA_TRIG_RX_RIS[RXINT] Bits */
+#define UART_DMA_TRIG_RX_RIS_RXINT_OFS           (10)                            /* !< RXINT Offset */
+#define UART_DMA_TRIG_RX_RIS_RXINT_MASK          ((uint32_t)0x00000400U)         /* !< UART Receive Interrupt. */
+#define UART_DMA_TRIG_RX_RIS_RXINT_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_DMA_TRIG_RX_RIS_RXINT_SET           ((uint32_t)0x00000400U)         /* !< Interrupt occured */
+
+/* UART_DMA_TRIG_RX_MIS Bits */
+/* UART_DMA_TRIG_RX_MIS[RTOUT] Bits */
+#define UART_DMA_TRIG_RX_MIS_RTOUT_OFS           (0)                             /* !< RTOUT Offset */
+#define UART_DMA_TRIG_RX_MIS_RTOUT_MASK          ((uint32_t)0x00000001U)         /* !< Masked UARTOUT Receive Time-Out
+                                                                                    Interrupt. */
+#define UART_DMA_TRIG_RX_MIS_RTOUT_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_DMA_TRIG_RX_MIS_RTOUT_SET           ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+/* UART_DMA_TRIG_RX_MIS[RXINT] Bits */
+#define UART_DMA_TRIG_RX_MIS_RXINT_OFS           (10)                            /* !< RXINT Offset */
+#define UART_DMA_TRIG_RX_MIS_RXINT_MASK          ((uint32_t)0x00000400U)         /* !< Masked UART Receive Interrupt. */
+#define UART_DMA_TRIG_RX_MIS_RXINT_CLR           ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_DMA_TRIG_RX_MIS_RXINT_SET           ((uint32_t)0x00000400U)         /* !< Interrupt occured */
+
+/* UART_DMA_TRIG_RX_ISET Bits */
+/* UART_DMA_TRIG_RX_ISET[RTOUT] Bits */
+#define UART_DMA_TRIG_RX_ISET_RTOUT_OFS          (0)                             /* !< RTOUT Offset */
+#define UART_DMA_TRIG_RX_ISET_RTOUT_MASK         ((uint32_t)0x00000001U)         /* !< Set UARTOUT Receive Time-Out
+                                                                                    Interrupt. */
+#define UART_DMA_TRIG_RX_ISET_RTOUT_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_DMA_TRIG_RX_ISET_RTOUT_SET          ((uint32_t)0x00000001U)         /* !< Set Interrupt */
+/* UART_DMA_TRIG_RX_ISET[RXINT] Bits */
+#define UART_DMA_TRIG_RX_ISET_RXINT_OFS          (10)                            /* !< RXINT Offset */
+#define UART_DMA_TRIG_RX_ISET_RXINT_MASK         ((uint32_t)0x00000400U)         /* !< Set UART Receive Interrupt. */
+#define UART_DMA_TRIG_RX_ISET_RXINT_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_DMA_TRIG_RX_ISET_RXINT_SET          ((uint32_t)0x00000400U)         /* !< Set Interrupt */
+
+/* UART_DMA_TRIG_RX_ICLR Bits */
+/* UART_DMA_TRIG_RX_ICLR[RTOUT] Bits */
+#define UART_DMA_TRIG_RX_ICLR_RTOUT_OFS          (0)                             /* !< RTOUT Offset */
+#define UART_DMA_TRIG_RX_ICLR_RTOUT_MASK         ((uint32_t)0x00000001U)         /* !< Clear UARTOUT Receive Time-Out
+                                                                                    Interrupt. */
+#define UART_DMA_TRIG_RX_ICLR_RTOUT_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_DMA_TRIG_RX_ICLR_RTOUT_CLR          ((uint32_t)0x00000001U)         /* !< Clear Interrupt */
+/* UART_DMA_TRIG_RX_ICLR[RXINT] Bits */
+#define UART_DMA_TRIG_RX_ICLR_RXINT_OFS          (10)                            /* !< RXINT Offset */
+#define UART_DMA_TRIG_RX_ICLR_RXINT_MASK         ((uint32_t)0x00000400U)         /* !< Clear UART Receive Interrupt. */
+#define UART_DMA_TRIG_RX_ICLR_RXINT_NO_EFFECT    ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_DMA_TRIG_RX_ICLR_RXINT_CLR          ((uint32_t)0x00000400U)         /* !< Clear Interrupt */
+
+/* UART_CPU_INT_IIDX Bits */
+/* UART_CPU_INT_IIDX[STAT] Bits */
+#define UART_CPU_INT_IIDX_STAT_OFS               (0)                             /* !< STAT Offset */
+#define UART_CPU_INT_IIDX_STAT_MASK              ((uint32_t)0x000000FFU)         /* !< UART Module Interrupt Vector Value.
+                                                                                    This register provides the highes
+                                                                                    priority interrupt index. A read
+                                                                                    clears the corresponding interrupt
+                                                                                    flag in RIS and MIS registers.
+                                                                                    15h-1Fh = Reserved */
+#define UART_CPU_INT_IIDX_STAT_NO_INTR           ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define UART_CPU_INT_IIDX_STAT_RTFG              ((uint32_t)0x00000001U)         /* !< UART receive time-out interrupt;
+                                                                                    Interrupt Flag: RT; Interrupt
+                                                                                    Priority: Highest */
+#define UART_CPU_INT_IIDX_STAT_FEFG              ((uint32_t)0x00000002U)         /* !< UART framing error interrupt;
+                                                                                    Interrupt Flag: FE */
+#define UART_CPU_INT_IIDX_STAT_PEFG              ((uint32_t)0x00000003U)         /* !< UART parity error interrupt;
+                                                                                    Interrupt Flag: PE */
+#define UART_CPU_INT_IIDX_STAT_BEFG              ((uint32_t)0x00000004U)         /* !< UART break error interrupt;
+                                                                                    Interrupt Flag: BE */
+#define UART_CPU_INT_IIDX_STAT_OEFG              ((uint32_t)0x00000005U)         /* !< UART receive overrun error
+                                                                                    interrupt; Interrupt Flag: OE */
+#define UART_CPU_INT_IIDX_STAT_RXNE              ((uint32_t)0x00000006U)         /* !< Negative edge on UARTxRXD
+                                                                                    interrupt; Interrupt Flag: RXNE */
+#define UART_CPU_INT_IIDX_STAT_RXPE              ((uint32_t)0x00000007U)         /* !< Positive edge on UARTxRXD
+                                                                                    interrupt; Interrupt Flag: RXPE */
+#define UART_CPU_INT_IIDX_STAT_LINC0             ((uint32_t)0x00000008U)         /* !< LIN capture 0 / match interrupt;
+                                                                                    Interrupt Flag: LINC0 */
+#define UART_CPU_INT_IIDX_STAT_LINC1             ((uint32_t)0x00000009U)         /* !< LIN capture 1 interrupt; Interrupt
+                                                                                    Flag: LINC1 */
+#define UART_CPU_INT_IIDX_STAT_LINOVF            ((uint32_t)0x0000000AU)         /* !< LIN hardware counter overflow
+                                                                                    interrupt; Interrupt Flag: LINOVF */
+#define UART_CPU_INT_IIDX_STAT_RXIFG             ((uint32_t)0x0000000BU)         /* !< UART receive interrupt; Interrupt
+                                                                                    Flag: RX */
+#define UART_CPU_INT_IIDX_STAT_TXIFG             ((uint32_t)0x0000000CU)         /* !< UART transmit interrupt; Interrupt
+                                                                                    Flag: TX */
+#define UART_CPU_INT_IIDX_STAT_EOT               ((uint32_t)0x0000000DU)         /* !< UART end of transmission interrupt
+                                                                                    (transmit serializer empty);
+                                                                                    Interrupt Flag: EOT */
+#define UART_CPU_INT_IIDX_STAT_MODE_9B           ((uint32_t)0x0000000EU)         /* !< 9-bit mode address match interrupt;
+                                                                                    Interrupt Flag: MODE_9B */
+#define UART_CPU_INT_IIDX_STAT_CTS               ((uint32_t)0x0000000FU)         /* !< UART Clear to Send Modem interrupt;
+                                                                                    Interrupt Flag: CTS */
+#define UART_CPU_INT_IIDX_STAT_DMA_DONE_RX       ((uint32_t)0x00000010U)         /* !< DMA DONE on RX */
+#define UART_CPU_INT_IIDX_STAT_DMA_DONE_TX       ((uint32_t)0x00000011U)         /* !< DMA DONE on TX */
+#define UART_CPU_INT_IIDX_STAT_NERR_EVT          ((uint32_t)0x00000012U)         /* !< Noise Error Event */
+
+/* UART_CPU_INT_IMASK Bits */
+/* UART_CPU_INT_IMASK[FRMERR] Bits */
+#define UART_CPU_INT_IMASK_FRMERR_OFS            (1)                             /* !< FRMERR Offset */
+#define UART_CPU_INT_IMASK_FRMERR_MASK           ((uint32_t)0x00000002U)         /* !< Enable UART Framing Error
+                                                                                    Interrupt. */
+#define UART_CPU_INT_IMASK_FRMERR_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_FRMERR_SET            ((uint32_t)0x00000002U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[PARERR] Bits */
+#define UART_CPU_INT_IMASK_PARERR_OFS            (2)                             /* !< PARERR Offset */
+#define UART_CPU_INT_IMASK_PARERR_MASK           ((uint32_t)0x00000004U)         /* !< Enable UART Parity Error Interrupt. */
+#define UART_CPU_INT_IMASK_PARERR_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_PARERR_SET            ((uint32_t)0x00000004U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[BRKERR] Bits */
+#define UART_CPU_INT_IMASK_BRKERR_OFS            (3)                             /* !< BRKERR Offset */
+#define UART_CPU_INT_IMASK_BRKERR_MASK           ((uint32_t)0x00000008U)         /* !< Enable UART Break Error Interrupt. */
+#define UART_CPU_INT_IMASK_BRKERR_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_BRKERR_SET            ((uint32_t)0x00000008U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[OVRERR] Bits */
+#define UART_CPU_INT_IMASK_OVRERR_OFS            (4)                             /* !< OVRERR Offset */
+#define UART_CPU_INT_IMASK_OVRERR_MASK           ((uint32_t)0x00000010U)         /* !< Enable UART Receive Overrun Error
+                                                                                    Interrupt. */
+#define UART_CPU_INT_IMASK_OVRERR_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_OVRERR_SET            ((uint32_t)0x00000010U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[RXNE] Bits */
+#define UART_CPU_INT_IMASK_RXNE_OFS              (5)                             /* !< RXNE Offset */
+#define UART_CPU_INT_IMASK_RXNE_MASK             ((uint32_t)0x00000020U)         /* !< Enable Negative Edge on UARTxRXD
+                                                                                    Interrupt. */
+#define UART_CPU_INT_IMASK_RXNE_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_RXNE_SET              ((uint32_t)0x00000020U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[RXPE] Bits */
+#define UART_CPU_INT_IMASK_RXPE_OFS              (6)                             /* !< RXPE Offset */
+#define UART_CPU_INT_IMASK_RXPE_MASK             ((uint32_t)0x00000040U)         /* !< Enable Positive Edge on UARTxRXD
+                                                                                    Interrupt. */
+#define UART_CPU_INT_IMASK_RXPE_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_RXPE_SET              ((uint32_t)0x00000040U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[LINOVF] Bits */
+#define UART_CPU_INT_IMASK_LINOVF_OFS            (9)                             /* !< LINOVF Offset */
+#define UART_CPU_INT_IMASK_LINOVF_MASK           ((uint32_t)0x00000200U)         /* !< Enable LIN Hardware Counter
+                                                                                    Overflow Interrupt. */
+#define UART_CPU_INT_IMASK_LINOVF_CLR            ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_LINOVF_SET            ((uint32_t)0x00000200U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[RXINT] Bits */
+#define UART_CPU_INT_IMASK_RXINT_OFS             (10)                            /* !< RXINT Offset */
+#define UART_CPU_INT_IMASK_RXINT_MASK            ((uint32_t)0x00000400U)         /* !< Enable UART Receive Interrupt. */
+#define UART_CPU_INT_IMASK_RXINT_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_RXINT_SET             ((uint32_t)0x00000400U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[TXINT] Bits */
+#define UART_CPU_INT_IMASK_TXINT_OFS             (11)                            /* !< TXINT Offset */
+#define UART_CPU_INT_IMASK_TXINT_MASK            ((uint32_t)0x00000800U)         /* !< Enable UART Transmit Interrupt. */
+#define UART_CPU_INT_IMASK_TXINT_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_TXINT_SET             ((uint32_t)0x00000800U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[EOT] Bits */
+#define UART_CPU_INT_IMASK_EOT_OFS               (12)                            /* !< EOT Offset */
+#define UART_CPU_INT_IMASK_EOT_MASK              ((uint32_t)0x00001000U)         /* !< Enable UART End of Transmission
+                                                                                    Interrupt Indicates that the last bit
+                                                                                    of all transmitted data and flags has
+                                                                                    left the serializer and without any
+                                                                                    further Data in the TX Fifo or
+                                                                                    Buffer. */
+#define UART_CPU_INT_IMASK_EOT_CLR               ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_EOT_SET               ((uint32_t)0x00001000U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[ADDR_MATCH] Bits */
+#define UART_CPU_INT_IMASK_ADDR_MATCH_OFS        (13)                            /* !< ADDR_MATCH Offset */
+#define UART_CPU_INT_IMASK_ADDR_MATCH_MASK       ((uint32_t)0x00002000U)         /* !< Enable Address Match Interrupt. */
+#define UART_CPU_INT_IMASK_ADDR_MATCH_CLR        ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_ADDR_MATCH_SET        ((uint32_t)0x00002000U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[CTS] Bits */
+#define UART_CPU_INT_IMASK_CTS_OFS               (14)                            /* !< CTS Offset */
+#define UART_CPU_INT_IMASK_CTS_MASK              ((uint32_t)0x00004000U)         /* !< Enable UART Clear to Send Modem
+                                                                                    Interrupt. */
+#define UART_CPU_INT_IMASK_CTS_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define UART_CPU_INT_IMASK_CTS_SET               ((uint32_t)0x00004000U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[DMA_DONE_RX] Bits */
+#define UART_CPU_INT_IMASK_DMA_DONE_RX_OFS       (15)                            /* !< DMA_DONE_RX Offset */
+#define UART_CPU_INT_IMASK_DMA_DONE_RX_MASK      ((uint32_t)0x00008000U)         /* !< Enable DMA Done on RX Event Channel
+                                                                                    Interrupt */
+#define UART_CPU_INT_IMASK_DMA_DONE_RX_CLR       ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define UART_CPU_INT_IMASK_DMA_DONE_RX_SET       ((uint32_t)0x00008000U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[DMA_DONE_TX] Bits */
+#define UART_CPU_INT_IMASK_DMA_DONE_TX_OFS       (16)                            /* !< DMA_DONE_TX Offset */
+#define UART_CPU_INT_IMASK_DMA_DONE_TX_MASK      ((uint32_t)0x00010000U)         /* !< Enable DMA Done on TX Event Channel
+                                                                                    Interrupt */
+#define UART_CPU_INT_IMASK_DMA_DONE_TX_CLR       ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define UART_CPU_INT_IMASK_DMA_DONE_TX_SET       ((uint32_t)0x00010000U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[RTOUT] Bits */
+#define UART_CPU_INT_IMASK_RTOUT_OFS             (0)                             /* !< RTOUT Offset */
+#define UART_CPU_INT_IMASK_RTOUT_MASK            ((uint32_t)0x00000001U)         /* !< Enable UARTOUT Receive Time-Out
+                                                                                    Interrupt. */
+#define UART_CPU_INT_IMASK_RTOUT_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_RTOUT_SET             ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[LINC0] Bits */
+#define UART_CPU_INT_IMASK_LINC0_OFS             (7)                             /* !< LINC0 Offset */
+#define UART_CPU_INT_IMASK_LINC0_MASK            ((uint32_t)0x00000080U)         /* !< Enable LIN Capture 0 / Match
+                                                                                    Interrupt . */
+#define UART_CPU_INT_IMASK_LINC0_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_LINC0_SET             ((uint32_t)0x00000080U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[LINC1] Bits */
+#define UART_CPU_INT_IMASK_LINC1_OFS             (8)                             /* !< LINC1 Offset */
+#define UART_CPU_INT_IMASK_LINC1_MASK            ((uint32_t)0x00000100U)         /* !< Enable LIN Capture 1 Interrupt. */
+#define UART_CPU_INT_IMASK_LINC1_CLR             ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_LINC1_SET             ((uint32_t)0x00000100U)         /* !< Set Interrupt Mask */
+/* UART_CPU_INT_IMASK[NERR] Bits */
+#define UART_CPU_INT_IMASK_NERR_OFS              (17)                            /* !< NERR Offset */
+#define UART_CPU_INT_IMASK_NERR_MASK             ((uint32_t)0x00020000U)         /* !< Noise Error on triple voting.
+                                                                                    Asserted when the 3 samples of
+                                                                                    majority voting are not equal */
+#define UART_CPU_INT_IMASK_NERR_CLR              ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define UART_CPU_INT_IMASK_NERR_SET              ((uint32_t)0x00020000U)         /* !< Set Interrupt Mask */
+
+/* UART_CPU_INT_RIS Bits */
+/* UART_CPU_INT_RIS[RTOUT] Bits */
+#define UART_CPU_INT_RIS_RTOUT_OFS               (0)                             /* !< RTOUT Offset */
+#define UART_CPU_INT_RIS_RTOUT_MASK              ((uint32_t)0x00000001U)         /* !< UARTOUT Receive Time-Out Interrupt. */
+#define UART_CPU_INT_RIS_RTOUT_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_RTOUT_SET               ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[FRMERR] Bits */
+#define UART_CPU_INT_RIS_FRMERR_OFS              (1)                             /* !< FRMERR Offset */
+#define UART_CPU_INT_RIS_FRMERR_MASK             ((uint32_t)0x00000002U)         /* !< UART Framing Error Interrupt. */
+#define UART_CPU_INT_RIS_FRMERR_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_FRMERR_SET              ((uint32_t)0x00000002U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[PARERR] Bits */
+#define UART_CPU_INT_RIS_PARERR_OFS              (2)                             /* !< PARERR Offset */
+#define UART_CPU_INT_RIS_PARERR_MASK             ((uint32_t)0x00000004U)         /* !< UART Parity Error Interrupt. */
+#define UART_CPU_INT_RIS_PARERR_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_PARERR_SET              ((uint32_t)0x00000004U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[BRKERR] Bits */
+#define UART_CPU_INT_RIS_BRKERR_OFS              (3)                             /* !< BRKERR Offset */
+#define UART_CPU_INT_RIS_BRKERR_MASK             ((uint32_t)0x00000008U)         /* !< UART Break Error Interrupt. */
+#define UART_CPU_INT_RIS_BRKERR_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_BRKERR_SET              ((uint32_t)0x00000008U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[OVRERR] Bits */
+#define UART_CPU_INT_RIS_OVRERR_OFS              (4)                             /* !< OVRERR Offset */
+#define UART_CPU_INT_RIS_OVRERR_MASK             ((uint32_t)0x00000010U)         /* !< UART Receive Overrun Error
+                                                                                    Interrupt. */
+#define UART_CPU_INT_RIS_OVRERR_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_OVRERR_SET              ((uint32_t)0x00000010U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[RXNE] Bits */
+#define UART_CPU_INT_RIS_RXNE_OFS                (5)                             /* !< RXNE Offset */
+#define UART_CPU_INT_RIS_RXNE_MASK               ((uint32_t)0x00000020U)         /* !< Negative Edge on UARTxRXD
+                                                                                    Interrupt. */
+#define UART_CPU_INT_RIS_RXNE_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_RXNE_SET                ((uint32_t)0x00000020U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[RXPE] Bits */
+#define UART_CPU_INT_RIS_RXPE_OFS                (6)                             /* !< RXPE Offset */
+#define UART_CPU_INT_RIS_RXPE_MASK               ((uint32_t)0x00000040U)         /* !< Positive Edge on UARTxRXD
+                                                                                    Interrupt. */
+#define UART_CPU_INT_RIS_RXPE_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_RXPE_SET                ((uint32_t)0x00000040U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[LINC0] Bits */
+#define UART_CPU_INT_RIS_LINC0_OFS               (7)                             /* !< LINC0 Offset */
+#define UART_CPU_INT_RIS_LINC0_MASK              ((uint32_t)0x00000080U)         /* !< LIN Capture 0 / Match Interrupt . */
+#define UART_CPU_INT_RIS_LINC0_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_LINC0_SET               ((uint32_t)0x00000080U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[LINC1] Bits */
+#define UART_CPU_INT_RIS_LINC1_OFS               (8)                             /* !< LINC1 Offset */
+#define UART_CPU_INT_RIS_LINC1_MASK              ((uint32_t)0x00000100U)         /* !< LIN Capture 1 Interrupt. */
+#define UART_CPU_INT_RIS_LINC1_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_LINC1_SET               ((uint32_t)0x00000100U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[LINOVF] Bits */
+#define UART_CPU_INT_RIS_LINOVF_OFS              (9)                             /* !< LINOVF Offset */
+#define UART_CPU_INT_RIS_LINOVF_MASK             ((uint32_t)0x00000200U)         /* !< LIN Hardware Counter Overflow
+                                                                                    Interrupt. */
+#define UART_CPU_INT_RIS_LINOVF_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_LINOVF_SET              ((uint32_t)0x00000200U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[RXINT] Bits */
+#define UART_CPU_INT_RIS_RXINT_OFS               (10)                            /* !< RXINT Offset */
+#define UART_CPU_INT_RIS_RXINT_MASK              ((uint32_t)0x00000400U)         /* !< UART Receive Interrupt. */
+#define UART_CPU_INT_RIS_RXINT_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_RXINT_SET               ((uint32_t)0x00000400U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[TXINT] Bits */
+#define UART_CPU_INT_RIS_TXINT_OFS               (11)                            /* !< TXINT Offset */
+#define UART_CPU_INT_RIS_TXINT_MASK              ((uint32_t)0x00000800U)         /* !< UART Transmit Interrupt. */
+#define UART_CPU_INT_RIS_TXINT_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_TXINT_SET               ((uint32_t)0x00000800U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[EOT] Bits */
+#define UART_CPU_INT_RIS_EOT_OFS                 (12)                            /* !< EOT Offset */
+#define UART_CPU_INT_RIS_EOT_MASK                ((uint32_t)0x00001000U)         /* !< UART End of Transmission Interrupt
+                                                                                    Indicates that the last bit of all
+                                                                                    transmitted data and flags has left
+                                                                                    the serializer and without any
+                                                                                    further Data in the TX Fifo or
+                                                                                    Buffer. */
+#define UART_CPU_INT_RIS_EOT_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_EOT_SET                 ((uint32_t)0x00001000U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[ADDR_MATCH] Bits */
+#define UART_CPU_INT_RIS_ADDR_MATCH_OFS          (13)                            /* !< ADDR_MATCH Offset */
+#define UART_CPU_INT_RIS_ADDR_MATCH_MASK         ((uint32_t)0x00002000U)         /* !< Address Match Interrupt. */
+#define UART_CPU_INT_RIS_ADDR_MATCH_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_ADDR_MATCH_SET          ((uint32_t)0x00002000U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[CTS] Bits */
+#define UART_CPU_INT_RIS_CTS_OFS                 (14)                            /* !< CTS Offset */
+#define UART_CPU_INT_RIS_CTS_MASK                ((uint32_t)0x00004000U)         /* !< UART Clear to Send Modem Interrupt. */
+#define UART_CPU_INT_RIS_CTS_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define UART_CPU_INT_RIS_CTS_SET                 ((uint32_t)0x00004000U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[DMA_DONE_RX] Bits */
+#define UART_CPU_INT_RIS_DMA_DONE_RX_OFS         (15)                            /* !< DMA_DONE_RX Offset */
+#define UART_CPU_INT_RIS_DMA_DONE_RX_MASK        ((uint32_t)0x00008000U)         /* !< DMA Done on RX Event Channel
+                                                                                    Interrupt */
+#define UART_CPU_INT_RIS_DMA_DONE_RX_CLR         ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define UART_CPU_INT_RIS_DMA_DONE_RX_SET         ((uint32_t)0x00008000U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[DMA_DONE_TX] Bits */
+#define UART_CPU_INT_RIS_DMA_DONE_TX_OFS         (16)                            /* !< DMA_DONE_TX Offset */
+#define UART_CPU_INT_RIS_DMA_DONE_TX_MASK        ((uint32_t)0x00010000U)         /* !< DMA Done on TX Event Channel
+                                                                                    Interrupt */
+#define UART_CPU_INT_RIS_DMA_DONE_TX_CLR         ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define UART_CPU_INT_RIS_DMA_DONE_TX_SET         ((uint32_t)0x00010000U)         /* !< Interrupt occured */
+/* UART_CPU_INT_RIS[NERR] Bits */
+#define UART_CPU_INT_RIS_NERR_OFS                (17)                            /* !< NERR Offset */
+#define UART_CPU_INT_RIS_NERR_MASK               ((uint32_t)0x00020000U)         /* !< Noise Error on triple voting.
+                                                                                    Asserted when the 3 samples of
+                                                                                    majority voting are not equal */
+#define UART_CPU_INT_RIS_NERR_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_RIS_NERR_SET                ((uint32_t)0x00020000U)         /* !< Interrupt occured */
+
+/* UART_CPU_INT_MIS Bits */
+/* UART_CPU_INT_MIS[RTOUT] Bits */
+#define UART_CPU_INT_MIS_RTOUT_OFS               (0)                             /* !< RTOUT Offset */
+#define UART_CPU_INT_MIS_RTOUT_MASK              ((uint32_t)0x00000001U)         /* !< Masked UARTOUT Receive Time-Out
+                                                                                    Interrupt. */
+#define UART_CPU_INT_MIS_RTOUT_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_RTOUT_SET               ((uint32_t)0x00000001U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[FRMERR] Bits */
+#define UART_CPU_INT_MIS_FRMERR_OFS              (1)                             /* !< FRMERR Offset */
+#define UART_CPU_INT_MIS_FRMERR_MASK             ((uint32_t)0x00000002U)         /* !< Masked UART Framing Error
+                                                                                    Interrupt. */
+#define UART_CPU_INT_MIS_FRMERR_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_FRMERR_SET              ((uint32_t)0x00000002U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[PARERR] Bits */
+#define UART_CPU_INT_MIS_PARERR_OFS              (2)                             /* !< PARERR Offset */
+#define UART_CPU_INT_MIS_PARERR_MASK             ((uint32_t)0x00000004U)         /* !< Masked UART Parity Error Interrupt. */
+#define UART_CPU_INT_MIS_PARERR_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_PARERR_SET              ((uint32_t)0x00000004U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[BRKERR] Bits */
+#define UART_CPU_INT_MIS_BRKERR_OFS              (3)                             /* !< BRKERR Offset */
+#define UART_CPU_INT_MIS_BRKERR_MASK             ((uint32_t)0x00000008U)         /* !< Masked UART Break Error Interrupt. */
+#define UART_CPU_INT_MIS_BRKERR_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_BRKERR_SET              ((uint32_t)0x00000008U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[OVRERR] Bits */
+#define UART_CPU_INT_MIS_OVRERR_OFS              (4)                             /* !< OVRERR Offset */
+#define UART_CPU_INT_MIS_OVRERR_MASK             ((uint32_t)0x00000010U)         /* !< Masked UART Receive Overrun Error
+                                                                                    Interrupt. */
+#define UART_CPU_INT_MIS_OVRERR_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_OVRERR_SET              ((uint32_t)0x00000010U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[RXNE] Bits */
+#define UART_CPU_INT_MIS_RXNE_OFS                (5)                             /* !< RXNE Offset */
+#define UART_CPU_INT_MIS_RXNE_MASK               ((uint32_t)0x00000020U)         /* !< Masked Negative Edge on UARTxRXD
+                                                                                    Interrupt. */
+#define UART_CPU_INT_MIS_RXNE_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_RXNE_SET                ((uint32_t)0x00000020U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[RXPE] Bits */
+#define UART_CPU_INT_MIS_RXPE_OFS                (6)                             /* !< RXPE Offset */
+#define UART_CPU_INT_MIS_RXPE_MASK               ((uint32_t)0x00000040U)         /* !< Masked Positive Edge on UARTxRXD
+                                                                                    Interrupt. */
+#define UART_CPU_INT_MIS_RXPE_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_RXPE_SET                ((uint32_t)0x00000040U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[LINC0] Bits */
+#define UART_CPU_INT_MIS_LINC0_OFS               (7)                             /* !< LINC0 Offset */
+#define UART_CPU_INT_MIS_LINC0_MASK              ((uint32_t)0x00000080U)         /* !< Masked LIN Capture 0 / Match
+                                                                                    Interrupt . */
+#define UART_CPU_INT_MIS_LINC0_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_LINC0_SET               ((uint32_t)0x00000080U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[LINC1] Bits */
+#define UART_CPU_INT_MIS_LINC1_OFS               (8)                             /* !< LINC1 Offset */
+#define UART_CPU_INT_MIS_LINC1_MASK              ((uint32_t)0x00000100U)         /* !< Masked LIN Capture 1 Interrupt. */
+#define UART_CPU_INT_MIS_LINC1_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_LINC1_SET               ((uint32_t)0x00000100U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[LINOVF] Bits */
+#define UART_CPU_INT_MIS_LINOVF_OFS              (9)                             /* !< LINOVF Offset */
+#define UART_CPU_INT_MIS_LINOVF_MASK             ((uint32_t)0x00000200U)         /* !< Masked LIN Hardware Counter
+                                                                                    Overflow Interrupt. */
+#define UART_CPU_INT_MIS_LINOVF_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_LINOVF_SET              ((uint32_t)0x00000200U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[RXINT] Bits */
+#define UART_CPU_INT_MIS_RXINT_OFS               (10)                            /* !< RXINT Offset */
+#define UART_CPU_INT_MIS_RXINT_MASK              ((uint32_t)0x00000400U)         /* !< Masked UART Receive Interrupt. */
+#define UART_CPU_INT_MIS_RXINT_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_RXINT_SET               ((uint32_t)0x00000400U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[TXINT] Bits */
+#define UART_CPU_INT_MIS_TXINT_OFS               (11)                            /* !< TXINT Offset */
+#define UART_CPU_INT_MIS_TXINT_MASK              ((uint32_t)0x00000800U)         /* !< Masked UART Transmit Interrupt. */
+#define UART_CPU_INT_MIS_TXINT_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_TXINT_SET               ((uint32_t)0x00000800U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[EOT] Bits */
+#define UART_CPU_INT_MIS_EOT_OFS                 (12)                            /* !< EOT Offset */
+#define UART_CPU_INT_MIS_EOT_MASK                ((uint32_t)0x00001000U)         /* !< UART End of Transmission Interrupt
+                                                                                    Indicates that the last bit of all
+                                                                                    transmitted data and flags has left
+                                                                                    the serializer and without any
+                                                                                    further Data in the TX Fifo or
+                                                                                    Buffer. */
+#define UART_CPU_INT_MIS_EOT_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_EOT_SET                 ((uint32_t)0x00001000U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[ADDR_MATCH] Bits */
+#define UART_CPU_INT_MIS_ADDR_MATCH_OFS          (13)                            /* !< ADDR_MATCH Offset */
+#define UART_CPU_INT_MIS_ADDR_MATCH_MASK         ((uint32_t)0x00002000U)         /* !< Masked Address Match Interrupt. */
+#define UART_CPU_INT_MIS_ADDR_MATCH_CLR          ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_ADDR_MATCH_SET          ((uint32_t)0x00002000U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[CTS] Bits */
+#define UART_CPU_INT_MIS_CTS_OFS                 (14)                            /* !< CTS Offset */
+#define UART_CPU_INT_MIS_CTS_MASK                ((uint32_t)0x00004000U)         /* !< Masked UART Clear to Send Modem
+                                                                                    Interrupt. */
+#define UART_CPU_INT_MIS_CTS_CLR                 ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_CTS_SET                 ((uint32_t)0x00004000U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[DMA_DONE_RX] Bits */
+#define UART_CPU_INT_MIS_DMA_DONE_RX_OFS         (15)                            /* !< DMA_DONE_RX Offset */
+#define UART_CPU_INT_MIS_DMA_DONE_RX_MASK        ((uint32_t)0x00008000U)         /* !< Masked DMA Done on RX Event Channel
+                                                                                    Interrupt */
+#define UART_CPU_INT_MIS_DMA_DONE_RX_CLR         ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_DMA_DONE_RX_SET         ((uint32_t)0x00008000U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[DMA_DONE_TX] Bits */
+#define UART_CPU_INT_MIS_DMA_DONE_TX_OFS         (16)                            /* !< DMA_DONE_TX Offset */
+#define UART_CPU_INT_MIS_DMA_DONE_TX_MASK        ((uint32_t)0x00010000U)         /* !< Masked DMA Done on TX Event Channel
+                                                                                    Interrupt */
+#define UART_CPU_INT_MIS_DMA_DONE_TX_CLR         ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_DMA_DONE_TX_SET         ((uint32_t)0x00010000U)         /* !< Interrupt occured */
+/* UART_CPU_INT_MIS[NERR] Bits */
+#define UART_CPU_INT_MIS_NERR_OFS                (17)                            /* !< NERR Offset */
+#define UART_CPU_INT_MIS_NERR_MASK               ((uint32_t)0x00020000U)         /* !< Noise Error on triple voting.
+                                                                                    Asserted when the 3 samples of
+                                                                                    majority voting are not equal */
+#define UART_CPU_INT_MIS_NERR_CLR                ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define UART_CPU_INT_MIS_NERR_SET                ((uint32_t)0x00020000U)         /* !< Interrupt occured */
+
+/* UART_CPU_INT_ISET Bits */
+/* UART_CPU_INT_ISET[FRMERR] Bits */
+#define UART_CPU_INT_ISET_FRMERR_OFS             (1)                             /* !< FRMERR Offset */
+#define UART_CPU_INT_ISET_FRMERR_MASK            ((uint32_t)0x00000002U)         /* !< Set UART Framing Error Interrupt. */
+#define UART_CPU_INT_ISET_FRMERR_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_FRMERR_SET             ((uint32_t)0x00000002U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[PARERR] Bits */
+#define UART_CPU_INT_ISET_PARERR_OFS             (2)                             /* !< PARERR Offset */
+#define UART_CPU_INT_ISET_PARERR_MASK            ((uint32_t)0x00000004U)         /* !< Set UART Parity Error Interrupt. */
+#define UART_CPU_INT_ISET_PARERR_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_PARERR_SET             ((uint32_t)0x00000004U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[BRKERR] Bits */
+#define UART_CPU_INT_ISET_BRKERR_OFS             (3)                             /* !< BRKERR Offset */
+#define UART_CPU_INT_ISET_BRKERR_MASK            ((uint32_t)0x00000008U)         /* !< Set UART Break Error Interrupt. */
+#define UART_CPU_INT_ISET_BRKERR_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_BRKERR_SET             ((uint32_t)0x00000008U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[OVRERR] Bits */
+#define UART_CPU_INT_ISET_OVRERR_OFS             (4)                             /* !< OVRERR Offset */
+#define UART_CPU_INT_ISET_OVRERR_MASK            ((uint32_t)0x00000010U)         /* !< Set  UART Receive Overrun Error
+                                                                                    Interrupt. */
+#define UART_CPU_INT_ISET_OVRERR_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_OVRERR_SET             ((uint32_t)0x00000010U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[RXNE] Bits */
+#define UART_CPU_INT_ISET_RXNE_OFS               (5)                             /* !< RXNE Offset */
+#define UART_CPU_INT_ISET_RXNE_MASK              ((uint32_t)0x00000020U)         /* !< Set Negative Edge on UARTxRXD
+                                                                                    Interrupt. */
+#define UART_CPU_INT_ISET_RXNE_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_RXNE_SET               ((uint32_t)0x00000020U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[RXPE] Bits */
+#define UART_CPU_INT_ISET_RXPE_OFS               (6)                             /* !< RXPE Offset */
+#define UART_CPU_INT_ISET_RXPE_MASK              ((uint32_t)0x00000040U)         /* !< Set Positive Edge on UARTxRXD
+                                                                                    Interrupt. */
+#define UART_CPU_INT_ISET_RXPE_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_RXPE_SET               ((uint32_t)0x00000040U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[LINC0] Bits */
+#define UART_CPU_INT_ISET_LINC0_OFS              (7)                             /* !< LINC0 Offset */
+#define UART_CPU_INT_ISET_LINC0_MASK             ((uint32_t)0x00000080U)         /* !< Set LIN Capture 0 / Match Interrupt
+                                                                                    . */
+#define UART_CPU_INT_ISET_LINC0_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_LINC0_SET              ((uint32_t)0x00000080U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[LINC1] Bits */
+#define UART_CPU_INT_ISET_LINC1_OFS              (8)                             /* !< LINC1 Offset */
+#define UART_CPU_INT_ISET_LINC1_MASK             ((uint32_t)0x00000100U)         /* !< Set LIN Capture 1 Interrupt. */
+#define UART_CPU_INT_ISET_LINC1_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_LINC1_SET              ((uint32_t)0x00000100U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[LINOVF] Bits */
+#define UART_CPU_INT_ISET_LINOVF_OFS             (9)                             /* !< LINOVF Offset */
+#define UART_CPU_INT_ISET_LINOVF_MASK            ((uint32_t)0x00000200U)         /* !< Set LIN Hardware Counter Overflow
+                                                                                    Interrupt. */
+#define UART_CPU_INT_ISET_LINOVF_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_LINOVF_SET             ((uint32_t)0x00000200U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[RXINT] Bits */
+#define UART_CPU_INT_ISET_RXINT_OFS              (10)                            /* !< RXINT Offset */
+#define UART_CPU_INT_ISET_RXINT_MASK             ((uint32_t)0x00000400U)         /* !< Set UART Receive Interrupt. */
+#define UART_CPU_INT_ISET_RXINT_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_RXINT_SET              ((uint32_t)0x00000400U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[TXINT] Bits */
+#define UART_CPU_INT_ISET_TXINT_OFS              (11)                            /* !< TXINT Offset */
+#define UART_CPU_INT_ISET_TXINT_MASK             ((uint32_t)0x00000800U)         /* !< Set UART Transmit Interrupt. */
+#define UART_CPU_INT_ISET_TXINT_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_TXINT_SET              ((uint32_t)0x00000800U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[EOT] Bits */
+#define UART_CPU_INT_ISET_EOT_OFS                (12)                            /* !< EOT Offset */
+#define UART_CPU_INT_ISET_EOT_MASK               ((uint32_t)0x00001000U)         /* !< Set UART End of Transmission
+                                                                                    Interrupt Indicates that the last bit
+                                                                                    of all transmitted data and flags has
+                                                                                    left the serializer and without any
+                                                                                    further Data in the TX Fifo or
+                                                                                    Buffer. */
+#define UART_CPU_INT_ISET_EOT_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_EOT_SET                ((uint32_t)0x00001000U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[ADDR_MATCH] Bits */
+#define UART_CPU_INT_ISET_ADDR_MATCH_OFS         (13)                            /* !< ADDR_MATCH Offset */
+#define UART_CPU_INT_ISET_ADDR_MATCH_MASK        ((uint32_t)0x00002000U)         /* !< Set Address Match Interrupt. */
+#define UART_CPU_INT_ISET_ADDR_MATCH_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_ADDR_MATCH_SET         ((uint32_t)0x00002000U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[CTS] Bits */
+#define UART_CPU_INT_ISET_CTS_OFS                (14)                            /* !< CTS Offset */
+#define UART_CPU_INT_ISET_CTS_MASK               ((uint32_t)0x00004000U)         /* !< Set UART Clear to Send Modem
+                                                                                    Interrupt. */
+#define UART_CPU_INT_ISET_CTS_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_CTS_SET                ((uint32_t)0x00004000U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[DMA_DONE_RX] Bits */
+#define UART_CPU_INT_ISET_DMA_DONE_RX_OFS        (15)                            /* !< DMA_DONE_RX Offset */
+#define UART_CPU_INT_ISET_DMA_DONE_RX_MASK       ((uint32_t)0x00008000U)         /* !< Set DMA Done on RX Event Channel
+                                                                                    Interrupt */
+#define UART_CPU_INT_ISET_DMA_DONE_RX_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define UART_CPU_INT_ISET_DMA_DONE_RX_SET        ((uint32_t)0x00008000U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[DMA_DONE_TX] Bits */
+#define UART_CPU_INT_ISET_DMA_DONE_TX_OFS        (16)                            /* !< DMA_DONE_TX Offset */
+#define UART_CPU_INT_ISET_DMA_DONE_TX_MASK       ((uint32_t)0x00010000U)         /* !< Set DMA Done on TX Event Channel
+                                                                                    Interrupt */
+#define UART_CPU_INT_ISET_DMA_DONE_TX_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define UART_CPU_INT_ISET_DMA_DONE_TX_SET        ((uint32_t)0x00010000U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[RTOUT] Bits */
+#define UART_CPU_INT_ISET_RTOUT_OFS              (0)                             /* !< RTOUT Offset */
+#define UART_CPU_INT_ISET_RTOUT_MASK             ((uint32_t)0x00000001U)         /* !< Set UARTOUT Receive Time-Out
+                                                                                    Interrupt. */
+#define UART_CPU_INT_ISET_RTOUT_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ISET_RTOUT_SET              ((uint32_t)0x00000001U)         /* !< Set Interrupt */
+/* UART_CPU_INT_ISET[NERR] Bits */
+#define UART_CPU_INT_ISET_NERR_OFS               (17)                            /* !< NERR Offset */
+#define UART_CPU_INT_ISET_NERR_MASK              ((uint32_t)0x00020000U)         /* !< Noise Error on triple voting.
+                                                                                    Asserted when the 3 samples of
+                                                                                    majority voting are not equal */
+#define UART_CPU_INT_ISET_NERR_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing this has no effect */
+#define UART_CPU_INT_ISET_NERR_SET               ((uint32_t)0x00020000U)         /* !< Set the interrupt */
+
+/* UART_CPU_INT_ICLR Bits */
+/* UART_CPU_INT_ICLR[FRMERR] Bits */
+#define UART_CPU_INT_ICLR_FRMERR_OFS             (1)                             /* !< FRMERR Offset */
+#define UART_CPU_INT_ICLR_FRMERR_MASK            ((uint32_t)0x00000002U)         /* !< Clear UART Framing Error Interrupt. */
+#define UART_CPU_INT_ICLR_FRMERR_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_FRMERR_CLR             ((uint32_t)0x00000002U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[PARERR] Bits */
+#define UART_CPU_INT_ICLR_PARERR_OFS             (2)                             /* !< PARERR Offset */
+#define UART_CPU_INT_ICLR_PARERR_MASK            ((uint32_t)0x00000004U)         /* !< Clear UART Parity Error Interrupt. */
+#define UART_CPU_INT_ICLR_PARERR_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_PARERR_CLR             ((uint32_t)0x00000004U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[BRKERR] Bits */
+#define UART_CPU_INT_ICLR_BRKERR_OFS             (3)                             /* !< BRKERR Offset */
+#define UART_CPU_INT_ICLR_BRKERR_MASK            ((uint32_t)0x00000008U)         /* !< Clear UART Break Error Interrupt. */
+#define UART_CPU_INT_ICLR_BRKERR_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_BRKERR_CLR             ((uint32_t)0x00000008U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[OVRERR] Bits */
+#define UART_CPU_INT_ICLR_OVRERR_OFS             (4)                             /* !< OVRERR Offset */
+#define UART_CPU_INT_ICLR_OVRERR_MASK            ((uint32_t)0x00000010U)         /* !< Clear UART Receive Overrun Error
+                                                                                    Interrupt. */
+#define UART_CPU_INT_ICLR_OVRERR_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_OVRERR_CLR             ((uint32_t)0x00000010U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[RXNE] Bits */
+#define UART_CPU_INT_ICLR_RXNE_OFS               (5)                             /* !< RXNE Offset */
+#define UART_CPU_INT_ICLR_RXNE_MASK              ((uint32_t)0x00000020U)         /* !< Clear Negative Edge on UARTxRXD
+                                                                                    Interrupt. */
+#define UART_CPU_INT_ICLR_RXNE_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_RXNE_CLR               ((uint32_t)0x00000020U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[RXPE] Bits */
+#define UART_CPU_INT_ICLR_RXPE_OFS               (6)                             /* !< RXPE Offset */
+#define UART_CPU_INT_ICLR_RXPE_MASK              ((uint32_t)0x00000040U)         /* !< Clear Positive Edge on UARTxRXD
+                                                                                    Interrupt. */
+#define UART_CPU_INT_ICLR_RXPE_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_RXPE_CLR               ((uint32_t)0x00000040U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[LINC0] Bits */
+#define UART_CPU_INT_ICLR_LINC0_OFS              (7)                             /* !< LINC0 Offset */
+#define UART_CPU_INT_ICLR_LINC0_MASK             ((uint32_t)0x00000080U)         /* !< Clear LIN Capture 0 / Match
+                                                                                    Interrupt . */
+#define UART_CPU_INT_ICLR_LINC0_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_LINC0_CLR              ((uint32_t)0x00000080U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[LINC1] Bits */
+#define UART_CPU_INT_ICLR_LINC1_OFS              (8)                             /* !< LINC1 Offset */
+#define UART_CPU_INT_ICLR_LINC1_MASK             ((uint32_t)0x00000100U)         /* !< Clear LIN Capture 1 Interrupt. */
+#define UART_CPU_INT_ICLR_LINC1_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_LINC1_CLR              ((uint32_t)0x00000100U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[LINOVF] Bits */
+#define UART_CPU_INT_ICLR_LINOVF_OFS             (9)                             /* !< LINOVF Offset */
+#define UART_CPU_INT_ICLR_LINOVF_MASK            ((uint32_t)0x00000200U)         /* !< Clear LIN Hardware Counter Overflow
+                                                                                    Interrupt. */
+#define UART_CPU_INT_ICLR_LINOVF_NO_EFFECT       ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_LINOVF_CLR             ((uint32_t)0x00000200U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[RXINT] Bits */
+#define UART_CPU_INT_ICLR_RXINT_OFS              (10)                            /* !< RXINT Offset */
+#define UART_CPU_INT_ICLR_RXINT_MASK             ((uint32_t)0x00000400U)         /* !< Clear UART Receive Interrupt. */
+#define UART_CPU_INT_ICLR_RXINT_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_RXINT_CLR              ((uint32_t)0x00000400U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[TXINT] Bits */
+#define UART_CPU_INT_ICLR_TXINT_OFS              (11)                            /* !< TXINT Offset */
+#define UART_CPU_INT_ICLR_TXINT_MASK             ((uint32_t)0x00000800U)         /* !< Clear UART Transmit Interrupt. */
+#define UART_CPU_INT_ICLR_TXINT_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_TXINT_CLR              ((uint32_t)0x00000800U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[EOT] Bits */
+#define UART_CPU_INT_ICLR_EOT_OFS                (12)                            /* !< EOT Offset */
+#define UART_CPU_INT_ICLR_EOT_MASK               ((uint32_t)0x00001000U)         /* !< Clear UART End of Transmission
+                                                                                    Interrupt Indicates that the last bit
+                                                                                    of all transmitted data and flags has
+                                                                                    left the serializer and without any
+                                                                                    further Data in the TX Fifo or
+                                                                                    Buffer. */
+#define UART_CPU_INT_ICLR_EOT_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_EOT_CLR                ((uint32_t)0x00001000U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[ADDR_MATCH] Bits */
+#define UART_CPU_INT_ICLR_ADDR_MATCH_OFS         (13)                            /* !< ADDR_MATCH Offset */
+#define UART_CPU_INT_ICLR_ADDR_MATCH_MASK        ((uint32_t)0x00002000U)         /* !< Clear Address Match Interrupt. */
+#define UART_CPU_INT_ICLR_ADDR_MATCH_NO_EFFECT   ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_ADDR_MATCH_CLR         ((uint32_t)0x00002000U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[CTS] Bits */
+#define UART_CPU_INT_ICLR_CTS_OFS                (14)                            /* !< CTS Offset */
+#define UART_CPU_INT_ICLR_CTS_MASK               ((uint32_t)0x00004000U)         /* !< Clear UART Clear to Send Modem
+                                                                                    Interrupt. */
+#define UART_CPU_INT_ICLR_CTS_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_CTS_CLR                ((uint32_t)0x00004000U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[DMA_DONE_RX] Bits */
+#define UART_CPU_INT_ICLR_DMA_DONE_RX_OFS        (15)                            /* !< DMA_DONE_RX Offset */
+#define UART_CPU_INT_ICLR_DMA_DONE_RX_MASK       ((uint32_t)0x00008000U)         /* !< Clear DMA Done on RX Event Channel
+                                                                                    Interrupt */
+#define UART_CPU_INT_ICLR_DMA_DONE_RX_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define UART_CPU_INT_ICLR_DMA_DONE_RX_CLR        ((uint32_t)0x00008000U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[DMA_DONE_TX] Bits */
+#define UART_CPU_INT_ICLR_DMA_DONE_TX_OFS        (16)                            /* !< DMA_DONE_TX Offset */
+#define UART_CPU_INT_ICLR_DMA_DONE_TX_MASK       ((uint32_t)0x00010000U)         /* !< Clear DMA Done on TX Event Channel
+                                                                                    Interrupt */
+#define UART_CPU_INT_ICLR_DMA_DONE_TX_NO_EFFECT  ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define UART_CPU_INT_ICLR_DMA_DONE_TX_CLR        ((uint32_t)0x00010000U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[RTOUT] Bits */
+#define UART_CPU_INT_ICLR_RTOUT_OFS              (0)                             /* !< RTOUT Offset */
+#define UART_CPU_INT_ICLR_RTOUT_MASK             ((uint32_t)0x00000001U)         /* !< Clear UARTOUT Receive Time-Out
+                                                                                    Interrupt. */
+#define UART_CPU_INT_ICLR_RTOUT_NO_EFFECT        ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_RTOUT_CLR              ((uint32_t)0x00000001U)         /* !< Clear Interrupt */
+/* UART_CPU_INT_ICLR[NERR] Bits */
+#define UART_CPU_INT_ICLR_NERR_OFS               (17)                            /* !< NERR Offset */
+#define UART_CPU_INT_ICLR_NERR_MASK              ((uint32_t)0x00020000U)         /* !< Noise Error on triple voting.
+                                                                                    Asserted when the 3 samples of
+                                                                                    majority voting are not equal */
+#define UART_CPU_INT_ICLR_NERR_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_CPU_INT_ICLR_NERR_CLR               ((uint32_t)0x00020000U)         /* !< Clear Interrupt */
+
+/* UART_PWREN Bits */
+/* UART_PWREN[ENABLE] Bits */
+#define UART_PWREN_ENABLE_OFS                    (0)                             /* !< ENABLE Offset */
+#define UART_PWREN_ENABLE_MASK                   ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define UART_PWREN_ENABLE_DISABLE                ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define UART_PWREN_ENABLE_ENABLE                 ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* UART_PWREN[KEY] Bits */
+#define UART_PWREN_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define UART_PWREN_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define UART_PWREN_KEY_UNLOCK_W                  ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* UART_RSTCTL Bits */
+/* UART_RSTCTL[RESETSTKYCLR] Bits */
+#define UART_RSTCTL_RESETSTKYCLR_OFS             (1)                             /* !< RESETSTKYCLR Offset */
+#define UART_RSTCTL_RESETSTKYCLR_MASK            ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define UART_RSTCTL_RESETSTKYCLR_NOP             ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_RSTCTL_RESETSTKYCLR_CLR             ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* UART_RSTCTL[RESETASSERT] Bits */
+#define UART_RSTCTL_RESETASSERT_OFS              (0)                             /* !< RESETASSERT Offset */
+#define UART_RSTCTL_RESETASSERT_MASK             ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define UART_RSTCTL_RESETASSERT_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define UART_RSTCTL_RESETASSERT_ASSERT           ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* UART_RSTCTL[KEY] Bits */
+#define UART_RSTCTL_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define UART_RSTCTL_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define UART_RSTCTL_KEY_UNLOCK_W                 ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* UART_CLKCFG Bits */
+/* UART_CLKCFG[KEY] Bits */
+#define UART_CLKCFG_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define UART_CLKCFG_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define UART_CLKCFG_KEY_UNLOCK                   ((uint32_t)0xA9000000U)
+/* UART_CLKCFG[BLOCKASYNC] Bits */
+#define UART_CLKCFG_BLOCKASYNC_OFS               (8)                             /* !< BLOCKASYNC Offset */
+#define UART_CLKCFG_BLOCKASYNC_MASK              ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define UART_CLKCFG_BLOCKASYNC_DISABLE           ((uint32_t)0x00000000U)
+#define UART_CLKCFG_BLOCKASYNC_ENABLE            ((uint32_t)0x00000100U)
+
+/* UART_GPRCM_STAT Bits */
+/* UART_GPRCM_STAT[RESETSTKY] Bits */
+#define UART_GPRCM_STAT_RESETSTKY_OFS            (16)                            /* !< RESETSTKY Offset */
+#define UART_GPRCM_STAT_RESETSTKY_MASK           ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define UART_GPRCM_STAT_RESETSTKY_NORES          ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define UART_GPRCM_STAT_RESETSTKY_RESET          ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* UART_CLKDIV Bits */
+/* UART_CLKDIV[RATIO] Bits */
+#define UART_CLKDIV_RATIO_OFS                    (0)                             /* !< RATIO Offset */
+#define UART_CLKDIV_RATIO_MASK                   ((uint32_t)0x00000007U)         /* !< Selects divide ratio of module
+                                                                                    clock */
+#define UART_CLKDIV_RATIO_DIV_BY_1               ((uint32_t)0x00000000U)         /* !< Do not divide clock source */
+#define UART_CLKDIV_RATIO_DIV_BY_2               ((uint32_t)0x00000001U)         /* !< Divide clock source by 2 */
+#define UART_CLKDIV_RATIO_DIV_BY_3               ((uint32_t)0x00000002U)         /* !< Divide clock source by 3 */
+#define UART_CLKDIV_RATIO_DIV_BY_4               ((uint32_t)0x00000003U)         /* !< Divide clock source by 4 */
+#define UART_CLKDIV_RATIO_DIV_BY_5               ((uint32_t)0x00000004U)         /* !< Divide clock source by 5 */
+#define UART_CLKDIV_RATIO_DIV_BY_6               ((uint32_t)0x00000005U)         /* !< Divide clock source by 6 */
+#define UART_CLKDIV_RATIO_DIV_BY_7               ((uint32_t)0x00000006U)         /* !< Divide clock source by 7 */
+#define UART_CLKDIV_RATIO_DIV_BY_8               ((uint32_t)0x00000007U)         /* !< Divide clock source by 8 */
+
+/* UART_CLKSEL Bits */
+/* UART_CLKSEL[MFCLK_SEL] Bits */
+#define UART_CLKSEL_MFCLK_SEL_OFS                (2)                             /* !< MFCLK_SEL Offset */
+#define UART_CLKSEL_MFCLK_SEL_MASK               ((uint32_t)0x00000004U)         /* !< Selects MFCLK as clock source if
+                                                                                    enabled */
+#define UART_CLKSEL_MFCLK_SEL_DISABLE            ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define UART_CLKSEL_MFCLK_SEL_ENABLE             ((uint32_t)0x00000004U)         /* !< Select this clock as a source */
+/* UART_CLKSEL[BUSCLK_SEL] Bits */
+#define UART_CLKSEL_BUSCLK_SEL_OFS               (3)                             /* !< BUSCLK_SEL Offset */
+#define UART_CLKSEL_BUSCLK_SEL_MASK              ((uint32_t)0x00000008U)         /* !< Selects BUS CLK as clock source if
+                                                                                    enabled */
+#define UART_CLKSEL_BUSCLK_SEL_DISABLE           ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define UART_CLKSEL_BUSCLK_SEL_ENABLE            ((uint32_t)0x00000008U)         /* !< Select this clock as a source */
+/* UART_CLKSEL[LFCLK_SEL] Bits */
+#define UART_CLKSEL_LFCLK_SEL_OFS                (1)                             /* !< LFCLK_SEL Offset */
+#define UART_CLKSEL_LFCLK_SEL_MASK               ((uint32_t)0x00000002U)         /* !< Selects LFCLK as clock source if
+                                                                                    enabled */
+#define UART_CLKSEL_LFCLK_SEL_DISABLE            ((uint32_t)0x00000000U)         /* !< Does not select this clock as a
+                                                                                    source */
+#define UART_CLKSEL_LFCLK_SEL_ENABLE             ((uint32_t)0x00000002U)         /* !< Select this clock as a source */
+
+/* UART_PDBGCTL Bits */
+/* UART_PDBGCTL[FREE] Bits */
+#define UART_PDBGCTL_FREE_OFS                    (0)                             /* !< FREE Offset */
+#define UART_PDBGCTL_FREE_MASK                   ((uint32_t)0x00000001U)         /* !< Free run control */
+#define UART_PDBGCTL_FREE_STOP                   ((uint32_t)0x00000000U)         /* !< The peripheral freezes
+                                                                                    functionality while the Core Halted
+                                                                                    input is asserted and resumes when it
+                                                                                    is deasserted. */
+#define UART_PDBGCTL_FREE_RUN                    ((uint32_t)0x00000001U)         /* !< The peripheral ignores the state of
+                                                                                    the Core Halted input */
+/* UART_PDBGCTL[SOFT] Bits */
+#define UART_PDBGCTL_SOFT_OFS                    (1)                             /* !< SOFT Offset */
+#define UART_PDBGCTL_SOFT_MASK                   ((uint32_t)0x00000002U)         /* !< Soft halt boundary control. This
+                                                                                    function is only available, if [FREE]
+                                                                                    is set to 'STOP' */
+#define UART_PDBGCTL_SOFT_IMMEDIATE              ((uint32_t)0x00000000U)         /* !< The peripheral will halt
+                                                                                    immediately, even if the resultant
+                                                                                    state will result in corruption if
+                                                                                    the system is restarted */
+#define UART_PDBGCTL_SOFT_DELAYED                ((uint32_t)0x00000002U)         /* !< The peripheral blocks the debug
+                                                                                    freeze until it has reached a
+                                                                                    boundary where it can resume without
+                                                                                    corruption */
+
+/* UART_EVT_MODE Bits */
+/* UART_EVT_MODE[INT0_CFG] Bits */
+#define UART_EVT_MODE_INT0_CFG_OFS               (0)                             /* !< INT0_CFG Offset */
+#define UART_EVT_MODE_INT0_CFG_MASK              ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT0] */
+#define UART_EVT_MODE_INT0_CFG_DISABLE           ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define UART_EVT_MODE_INT0_CFG_SOFTWARE          ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define UART_EVT_MODE_INT0_CFG_HARDWARE          ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* UART_EVT_MODE[INT1_CFG] Bits */
+#define UART_EVT_MODE_INT1_CFG_OFS               (2)                             /* !< INT1_CFG Offset */
+#define UART_EVT_MODE_INT1_CFG_MASK              ((uint32_t)0x0000000CU)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT1] */
+#define UART_EVT_MODE_INT1_CFG_DISABLE           ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define UART_EVT_MODE_INT1_CFG_SOFTWARE          ((uint32_t)0x00000004U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define UART_EVT_MODE_INT1_CFG_HARDWARE          ((uint32_t)0x00000008U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+/* UART_EVT_MODE[INT2_CFG] Bits */
+#define UART_EVT_MODE_INT2_CFG_OFS               (4)                             /* !< INT2_CFG Offset */
+#define UART_EVT_MODE_INT2_CFG_MASK              ((uint32_t)0x00000030U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.INT_EVENT2] */
+#define UART_EVT_MODE_INT2_CFG_DISABLE           ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define UART_EVT_MODE_INT2_CFG_SOFTWARE          ((uint32_t)0x00000010U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define UART_EVT_MODE_INT2_CFG_HARDWARE          ((uint32_t)0x00000020U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* UART_INTCTL Bits */
+/* UART_INTCTL[INTEVAL] Bits */
+#define UART_INTCTL_INTEVAL_OFS                  (0)                             /* !< INTEVAL Offset */
+#define UART_INTCTL_INTEVAL_MASK                 ((uint32_t)0x00000001U)         /* !< Writing a 1 to this field
+                                                                                    re-evaluates the interrupt sources. */
+#define UART_INTCTL_INTEVAL_DISABLE              ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define UART_INTCTL_INTEVAL_EVAL                 ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+
+/* UART_CTL0 Bits */
+/* UART_CTL0[ENABLE] Bits */
+#define UART_CTL0_ENABLE_OFS                     (0)                             /* !< ENABLE Offset */
+#define UART_CTL0_ENABLE_MASK                    ((uint32_t)0x00000001U)         /* !< UART Module Enable.  If the UART is
+                                                                                    disabled in the middle of
+                                                                                    transmission or reception, it
+                                                                                    completes the current character
+                                                                                    before stopping.  If the ENABLE bit
+                                                                                    is not set, all registers can still
+                                                                                    be accessed and updated. It is
+                                                                                    recommended to setup and change the
+                                                                                    UART operation mode with having the
+                                                                                    ENABLE bit cleared to avoid
+                                                                                    unpredictable behavior during the
+                                                                                    setup or update. If disabled the UART
+                                                                                    module will not send or receive any
+                                                                                    data and the logic is held in reset
+                                                                                    state. */
+#define UART_CTL0_ENABLE_DISABLE                 ((uint32_t)0x00000000U)         /* !< Disable Module */
+#define UART_CTL0_ENABLE_ENABLE                  ((uint32_t)0x00000001U)         /* !< Enable module */
+/* UART_CTL0[HSE] Bits */
+#define UART_CTL0_HSE_OFS                        (15)                            /* !< HSE Offset */
+#define UART_CTL0_HSE_MASK                       ((uint32_t)0x00018000U)         /* !< High-Speed Bit Oversampling Enable
+                                                                                    #b#NOTE:#/b# The bit oversampling
+                                                                                    influences the UART baud-rate
+                                                                                    configuration.  The state of this bit
+                                                                                    has no effect on clock generation in
+                                                                                    ISO7816 smart card mode (the SMART
+                                                                                    bit is set). */
+#define UART_CTL0_HSE_OVS16                      ((uint32_t)0x00000000U)         /* !< 16x oversampling. */
+#define UART_CTL0_HSE_OVS8                       ((uint32_t)0x00008000U)         /* !< 8x oversampling. */
+#define UART_CTL0_HSE_OVS3                       ((uint32_t)0x00010000U)         /* !< 3x oversampling. IrDA, Manchester
+                                                                                    and DALI not supported when 3x
+                                                                                    oversampling is enabled. */
+/* UART_CTL0[LBE] Bits */
+#define UART_CTL0_LBE_OFS                        (2)                             /* !< LBE Offset */
+#define UART_CTL0_LBE_MASK                       ((uint32_t)0x00000004U)         /* !< UART Loop Back Enable */
+#define UART_CTL0_LBE_DISABLE                    ((uint32_t)0x00000000U)         /* !< Normal operation. */
+#define UART_CTL0_LBE_ENABLE                     ((uint32_t)0x00000004U)         /* !< The UARTxTX path is fed through the
+                                                                                    UARTxRX path internally. */
+/* UART_CTL0[RXE] Bits */
+#define UART_CTL0_RXE_OFS                        (3)                             /* !< RXE Offset */
+#define UART_CTL0_RXE_MASK                       ((uint32_t)0x00000008U)         /* !< UART Receive Enable  If the UART is
+                                                                                    disabled in the middle of a receive,
+                                                                                    it completes the current character
+                                                                                    before stopping.   #b#NOTE:#/b# To
+                                                                                    enable reception, the UARTEN bit must
+                                                                                    be set. */
+#define UART_CTL0_RXE_DISABLE                    ((uint32_t)0x00000000U)         /* !< The receive section of the UART is
+                                                                                    disabled. */
+#define UART_CTL0_RXE_ENABLE                     ((uint32_t)0x00000008U)         /* !< The receive section of the UART is
+                                                                                    enabled. */
+/* UART_CTL0[TXE] Bits */
+#define UART_CTL0_TXE_OFS                        (4)                             /* !< TXE Offset */
+#define UART_CTL0_TXE_MASK                       ((uint32_t)0x00000010U)         /* !< UART Transmit Enable  If the UART
+                                                                                    is disabled in the middle of a
+                                                                                    transmission, it completes the
+                                                                                    current character before stopping.
+                                                                                    #b#NOTE:#/b# To enable transmission,
+                                                                                    the UARTEN bit must be set. */
+#define UART_CTL0_TXE_DISABLE                    ((uint32_t)0x00000000U)         /* !< The transmit section of the UART is
+                                                                                    disabled. The UARTxTXD pin of the
+                                                                                    UART can be controlled by the TXD_CTL
+                                                                                    bit when enabled. */
+#define UART_CTL0_TXE_ENABLE                     ((uint32_t)0x00000010U)         /* !< The transmit section of the UART is
+                                                                                    enabled. */
+/* UART_CTL0[RTS] Bits */
+#define UART_CTL0_RTS_OFS                        (12)                            /* !< RTS Offset */
+#define UART_CTL0_RTS_MASK                       ((uint32_t)0x00001000U)         /* !< Request to Send    If RTSEN is set
+                                                                                    the RTS output signals is controlled
+                                                                                    by the hardware logic using the FIFO
+                                                                                    fill level or TXDATA buffer.  If
+                                                                                    RTSEN is cleared the RTS output is
+                                                                                    controlled by the RTS bit. The bit is
+                                                                                    the complement of the UART request to
+                                                                                    send, RTS modem status output. */
+#define UART_CTL0_RTS_CLR                        ((uint32_t)0x00000000U)         /* !< Signal not RTS */
+#define UART_CTL0_RTS_SET                        ((uint32_t)0x00001000U)         /* !< Signal RTS */
+/* UART_CTL0[RTSEN] Bits */
+#define UART_CTL0_RTSEN_OFS                      (13)                            /* !< RTSEN Offset */
+#define UART_CTL0_RTSEN_MASK                     ((uint32_t)0x00002000U)         /* !< Enable hardware controlled Request
+                                                                                    to Send */
+#define UART_CTL0_RTSEN_DISABLE                  ((uint32_t)0x00000000U)         /* !< RTS hardware flow control is
+                                                                                    disabled. */
+#define UART_CTL0_RTSEN_ENABLE                   ((uint32_t)0x00002000U)         /* !< RTS hardware flow control is
+                                                                                    enabled. Data is only requested (by
+                                                                                    asserting UARTxRTS) when the receive
+                                                                                    FIFO has available entries. */
+/* UART_CTL0[CTSEN] Bits */
+#define UART_CTL0_CTSEN_OFS                      (14)                            /* !< CTSEN Offset */
+#define UART_CTL0_CTSEN_MASK                     ((uint32_t)0x00004000U)         /* !< Enable Clear To Send */
+#define UART_CTL0_CTSEN_DISABLE                  ((uint32_t)0x00000000U)         /* !< CTS hardware flow control is
+                                                                                    disabled. */
+#define UART_CTL0_CTSEN_ENABLE                   ((uint32_t)0x00004000U)         /* !< CTS hardware flow control is
+                                                                                    enabled. Data is only transmitted
+                                                                                    when the UARTxCTS signal is asserted. */
+/* UART_CTL0[MENC] Bits */
+#define UART_CTL0_MENC_OFS                       (7)                             /* !< MENC Offset */
+#define UART_CTL0_MENC_MASK                      ((uint32_t)0x00000080U)         /* !< Manchester Encode enable */
+#define UART_CTL0_MENC_DISABLE                   ((uint32_t)0x00000000U)         /* !< Disable Manchester Encoding */
+#define UART_CTL0_MENC_ENABLE                    ((uint32_t)0x00000080U)         /* !< Enable Manchester Encoding */
+/* UART_CTL0[MODE] Bits */
+#define UART_CTL0_MODE_OFS                       (8)                             /* !< MODE Offset */
+#define UART_CTL0_MODE_MASK                      ((uint32_t)0x00000700U)         /* !< Set the communication mode and
+                                                                                    protocol used. (Not defined settings
+                                                                                    uses the default setting: 0) */
+#define UART_CTL0_MODE_UART                      ((uint32_t)0x00000000U)         /* !< Normal operation */
+#define UART_CTL0_MODE_RS485                     ((uint32_t)0x00000100U)         /* !< RS485 mode: UART needs to be IDLE
+                                                                                    with receiving data for the in
+                                                                                    EXTDIR_HOLD set time. EXTDIR_SETUP
+                                                                                    defines the time the RTS line is set
+                                                                                    to high before sending. When the
+                                                                                    buffer is empty the RTS line is set
+                                                                                    low again. A transmit will be delayed
+                                                                                    as long the UART is receiving data. */
+#define UART_CTL0_MODE_IDLELINE                  ((uint32_t)0x00000200U)         /* !< The UART operates in IDLE Line Mode */
+#define UART_CTL0_MODE_ADDR9BIT                  ((uint32_t)0x00000300U)         /* !< The UART operates in 9 Bit Address
+                                                                                    mode */
+#define UART_CTL0_MODE_SMART                     ((uint32_t)0x00000400U)         /* !< ISO7816 Smart Card Support  The
+                                                                                    application must ensure that it sets
+                                                                                    8-bit word length (WLEN set to 3h)
+                                                                                    and even parity (PEN set to 1, EPS
+                                                                                    set to 1, SPS set to 0) in UARTLCRH
+                                                                                    when using ISO7816 mode. The value of
+                                                                                    the STP2 bit in UARTLCRH is ignored
+                                                                                    and the number of stop bits is forced
+                                                                                    to 2. */
+#define UART_CTL0_MODE_DALI                      ((uint32_t)0x00000500U)         /* !< DALI Mode: */
+/* UART_CTL0[FEN] Bits */
+#define UART_CTL0_FEN_OFS                        (17)                            /* !< FEN Offset */
+#define UART_CTL0_FEN_MASK                       ((uint32_t)0x00020000U)         /* !< UART Enable FIFOs */
+#define UART_CTL0_FEN_DISABLE                    ((uint32_t)0x00000000U)         /* !< The FIFOs are disabled (Character
+                                                                                    mode). The FIFOs become 1-byte-deep
+                                                                                    holding registers. */
+#define UART_CTL0_FEN_ENABLE                     ((uint32_t)0x00020000U)         /* !< The transmit and receive FIFO
+                                                                                    buffers are enabled (FIFO mode). */
+/* UART_CTL0[TXD_OUT] Bits */
+#define UART_CTL0_TXD_OUT_OFS                    (6)                             /* !< TXD_OUT Offset */
+#define UART_CTL0_TXD_OUT_MASK                   ((uint32_t)0x00000040U)         /* !< TXD Pin Control Controls the TXD
+                                                                                    pin when TXD_OUT_EN = 1 and TXE = 0. */
+#define UART_CTL0_TXD_OUT_LOW                    ((uint32_t)0x00000000U)         /* !< TXD pin is low */
+#define UART_CTL0_TXD_OUT_HIGH                   ((uint32_t)0x00000040U)         /* !< TXD pin is high */
+/* UART_CTL0[TXD_OUT_EN] Bits */
+#define UART_CTL0_TXD_OUT_EN_OFS                 (5)                             /* !< TXD_OUT_EN Offset */
+#define UART_CTL0_TXD_OUT_EN_MASK                ((uint32_t)0x00000020U)         /* !< TXD Pin Control Enable. When the
+                                                                                    transmit section of the UART is
+                                                                                    disabled (TXE = 0), the TXD pin can
+                                                                                    be controlled by the TXD_OUT bit. */
+#define UART_CTL0_TXD_OUT_EN_DISABLE             ((uint32_t)0x00000000U)         /* !< TXD pin can not be controlled by
+                                                                                    TXD_OUT */
+#define UART_CTL0_TXD_OUT_EN_ENABLE              ((uint32_t)0x00000020U)         /* !< TXD pin can be controlled by
+                                                                                    TXD_OUT */
+/* UART_CTL0[MAJVOTE] Bits */
+#define UART_CTL0_MAJVOTE_OFS                    (18)                            /* !< MAJVOTE Offset */
+#define UART_CTL0_MAJVOTE_MASK                   ((uint32_t)0x00040000U)         /* !< Majority Vote Enable   When
+                                                                                    Majority Voting is enabled, the three
+                                                                                    center bits are used to determine
+                                                                                    received sample value. In case of
+                                                                                    error (i.e. all 3 bits are not the
+                                                                                    same), noise error is detected and
+                                                                                    bits RIS.NERR and register
+                                                                                    RXDATA.NERR are set.
+                                                                                    Oversampling of 16 : bits 7, 8, 9 are
+                                                                                    used      Oversampling of 8 : bits 3,
+                                                                                    4, 5 are used Disabled : Single
+                                                                                    sample value (center value) used */
+#define UART_CTL0_MAJVOTE_DISABLE                ((uint32_t)0x00000000U)         /* !< Majority voting is disabled */
+#define UART_CTL0_MAJVOTE_ENABLE                 ((uint32_t)0x00040000U)         /* !< Majority voting is enabled */
+/* UART_CTL0[MSBFIRST] Bits */
+#define UART_CTL0_MSBFIRST_OFS                   (19)                            /* !< MSBFIRST Offset */
+#define UART_CTL0_MSBFIRST_MASK                  ((uint32_t)0x00080000U)         /* !< Most Significant Bit First This bit
+                                                                                    has effect both on the way protocol
+                                                                                    byte is transmitted and received.
+                                                                                    Notes: User needs to match the
+                                                                                    protocol to the correct value of this
+                                                                                    bit to send MSb or LSb first. The
+                                                                                    hardware engine will send the byte
+                                                                                    entirely based on this bit. */
+#define UART_CTL0_MSBFIRST_DISABLE               ((uint32_t)0x00000000U)         /* !< Least significant bit is sent first
+                                                                                    in the protocol packet */
+#define UART_CTL0_MSBFIRST_ENABLE                ((uint32_t)0x00080000U)         /* !< Most significant bit is sent first
+                                                                                    in the protocol packet */
+
+/* UART_LCRH Bits */
+/* UART_LCRH[BRK] Bits */
+#define UART_LCRH_BRK_OFS                        (0)                             /* !< BRK Offset */
+#define UART_LCRH_BRK_MASK                       ((uint32_t)0x00000001U)         /* !< UART Send Break (for LIN Protocol) */
+#define UART_LCRH_BRK_DISABLE                    ((uint32_t)0x00000000U)         /* !< Normal use. */
+#define UART_LCRH_BRK_ENABLE                     ((uint32_t)0x00000001U)         /* !< A low level is continually output
+                                                                                    on the UARTxTXD signal, after
+                                                                                    completing transmission of the
+                                                                                    current character. For the proper
+                                                                                    execution of the break command,
+                                                                                    software must set this bit for at
+                                                                                    least two frames (character periods). */
+/* UART_LCRH[PEN] Bits */
+#define UART_LCRH_PEN_OFS                        (1)                             /* !< PEN Offset */
+#define UART_LCRH_PEN_MASK                       ((uint32_t)0x00000002U)         /* !< UART Parity Enable */
+#define UART_LCRH_PEN_DISABLE                    ((uint32_t)0x00000000U)         /* !< Parity is disabled and no parity
+                                                                                    bit is added to the data frame. */
+#define UART_LCRH_PEN_ENABLE                     ((uint32_t)0x00000002U)         /* !< Parity checking and generation is
+                                                                                    enabled. */
+/* UART_LCRH[EPS] Bits */
+#define UART_LCRH_EPS_OFS                        (2)                             /* !< EPS Offset */
+#define UART_LCRH_EPS_MASK                       ((uint32_t)0x00000004U)         /* !< UART Even Parity Select  This bit
+                                                                                    has no effect when parity is disabled
+                                                                                    by the PEN bit.  For 9-Bit UART Mode
+                                                                                    transmissions, this bit controls the
+                                                                                    address byte and data byte indication
+                                                                                    (9th bit). 0 = The transferred byte
+                                                                                    is a data byte 1 = The transferred
+                                                                                    byte is an address byte */
+#define UART_LCRH_EPS_ODD                        ((uint32_t)0x00000000U)         /* !< Odd parity is performed, which
+                                                                                    checks for an odd number of 1s. */
+#define UART_LCRH_EPS_EVEN                       ((uint32_t)0x00000004U)         /* !< Even parity generation and checking
+                                                                                    is performed during transmission and
+                                                                                    reception, which checks for an even
+                                                                                    number of 1s in data and parity bits. */
+/* UART_LCRH[STP2] Bits */
+#define UART_LCRH_STP2_OFS                       (3)                             /* !< STP2 Offset */
+#define UART_LCRH_STP2_MASK                      ((uint32_t)0x00000008U)         /* !< UART Two Stop Bits Select     When
+                                                                                    in 7816 smart card mode (the SMART
+                                                                                    bit is set in the UARTCTL register),
+                                                                                    the number of stop bits is forced to
+                                                                                    2. */
+#define UART_LCRH_STP2_DISABLE                   ((uint32_t)0x00000000U)         /* !< One stop bit is transmitted at the
+                                                                                    end of a frame. */
+#define UART_LCRH_STP2_ENABLE                    ((uint32_t)0x00000008U)         /* !< Two stop bits are transmitted at
+                                                                                    the end of a frame. The receive logic
+                                                                                    checks for two stop bits being
+                                                                                    received and provide Frame Error if
+                                                                                    either is invalid. */
+/* UART_LCRH[WLEN] Bits */
+#define UART_LCRH_WLEN_OFS                       (4)                             /* !< WLEN Offset */
+#define UART_LCRH_WLEN_MASK                      ((uint32_t)0x00000030U)         /* !< UART Word Length  The bits indicate
+                                                                                    the number of data bits transmitted
+                                                                                    or received in a frame as follows: */
+#define UART_LCRH_WLEN_DATABIT5                  ((uint32_t)0x00000000U)         /* !< 5 bits (default) */
+#define UART_LCRH_WLEN_DATABIT6                  ((uint32_t)0x00000010U)         /* !< 6 bits */
+#define UART_LCRH_WLEN_DATABIT7                  ((uint32_t)0x00000020U)         /* !< 7 bits */
+#define UART_LCRH_WLEN_DATABIT8                  ((uint32_t)0x00000030U)         /* !< 8 bits */
+/* UART_LCRH[SPS] Bits */
+#define UART_LCRH_SPS_OFS                        (6)                             /* !< SPS Offset */
+#define UART_LCRH_SPS_MASK                       ((uint32_t)0x00000040U)         /* !< UART Stick Parity Select The Stick
+                                                                                    Parity Select (SPS) bit is used to
+                                                                                    set either a permanent '1' or a
+                                                                                    permanent '0' as parity when
+                                                                                    transmitting or receiving data. Its
+                                                                                    purpose is to typically indicate the
+                                                                                    first byte of a package or to mark an
+                                                                                    address byte, for example in a
+                                                                                    multi-drop RS-485 network.  When bits
+                                                                                    PEN, EPS, and SPS of UARTLCRH are
+                                                                                    set, the parity bit is transmitted
+                                                                                    and checked as a 0.  When bits PEN
+                                                                                    and SPS are set and EPS is cleared,
+                                                                                    the parity bit is transmitted and
+                                                                                    checked as a 1. */
+#define UART_LCRH_SPS_DISABLE                    ((uint32_t)0x00000000U)         /* !< Disable Stick Parity */
+#define UART_LCRH_SPS_ENABLE                     ((uint32_t)0x00000040U)         /* !< Enable Stick Parity */
+/* UART_LCRH[SENDIDLE] Bits */
+#define UART_LCRH_SENDIDLE_OFS                   (7)                             /* !< SENDIDLE Offset */
+#define UART_LCRH_SENDIDLE_MASK                  ((uint32_t)0x00000080U)         /* !< UART send IDLE pattern. When this
+                                                                                    bit is set an SENDIDLE period of 11
+                                                                                    bit times will be sent on the TX
+                                                                                    line. The bit is cleared by hardware
+                                                                                    afterwards. */
+#define UART_LCRH_SENDIDLE_DISABLE               ((uint32_t)0x00000000U)         /* !< Disable Send Idle Pattern */
+#define UART_LCRH_SENDIDLE_ENABLE                ((uint32_t)0x00000080U)         /* !< Enable Send Idle Pattern */
+/* UART_LCRH[EXTDIR_SETUP] Bits */
+#define UART_LCRH_EXTDIR_SETUP_OFS               (16)                            /* !< EXTDIR_SETUP Offset */
+#define UART_LCRH_EXTDIR_SETUP_MASK              ((uint32_t)0x001F0000U)         /* !< Defines the number of UARTclk ticks
+                                                                                    the signal to control the external
+                                                                                    driver for the RS485 will be set
+                                                                                    before the START bit is send */
+#define UART_LCRH_EXTDIR_SETUP_MINIMUM           ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define UART_LCRH_EXTDIR_SETUP_MAXIMUM           ((uint32_t)0x001F0000U)         /* !< Highest possible value */
+/* UART_LCRH[EXTDIR_HOLD] Bits */
+#define UART_LCRH_EXTDIR_HOLD_OFS                (21)                            /* !< EXTDIR_HOLD Offset */
+#define UART_LCRH_EXTDIR_HOLD_MASK               ((uint32_t)0x03E00000U)         /* !< Defines the number of UARTclk ticks
+                                                                                    the signal to control the external
+                                                                                    driver for the RS485 will be reset
+                                                                                    after the beginning of the stop bit.
+                                                                                    (If 2 STOP bits are enabled the
+                                                                                    beginning of the 2nd STOP bit.) */
+#define UART_LCRH_EXTDIR_HOLD_MINIMUM            ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define UART_LCRH_EXTDIR_HOLD_MAXIMUM            ((uint32_t)0x03E00000U)         /* !< Highest possible value */
+
+/* UART_STAT Bits */
+/* UART_STAT[BUSY] Bits */
+#define UART_STAT_BUSY_OFS                       (0)                             /* !< BUSY Offset */
+#define UART_STAT_BUSY_MASK                      ((uint32_t)0x00000001U)         /* !< UART Busy This bit is set as soon
+                                                                                    as the transmit FIFO or TXDATA
+                                                                                    register becomes non-empty
+                                                                                    (regardless of whether UART is
+                                                                                    enabled) or if a receive data is
+                                                                                    currently ongoing (after the start
+                                                                                    edge have been detected until a
+                                                                                    complete byte, including all stop
+                                                                                    bits, has been received by the shift
+                                                                                    register). In IDLE_Line mode the Busy
+                                                                                    signal also stays set during the idle
+                                                                                    time generation. */
+#define UART_STAT_BUSY_CLEARED                   ((uint32_t)0x00000000U)         /* !< The UART is not busy. */
+#define UART_STAT_BUSY_SET                       ((uint32_t)0x00000001U)         /* !< The UART is busy transmitting data.
+                                                                                    This bit remains set until the
+                                                                                    complete byte, including all stop
+                                                                                    bits, has been sent/received
+                                                                                    from/into the shift register. */
+/* UART_STAT[TXFF] Bits */
+#define UART_STAT_TXFF_OFS                       (7)                             /* !< TXFF Offset */
+#define UART_STAT_TXFF_MASK                      ((uint32_t)0x00000080U)         /* !< UART Transmit FIFO Full  The
+                                                                                    meaning of this bit depends on the
+                                                                                    state of the FEN bit in the CTL0
+                                                                                    register. */
+#define UART_STAT_TXFF_CLEARED                   ((uint32_t)0x00000000U)         /* !< The transmitter is not full. */
+#define UART_STAT_TXFF_SET                       ((uint32_t)0x00000080U)         /* !< If the FIFO is disabled (FEN is 0),
+                                                                                    the transmit holding register is
+                                                                                    full. If the FIFO is enabled (FEN is
+                                                                                    1), the transmit FIFO is full. */
+/* UART_STAT[RXFF] Bits */
+#define UART_STAT_RXFF_OFS                       (3)                             /* !< RXFF Offset */
+#define UART_STAT_RXFF_MASK                      ((uint32_t)0x00000008U)         /* !< UART Receive FIFO Full  The meaning
+                                                                                    of this bit depends on the state of
+                                                                                    the FEN bit in the CTL0 register. */
+#define UART_STAT_RXFF_CLEARED                   ((uint32_t)0x00000000U)         /* !< The receiver can receive data. */
+#define UART_STAT_RXFF_SET                       ((uint32_t)0x00000008U)         /* !< If the FIFO is disabled (FEN is 0),
+                                                                                    the receive holding register is full.
+                                                                                    If the FIFO is enabled (FEN is 1),
+                                                                                    the receive FIFO is full. */
+/* UART_STAT[TXFE] Bits */
+#define UART_STAT_TXFE_OFS                       (6)                             /* !< TXFE Offset */
+#define UART_STAT_TXFE_MASK                      ((uint32_t)0x00000040U)         /* !< UART Transmit FIFO Empty  The
+                                                                                    meaning of this bit depends on the
+                                                                                    state of the FEN bit in the CTL0
+                                                                                    register. */
+#define UART_STAT_TXFE_CLEARED                   ((uint32_t)0x00000000U)         /* !< The transmitter has data to
+                                                                                    transmit. */
+#define UART_STAT_TXFE_SET                       ((uint32_t)0x00000040U)         /* !< If the FIFO is disabled (FEN is 0),
+                                                                                    the transmit holding register is
+                                                                                    empty. If the FIFO is enabled (FEN is
+                                                                                    1), the transmit FIFO is empty. */
+/* UART_STAT[CTS] Bits */
+#define UART_STAT_CTS_OFS                        (8)                             /* !< CTS Offset */
+#define UART_STAT_CTS_MASK                       ((uint32_t)0x00000100U)         /* !< Clear To Send */
+#define UART_STAT_CTS_CLEARED                    ((uint32_t)0x00000000U)         /* !< The CTS signal is not asserted
+                                                                                    (high). */
+#define UART_STAT_CTS_SET                        ((uint32_t)0x00000100U)         /* !< The CTS signal is asserted (low). */
+/* UART_STAT[IDLE] Bits */
+#define UART_STAT_IDLE_OFS                       (9)                             /* !< IDLE Offset */
+#define UART_STAT_IDLE_MASK                      ((uint32_t)0x00000200U)         /* !< IDLE mode has been detected in
+                                                                                    Idleline-Multiprocessor-Mode. The
+                                                                                    IDLE bit is used as an address tag
+                                                                                    for each block of characters. In
+                                                                                    idle-line multiprocessor format, this
+                                                                                    bit is set when a received character
+                                                                                    is an address. */
+#define UART_STAT_IDLE_CLEARED                   ((uint32_t)0x00000000U)         /* !< IDLE has not been detected before
+                                                                                    last received character. (In
+                                                                                    idle-line multiprocessor mode). */
+#define UART_STAT_IDLE_SET                       ((uint32_t)0x00000200U)         /* !< IDLE has been detected before last
+                                                                                    received character. (In idle-line
+                                                                                    multiprocessor mode). */
+/* UART_STAT[RXFE] Bits */
+#define UART_STAT_RXFE_OFS                       (2)                             /* !< RXFE Offset */
+#define UART_STAT_RXFE_MASK                      ((uint32_t)0x00000004U)         /* !< UART Receive FIFO Empty  The
+                                                                                    meaning of this bit depends on the
+                                                                                    state of the FEN bit in the CTL0
+                                                                                    register. */
+#define UART_STAT_RXFE_CLEARED                   ((uint32_t)0x00000000U)         /* !< The receiver is not empty. */
+#define UART_STAT_RXFE_SET                       ((uint32_t)0x00000004U)         /* !< If the FIFO is disabled (FEN is 0),
+                                                                                    the receive holding register is
+                                                                                    empty. If the FIFO is enabled (FEN is
+                                                                                    1), the receive FIFO is empty. */
+
+/* UART_IFLS Bits */
+/* UART_IFLS[TXIFLSEL] Bits */
+#define UART_IFLS_TXIFLSEL_OFS                   (0)                             /* !< TXIFLSEL Offset */
+#define UART_IFLS_TXIFLSEL_MASK                  ((uint32_t)0x00000007U)         /* !< UART Transmit Interrupt FIFO Level
+                                                                                    Select  The trigger points for the
+                                                                                    transmit interrupt are as follows:
+                                                                                    Note: for undefined settings the
+                                                                                    default configuration is used. */
+#define UART_IFLS_TXIFLSEL_LVL_3_4               ((uint32_t)0x00000001U)         /* !< TX FIFO <= 3/4 empty */
+#define UART_IFLS_TXIFLSEL_LVL_1_2               ((uint32_t)0x00000002U)         /* !< TX FIFO <= 1/2 empty (default) */
+#define UART_IFLS_TXIFLSEL_LVL_1_4               ((uint32_t)0x00000003U)         /* !< TX FIFO <= 1/4 empty */
+#define UART_IFLS_TXIFLSEL_LVL_EMPTY             ((uint32_t)0x00000005U)         /* !< TX FIFO is empty */
+#define UART_IFLS_TXIFLSEL_LVL_1                 ((uint32_t)0x00000007U)         /* !< TX FIFO >= 1 entry free Note: esp.
+                                                                                    required for DMA Trigger */
+/* UART_IFLS[RXIFLSEL] Bits */
+#define UART_IFLS_RXIFLSEL_OFS                   (4)                             /* !< RXIFLSEL Offset */
+#define UART_IFLS_RXIFLSEL_MASK                  ((uint32_t)0x00000070U)         /* !< UART Receive Interrupt FIFO Level
+                                                                                    Select  The trigger points for the
+                                                                                    receive interrupt are as follows:
+                                                                                    Note:    In ULP domain the trigger
+                                                                                    levels are used for:   0: LVL_1_4
+                                                                                    4: LVL_FULL   For undefined settings
+                                                                                    the default configuration is used. */
+#define UART_IFLS_RXIFLSEL_LVL_1_4_RES           ((uint32_t)0x00000000U)         /* !< RX FIFO >= 1/4 full Note: For ULP
+                                                                                    Domain */
+#define UART_IFLS_RXIFLSEL_LVL_1_4               ((uint32_t)0x00000010U)         /* !< RX FIFO >= 1/4 full */
+#define UART_IFLS_RXIFLSEL_LVL_1_2               ((uint32_t)0x00000020U)         /* !< RX FIFO >= 1/2 full (default) */
+#define UART_IFLS_RXIFLSEL_LVL_3_4               ((uint32_t)0x00000030U)         /* !< RX FIFO >= 3/4 full */
+#define UART_IFLS_RXIFLSEL_LVL_FULL_RES          ((uint32_t)0x00000040U)         /* !< RX FIFO is full Note: For ULP
+                                                                                    Domain */
+#define UART_IFLS_RXIFLSEL_LVL_FULL              ((uint32_t)0x00000050U)         /* !< RX FIFO is full */
+#define UART_IFLS_RXIFLSEL_LVL_1                 ((uint32_t)0x00000070U)         /* !< RX FIFO >= 1 entry available Note:
+                                                                                    esp. required for DMA Trigger */
+/* UART_IFLS[RXTOSEL] Bits */
+#define UART_IFLS_RXTOSEL_OFS                    (8)                             /* !< RXTOSEL Offset */
+#define UART_IFLS_RXTOSEL_MASK                   ((uint32_t)0x00000F00U)         /* !< UART Receive Interrupt Timeout
+                                                                                    Select. When receiving no start edge
+                                                                                    for an additional character within
+                                                                                    the set bittimes a RX interrupt is
+                                                                                    set even if the FIFO level is not
+                                                                                    reached. A value of 0 disables this
+                                                                                    function. */
+#define UART_IFLS_RXTOSEL_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define UART_IFLS_RXTOSEL_MAXIMUM                ((uint32_t)0x00000F00U)         /* !< Highest possible value */
+
+/* UART_IBRD Bits */
+/* UART_IBRD[DIVINT] Bits */
+#define UART_IBRD_DIVINT_OFS                     (0)                             /* !< DIVINT Offset */
+#define UART_IBRD_DIVINT_MASK                    ((uint32_t)0x0000FFFFU)         /* !< Integer Baud-Rate Divisor */
+#define UART_IBRD_DIVINT_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define UART_IBRD_DIVINT_MAXIMUM                 ((uint32_t)0x0000FFFFU)         /* !< Highest possible value */
+
+/* UART_FBRD Bits */
+/* UART_FBRD[DIVFRAC] Bits */
+#define UART_FBRD_DIVFRAC_OFS                    (0)                             /* !< DIVFRAC Offset */
+#define UART_FBRD_DIVFRAC_MASK                   ((uint32_t)0x0000003FU)         /* !< Fractional Baud-Rate Divisor */
+#define UART_FBRD_DIVFRAC_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define UART_FBRD_DIVFRAC_MAXIMUM                ((uint32_t)0x0000003FU)         /* !< Highest possible value */
+
+/* UART_GFCTL Bits */
+/* UART_GFCTL[AGFSEL] Bits */
+#define UART_GFCTL_AGFSEL_OFS                    (9)                             /* !< AGFSEL Offset */
+#define UART_GFCTL_AGFSEL_MASK                   ((uint32_t)0x00000600U)         /* !< Analog Glitch Suppression Pulse
+                                                                                    Width This field controls the pulse
+                                                                                    width select for the analog glitch
+                                                                                    suppression on the RX line. See
+                                                                                    device datasheet for exact values. */
+#define UART_GFCTL_AGFSEL_AGLIT_5                ((uint32_t)0x00000000U)         /* !< Pulses shorter then 5ns length are
+                                                                                    filtered. */
+#define UART_GFCTL_AGFSEL_AGLIT_10               ((uint32_t)0x00000200U)         /* !< Pulses shorter then 10ns length are
+                                                                                    filtered. */
+#define UART_GFCTL_AGFSEL_AGLIT_25               ((uint32_t)0x00000400U)         /* !< Pulses shorter then 25ns length are
+                                                                                    filtered. */
+#define UART_GFCTL_AGFSEL_AGLIT_50               ((uint32_t)0x00000600U)         /* !< Pulses shorter then 50ns length are
+                                                                                    filtered. */
+/* UART_GFCTL[AGFEN] Bits */
+#define UART_GFCTL_AGFEN_OFS                     (8)                             /* !< AGFEN Offset */
+#define UART_GFCTL_AGFEN_MASK                    ((uint32_t)0x00000100U)         /* !< Analog Glitch Suppression Enable */
+#define UART_GFCTL_AGFEN_DISABLE                 ((uint32_t)0x00000000U)         /* !< Analog Glitch Filter disable */
+#define UART_GFCTL_AGFEN_ENABLE                  ((uint32_t)0x00000100U)         /* !< Analog Glitch Filter enable */
+/* UART_GFCTL[DGFSEL] Bits */
+#define UART_GFCTL_DGFSEL_OFS                    (0)                             /* !< DGFSEL Offset */
+#define UART_GFCTL_DGFSEL_MASK                   ((uint32_t)0x0000003FU)         /* !< Glitch Suppression Pulse Width
+                                                                                    This field controls the pulse width
+                                                                                    select for glitch suppression on the
+                                                                                    RX line.  The value programmed in
+                                                                                    this field gives the number of cycles
+                                                                                    of functional clock up to which the
+                                                                                    glitch has to be suppressed on the RX
+                                                                                    line.  In IRDA mode: The minimum
+                                                                                    pulse length for receive is given by:
+                                                                                    t(MIN) = (DGFSEL) / f(IRTXCLK) */
+#define UART_GFCTL_DGFSEL_DISABLED               ((uint32_t)0x00000000U)         /* !< Bypass GF */
+#define UART_GFCTL_DGFSEL_MAXIMUM                ((uint32_t)0x0000003FU)         /* !< Highest Possible Value */
+/* UART_GFCTL[CHAIN] Bits */
+#define UART_GFCTL_CHAIN_OFS                     (11)                            /* !< CHAIN Offset */
+#define UART_GFCTL_CHAIN_MASK                    ((uint32_t)0x00000800U)         /* !< Analog and digital noise filters
+                                                                                    chaining enable.         0 DISABLE:
+                                                                                    When 0, chaining is disabled and only
+                                                                                    digital filter output is available to
+                                                                                    IP logic for sampling         1
+                                                                                    ENABLE: When 1, analog and digital
+                                                                                    glitch filters are chained and the
+                                                                                    output of the combination is made
+                                                                                    available to IP logic for sampling */
+#define UART_GFCTL_CHAIN_DISABLED                ((uint32_t)0x00000000U)         /* !< Disabled */
+#define UART_GFCTL_CHAIN_ENABLED                 ((uint32_t)0x00000800U)         /* !< Enabled */
+
+/* UART_TXDATA Bits */
+/* UART_TXDATA[DATA] Bits */
+#define UART_TXDATA_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define UART_TXDATA_DATA_MASK                    ((uint32_t)0x000000FFU)         /* !< Data Transmitted or Received  Data
+                                                                                    that is to be transmitted via the
+                                                                                    UART is written to this field.  When
+                                                                                    read, this field contains the data
+                                                                                    that was received by the UART. */
+#define UART_TXDATA_DATA_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define UART_TXDATA_DATA_MAXIMUM                 ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+
+/* UART_RXDATA Bits */
+/* UART_RXDATA[DATA] Bits */
+#define UART_RXDATA_DATA_OFS                     (0)                             /* !< DATA Offset */
+#define UART_RXDATA_DATA_MASK                    ((uint32_t)0x000000FFU)         /* !< Received Data.  When read, this
+                                                                                    field contains the data that was
+                                                                                    received by the UART. */
+#define UART_RXDATA_DATA_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define UART_RXDATA_DATA_MAXIMUM                 ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+/* UART_RXDATA[FRMERR] Bits */
+#define UART_RXDATA_FRMERR_OFS                   (8)                             /* !< FRMERR Offset */
+#define UART_RXDATA_FRMERR_MASK                  ((uint32_t)0x00000100U)         /* !< UART Framing Error  Writing to this
+                                                                                    bit has no effect. The flag is
+                                                                                    cleared by writing 1 to the FRMERR
+                                                                                    bit in the UART EVENT ICLR register.
+                                                                                    This error is associated with the
+                                                                                    character at the top of the FIFO. */
+#define UART_RXDATA_FRMERR_CLR                   ((uint32_t)0x00000000U)         /* !< No framing error has occurred */
+#define UART_RXDATA_FRMERR_SET                   ((uint32_t)0x00000100U)         /* !< The received character does not
+                                                                                    have a valid stop bit sequence, which
+                                                                                    is one or two stop bits depending on
+                                                                                    the UARTLCRH.STP2 setting (a valid
+                                                                                    stop bit is 1). */
+/* UART_RXDATA[PARERR] Bits */
+#define UART_RXDATA_PARERR_OFS                   (9)                             /* !< PARERR Offset */
+#define UART_RXDATA_PARERR_MASK                  ((uint32_t)0x00000200U)         /* !< UART Parity Error   Writing to this
+                                                                                    bit has no effect. The flag is
+                                                                                    cleared by writing 1 to the PARERR
+                                                                                    bit in the UART EVENT ICLR register. */
+#define UART_RXDATA_PARERR_CLR                   ((uint32_t)0x00000000U)         /* !< No parity error has occurred */
+#define UART_RXDATA_PARERR_SET                   ((uint32_t)0x00000200U)         /* !< The parity of the received data
+                                                                                    character does not match the parity
+                                                                                    defined by bits 2 and 7 of the
+                                                                                    UARTLCRH register. */
+/* UART_RXDATA[BRKERR] Bits */
+#define UART_RXDATA_BRKERR_OFS                   (10)                            /* !< BRKERR Offset */
+#define UART_RXDATA_BRKERR_MASK                  ((uint32_t)0x00000400U)         /* !< UART Break Error  Writing to this
+                                                                                    bit has no effect. The flag is
+                                                                                    cleared by writing 1 to the BRKERR
+                                                                                    bit in the UART EVENT ICLR register.
+                                                                                    This error is associated with the
+                                                                                    character at the top of the FIFO.
+                                                                                    When a break occurs, only one 0
+                                                                                    character is loaded into the FIFO.
+                                                                                    The next character is only enabled
+                                                                                    after the receive data input goes to
+                                                                                    a 1 (marking state) and the next
+                                                                                    valid start bit is received. */
+#define UART_RXDATA_BRKERR_CLR                   ((uint32_t)0x00000000U)         /* !< No break condition has occurred */
+#define UART_RXDATA_BRKERR_SET                   ((uint32_t)0x00000400U)         /* !< A break condition has been
+                                                                                    detected, indicating that the receive
+                                                                                    data input was held low for longer
+                                                                                    than a full-word transmission time
+                                                                                    (defined as start, data, parity, and
+                                                                                    stop bits). */
+/* UART_RXDATA[OVRERR] Bits */
+#define UART_RXDATA_OVRERR_OFS                   (11)                            /* !< OVRERR Offset */
+#define UART_RXDATA_OVRERR_MASK                  ((uint32_t)0x00000800U)         /* !< UART Receive Overrun Error  Writing
+                                                                                    to this bit has no effect. The flag
+                                                                                    is cleared by writing 1 to the OVRERR
+                                                                                    bit in the UART EVENT ICLR register.
+                                                                                    In case of a receive FIFO overflow,
+                                                                                    the FIFO contents remain valid
+                                                                                    because no further data is written
+                                                                                    when the FIFO is full. Only the
+                                                                                    contents of the shift register are
+                                                                                    overwritten. The CPU must read the
+                                                                                    data in order to empty the FIFO. */
+#define UART_RXDATA_OVRERR_CLR                   ((uint32_t)0x00000000U)         /* !< No data has been lost due to a
+                                                                                    receive overrun. */
+#define UART_RXDATA_OVRERR_SET                   ((uint32_t)0x00000800U)         /* !< New data was received but could not
+                                                                                    be stored, because the previous data
+                                                                                    was not read (resulting in data
+                                                                                    loss). */
+/* UART_RXDATA[NERR] Bits */
+#define UART_RXDATA_NERR_OFS                     (12)                            /* !< NERR Offset */
+#define UART_RXDATA_NERR_MASK                    ((uint32_t)0x00001000U)         /* !< Noise Error. Writing to this bit
+                                                                                    has no effect. The flag is cleared by
+                                                                                    writing 1 to the NERR bit in the UART
+                                                                                    EVENT ICLR register. */
+#define UART_RXDATA_NERR_CLR                     ((uint32_t)0x00000000U)         /* !< No noise error occured */
+#define UART_RXDATA_NERR_SET                     ((uint32_t)0x00001000U)         /* !< Noise error occured during majority
+                                                                                    voting */
+
+/* UART_LINCNT Bits */
+/* UART_LINCNT[VALUE] Bits */
+#define UART_LINCNT_VALUE_OFS                    (0)                             /* !< VALUE Offset */
+#define UART_LINCNT_VALUE_MASK                   ((uint32_t)0x0000FFFFU)         /* !< 16 bit up counter clocked by the
+                                                                                    functional clock of the UART. */
+#define UART_LINCNT_VALUE_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define UART_LINCNT_VALUE_MAXIMUM                ((uint32_t)0x0000FFFFU)         /* !< Highest possible value */
+
+/* UART_LINCTL Bits */
+/* UART_LINCTL[CTRENA] Bits */
+#define UART_LINCTL_CTRENA_OFS                   (0)                             /* !< CTRENA Offset */
+#define UART_LINCTL_CTRENA_MASK                  ((uint32_t)0x00000001U)         /* !< LIN Counter Enable. LIN counter
+                                                                                    will only count when enabled. */
+#define UART_LINCTL_CTRENA_DISABLE               ((uint32_t)0x00000000U)         /* !< Counter disabled */
+#define UART_LINCTL_CTRENA_ENABLE                ((uint32_t)0x00000001U)         /* !< Counter enabled */
+/* UART_LINCTL[ZERONE] Bits */
+#define UART_LINCTL_ZERONE_OFS                   (1)                             /* !< ZERONE Offset */
+#define UART_LINCTL_ZERONE_MASK                  ((uint32_t)0x00000002U)         /* !< Zero on negative Edge of RXD. When
+                                                                                    enabled the counter is set to 0 and
+                                                                                    starts counting on a negative edge of
+                                                                                    RXD */
+#define UART_LINCTL_ZERONE_DISABLE               ((uint32_t)0x00000000U)         /* !< Zero on negative edge disabled */
+#define UART_LINCTL_ZERONE_ENABLE                ((uint32_t)0x00000002U)         /* !< Zero on negative edge enabled */
+/* UART_LINCTL[CNTRXLOW] Bits */
+#define UART_LINCTL_CNTRXLOW_OFS                 (2)                             /* !< CNTRXLOW Offset */
+#define UART_LINCTL_CNTRXLOW_MASK                ((uint32_t)0x00000004U)         /* !< Count while low Signal on RXD When
+                                                                                    counter is enabled and the signal on
+                                                                                    RXD is low, the counter increments. */
+#define UART_LINCTL_CNTRXLOW_DISABLE             ((uint32_t)0x00000000U)         /* !< Count while low Signal on UARTxRXD
+                                                                                    disabled */
+#define UART_LINCTL_CNTRXLOW_ENABLE              ((uint32_t)0x00000004U)         /* !< Count while low Signal on UARTxRXD
+                                                                                    enabled */
+/* UART_LINCTL[LINC0CAP] Bits */
+#define UART_LINCTL_LINC0CAP_OFS                 (4)                             /* !< LINC0CAP Offset */
+#define UART_LINCTL_LINC0CAP_MASK                ((uint32_t)0x00000010U)         /* !< Capture Counter on negative RXD
+                                                                                    Edge. When enabled the counter value
+                                                                                    is captured to LINC0 register on each
+                                                                                    negative RXD edge. A LINC0 interrupt
+                                                                                    is triggered when enabled. */
+#define UART_LINCTL_LINC0CAP_DISABLE             ((uint32_t)0x00000000U)         /* !< Capture counter on negative
+                                                                                    UARTxRXD edge disabled */
+#define UART_LINCTL_LINC0CAP_ENABLE              ((uint32_t)0x00000010U)         /* !< Capture counter on negative
+                                                                                    UARTxRXD edge enabled */
+/* UART_LINCTL[LINC1CAP] Bits */
+#define UART_LINCTL_LINC1CAP_OFS                 (5)                             /* !< LINC1CAP Offset */
+#define UART_LINCTL_LINC1CAP_MASK                ((uint32_t)0x00000020U)         /* !< Capture Counter on positive RXD
+                                                                                    Edge. When enabled the counter value
+                                                                                    is captured to LINC1 register on each
+                                                                                    positive RXD edge. A LINC1 interrupt
+                                                                                    is triggered when enabled. */
+#define UART_LINCTL_LINC1CAP_DISABLE             ((uint32_t)0x00000000U)         /* !< Capture counter on positive
+                                                                                    UARTxRXD edge disabled */
+#define UART_LINCTL_LINC1CAP_ENABLE              ((uint32_t)0x00000020U)         /* !< Capture counter on positive
+                                                                                    UARTxRXD edge enabled */
+/* UART_LINCTL[LINC0_MATCH] Bits */
+#define UART_LINCTL_LINC0_MATCH_OFS              (6)                             /* !< LINC0_MATCH Offset */
+#define UART_LINCTL_LINC0_MATCH_MASK             ((uint32_t)0x00000040U)         /* !< Counter Compare Match Mode  When
+                                                                                    this bit is set to 1 a counter
+                                                                                    compare match with LINC0 register
+                                                                                    triggers an LINC0 interrupt when
+                                                                                    enabled. */
+#define UART_LINCTL_LINC0_MATCH_DISABLE          ((uint32_t)0x00000000U)         /* !< Counter compare match mode disabled
+                                                                                    (capture mode enabled) */
+#define UART_LINCTL_LINC0_MATCH_ENABLE           ((uint32_t)0x00000040U)         /* !< Counter compare match enabled
+                                                                                    (capture mode disabled) */
+
+/* UART_LINC0 Bits */
+/* UART_LINC0[DATA] Bits */
+#define UART_LINC0_DATA_OFS                      (0)                             /* !< DATA Offset */
+#define UART_LINC0_DATA_MASK                     ((uint32_t)0x0000FFFFU)         /* !< 16 Bit Capture / Compare Register
+                                                                                    Captures current LINCTR value on RXD
+                                                                                    falling edge and can generate a LINC0
+                                                                                    interrupt when capture is enabled
+                                                                                    (LINC0CAP = 1).  If compare mode is
+                                                                                    enabled (LINC0_MATCH = 1), a counter
+                                                                                    match can generate a LINC0 interrupt. */
+#define UART_LINC0_DATA_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define UART_LINC0_DATA_MAXIMUM                  ((uint32_t)0x0000FFFFU)         /* !< Highest possible value */
+
+/* UART_LINC1 Bits */
+/* UART_LINC1[DATA] Bits */
+#define UART_LINC1_DATA_OFS                      (0)                             /* !< DATA Offset */
+#define UART_LINC1_DATA_MASK                     ((uint32_t)0x0000FFFFU)         /* !< 16 Bit Capture / Compare Register
+                                                                                    Captures current LINCTR value on RXD
+                                                                                    rising edge and can generate a LINC1
+                                                                                    interrupt when capture is enabled
+                                                                                    (LINC1CAP = 1) */
+#define UART_LINC1_DATA_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define UART_LINC1_DATA_MAXIMUM                  ((uint32_t)0x0000FFFFU)         /* !< Highest possible value */
+
+/* UART_IRCTL Bits */
+/* UART_IRCTL[IRTXPL] Bits */
+#define UART_IRCTL_IRTXPL_OFS                    (2)                             /* !< IRTXPL Offset */
+#define UART_IRCTL_IRTXPL_MASK                   ((uint32_t)0x000000FCU)         /* !< Transmit pulse length. Pulse length
+                                                                                    t(PULSE) = (IRTXPLx + 1) / [2 *
+                                                                                    f(IRTXCLK)] (IRTXCLK = functional
+                                                                                    clock of the UART) */
+#define UART_IRCTL_IRTXPL_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define UART_IRCTL_IRTXPL_MAXIMUM                ((uint32_t)0x000000FCU)         /* !< Highest possible value */
+/* UART_IRCTL[IRRXPL] Bits */
+#define UART_IRCTL_IRRXPL_OFS                    (9)                             /* !< IRRXPL Offset */
+#define UART_IRCTL_IRRXPL_MASK                   ((uint32_t)0x00000200U)         /* !< IrDA receive input UCAxRXD polarity */
+#define UART_IRCTL_IRRXPL_HIGH                   ((uint32_t)0x00000000U)         /* !< IrDA transceiver delivers a high
+                                                                                    pulse when a light pulse is seen */
+#define UART_IRCTL_IRRXPL_LOW                    ((uint32_t)0x00000200U)         /* !< IrDA transceiver delivers a low
+                                                                                    pulse when a light pulse is seen */
+/* UART_IRCTL[IREN] Bits */
+#define UART_IRCTL_IREN_OFS                      (0)                             /* !< IREN Offset */
+#define UART_IRCTL_IREN_MASK                     ((uint32_t)0x00000001U)         /* !< IrDA encoder/decoder enable */
+#define UART_IRCTL_IREN_DISABLE                  ((uint32_t)0x00000000U)         /* !< IrDA encoder/decoder disabled */
+#define UART_IRCTL_IREN_ENABLE                   ((uint32_t)0x00000001U)         /* !< IrDA encoder/decoder enabled */
+/* UART_IRCTL[IRTXCLK] Bits */
+#define UART_IRCTL_IRTXCLK_OFS                   (1)                             /* !< IRTXCLK Offset */
+#define UART_IRCTL_IRTXCLK_MASK                  ((uint32_t)0x00000002U)         /* !< IrDA transmit pulse clock select */
+#define UART_IRCTL_IRTXCLK_BITCLK                ((uint32_t)0x00000000U)         /* !< IrDA encode data is based on the
+                                                                                    functional clock. */
+#define UART_IRCTL_IRTXCLK_BRCLK                 ((uint32_t)0x00000002U)         /* !< IrDA encode data is based on the
+                                                                                    Baud Rate clock< when select 8x
+                                                                                    oversampling, the IRTXPL cycle should
+                                                                                    less 8;  when select 16x
+                                                                                    oversampling, the IRTXPL cycle should
+                                                                                    less 16. */
+
+/* UART_AMASK Bits */
+/* UART_AMASK[VALUE] Bits */
+#define UART_AMASK_VALUE_OFS                     (0)                             /* !< VALUE Offset */
+#define UART_AMASK_VALUE_MASK                    ((uint32_t)0x000000FFU)         /* !< Self Address Mask for 9-Bit Mode
+                                                                                    This field contains the address mask
+                                                                                    that creates a set of addresses that
+                                                                                    should be matched.  A 0 bit in the
+                                                                                    MSK bitfield configures, that the
+                                                                                    corresponding bit in the ADDR
+                                                                                    bitfield of the UARTxADDR register is
+                                                                                    don't care. A 1 bit in the MSK
+                                                                                    bitfield configures, that the
+                                                                                    corresponding bit in the ADDR
+                                                                                    bitfield of the UARTxADDR register
+                                                                                    must match. */
+#define UART_AMASK_VALUE_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define UART_AMASK_VALUE_MAXIMUM                 ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+
+/* UART_ADDR Bits */
+/* UART_ADDR[VALUE] Bits */
+#define UART_ADDR_VALUE_OFS                      (0)                             /* !< VALUE Offset */
+#define UART_ADDR_VALUE_MASK                     ((uint32_t)0x000000FFU)         /* !< Self Address for 9-Bit Mode  This
+                                                                                    field contains the address that
+                                                                                    should be matched when UARTxAMASK is
+                                                                                    FFh. */
+#define UART_ADDR_VALUE_MINIMUM                  ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define UART_ADDR_VALUE_MAXIMUM                  ((uint32_t)0x000000FFU)         /* !< Highest possible value */
+
+/* UART_CLKDIV2 Bits */
+/* UART_CLKDIV2[RATIO] Bits */
+#define UART_CLKDIV2_RATIO_OFS                   (0)                             /* !< RATIO Offset */
+#define UART_CLKDIV2_RATIO_MASK                  ((uint32_t)0x00000007U)         /* !< Selects divide ratio of module
+                                                                                    clock */
+#define UART_CLKDIV2_RATIO_DIV_BY_1              ((uint32_t)0x00000000U)         /* !< Do not divide clock source */
+#define UART_CLKDIV2_RATIO_DIV_BY_2              ((uint32_t)0x00000001U)         /* !< Divide clock source by 2 */
+#define UART_CLKDIV2_RATIO_DIV_BY_3              ((uint32_t)0x00000002U)         /* !< Divide clock source by 3 */
+#define UART_CLKDIV2_RATIO_DIV_BY_4              ((uint32_t)0x00000003U)         /* !< Divide clock source by 4 */
+#define UART_CLKDIV2_RATIO_DIV_BY_5              ((uint32_t)0x00000004U)         /* !< Divide clock source by 5 */
+#define UART_CLKDIV2_RATIO_DIV_BY_6              ((uint32_t)0x00000005U)         /* !< Divide clock source by 6 */
+#define UART_CLKDIV2_RATIO_DIV_BY_7              ((uint32_t)0x00000006U)         /* !< Divide clock source by 7 */
+#define UART_CLKDIV2_RATIO_DIV_BY_8              ((uint32_t)0x00000007U)         /* !< Divide clock source by 8 */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_uart__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_vref.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_vref.h
@@ -1,0 +1,244 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_vref__include
+#define ti_devices_msp_peripherals_hw_vref__include
+
+/* Filename: hw_vref.h */
+/* Revised: 2023-05-10 21:34:47 */
+/* Revision: 346daa750fb9270ab4d9c503b44addb19c7cc8cc */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* VREF Registers
+******************************************************************************/
+#define VREF_GPRCM_OFS                           ((uint32_t)0x00000800U)
+
+
+/** @addtogroup VREF_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} VREF_GPRCM_Regs;
+
+/*@}*/ /* end of group VREF_GPRCM */
+
+/** @addtogroup VREF
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  VREF_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED1[506];
+  __IO uint32_t CLKDIV;                            /* !< (@ 0x00001000) Clock Divider */
+       uint32_t RESERVED2;
+  __IO uint32_t CLKSEL;                            /* !< (@ 0x00001008) Clock Selection */
+       uint32_t RESERVED3[61];
+  __IO uint32_t CTL0;                              /* !< (@ 0x00001100) Control 0 */
+  __IO uint32_t CTL1;                              /* !< (@ 0x00001104) Control 1 */
+  __IO uint32_t CTL2;                              /* !< (@ 0x00001108) Control 2 */
+} VREF_Regs;
+
+/*@}*/ /* end of group VREF */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* VREF Register Control Bits
+******************************************************************************/
+
+/* VREF_PWREN Bits */
+/* VREF_PWREN[ENABLE] Bits */
+#define VREF_PWREN_ENABLE_OFS                    (0)                             /* !< ENABLE Offset */
+#define VREF_PWREN_ENABLE_MASK                   ((uint32_t)0x00000001U)         /* !< Enable the power */
+#define VREF_PWREN_ENABLE_DISABLE                ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define VREF_PWREN_ENABLE_ENABLE                 ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* VREF_PWREN[KEY] Bits */
+#define VREF_PWREN_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define VREF_PWREN_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define VREF_PWREN_KEY_UNLOCK_W                  ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* VREF_RSTCTL Bits */
+/* VREF_RSTCTL[RESETSTKYCLR] Bits */
+#define VREF_RSTCTL_RESETSTKYCLR_OFS             (1)                             /* !< RESETSTKYCLR Offset */
+#define VREF_RSTCTL_RESETSTKYCLR_MASK            ((uint32_t)0x00000002U)         /* !< Clear the RESETSTKY bit in the STAT
+                                                                                    register */
+#define VREF_RSTCTL_RESETSTKYCLR_NOP             ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define VREF_RSTCTL_RESETSTKYCLR_CLR             ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* VREF_RSTCTL[RESETASSERT] Bits */
+#define VREF_RSTCTL_RESETASSERT_OFS              (0)                             /* !< RESETASSERT Offset */
+#define VREF_RSTCTL_RESETASSERT_MASK             ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral */
+#define VREF_RSTCTL_RESETASSERT_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define VREF_RSTCTL_RESETASSERT_ASSERT           ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* VREF_RSTCTL[KEY] Bits */
+#define VREF_RSTCTL_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define VREF_RSTCTL_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define VREF_RSTCTL_KEY_UNLOCK_W                 ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* VREF_STAT Bits */
+/* VREF_STAT[RESETSTKY] Bits */
+#define VREF_STAT_RESETSTKY_OFS                  (16)                            /* !< RESETSTKY Offset */
+#define VREF_STAT_RESETSTKY_MASK                 ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define VREF_STAT_RESETSTKY_NORES                ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define VREF_STAT_RESETSTKY_RESET                ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* VREF_CLKDIV Bits */
+/* VREF_CLKDIV[RATIO] Bits */
+#define VREF_CLKDIV_RATIO_OFS                    (0)                             /* !< RATIO Offset */
+#define VREF_CLKDIV_RATIO_MASK                   ((uint32_t)0x00000007U)         /* !< Selects divide ratio of module
+                                                                                    clock to be used in sample and hold
+                                                                                    logic */
+
+/* VREF_CLKSEL Bits */
+/* VREF_CLKSEL[LFCLK_SEL] Bits */
+#define VREF_CLKSEL_LFCLK_SEL_OFS                (1)                             /* !< LFCLK_SEL Offset */
+#define VREF_CLKSEL_LFCLK_SEL_MASK               ((uint32_t)0x00000002U)         /* !< Selects LFCLK as clock source if
+                                                                                    enabled */
+/* VREF_CLKSEL[MFCLK_SEL] Bits */
+#define VREF_CLKSEL_MFCLK_SEL_OFS                (2)                             /* !< MFCLK_SEL Offset */
+#define VREF_CLKSEL_MFCLK_SEL_MASK               ((uint32_t)0x00000004U)         /* !< Selects MFCLK as clock source if
+                                                                                    enabled */
+/* VREF_CLKSEL[BUSCLK_SEL] Bits */
+#define VREF_CLKSEL_BUSCLK_SEL_OFS               (3)                             /* !< BUSCLK_SEL Offset */
+#define VREF_CLKSEL_BUSCLK_SEL_MASK              ((uint32_t)0x00000008U)         /* !< Selects BUSCLK as clock source if
+                                                                                    enabled */
+
+/* VREF_CTL0 Bits */
+/* VREF_CTL0[ENABLE] Bits */
+#define VREF_CTL0_ENABLE_OFS                     (0)                             /* !< ENABLE Offset */
+#define VREF_CTL0_ENABLE_MASK                    ((uint32_t)0x00000001U)         /* !< This bit enables the VREF module. */
+#define VREF_CTL0_ENABLE_DISABLE                 ((uint32_t)0x00000000U)         /* !< VREF is disabled */
+#define VREF_CTL0_ENABLE_ENABLE                  ((uint32_t)0x00000001U)         /* !< VREF is enabled */
+/* VREF_CTL0[BUFCONFIG] Bits */
+#define VREF_CTL0_BUFCONFIG_OFS                  (7)                             /* !< BUFCONFIG Offset */
+#define VREF_CTL0_BUFCONFIG_MASK                 ((uint32_t)0x00000080U)         /* !< These bits configure output buffer. */
+#define VREF_CTL0_BUFCONFIG_OUTPUT2P5V           ((uint32_t)0x00000000U)         /* !< Configure Output Buffer to 2.5v */
+#define VREF_CTL0_BUFCONFIG_OUTPUT1P4V           ((uint32_t)0x00000080U)         /* !< Configure Output Buffer to 1.4v */
+/* VREF_CTL0[SHMODE] Bits */
+#define VREF_CTL0_SHMODE_OFS                     (8)                             /* !< SHMODE Offset */
+#define VREF_CTL0_SHMODE_MASK                    ((uint32_t)0x00000100U)         /* !< This bit enable sample and hold
+                                                                                    mode */
+#define VREF_CTL0_SHMODE_DISABLE                 ((uint32_t)0x00000000U)         /* !< Sample and hold mode is disable */
+#define VREF_CTL0_SHMODE_ENABLE                  ((uint32_t)0x00000100U)         /* !< Sample and hold mode is enable */
+/* VREF_CTL0[COMP_VREF_ENABLE] Bits */
+#define VREF_CTL0_COMP_VREF_ENABLE_OFS           (1)                             /* !< COMP_VREF_ENABLE Offset */
+#define VREF_CTL0_COMP_VREF_ENABLE_MASK          ((uint32_t)0x00000002U)         /* !< Comparator Vref Enable */
+#define VREF_CTL0_COMP_VREF_ENABLE_DISABLE       ((uint32_t)0x00000000U)         /* !< COMP VREF is disabled */
+#define VREF_CTL0_COMP_VREF_ENABLE_ENABLE        ((uint32_t)0x00000002U)         /* !< COMP VREF is enabled */
+
+/* VREF_CTL1 Bits */
+/* VREF_CTL1[READY] Bits */
+#define VREF_CTL1_READY_OFS                      (0)                             /* !< READY Offset */
+#define VREF_CTL1_READY_MASK                     ((uint32_t)0x00000001U)         /* !< These bits defines status of VREF */
+#define VREF_CTL1_READY_NOTRDY                   ((uint32_t)0x00000000U)         /* !< VREF output is not ready */
+#define VREF_CTL1_READY_RDY                      ((uint32_t)0x00000001U)         /* !< VREF output is ready */
+
+/* VREF_CTL2 Bits */
+/* VREF_CTL2[SHCYCLE] Bits */
+#define VREF_CTL2_SHCYCLE_OFS                    (0)                             /* !< SHCYCLE Offset */
+#define VREF_CTL2_SHCYCLE_MASK                   ((uint32_t)0x0000FFFFU)         /* !< Sample and Hold cycle count Total
+                                                                                    cycles of module clock for sample and
+                                                                                    hold phase when VREF is working in
+                                                                                    sample and hold mode in STANDBY to
+                                                                                    save power. This field should be
+                                                                                    greater than HCYCLE field. The
+                                                                                    difference between this field and
+                                                                                    HCYCLE gives the number of cycles of
+                                                                                    sample phase. Please refer VREF
+                                                                                    section of datasheet for recommended
+                                                                                    values of sample and hold times. */
+#define VREF_CTL2_SHCYCLE_MINIMUM                ((uint32_t)0x00000000U)         /* !< smallest sample and hold cycle
+                                                                                    count */
+#define VREF_CTL2_SHCYCLE_MAXIMUM                ((uint32_t)0x0000FFFFU)         /* !< largest sample and hold cycle */
+/* VREF_CTL2[HCYCLE] Bits */
+#define VREF_CTL2_HCYCLE_OFS                     (16)                            /* !< HCYCLE Offset */
+#define VREF_CTL2_HCYCLE_MASK                    ((uint32_t)0xFFFF0000U)         /* !< Hold cycle count Total cycles of
+                                                                                    module clock for hold phase when VREF
+                                                                                    is working in sample and hold mode in
+                                                                                    STANDBY to save power. Please refer
+                                                                                    VREF section of datasheet for
+                                                                                    recommended values of sample and hold
+                                                                                    times. */
+#define VREF_CTL2_HCYCLE_MINIMUM                 ((uint32_t)0x00000000U)         /* !< smallest hold cycle */
+#define VREF_CTL2_HCYCLE_MAXIMUM                 ((uint32_t)0xFFFF0000U)         /* !< largest hold cycle */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_vref__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_wuc.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_wuc.h
@@ -1,0 +1,128 @@
+/*****************************************************************************
+
+  Copyright (C) 2022 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_wuc__include
+#define ti_devices_msp_peripherals_hw_wuc__include
+
+/* This preliminary header file does not have a version number */
+/* MMR repo: https://bitbucket.itg.ti.com/projects/cmcu_msp65ip/repos/f65mspwuc */
+/* MMR revision: 3f3c7febcc901c572b112d1a4f92d5ccd9701ce1 */
+/* Generator revision: 77992b62fb4e9926f5a9143aae1e89fec6a84738
+   (MInT: ec7ec7482a60c6871be32db8b378ec27aa4771f6) */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* WUC Registers
+******************************************************************************/
+
+
+/** @addtogroup WUC
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[256];
+  __IO uint32_t FSUB_0;                            /* !< (@ 0x00000400) Subscriber Port 0 */
+  __IO uint32_t FSUB_1;                            /* !< (@ 0x00000404) Subscriber Port 1 */
+} WUC_Regs;
+
+/*@}*/ /* end of group WUC */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* WUC Register Control Bits
+******************************************************************************/
+
+/* WUC_FSUB_0 Bits */
+/* WUC_FSUB_0[CHANID] Bits */
+#define WUC_FSUB_0_CHANID_OFS                    (0)                             /* !< CHANID Offset */
+#define WUC_FSUB_0_CHANID_MASK                   ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define WUC_FSUB_0_CHANID_MNIMUM                 ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define WUC_FSUB_0_CHANID_UNCONNECTED            ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define WUC_FSUB_0_CHANID_MAXIMUM                ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than 15. */
+
+/* WUC_FSUB_1 Bits */
+/* WUC_FSUB_1[CHANID] Bits */
+#define WUC_FSUB_1_CHANID_OFS                    (0)                             /* !< CHANID Offset */
+#define WUC_FSUB_1_CHANID_MASK                   ((uint32_t)0x000000FFU)         /* !< 0 = disconnected. 1-15 = connected
+                                                                                    to channelID = CHANID. */
+#define WUC_FSUB_1_CHANID_MNIMUM                 ((uint32_t)0x00000000U)         /* !< 0 is an allowed value, signifying
+                                                                                    that the event is unconnected */
+#define WUC_FSUB_1_CHANID_UNCONNECTED            ((uint32_t)0x00000000U)         /* !< A value of 0 specifies that the
+                                                                                    event is not connected */
+#define WUC_FSUB_1_CHANID_MAXIMUM                ((uint32_t)0x0000000FU)         /* !< Consult your device datasheet as
+                                                                                    the actual allowed maximum may be
+                                                                                    less than15. */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_wuc__include */

--- a/mspm0/source/ti/devices/msp/peripherals/hw_wwdt.h
+++ b/mspm0/source/ti/devices/msp/peripherals/hw_wwdt.h
@@ -1,0 +1,448 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_wwdt__include
+#define ti_devices_msp_peripherals_hw_wwdt__include
+
+/* Filename: hw_wwdt.h */
+/* Revised: 2023-05-10 21:36:51 */
+/* Revision: 662977591cca7f583e1df6fe4b402c6c07949212 */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* WWDT Registers
+******************************************************************************/
+#define WWDT_CPU_INT_OFS                         ((uint32_t)0x00001020U)
+#define WWDT_GPRCM_OFS                           ((uint32_t)0x00000800U)
+
+
+/** @addtogroup WWDT_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} WWDT_CPU_INT_Regs;
+
+/*@}*/ /* end of group WWDT_CPU_INT */
+
+/** @addtogroup WWDT_GPRCM
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) Power enable */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Reset Control */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) Status Register */
+} WWDT_GPRCM_Regs;
+
+/*@}*/ /* end of group WWDT_GPRCM */
+
+/** @addtogroup WWDT
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  WWDT_GPRCM_Regs  GPRCM;                             /* !< (@ 0x00000800) */
+       uint32_t RESERVED1[512];
+  __IO uint32_t PDBGCTL;                           /* !< (@ 0x00001018) Peripheral Debug Control */
+       uint32_t RESERVED2;
+  WWDT_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED3[37];
+  __IO uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED4[6];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Module Description */
+  __IO uint32_t WWDTCTL0;                          /* !< (@ 0x00001100) Window Watchdog Timer Control Register 0 */
+  __IO uint32_t WWDTCTL1;                          /* !< (@ 0x00001104) Window Watchdog Timer Control Register 0 */
+  __IO uint32_t WWDTCNTRST;                        /* !< (@ 0x00001108) Window Watchdog Timer Counter Reset Register */
+  __I  uint32_t WWDTSTAT;                          /* !< (@ 0x0000110C) Window Watchdog Timer Status Register */
+} WWDT_Regs;
+
+/*@}*/ /* end of group WWDT */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* WWDT Register Control Bits
+******************************************************************************/
+
+/* WWDT_IIDX Bits */
+/* WWDT_IIDX[STAT] Bits */
+#define WWDT_IIDX_STAT_OFS                       (0)                             /* !< STAT Offset */
+#define WWDT_IIDX_STAT_MASK                      ((uint32_t)0x0000001FU)         /* !< Module Interrupt Vector Value.
+                                                                                    This register provides the highest
+                                                                                    priority interrupt index. A read
+                                                                                    clears the corresponding interrupt
+                                                                                    flag in RIS and MISC. */
+#define WWDT_IIDX_STAT_NO_INTR                   ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define WWDT_IIDX_STAT_INTTIM                    ((uint32_t)0x00000001U)         /* !< Interval Timer Interrupt; Interrupt
+                                                                                    Flag: INTTIM; Interrupt Priority:
+                                                                                    Highest */
+
+/* WWDT_IMASK Bits */
+/* WWDT_IMASK[INTTIM] Bits */
+#define WWDT_IMASK_INTTIM_OFS                    (0)                             /* !< INTTIM Offset */
+#define WWDT_IMASK_INTTIM_MASK                   ((uint32_t)0x00000001U)         /* !< Interval Timer Interrupt. */
+#define WWDT_IMASK_INTTIM_CLR                    ((uint32_t)0x00000000U)         /* !< Clear Interrupt Mask */
+#define WWDT_IMASK_INTTIM_SET                    ((uint32_t)0x00000001U)         /* !< Set Interrupt Mask */
+
+/* WWDT_RIS Bits */
+/* WWDT_RIS[INTTIM] Bits */
+#define WWDT_RIS_INTTIM_OFS                      (0)                             /* !< INTTIM Offset */
+#define WWDT_RIS_INTTIM_MASK                     ((uint32_t)0x00000001U)         /* !< Interval Timer Interrupt. */
+#define WWDT_RIS_INTTIM_CLR                      ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define WWDT_RIS_INTTIM_SET                      ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+
+/* WWDT_MIS Bits */
+/* WWDT_MIS[INTTIM] Bits */
+#define WWDT_MIS_INTTIM_OFS                      (0)                             /* !< INTTIM Offset */
+#define WWDT_MIS_INTTIM_MASK                     ((uint32_t)0x00000001U)         /* !< Interval Timer Interrupt. */
+#define WWDT_MIS_INTTIM_CLR                      ((uint32_t)0x00000000U)         /* !< Interrupt did not occur */
+#define WWDT_MIS_INTTIM_SET                      ((uint32_t)0x00000001U)         /* !< Interrupt occurred */
+
+/* WWDT_ISET Bits */
+/* WWDT_ISET[INTTIM] Bits */
+#define WWDT_ISET_INTTIM_OFS                     (0)                             /* !< INTTIM Offset */
+#define WWDT_ISET_INTTIM_MASK                    ((uint32_t)0x00000001U)         /* !< Interval Timer Interrupt. */
+#define WWDT_ISET_INTTIM_NO_EFFECT               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define WWDT_ISET_INTTIM_SET                     ((uint32_t)0x00000001U)         /* !< Set Interrupt */
+
+/* WWDT_ICLR Bits */
+/* WWDT_ICLR[INTTIM] Bits */
+#define WWDT_ICLR_INTTIM_OFS                     (0)                             /* !< INTTIM Offset */
+#define WWDT_ICLR_INTTIM_MASK                    ((uint32_t)0x00000001U)         /* !< Interval Timer Interrupt. */
+#define WWDT_ICLR_INTTIM_NO_EFFECT               ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define WWDT_ICLR_INTTIM_CLR                     ((uint32_t)0x00000001U)         /* !< Clear Interrupt */
+
+/* WWDT_PWREN Bits */
+/* WWDT_PWREN[ENABLE] Bits */
+#define WWDT_PWREN_ENABLE_OFS                    (0)                             /* !< ENABLE Offset */
+#define WWDT_PWREN_ENABLE_MASK                   ((uint32_t)0x00000001U)         /* !< Enable the power Note: For safety
+                                                                                    devices the power cannot be disabled
+                                                                                    once enabled. */
+#define WWDT_PWREN_ENABLE_DISABLE                ((uint32_t)0x00000000U)         /* !< Disable Power */
+#define WWDT_PWREN_ENABLE_ENABLE                 ((uint32_t)0x00000001U)         /* !< Enable Power */
+/* WWDT_PWREN[KEY] Bits */
+#define WWDT_PWREN_KEY_OFS                       (24)                            /* !< KEY Offset */
+#define WWDT_PWREN_KEY_MASK                      ((uint32_t)0xFF000000U)         /* !< KEY to allow Power State Change */
+#define WWDT_PWREN_KEY_UNLOCK_W                  ((uint32_t)0x26000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* WWDT_RSTCTL Bits */
+/* WWDT_RSTCTL[RESETSTKYCLR] Bits */
+#define WWDT_RSTCTL_RESETSTKYCLR_OFS             (1)                             /* !< RESETSTKYCLR Offset */
+#define WWDT_RSTCTL_RESETSTKYCLR_MASK            ((uint32_t)0x00000002U)         /* !< Clear [GPRCM.STAT.RESETSTKY] */
+#define WWDT_RSTCTL_RESETSTKYCLR_NOP             ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define WWDT_RSTCTL_RESETSTKYCLR_CLR             ((uint32_t)0x00000002U)         /* !< Clear reset sticky bit */
+/* WWDT_RSTCTL[RESETASSERT] Bits */
+#define WWDT_RSTCTL_RESETASSERT_OFS              (0)                             /* !< RESETASSERT Offset */
+#define WWDT_RSTCTL_RESETASSERT_MASK             ((uint32_t)0x00000001U)         /* !< Assert reset to the peripheral
+                                                                                    Note: For safety devices a watchdog
+                                                                                    reset by software is not possible. */
+#define WWDT_RSTCTL_RESETASSERT_NOP              ((uint32_t)0x00000000U)         /* !< Writing 0 has no effect */
+#define WWDT_RSTCTL_RESETASSERT_ASSERT           ((uint32_t)0x00000001U)         /* !< Assert reset */
+/* WWDT_RSTCTL[KEY] Bits */
+#define WWDT_RSTCTL_KEY_OFS                      (24)                            /* !< KEY Offset */
+#define WWDT_RSTCTL_KEY_MASK                     ((uint32_t)0xFF000000U)         /* !< Unlock key */
+#define WWDT_RSTCTL_KEY_UNLOCK_W                 ((uint32_t)0xB1000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+
+/* WWDT_STAT Bits */
+/* WWDT_STAT[RESETSTKY] Bits */
+#define WWDT_STAT_RESETSTKY_OFS                  (16)                            /* !< RESETSTKY Offset */
+#define WWDT_STAT_RESETSTKY_MASK                 ((uint32_t)0x00010000U)         /* !< This bit indicates, if the
+                                                                                    peripheral was reset, since this bit
+                                                                                    was cleared by RESETSTKYCLR in the
+                                                                                    RSTCTL register */
+#define WWDT_STAT_RESETSTKY_NORES                ((uint32_t)0x00000000U)         /* !< The peripheral has not been reset
+                                                                                    since this bit was last cleared by
+                                                                                    RESETSTKYCLR in the RSTCTL register */
+#define WWDT_STAT_RESETSTKY_RESET                ((uint32_t)0x00010000U)         /* !< The peripheral was reset since the
+                                                                                    last bit clear */
+
+/* WWDT_PDBGCTL Bits */
+/* WWDT_PDBGCTL[FREE] Bits */
+#define WWDT_PDBGCTL_FREE_OFS                    (0)                             /* !< FREE Offset */
+#define WWDT_PDBGCTL_FREE_MASK                   ((uint32_t)0x00000001U)         /* !< Free run control */
+#define WWDT_PDBGCTL_FREE_STOP                   ((uint32_t)0x00000000U)         /* !< The peripheral freezes
+                                                                                    functionality while the Core Halted
+                                                                                    input is asserted and resumes when it
+                                                                                    is deasserted. */
+#define WWDT_PDBGCTL_FREE_RUN                    ((uint32_t)0x00000001U)         /* !< The peripheral ignores the state of
+                                                                                    the Core Halted input */
+
+/* WWDT_EVT_MODE Bits */
+/* WWDT_EVT_MODE[INT0_CFG] Bits */
+#define WWDT_EVT_MODE_INT0_CFG_OFS               (0)                             /* !< INT0_CFG Offset */
+#define WWDT_EVT_MODE_INT0_CFG_MASK              ((uint32_t)0x00000003U)         /* !< Event line mode select for event
+                                                                                    corresponding to
+                                                                                    [IPSTANDARD.CPU_INT][0] */
+#define WWDT_EVT_MODE_INT0_CFG_DISABLE           ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define WWDT_EVT_MODE_INT0_CFG_SOFTWARE          ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define WWDT_EVT_MODE_INT0_CFG_HARDWARE          ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* WWDT_DESC Bits */
+/* WWDT_DESC[MINREV] Bits */
+#define WWDT_DESC_MINREV_OFS                     (0)                             /* !< MINREV Offset */
+#define WWDT_DESC_MINREV_MASK                    ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+#define WWDT_DESC_MINREV_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define WWDT_DESC_MINREV_MAXIMUM                 ((uint32_t)0x0000000FU)         /* !< Highest possible value */
+/* WWDT_DESC[MAJREV] Bits */
+#define WWDT_DESC_MAJREV_OFS                     (4)                             /* !< MAJREV Offset */
+#define WWDT_DESC_MAJREV_MASK                    ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+#define WWDT_DESC_MAJREV_MINIMUM                 ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define WWDT_DESC_MAJREV_MAXIMUM                 ((uint32_t)0x000000F0U)         /* !< Highest possible value */
+/* WWDT_DESC[INSTNUM] Bits */
+#define WWDT_DESC_INSTNUM_OFS                    (8)                             /* !< INSTNUM Offset */
+#define WWDT_DESC_INSTNUM_MASK                   ((uint32_t)0x00000F00U)         /* !< Instance Number within the device.
+                                                                                    This will be a parameter to the RTL
+                                                                                    for modules that can have multiple
+                                                                                    instances */
+#define WWDT_DESC_INSTNUM_MINIMUM                ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define WWDT_DESC_INSTNUM_MAXIMUM                ((uint32_t)0x00000F00U)         /* !< Highest possible value */
+/* WWDT_DESC[FEATUREVER] Bits */
+#define WWDT_DESC_FEATUREVER_OFS                 (12)                            /* !< FEATUREVER Offset */
+#define WWDT_DESC_FEATUREVER_MASK                ((uint32_t)0x0000F000U)         /* !< Feature Set for the module
+                                                                                    *instance* */
+#define WWDT_DESC_FEATUREVER_MINIMUM             ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define WWDT_DESC_FEATUREVER_MAXIMUM             ((uint32_t)0x0000F000U)         /* !< Highest possible value */
+/* WWDT_DESC[MODULEID] Bits */
+#define WWDT_DESC_MODULEID_OFS                   (16)                            /* !< MODULEID Offset */
+#define WWDT_DESC_MODULEID_MASK                  ((uint32_t)0xFFFF0000U)         /* !< Module identification contains a
+                                                                                    unique peripheral identification
+                                                                                    number. The assignments are
+                                                                                    maintained in a central database for
+                                                                                    all of the platform modules to ensure
+                                                                                    uniqueness. */
+#define WWDT_DESC_MODULEID_MINIMUM               ((uint32_t)0x00000000U)         /* !< Smallest value */
+#define WWDT_DESC_MODULEID_MAXIMUM               ((uint32_t)0xFFFF0000U)         /* !< Highest possible value */
+
+/* WWDT_WWDTCTL0 Bits */
+/* WWDT_WWDTCTL0[PER] Bits */
+#define WWDT_WWDTCTL0_PER_OFS                    (4)                             /* !< PER Offset */
+#define WWDT_WWDTCTL0_PER_MASK                   ((uint32_t)0x00000070U)         /* !< Timer Period of the WWDT. These
+                                                                                    bits select the total watchdog timer
+                                                                                    count. */
+#define WWDT_WWDTCTL0_PER_EN_25                  ((uint32_t)0x00000000U)         /* !< Total timer count is 2^25 */
+#define WWDT_WWDTCTL0_PER_EN_21                  ((uint32_t)0x00000010U)         /* !< Total timer count is 2^21 */
+#define WWDT_WWDTCTL0_PER_EN_18                  ((uint32_t)0x00000020U)         /* !< Total timer count is 2^18 */
+#define WWDT_WWDTCTL0_PER_EN_15                  ((uint32_t)0x00000030U)         /* !< Total timer count is 2^15 */
+#define WWDT_WWDTCTL0_PER_EN_12                  ((uint32_t)0x00000040U)         /* !< Total timer count is 2^12 (default) */
+#define WWDT_WWDTCTL0_PER_EN_10                  ((uint32_t)0x00000050U)         /* !< Total timer count is 2^10 */
+#define WWDT_WWDTCTL0_PER_EN_8                   ((uint32_t)0x00000060U)         /* !< Total timer count is 2^8 */
+#define WWDT_WWDTCTL0_PER_EN_6                   ((uint32_t)0x00000070U)         /* !< Total timer count is 2^6 */
+/* WWDT_WWDTCTL0[WINDOW0] Bits */
+#define WWDT_WWDTCTL0_WINDOW0_OFS                (8)                             /* !< WINDOW0 Offset */
+#define WWDT_WWDTCTL0_WINDOW0_MASK               ((uint32_t)0x00000700U)         /* !< Closed window period in percentage
+                                                                                    of the timer interval.
+                                                                                    WWDTCTL1.WINSEL determines the active
+                                                                                    window setting (WWDTCTL0.WINDOW0 or
+                                                                                    WWDTCTL0.WINDOW1). */
+#define WWDT_WWDTCTL0_WINDOW0_SIZE_0             ((uint32_t)0x00000000U)         /* !< 0% (No closed Window) */
+#define WWDT_WWDTCTL0_WINDOW0_SIZE_12            ((uint32_t)0x00000100U)         /* !< 12.50% of the total timer period is
+                                                                                    closed window */
+#define WWDT_WWDTCTL0_WINDOW0_SIZE_18            ((uint32_t)0x00000200U)         /* !< 18.75% of the total timer period is
+                                                                                    closed window */
+#define WWDT_WWDTCTL0_WINDOW0_SIZE_25            ((uint32_t)0x00000300U)         /* !< 25% of the total timer period is
+                                                                                    closed window */
+#define WWDT_WWDTCTL0_WINDOW0_SIZE_50            ((uint32_t)0x00000400U)         /* !< 50% of the total timer period is
+                                                                                    closed window */
+#define WWDT_WWDTCTL0_WINDOW0_SIZE_75            ((uint32_t)0x00000500U)         /* !< 75% of the total timer period is
+                                                                                    closed window */
+#define WWDT_WWDTCTL0_WINDOW0_SIZE_81            ((uint32_t)0x00000600U)         /* !< 81.25% of the total timer period is
+                                                                                    closed window */
+#define WWDT_WWDTCTL0_WINDOW0_SIZE_87            ((uint32_t)0x00000700U)         /* !< 87.50% of the total timer period is
+                                                                                    closed window */
+/* WWDT_WWDTCTL0[MODE] Bits */
+#define WWDT_WWDTCTL0_MODE_OFS                   (16)                            /* !< MODE Offset */
+#define WWDT_WWDTCTL0_MODE_MASK                  ((uint32_t)0x00010000U)         /* !< Window Watchdog Timer Mode */
+#define WWDT_WWDTCTL0_MODE_WINDOW                ((uint32_t)0x00000000U)         /* !< Window Watchdog Timer Mode. The
+                                                                                    WWDT will generate a error signal to
+                                                                                    the ESM when following conditions
+                                                                                    occur: - Timer Expiration (Timeout) -
+                                                                                    Reset WWDT during the active window
+                                                                                    closed period - Keyword violation */
+#define WWDT_WWDTCTL0_MODE_INTERVAL              ((uint32_t)0x00010000U)         /* !< Interval Timer Mode. The WWDT acts
+                                                                                    as an interval timer. It generates an
+                                                                                    interrupt on timeout. */
+/* WWDT_WWDTCTL0[STISM] Bits */
+#define WWDT_WWDTCTL0_STISM_OFS                  (17)                            /* !< STISM Offset */
+#define WWDT_WWDTCTL0_STISM_MASK                 ((uint32_t)0x00020000U)         /* !< Stop In Sleep Mode.    The
+                                                                                    functionality of this bit requires
+                                                                                    that POLICY.HWCEN = 0. If
+                                                                                    POLICY.HWCEN = 1 the WWDT resets
+                                                                                    during sleep and needs
+                                                                                    re-configuration. Note: This bit has
+                                                                                    no effect for the global Window
+                                                                                    Watchdog as Sleep Mode is not
+                                                                                    supported. */
+#define WWDT_WWDTCTL0_STISM_CONT                 ((uint32_t)0x00000000U)         /* !< The WWDT continues to function in
+                                                                                    Sleep mode. */
+#define WWDT_WWDTCTL0_STISM_STOP                 ((uint32_t)0x00020000U)         /* !< The WWDT stops in Sleep mode and
+                                                                                    resumes where it was stopped after
+                                                                                    wakeup. */
+/* WWDT_WWDTCTL0[KEY] Bits */
+#define WWDT_WWDTCTL0_KEY_OFS                    (24)                            /* !< KEY Offset */
+#define WWDT_WWDTCTL0_KEY_MASK                   ((uint32_t)0xFF000000U)         /* !< KEY to allow write access to this
+                                                                                    register.  Writing to this register
+                                                                                    with an incorrect key activates the
+                                                                                    WWDT error signal to the ESM. Read as
+                                                                                    0. */
+#define WWDT_WWDTCTL0_KEY_UNLOCK_W               ((uint32_t)0xC9000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+/* WWDT_WWDTCTL0[CLKDIV] Bits */
+#define WWDT_WWDTCTL0_CLKDIV_OFS                 (0)                             /* !< CLKDIV Offset */
+#define WWDT_WWDTCTL0_CLKDIV_MASK                ((uint32_t)0x00000007U)         /* !< Module Clock Divider, Divide the
+                                                                                    clock source by CLKDIV+1. Divider
+                                                                                    values from /1 to /8 are possible.
+                                                                                    The clock divider is currently 4
+                                                                                    bits. Bit 4 has no effect and should
+                                                                                    always be written with 0. */
+#define WWDT_WWDTCTL0_CLKDIV_MINIMUM             ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define WWDT_WWDTCTL0_CLKDIV_MAXIMUM             ((uint32_t)0x00000007U)         /* !< Maximum value */
+/* WWDT_WWDTCTL0[WINDOW1] Bits */
+#define WWDT_WWDTCTL0_WINDOW1_OFS                (12)                            /* !< WINDOW1 Offset */
+#define WWDT_WWDTCTL0_WINDOW1_MASK               ((uint32_t)0x00007000U)         /* !< Closed window period in percentage
+                                                                                    of the timer interval.
+                                                                                    WWDTCTL1.WINSEL determines the active
+                                                                                    window setting (WWDTCTL0.WINDOW0 or
+                                                                                    WWDTCTL0.WINDOW1). */
+#define WWDT_WWDTCTL0_WINDOW1_SIZE_0             ((uint32_t)0x00000000U)         /* !< 0% (No closed Window) */
+#define WWDT_WWDTCTL0_WINDOW1_SIZE_12            ((uint32_t)0x00001000U)         /* !< 12.50% of the total timer period is
+                                                                                    closed window */
+#define WWDT_WWDTCTL0_WINDOW1_SIZE_18            ((uint32_t)0x00002000U)         /* !< 18.75% of the total timer period is
+                                                                                    closed window */
+#define WWDT_WWDTCTL0_WINDOW1_SIZE_25            ((uint32_t)0x00003000U)         /* !< 25% of the total timer period is
+                                                                                    closed window */
+#define WWDT_WWDTCTL0_WINDOW1_SIZE_50            ((uint32_t)0x00004000U)         /* !< 50% of the total timer period is
+                                                                                    closed window */
+#define WWDT_WWDTCTL0_WINDOW1_SIZE_75            ((uint32_t)0x00005000U)         /* !< 75% of the total timer period is
+                                                                                    closed window */
+#define WWDT_WWDTCTL0_WINDOW1_SIZE_81            ((uint32_t)0x00006000U)         /* !< 81.25% of the total timer period is
+                                                                                    closed window */
+#define WWDT_WWDTCTL0_WINDOW1_SIZE_87            ((uint32_t)0x00007000U)         /* !< 87.50% of the total timer period is
+                                                                                    closed window */
+
+/* WWDT_WWDTCTL1 Bits */
+/* WWDT_WWDTCTL1[KEY] Bits */
+#define WWDT_WWDTCTL1_KEY_OFS                    (24)                            /* !< KEY Offset */
+#define WWDT_WWDTCTL1_KEY_MASK                   ((uint32_t)0xFF000000U)         /* !< KEY to allow write access to this
+                                                                                    register.  Writing to this register
+                                                                                    with an incorrect key activates the
+                                                                                    WWDT error signal to the ESM. Read as
+                                                                                    0. */
+#define WWDT_WWDTCTL1_KEY_UNLOCK_W               ((uint32_t)0xBE000000U)         /* !< KEY to allow write access to this
+                                                                                    register */
+/* WWDT_WWDTCTL1[WINSEL] Bits */
+#define WWDT_WWDTCTL1_WINSEL_OFS                 (0)                             /* !< WINSEL Offset */
+#define WWDT_WWDTCTL1_WINSEL_MASK                ((uint32_t)0x00000001U)         /* !< Close Window Select */
+#define WWDT_WWDTCTL1_WINSEL_WIN0                ((uint32_t)0x00000000U)         /* !< In window mode field WINDOW0 of
+                                                                                    WDDTCTL0 defines the closed window
+                                                                                    size. */
+#define WWDT_WWDTCTL1_WINSEL_WIN1                ((uint32_t)0x00000001U)         /* !< In window mode field WINDOW1 of
+                                                                                    WDDTCTL0 defines the closed window
+                                                                                    size. */
+
+/* WWDT_WWDTCNTRST Bits */
+/* WWDT_WWDTCNTRST[RESTART] Bits */
+#define WWDT_WWDTCNTRST_RESTART_OFS              (0)                             /* !< RESTART Offset */
+#define WWDT_WWDTCNTRST_RESTART_MASK             ((uint32_t)0xFFFFFFFFU)         /* !< Window Watchdog Timer Counter
+                                                                                    Restart Writing 00A7h to this
+                                                                                    register restarts the WWDT Counter.
+                                                                                    Writing any other value causes an
+                                                                                    error generation to the ESM. Read as
+                                                                                    0. */
+#define WWDT_WWDTCNTRST_RESTART_MINIMUM          ((uint32_t)0x00000000U)         /* !< Minimum value */
+#define WWDT_WWDTCNTRST_RESTART_MAXIMUM          ((uint32_t)0xFFFFFFFFU)         /* !< Maximum value */
+
+/* WWDT_WWDTSTAT Bits */
+/* WWDT_WWDTSTAT[RUN] Bits */
+#define WWDT_WWDTSTAT_RUN_OFS                    (0)                             /* !< RUN Offset */
+#define WWDT_WWDTSTAT_RUN_MASK                   ((uint32_t)0x00000001U)         /* !< Watchdog running status flag. */
+#define WWDT_WWDTSTAT_RUN_OFF                    ((uint32_t)0x00000000U)         /* !< Watchdog counter stopped. */
+#define WWDT_WWDTSTAT_RUN_ON                     ((uint32_t)0x00000001U)         /* !< Watchdog running. */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_wwdt__include */

--- a/mspm0/source/ti/devices/msp/peripherals/m0p/hw_cpuss.h
+++ b/mspm0/source/ti/devices/msp/peripherals/m0p/hw_cpuss.h
@@ -1,0 +1,268 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_m0p_hw_cpuss__include
+#define ti_devices_msp_peripherals_m0p_hw_cpuss__include
+
+/* Filename: hw_cpuss.h */
+/* Revised: 2023-04-30 21:36:20 */
+/* Revision: ec4f3de051dafa6135b4867f4e796eec5f1a339b */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* CPUSS Registers
+******************************************************************************/
+#define CPUSS_INT_GROUP_OFS                      ((uint32_t)0x00001100U)
+
+
+/** @addtogroup CPUSS_INT_GROUP
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001100) Interrupt index */
+       uint32_t RESERVED0;
+  __I  uint32_t IMASK;                             /* !< (@ 0x00001108) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001110) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001118) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001120) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001128) Interrupt clear */
+       uint32_t RESERVED5;
+} CPUSS_INT_GROUP_Regs;
+
+/*@}*/ /* end of group CPUSS_INT_GROUP */
+
+/** @addtogroup CPUSS
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[1080];
+  __I  uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED1[6];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Module Description */
+  CPUSS_INT_GROUP_Regs  INT_GROUP[5];                      /* !< (@ 0x00001100) */
+       uint32_t RESERVED2[68];
+  __IO uint32_t CTL;                               /* !< (@ 0x00001300) Prefetch/Cache control */
+} CPUSS_Regs;
+
+/*@}*/ /* end of group CPUSS */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* CPUSS Register Control Bits
+******************************************************************************/
+
+/* CPUSS_INT_GROUP_IIDX Bits */
+/* CPUSS_INT_GROUP_IIDX[STAT] Bits */
+#define CPUSS_INT_GROUP_IIDX_STAT_OFS            (0)                             /* !< STAT Offset */
+#define CPUSS_INT_GROUP_IIDX_STAT_MASK           ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define CPUSS_INT_GROUP_IIDX_STAT_NO_INTR        ((uint32_t)0x00000000U)         /* !< No pending interrupt */
+#define CPUSS_INT_GROUP_IIDX_STAT_INT0           ((uint32_t)0x00000001U)         /* !< Interrupt 0 */
+#define CPUSS_INT_GROUP_IIDX_STAT_INT1           ((uint32_t)0x00000002U)         /* !< Interrupt 1 */
+#define CPUSS_INT_GROUP_IIDX_STAT_INT2           ((uint32_t)0x00000003U)         /* !< Interrupt 2 */
+#define CPUSS_INT_GROUP_IIDX_STAT_INT3           ((uint32_t)0x00000004U)         /* !< Interrupt 3 */
+#define CPUSS_INT_GROUP_IIDX_STAT_INT4           ((uint32_t)0x00000005U)         /* !< Interrupt 4 */
+#define CPUSS_INT_GROUP_IIDX_STAT_INT5           ((uint32_t)0x00000006U)         /* !< Interrupt 5 */
+#define CPUSS_INT_GROUP_IIDX_STAT_INT6           ((uint32_t)0x00000007U)         /* !< Interrupt 6 */
+#define CPUSS_INT_GROUP_IIDX_STAT_INT7           ((uint32_t)0x00000008U)         /* !< Interrupt 7 */
+
+/* CPUSS_INT_GROUP_IMASK Bits */
+/* CPUSS_INT_GROUP_IMASK[INT] Bits */
+#define CPUSS_INT_GROUP_IMASK_INT_OFS            (0)                             /* !< INT Offset */
+#define CPUSS_INT_GROUP_IMASK_INT_MASK           ((uint32_t)0x000000FFU)         /* !< Masks the corresponding interrupt */
+#define CPUSS_INT_GROUP_IMASK_INT_INT0           ((uint32_t)0x00000001U)         /* !< Interrupt 0 */
+#define CPUSS_INT_GROUP_IMASK_INT_INT1           ((uint32_t)0x00000002U)         /* !< Interrupt 1 */
+#define CPUSS_INT_GROUP_IMASK_INT_INT2           ((uint32_t)0x00000004U)         /* !< Interrupt 2 */
+#define CPUSS_INT_GROUP_IMASK_INT_INT3           ((uint32_t)0x00000008U)         /* !< Interrupt 3 */
+#define CPUSS_INT_GROUP_IMASK_INT_INT4           ((uint32_t)0x00000010U)         /* !< Interrupt 4 */
+#define CPUSS_INT_GROUP_IMASK_INT_INT5           ((uint32_t)0x00000020U)         /* !< Interrupt 5 */
+#define CPUSS_INT_GROUP_IMASK_INT_INT6           ((uint32_t)0x00000040U)         /* !< Interrupt 6 */
+#define CPUSS_INT_GROUP_IMASK_INT_INT7           ((uint32_t)0x00000080U)         /* !< Interrupt 7 */
+
+/* CPUSS_INT_GROUP_RIS Bits */
+/* CPUSS_INT_GROUP_RIS[INT] Bits */
+#define CPUSS_INT_GROUP_RIS_INT_OFS              (0)                             /* !< INT Offset */
+#define CPUSS_INT_GROUP_RIS_INT_MASK             ((uint32_t)0x000000FFU)         /* !< Raw interrupt status for INT */
+#define CPUSS_INT_GROUP_RIS_INT_INT0             ((uint32_t)0x00000001U)         /* !< Interrupt 0 */
+#define CPUSS_INT_GROUP_RIS_INT_INT1             ((uint32_t)0x00000002U)         /* !< Interrupt 1 */
+#define CPUSS_INT_GROUP_RIS_INT_INT2             ((uint32_t)0x00000004U)         /* !< Interrupt 2 */
+#define CPUSS_INT_GROUP_RIS_INT_INT3             ((uint32_t)0x00000008U)         /* !< Interrupt 3 */
+#define CPUSS_INT_GROUP_RIS_INT_INT4             ((uint32_t)0x00000010U)         /* !< Interrupt 4 */
+#define CPUSS_INT_GROUP_RIS_INT_INT5             ((uint32_t)0x00000020U)         /* !< Interrupt 5 */
+#define CPUSS_INT_GROUP_RIS_INT_INT6             ((uint32_t)0x00000040U)         /* !< Interrupt 6 */
+#define CPUSS_INT_GROUP_RIS_INT_INT7             ((uint32_t)0x00000080U)         /* !< Interrupt 7 */
+
+/* CPUSS_INT_GROUP_MIS Bits */
+/* CPUSS_INT_GROUP_MIS[INT] Bits */
+#define CPUSS_INT_GROUP_MIS_INT_OFS              (0)                             /* !< INT Offset */
+#define CPUSS_INT_GROUP_MIS_INT_MASK             ((uint32_t)0x000000FFU)         /* !< Masked interrupt status for INT0 */
+#define CPUSS_INT_GROUP_MIS_INT_INT0             ((uint32_t)0x00000001U)         /* !< Interrupt 0 */
+#define CPUSS_INT_GROUP_MIS_INT_INT1             ((uint32_t)0x00000002U)         /* !< Interrupt 1 */
+#define CPUSS_INT_GROUP_MIS_INT_INT2             ((uint32_t)0x00000004U)         /* !< Interrupt 2 */
+#define CPUSS_INT_GROUP_MIS_INT_INT3             ((uint32_t)0x00000008U)         /* !< Interrupt 3 */
+#define CPUSS_INT_GROUP_MIS_INT_INT4             ((uint32_t)0x00000010U)         /* !< Interrupt 4 */
+#define CPUSS_INT_GROUP_MIS_INT_INT5             ((uint32_t)0x00000020U)         /* !< Interrupt 5 */
+#define CPUSS_INT_GROUP_MIS_INT_INT6             ((uint32_t)0x00000040U)         /* !< Interrupt 6 */
+#define CPUSS_INT_GROUP_MIS_INT_INT7             ((uint32_t)0x00000080U)         /* !< Interrupt 7 */
+
+/* CPUSS_INT_GROUP_ISET Bits */
+/* CPUSS_INT_GROUP_ISET[INT] Bits */
+#define CPUSS_INT_GROUP_ISET_INT_OFS             (0)                             /* !< INT Offset */
+#define CPUSS_INT_GROUP_ISET_INT_MASK            ((uint32_t)0x000000FFU)         /* !< Sets INT in RIS register */
+#define CPUSS_INT_GROUP_ISET_INT_INT0            ((uint32_t)0x00000001U)         /* !< Interrupt 0 */
+#define CPUSS_INT_GROUP_ISET_INT_INT1            ((uint32_t)0x00000002U)         /* !< Interrupt 1 */
+#define CPUSS_INT_GROUP_ISET_INT_INT2            ((uint32_t)0x00000004U)         /* !< Interrupt 2 */
+#define CPUSS_INT_GROUP_ISET_INT_INT3            ((uint32_t)0x00000008U)         /* !< Interrupt 3 */
+#define CPUSS_INT_GROUP_ISET_INT_INT4            ((uint32_t)0x00000010U)         /* !< Interrupt 4 */
+#define CPUSS_INT_GROUP_ISET_INT_INT5            ((uint32_t)0x00000020U)         /* !< Interrupt 5 */
+#define CPUSS_INT_GROUP_ISET_INT_INT6            ((uint32_t)0x00000040U)         /* !< Interrupt 6 */
+#define CPUSS_INT_GROUP_ISET_INT_INT7            ((uint32_t)0x00000080U)         /* !< Interrupt 7 */
+
+/* CPUSS_INT_GROUP_ICLR Bits */
+/* CPUSS_INT_GROUP_ICLR[INT] Bits */
+#define CPUSS_INT_GROUP_ICLR_INT_OFS             (0)                             /* !< INT Offset */
+#define CPUSS_INT_GROUP_ICLR_INT_MASK            ((uint32_t)0x000000FFU)         /* !< Clears INT in RIS register */
+#define CPUSS_INT_GROUP_ICLR_INT_INT0            ((uint32_t)0x00000001U)         /* !< Interrupt 0 */
+#define CPUSS_INT_GROUP_ICLR_INT_INT1            ((uint32_t)0x00000002U)         /* !< Interrupt 1 */
+#define CPUSS_INT_GROUP_ICLR_INT_INT2            ((uint32_t)0x00000004U)         /* !< Interrupt 2 */
+#define CPUSS_INT_GROUP_ICLR_INT_INT3            ((uint32_t)0x00000008U)         /* !< Interrupt 3 */
+#define CPUSS_INT_GROUP_ICLR_INT_INT4            ((uint32_t)0x00000010U)         /* !< Interrupt 4 */
+#define CPUSS_INT_GROUP_ICLR_INT_INT5            ((uint32_t)0x00000020U)         /* !< Interrupt 5 */
+#define CPUSS_INT_GROUP_ICLR_INT_INT6            ((uint32_t)0x00000040U)         /* !< Interrupt 6 */
+#define CPUSS_INT_GROUP_ICLR_INT_INT7            ((uint32_t)0x00000080U)         /* !< Interrupt 7 */
+
+/* CPUSS_EVT_MODE Bits */
+/* CPUSS_EVT_MODE[INT_CFG] Bits */
+#define CPUSS_EVT_MODE_INT_CFG_OFS               (0)                             /* !< INT_CFG Offset */
+#define CPUSS_EVT_MODE_INT_CFG_MASK              ((uint32_t)0x00000003U)         /* !< Event line mode select */
+#define CPUSS_EVT_MODE_INT_CFG_DISABLE           ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define CPUSS_EVT_MODE_INT_CFG_SOFTWARE          ((uint32_t)0x00000001U)         /* !< Event handled by software. Software
+                                                                                    must clear the associated RIS flag. */
+#define CPUSS_EVT_MODE_INT_CFG_HARDWARE          ((uint32_t)0x00000002U)         /* !< Event handled by hardware. The
+                                                                                    hardware (another module) clears
+                                                                                    automatically the associated RIS
+                                                                                    flag. */
+
+/* CPUSS_DESC Bits */
+/* CPUSS_DESC[MINREV] Bits */
+#define CPUSS_DESC_MINREV_OFS                    (0)                             /* !< MINREV Offset */
+#define CPUSS_DESC_MINREV_MASK                   ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+/* CPUSS_DESC[MAJREV] Bits */
+#define CPUSS_DESC_MAJREV_OFS                    (4)                             /* !< MAJREV Offset */
+#define CPUSS_DESC_MAJREV_MASK                   ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+/* CPUSS_DESC[FEATUREVER] Bits */
+#define CPUSS_DESC_FEATUREVER_OFS                (12)                            /* !< FEATUREVER Offset */
+#define CPUSS_DESC_FEATUREVER_MASK               ((uint32_t)0x0000F000U)         /* !< Feature Set for the module
+                                                                                    *instance* */
+/* CPUSS_DESC[MODULEID] Bits */
+#define CPUSS_DESC_MODULEID_OFS                  (16)                            /* !< MODULEID Offset */
+#define CPUSS_DESC_MODULEID_MASK                 ((uint32_t)0xFFFF0000U)         /* !< Module identification contains a
+                                                                                    unique peripheral identification
+                                                                                    number. The assignments are
+                                                                                    maintained in a central database for
+                                                                                    all of the platform modules to ensure
+                                                                                    uniqueness. */
+
+/* CPUSS_CTL Bits */
+/* CPUSS_CTL[PREFETCH] Bits */
+#define CPUSS_CTL_PREFETCH_OFS                   (0)                             /* !< PREFETCH Offset */
+#define CPUSS_CTL_PREFETCH_MASK                  ((uint32_t)0x00000001U)         /* !< Used to enable/disable instruction
+                                                                                    prefetch to Flash. */
+#define CPUSS_CTL_PREFETCH_DISABLE               ((uint32_t)0x00000000U)         /* !< Disable instruction prefetch. */
+#define CPUSS_CTL_PREFETCH_ENABLE                ((uint32_t)0x00000001U)         /* !< Enable instruction prefetch. */
+/* CPUSS_CTL[ICACHE] Bits */
+#define CPUSS_CTL_ICACHE_OFS                     (1)                             /* !< ICACHE Offset */
+#define CPUSS_CTL_ICACHE_MASK                    ((uint32_t)0x00000002U)         /* !< Used to enable/disable Instruction
+                                                                                    caching on flash access. */
+#define CPUSS_CTL_ICACHE_DISABLE                 ((uint32_t)0x00000000U)         /* !< Disable instruction caching. */
+#define CPUSS_CTL_ICACHE_ENABLE                  ((uint32_t)0x00000002U)         /* !< Enable instruction caching. */
+/* CPUSS_CTL[LITEN] Bits */
+#define CPUSS_CTL_LITEN_OFS                      (2)                             /* !< LITEN Offset */
+#define CPUSS_CTL_LITEN_MASK                     ((uint32_t)0x00000004U)         /* !< Literal caching and prefetch
+                                                                                    enable.  This bit is a subset of
+                                                                                    ICACHE/PREFETCH bit i.e. literal
+                                                                                    caching or literal prefetching will
+                                                                                    only happen if ICACHE or PREFETCH
+                                                                                    bits have been set respectively  When
+                                                                                    enabled, the cache and prefetcher
+                                                                                    structures inside CPUSS will cache
+                                                                                    and prefetch literals When disabled,
+                                                                                    the cache and prefetcher structures
+                                                                                    inside CPUSS will not cache and
+                                                                                    prefetch literals */
+#define CPUSS_CTL_LITEN_DISABLE                  ((uint32_t)0x00000000U)         /* !< Literal caching disabled */
+#define CPUSS_CTL_LITEN_ENABLE                   ((uint32_t)0x00000004U)         /* !< Literal caching enabled */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_m0p_hw_cpuss__include */

--- a/mspm0/source/ti/devices/msp/peripherals/m0p/hw_debugss.h
+++ b/mspm0/source/ti/devices/msp/peripherals/m0p/hw_debugss.h
@@ -1,0 +1,460 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_m0p_hw_debugss__include
+#define ti_devices_msp_peripherals_m0p_hw_debugss__include
+
+/* Filename: hw_debugss.h */
+/* Revised: 2023-05-10 21:16:53 */
+/* Revision: 2f29710894b537f621c6ebedd563efb234664827 */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* DEBUGSS Registers
+******************************************************************************/
+#define DEBUGSS_CPU_INT_OFS                      ((uint32_t)0x00001020U)
+
+
+/** @addtogroup DEBUGSS_CPU_INT
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) Interrupt index */
+       uint32_t RESERVED0;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) Interrupt mask */
+       uint32_t RESERVED1;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) Raw interrupt status */
+       uint32_t RESERVED2;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) Masked interrupt status */
+       uint32_t RESERVED3;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) Interrupt set */
+       uint32_t RESERVED4;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) Interrupt clear */
+} DEBUGSS_CPU_INT_Regs;
+
+/*@}*/ /* end of group DEBUGSS_CPU_INT */
+
+/** @addtogroup DEBUGSS
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[1032];
+  DEBUGSS_CPU_INT_Regs  CPU_INT;                           /* !< (@ 0x00001020) */
+       uint32_t RESERVED1[37];
+  __I  uint32_t EVT_MODE;                          /* !< (@ 0x000010E0) Event Mode */
+       uint32_t RESERVED2[6];
+  __I  uint32_t DESC;                              /* !< (@ 0x000010FC) Module Description */
+  __I  uint32_t TXD;                               /* !< (@ 0x00001100) Transmit data register */
+  __I  uint32_t TXCTL;                             /* !< (@ 0x00001104) Transmit control register */
+  __IO uint32_t RXD;                               /* !< (@ 0x00001108) Receive data register */
+  __IO uint32_t RXCTL;                             /* !< (@ 0x0000110C) Receive control register */
+       uint32_t RESERVED3[60];
+  __I  uint32_t SPECIAL_AUTH;                      /* !< (@ 0x00001200) Special enable authorization register */
+       uint32_t RESERVED4[3];
+  __I  uint32_t APP_AUTH;                          /* !< (@ 0x00001210) Application CPU0 authorization register */
+} DEBUGSS_Regs;
+
+/*@}*/ /* end of group DEBUGSS */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* DEBUGSS Register Control Bits
+******************************************************************************/
+
+/* DEBUGSS_IIDX Bits */
+/* DEBUGSS_IIDX[STAT] Bits */
+#define DEBUGSS_IIDX_STAT_OFS                    (0)                             /* !< STAT Offset */
+#define DEBUGSS_IIDX_STAT_MASK                   ((uint32_t)0x000000FFU)         /* !< Interrupt index status */
+#define DEBUGSS_IIDX_STAT_NO_INTR                ((uint32_t)0x00000000U)         /* !< No pending interrupt request */
+#define DEBUGSS_IIDX_STAT_TXIFG                  ((uint32_t)0x00000001U)         /* !< TX interrupt */
+#define DEBUGSS_IIDX_STAT_RXIFG                  ((uint32_t)0x00000002U)         /* !< RX interrupt */
+#define DEBUGSS_IIDX_STAT_PWRUP                  ((uint32_t)0x00000003U)         /* !< Power-up interrupt. A debug session
+                                                                                    has started. */
+#define DEBUGSS_IIDX_STAT_PWRDWN                 ((uint32_t)0x00000004U)         /* !< Power-up interrupt. A debug session
+                                                                                    has started. */
+
+/* DEBUGSS_IMASK Bits */
+/* DEBUGSS_IMASK[TXIFG] Bits */
+#define DEBUGSS_IMASK_TXIFG_OFS                  (0)                             /* !< TXIFG Offset */
+#define DEBUGSS_IMASK_TXIFG_MASK                 ((uint32_t)0x00000001U)         /* !< Masks TXIFG in MIS register */
+#define DEBUGSS_IMASK_TXIFG_CLR                  ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DEBUGSS_IMASK_TXIFG_SET                  ((uint32_t)0x00000001U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DEBUGSS_IMASK[RXIFG] Bits */
+#define DEBUGSS_IMASK_RXIFG_OFS                  (1)                             /* !< RXIFG Offset */
+#define DEBUGSS_IMASK_RXIFG_MASK                 ((uint32_t)0x00000002U)         /* !< Masks RXIFG in MIS register */
+#define DEBUGSS_IMASK_RXIFG_CLR                  ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DEBUGSS_IMASK_RXIFG_SET                  ((uint32_t)0x00000002U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DEBUGSS_IMASK[PWRUPIFG] Bits */
+#define DEBUGSS_IMASK_PWRUPIFG_OFS               (2)                             /* !< PWRUPIFG Offset */
+#define DEBUGSS_IMASK_PWRUPIFG_MASK              ((uint32_t)0x00000004U)         /* !< Masks PWRUPIFG in MIS register */
+#define DEBUGSS_IMASK_PWRUPIFG_CLR               ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DEBUGSS_IMASK_PWRUPIFG_SET               ((uint32_t)0x00000004U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+/* DEBUGSS_IMASK[PWRDWNIFG] Bits */
+#define DEBUGSS_IMASK_PWRDWNIFG_OFS              (3)                             /* !< PWRDWNIFG Offset */
+#define DEBUGSS_IMASK_PWRDWNIFG_MASK             ((uint32_t)0x00000008U)         /* !< Masks PWRDWNIFG in MIS register */
+#define DEBUGSS_IMASK_PWRDWNIFG_CLR              ((uint32_t)0x00000000U)         /* !< Interrupt is masked out */
+#define DEBUGSS_IMASK_PWRDWNIFG_SET              ((uint32_t)0x00000008U)         /* !< Interrupt will request an interrupt
+                                                                                    service routine and corresponding bit
+                                                                                    in MIS will be set */
+
+/* DEBUGSS_RIS Bits */
+/* DEBUGSS_RIS[TXIFG] Bits */
+#define DEBUGSS_RIS_TXIFG_OFS                    (0)                             /* !< TXIFG Offset */
+#define DEBUGSS_RIS_TXIFG_MASK                   ((uint32_t)0x00000001U)         /* !< Raw interrupt status for TXIFG */
+#define DEBUGSS_RIS_TXIFG_CLR                    ((uint32_t)0x00000000U)         /* !< TXIFG did not occur */
+#define DEBUGSS_RIS_TXIFG_SET                    ((uint32_t)0x00000001U)         /* !< TXIFG occurred */
+/* DEBUGSS_RIS[RXIFG] Bits */
+#define DEBUGSS_RIS_RXIFG_OFS                    (1)                             /* !< RXIFG Offset */
+#define DEBUGSS_RIS_RXIFG_MASK                   ((uint32_t)0x00000002U)         /* !< Raw interrupt status for RXIFG */
+#define DEBUGSS_RIS_RXIFG_CLR                    ((uint32_t)0x00000000U)         /* !< RXIFG did not occur */
+#define DEBUGSS_RIS_RXIFG_SET                    ((uint32_t)0x00000002U)         /* !< RXIFG occurred */
+/* DEBUGSS_RIS[PWRUPIFG] Bits */
+#define DEBUGSS_RIS_PWRUPIFG_OFS                 (2)                             /* !< PWRUPIFG Offset */
+#define DEBUGSS_RIS_PWRUPIFG_MASK                ((uint32_t)0x00000004U)         /* !< Raw interrupt status for PWRUPIFG */
+#define DEBUGSS_RIS_PWRUPIFG_CLR                 ((uint32_t)0x00000000U)         /* !< PWRUPIFG did not occur */
+#define DEBUGSS_RIS_PWRUPIFG_SET                 ((uint32_t)0x00000004U)         /* !< PWRUPIFG occurred */
+/* DEBUGSS_RIS[PWRDWNIFG] Bits */
+#define DEBUGSS_RIS_PWRDWNIFG_OFS                (3)                             /* !< PWRDWNIFG Offset */
+#define DEBUGSS_RIS_PWRDWNIFG_MASK               ((uint32_t)0x00000008U)         /* !< Raw interrupt status for PWRDWNIFG */
+#define DEBUGSS_RIS_PWRDWNIFG_CLR                ((uint32_t)0x00000000U)         /* !< PWRUPIFG did not occur */
+#define DEBUGSS_RIS_PWRDWNIFG_SET                ((uint32_t)0x00000008U)         /* !< PWRUPIFG occurred */
+
+/* DEBUGSS_MIS Bits */
+/* DEBUGSS_MIS[TXIFG] Bits */
+#define DEBUGSS_MIS_TXIFG_OFS                    (0)                             /* !< TXIFG Offset */
+#define DEBUGSS_MIS_TXIFG_MASK                   ((uint32_t)0x00000001U)         /* !< Masked interrupt status for TXIFG */
+#define DEBUGSS_MIS_TXIFG_CLR                    ((uint32_t)0x00000000U)         /* !< TXIFG did not request an interrupt
+                                                                                    service routine */
+#define DEBUGSS_MIS_TXIFG_SET                    ((uint32_t)0x00000001U)         /* !< TXIFG requests an interrupt service
+                                                                                    routine */
+/* DEBUGSS_MIS[RXIFG] Bits */
+#define DEBUGSS_MIS_RXIFG_OFS                    (1)                             /* !< RXIFG Offset */
+#define DEBUGSS_MIS_RXIFG_MASK                   ((uint32_t)0x00000002U)         /* !< Masked interrupt status for RXIFG */
+#define DEBUGSS_MIS_RXIFG_CLR                    ((uint32_t)0x00000000U)         /* !< RXIFG did not request an interrupt
+                                                                                    service routine */
+#define DEBUGSS_MIS_RXIFG_SET                    ((uint32_t)0x00000002U)         /* !< RXIFG requests an interrupt service
+                                                                                    routine */
+/* DEBUGSS_MIS[PWRUPIFG] Bits */
+#define DEBUGSS_MIS_PWRUPIFG_OFS                 (2)                             /* !< PWRUPIFG Offset */
+#define DEBUGSS_MIS_PWRUPIFG_MASK                ((uint32_t)0x00000004U)         /* !< Masked interrupt status for
+                                                                                    PWRUPIFG */
+#define DEBUGSS_MIS_PWRUPIFG_CLR                 ((uint32_t)0x00000000U)         /* !< PWRUPIFG did not request an
+                                                                                    interrupt service routine */
+#define DEBUGSS_MIS_PWRUPIFG_SET                 ((uint32_t)0x00000004U)         /* !< PWRUPIFG requests an interrupt
+                                                                                    service routine */
+/* DEBUGSS_MIS[PWRDWNIFG] Bits */
+#define DEBUGSS_MIS_PWRDWNIFG_OFS                (3)                             /* !< PWRDWNIFG Offset */
+#define DEBUGSS_MIS_PWRDWNIFG_MASK               ((uint32_t)0x00000008U)         /* !< Masked interrupt status for
+                                                                                    PWRDWNIFG */
+#define DEBUGSS_MIS_PWRDWNIFG_CLR                ((uint32_t)0x00000000U)         /* !< PWRUPIFG did not request an
+                                                                                    interrupt service routine */
+#define DEBUGSS_MIS_PWRDWNIFG_SET                ((uint32_t)0x00000008U)         /* !< PWRUPIFG requests an interrupt
+                                                                                    service routine */
+
+/* DEBUGSS_ISET Bits */
+/* DEBUGSS_ISET[TXIFG] Bits */
+#define DEBUGSS_ISET_TXIFG_OFS                   (0)                             /* !< TXIFG Offset */
+#define DEBUGSS_ISET_TXIFG_MASK                  ((uint32_t)0x00000001U)         /* !< Sets TXIFG in RIS register */
+#define DEBUGSS_ISET_TXIFG_NO_EFFECT             ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DEBUGSS_ISET_TXIFG_SET                   ((uint32_t)0x00000001U)         /* !< RIS bit corresponding to TXIFG is
+                                                                                    set */
+/* DEBUGSS_ISET[RXIFG] Bits */
+#define DEBUGSS_ISET_RXIFG_OFS                   (1)                             /* !< RXIFG Offset */
+#define DEBUGSS_ISET_RXIFG_MASK                  ((uint32_t)0x00000002U)         /* !< Sets RXIFG in RIS register */
+#define DEBUGSS_ISET_RXIFG_NO_EFFECT             ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DEBUGSS_ISET_RXIFG_SET                   ((uint32_t)0x00000002U)         /* !< RIS bit corresponding to RXIFG is
+                                                                                    set */
+/* DEBUGSS_ISET[PWRUPIFG] Bits */
+#define DEBUGSS_ISET_PWRUPIFG_OFS                (2)                             /* !< PWRUPIFG Offset */
+#define DEBUGSS_ISET_PWRUPIFG_MASK               ((uint32_t)0x00000004U)         /* !< Sets PWRUPIFG in RIS register */
+#define DEBUGSS_ISET_PWRUPIFG_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DEBUGSS_ISET_PWRUPIFG_SET                ((uint32_t)0x00000004U)         /* !< RIS bit corresponding to PWRUPIFG
+                                                                                    is set */
+/* DEBUGSS_ISET[PWRDWNIFG] Bits */
+#define DEBUGSS_ISET_PWRDWNIFG_OFS               (3)                             /* !< PWRDWNIFG Offset */
+#define DEBUGSS_ISET_PWRDWNIFG_MASK              ((uint32_t)0x00000008U)         /* !< Sets PWRDWNIFG in RIS register */
+#define DEBUGSS_ISET_PWRDWNIFG_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DEBUGSS_ISET_PWRDWNIFG_SET               ((uint32_t)0x00000008U)         /* !< RIS bit corresponding to PWRUPIFG
+                                                                                    is set */
+
+/* DEBUGSS_ICLR Bits */
+/* DEBUGSS_ICLR[TXIFG] Bits */
+#define DEBUGSS_ICLR_TXIFG_OFS                   (0)                             /* !< TXIFG Offset */
+#define DEBUGSS_ICLR_TXIFG_MASK                  ((uint32_t)0x00000001U)         /* !< Clears TXIFG in RIS register */
+#define DEBUGSS_ICLR_TXIFG_NO_EFFECT             ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DEBUGSS_ICLR_TXIFG_CLR                   ((uint32_t)0x00000001U)         /* !< RIS bit corresponding to TXIFG is
+                                                                                    cleared */
+/* DEBUGSS_ICLR[RXIFG] Bits */
+#define DEBUGSS_ICLR_RXIFG_OFS                   (1)                             /* !< RXIFG Offset */
+#define DEBUGSS_ICLR_RXIFG_MASK                  ((uint32_t)0x00000002U)         /* !< Clears RXIFG in RIS register */
+#define DEBUGSS_ICLR_RXIFG_NO_EFFECT             ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DEBUGSS_ICLR_RXIFG_CLR                   ((uint32_t)0x00000002U)         /* !< RIS bit corresponding to RXIFG is
+                                                                                    cleared */
+/* DEBUGSS_ICLR[PWRUPIFG] Bits */
+#define DEBUGSS_ICLR_PWRUPIFG_OFS                (2)                             /* !< PWRUPIFG Offset */
+#define DEBUGSS_ICLR_PWRUPIFG_MASK               ((uint32_t)0x00000004U)         /* !< Clears PWRUPIFG in RIS register */
+#define DEBUGSS_ICLR_PWRUPIFG_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DEBUGSS_ICLR_PWRUPIFG_CLR                ((uint32_t)0x00000004U)         /* !< RIS bit corresponding to PWRUPIFG
+                                                                                    is cleared */
+/* DEBUGSS_ICLR[PWRDWNIFG] Bits */
+#define DEBUGSS_ICLR_PWRDWNIFG_OFS               (3)                             /* !< PWRDWNIFG Offset */
+#define DEBUGSS_ICLR_PWRDWNIFG_MASK              ((uint32_t)0x00000008U)         /* !< Clears PWRDWNIFG in RIS register */
+#define DEBUGSS_ICLR_PWRDWNIFG_NO_EFFECT         ((uint32_t)0x00000000U)         /* !< Writing a 0 has no effect */
+#define DEBUGSS_ICLR_PWRDWNIFG_CLR               ((uint32_t)0x00000008U)         /* !< RIS bit corresponding to PWRUPIFG
+                                                                                    is cleared */
+
+/* DEBUGSS_EVT_MODE Bits */
+/* DEBUGSS_EVT_MODE[INT0_CFG] Bits */
+#define DEBUGSS_EVT_MODE_INT0_CFG_OFS            (0)                             /* !< INT0_CFG Offset */
+#define DEBUGSS_EVT_MODE_INT0_CFG_MASK           ((uint32_t)0x00000003U)         /* !< Event line mode select for
+                                                                                    peripheral events */
+#define DEBUGSS_EVT_MODE_INT0_CFG_DISABLE        ((uint32_t)0x00000000U)         /* !< The interrupt or event line is
+                                                                                    disabled. */
+#define DEBUGSS_EVT_MODE_INT0_CFG_SOFTWARE       ((uint32_t)0x00000001U)         /* !< The interrupt or event line is in
+                                                                                    software mode. Software must clear
+                                                                                    the RIS. */
+#define DEBUGSS_EVT_MODE_INT0_CFG_HARDWARE       ((uint32_t)0x00000002U)         /* !< The interrupt or event line is in
+                                                                                    hardware mode. The hardware (another
+                                                                                    module) clears automatically the
+                                                                                    associated RIS flag. */
+
+/* DEBUGSS_DESC Bits */
+/* DEBUGSS_DESC[MINREV] Bits */
+#define DEBUGSS_DESC_MINREV_OFS                  (0)                             /* !< MINREV Offset */
+#define DEBUGSS_DESC_MINREV_MASK                 ((uint32_t)0x0000000FU)         /* !< Minor rev of the IP */
+/* DEBUGSS_DESC[MAJREV] Bits */
+#define DEBUGSS_DESC_MAJREV_OFS                  (4)                             /* !< MAJREV Offset */
+#define DEBUGSS_DESC_MAJREV_MASK                 ((uint32_t)0x000000F0U)         /* !< Major rev of the IP */
+/* DEBUGSS_DESC[INSTNUM] Bits */
+#define DEBUGSS_DESC_INSTNUM_OFS                 (8)                             /* !< INSTNUM Offset */
+#define DEBUGSS_DESC_INSTNUM_MASK                ((uint32_t)0x00000F00U)         /* !< Instance Number within the device.
+                                                                                    This will be a parameter to the RTL
+                                                                                    for modules that can have multiple
+                                                                                    instances */
+/* DEBUGSS_DESC[FEATUREVER] Bits */
+#define DEBUGSS_DESC_FEATUREVER_OFS              (12)                            /* !< FEATUREVER Offset */
+#define DEBUGSS_DESC_FEATUREVER_MASK             ((uint32_t)0x0000F000U)         /* !< Feature Set for the module
+                                                                                    *instance* */
+/* DEBUGSS_DESC[MODULEID] Bits */
+#define DEBUGSS_DESC_MODULEID_OFS                (16)                            /* !< MODULEID Offset */
+#define DEBUGSS_DESC_MODULEID_MASK               ((uint32_t)0xFFFF0000U)         /* !< Module identification contains a
+                                                                                    unique peripheral identification
+                                                                                    number. The assignments are
+                                                                                    maintained in a central database for
+                                                                                    all of the platform modules to ensure
+                                                                                    uniqueness. */
+
+/* DEBUGSS_TXD Bits */
+/* DEBUGSS_TXD[TX_DATA] Bits */
+#define DEBUGSS_TXD_TX_DATA_OFS                  (0)                             /* !< TX_DATA Offset */
+#define DEBUGSS_TXD_TX_DATA_MASK                 ((uint32_t)0xFFFFFFFFU)         /* !< Contains data written by an
+                                                                                    external debug tool to the SEC-AP
+                                                                                    TXDATA register */
+
+/* DEBUGSS_TXCTL Bits */
+/* DEBUGSS_TXCTL[TRANSMIT] Bits */
+#define DEBUGSS_TXCTL_TRANSMIT_OFS               (0)                             /* !< TRANSMIT Offset */
+#define DEBUGSS_TXCTL_TRANSMIT_MASK              ((uint32_t)0x00000001U)         /* !< Indicates data request in DSSM.TXD,
+                                                                                    set on write via Debug AP to
+                                                                                    DSSM.TXD.  A read of the DSSM.TXD
+                                                                                    register by SW will clear the TX
+                                                                                    field. The tool can check that TXD is
+                                                                                    empty by reading this field. */
+#define DEBUGSS_TXCTL_TRANSMIT_EMPTY             ((uint32_t)0x00000000U)         /* !< TXD is empty */
+#define DEBUGSS_TXCTL_TRANSMIT_FULL              ((uint32_t)0x00000001U)         /* !< TXD is full */
+/* DEBUGSS_TXCTL[TRANSMIT_FLAGS] Bits */
+#define DEBUGSS_TXCTL_TRANSMIT_FLAGS_OFS         (1)                             /* !< TRANSMIT_FLAGS Offset */
+#define DEBUGSS_TXCTL_TRANSMIT_FLAGS_MASK        ((uint32_t)0xFFFFFFFEU)         /* !< Generic TX flags that can be set by
+                                                                                    external debug tool. Functionality is
+                                                                                    defined by SW. */
+
+/* DEBUGSS_RXD Bits */
+/* DEBUGSS_RXD[RX_DATA] Bits */
+#define DEBUGSS_RXD_RX_DATA_OFS                  (0)                             /* !< RX_DATA Offset */
+#define DEBUGSS_RXD_RX_DATA_MASK                 ((uint32_t)0xFFFFFFFFU)         /* !< Contains data written by SM/OW. */
+
+/* DEBUGSS_RXCTL Bits */
+/* DEBUGSS_RXCTL[RECEIVE] Bits */
+#define DEBUGSS_RXCTL_RECEIVE_OFS                (0)                             /* !< RECEIVE Offset */
+#define DEBUGSS_RXCTL_RECEIVE_MASK               ((uint32_t)0x00000001U)         /* !< Indicates SW write to the DSSM.RXD
+                                                                                    register. A read of the DSSM.RXD
+                                                                                    register by SWD Access Port will
+                                                                                    clear the RX field. */
+#define DEBUGSS_RXCTL_RECEIVE_EMPTY              ((uint32_t)0x00000000U)         /* !< RXD empty */
+#define DEBUGSS_RXCTL_RECEIVE_FULL               ((uint32_t)0x00000001U)         /* !< RXD full */
+/* DEBUGSS_RXCTL[RECEIVE_FLAGS] Bits */
+#define DEBUGSS_RXCTL_RECEIVE_FLAGS_OFS          (1)                             /* !< RECEIVE_FLAGS Offset */
+#define DEBUGSS_RXCTL_RECEIVE_FLAGS_MASK         ((uint32_t)0x000000FEU)         /* !< Generic RX flags that can be set by
+                                                                                    SW and read by external debug tool.
+                                                                                    Functionality is defined by SW. */
+
+/* DEBUGSS_SPECIAL_AUTH Bits */
+/* DEBUGSS_SPECIAL_AUTH[SECAPEN] Bits */
+#define DEBUGSS_SPECIAL_AUTH_SECAPEN_OFS         (0)                             /* !< SECAPEN Offset */
+#define DEBUGSS_SPECIAL_AUTH_SECAPEN_MASK        ((uint32_t)0x00000001U)         /* !< An active high input. When asserted
+                                                                                    (and SWD access is also permitted),
+                                                                                    the debug tools can use the
+                                                                                    Security-AP to communicate with
+                                                                                    security control logic. When
+                                                                                    deasserted, a DAPBUS firewall will
+                                                                                    isolate the AP and prevent access to
+                                                                                    the Security-AP. */
+#define DEBUGSS_SPECIAL_AUTH_SECAPEN_DISABLE     ((uint32_t)0x00000000U)         /* !< Disable SEC-AP */
+#define DEBUGSS_SPECIAL_AUTH_SECAPEN_ENABLE      ((uint32_t)0x00000001U)         /* !< Enable SEC-AP */
+/* DEBUGSS_SPECIAL_AUTH[SWDPORTEN] Bits */
+#define DEBUGSS_SPECIAL_AUTH_SWDPORTEN_OFS       (1)                             /* !< SWDPORTEN Offset */
+#define DEBUGSS_SPECIAL_AUTH_SWDPORTEN_MASK      ((uint32_t)0x00000002U)         /* !< When asserted, the SW-DP functions
+                                                                                    normally.  When deasserted, the SW-DP
+                                                                                    effectively disables all external
+                                                                                    debug access. */
+#define DEBUGSS_SPECIAL_AUTH_SWDPORTEN_DISABLE   ((uint32_t)0x00000000U)         /* !< Disable SWD port */
+#define DEBUGSS_SPECIAL_AUTH_SWDPORTEN_ENABLE    ((uint32_t)0x00000002U)         /* !< Enable SWD port */
+/* DEBUGSS_SPECIAL_AUTH[DFTAPEN] Bits */
+#define DEBUGSS_SPECIAL_AUTH_DFTAPEN_OFS         (2)                             /* !< DFTAPEN Offset */
+#define DEBUGSS_SPECIAL_AUTH_DFTAPEN_MASK        ((uint32_t)0x00000004U)         /* !< An active high input. When asserted
+                                                                                    (and SWD access is also permitted),
+                                                                                    the debug tools can then access the
+                                                                                    DFT-AP external to the DebugSS lite.
+                                                                                    When deasserted, a DAPBUS firewall
+                                                                                    will isolate the AP and prevent
+                                                                                    access. */
+#define DEBUGSS_SPECIAL_AUTH_DFTAPEN_DISABLE     ((uint32_t)0x00000000U)         /* !< Disable DFT-TAP */
+#define DEBUGSS_SPECIAL_AUTH_DFTAPEN_ENABLE      ((uint32_t)0x00000004U)         /* !< Enable DFT-TAP */
+/* DEBUGSS_SPECIAL_AUTH[ETAPEN] Bits */
+#define DEBUGSS_SPECIAL_AUTH_ETAPEN_OFS          (3)                             /* !< ETAPEN Offset */
+#define DEBUGSS_SPECIAL_AUTH_ETAPEN_MASK         ((uint32_t)0x00000008U)         /* !< An active high input. When asserted
+                                                                                    (and SWD access is also permitted),
+                                                                                    the debug tools can then access an
+                                                                                    ET-AP external to the DebugSS lite.
+                                                                                    When deasserted, a DAPBUS firewall
+                                                                                    will isolate the AP and prevent
+                                                                                    access. */
+#define DEBUGSS_SPECIAL_AUTH_ETAPEN_DISABLE      ((uint32_t)0x00000000U)         /* !< Disable ET+ -AP */
+#define DEBUGSS_SPECIAL_AUTH_ETAPEN_ENABLE       ((uint32_t)0x00000008U)         /* !< Enable ET+ -AP */
+/* DEBUGSS_SPECIAL_AUTH[CFGAPEN] Bits */
+#define DEBUGSS_SPECIAL_AUTH_CFGAPEN_OFS         (4)                             /* !< CFGAPEN Offset */
+#define DEBUGSS_SPECIAL_AUTH_CFGAPEN_MASK        ((uint32_t)0x00000010U)         /* !< An active high input. When asserted
+                                                                                    (and SWD access is also permitted),
+                                                                                    the debug tools can use the Config-AP
+                                                                                    to read device configuration
+                                                                                    information. When deasserted, a
+                                                                                    DAPBUS firewall will isolate the AP
+                                                                                    and prevent access to the Config-AP. */
+#define DEBUGSS_SPECIAL_AUTH_CFGAPEN_DISABLE     ((uint32_t)0x00000000U)         /* !< Disable CFG-AP */
+#define DEBUGSS_SPECIAL_AUTH_CFGAPEN_ENABLE      ((uint32_t)0x00000010U)         /* !< Enable CFG-AP */
+/* DEBUGSS_SPECIAL_AUTH[AHBAPEN] Bits */
+#define DEBUGSS_SPECIAL_AUTH_AHBAPEN_OFS         (5)                             /* !< AHBAPEN Offset */
+#define DEBUGSS_SPECIAL_AUTH_AHBAPEN_MASK        ((uint32_t)0x00000020U)         /* !< Disabling / enabling debug access
+                                                                                    to the M0+ Core via the AHB-AP DAP
+                                                                                    bus isolation. */
+#define DEBUGSS_SPECIAL_AUTH_AHBAPEN_DISABLE     ((uint32_t)0x00000000U)         /* !< Disable AHB-AP */
+#define DEBUGSS_SPECIAL_AUTH_AHBAPEN_ENABLE      ((uint32_t)0x00000020U)         /* !< Enable AHB-AP */
+/* DEBUGSS_SPECIAL_AUTH[PWRAPEN] Bits */
+#define DEBUGSS_SPECIAL_AUTH_PWRAPEN_OFS         (6)                             /* !< PWRAPEN Offset */
+#define DEBUGSS_SPECIAL_AUTH_PWRAPEN_MASK        ((uint32_t)0x00000040U)         /* !< An active high input. When asserted
+                                                                                    (and SWD access is also permitted),
+                                                                                    the debug tools can then access the
+                                                                                    PWR-AP to power and reset state of
+                                                                                    the CPU. When deasserted, a DAPBUS
+                                                                                    firewall will isolate the AP and
+                                                                                    prevent access. */
+#define DEBUGSS_SPECIAL_AUTH_PWRAPEN_DISABLE     ((uint32_t)0x00000000U)         /* !< Disable PWR-AP */
+#define DEBUGSS_SPECIAL_AUTH_PWRAPEN_ENABLE      ((uint32_t)0x00000040U)         /* !< Enable PWR-AP */
+
+/* DEBUGSS_APP_AUTH Bits */
+/* DEBUGSS_APP_AUTH[DBGEN] Bits */
+#define DEBUGSS_APP_AUTH_DBGEN_OFS               (0)                             /* !< DBGEN Offset */
+#define DEBUGSS_APP_AUTH_DBGEN_MASK              ((uint32_t)0x00000001U)         /* !< Controls invasive debug enable. */
+#define DEBUGSS_APP_AUTH_DBGEN_DISABLE           ((uint32_t)0x00000000U)         /* !< Invasive debug disabled */
+#define DEBUGSS_APP_AUTH_DBGEN_ENABLE            ((uint32_t)0x00000001U)         /* !< Invasive debug enabled */
+/* DEBUGSS_APP_AUTH[NIDEN] Bits */
+#define DEBUGSS_APP_AUTH_NIDEN_OFS               (1)                             /* !< NIDEN Offset */
+#define DEBUGSS_APP_AUTH_NIDEN_MASK              ((uint32_t)0x00000002U)         /* !< Controls non-invasive debug enable. */
+#define DEBUGSS_APP_AUTH_NIDEN_DISABLE           ((uint32_t)0x00000000U)         /* !< Non-invasive debug disabled */
+#define DEBUGSS_APP_AUTH_NIDEN_ENABLE            ((uint32_t)0x00000002U)         /* !< Non-invasive debug enabled */
+/* DEBUGSS_APP_AUTH[SPIDEN] Bits */
+#define DEBUGSS_APP_AUTH_SPIDEN_OFS              (2)                             /* !< SPIDEN Offset */
+#define DEBUGSS_APP_AUTH_SPIDEN_MASK             ((uint32_t)0x00000004U)         /* !< Secure invasive debug enable. */
+#define DEBUGSS_APP_AUTH_SPIDEN_DISABLE          ((uint32_t)0x00000000U)         /* !< Invasive debug disabled */
+#define DEBUGSS_APP_AUTH_SPIDEN_ENABLE           ((uint32_t)0x00000004U)         /* !< Invasive debug enabled */
+/* DEBUGSS_APP_AUTH[SPNIDEN] Bits */
+#define DEBUGSS_APP_AUTH_SPNIDEN_OFS             (3)                             /* !< SPNIDEN Offset */
+#define DEBUGSS_APP_AUTH_SPNIDEN_MASK            ((uint32_t)0x00000008U)         /* !< Secure non-invasive debug enable. */
+#define DEBUGSS_APP_AUTH_SPNIDEN_DISABLE         ((uint32_t)0x00000000U)         /* !< Invasive debug disabled */
+#define DEBUGSS_APP_AUTH_SPNIDEN_ENABLE          ((uint32_t)0x00000008U)         /* !< Invasive debug enabled */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_m0p_hw_debugss__include */

--- a/mspm0/source/ti/devices/msp/peripherals/m0p/hw_factoryregion.h
+++ b/mspm0/source/ti/devices/msp/peripherals/m0p/hw_factoryregion.h
@@ -1,0 +1,441 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_hw_factoryregion__include
+#define ti_devices_msp_peripherals_hw_factoryregion__include
+
+/* This preliminary header file does not have a version number */
+/* MMR repo: https://bitbucket.itg.ti.com/projects/cmcu_msp65soc/repos/trim_platform_constants */
+/* MMR revision: ff4b6bcad5d93ca548bdb94b818a30dc3f4acd3f */
+/* Generator revision: c98c4ac511e2bd0d918c5d427bd46b7a359dacf1
+   (MInT: ec7ec7482a60c6871be32db8b378ec27aa4771f6) */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* FACTORYREGION Registers
+******************************************************************************/
+#define FACTORYREGION_OPEN_OFS                   ((uint32_t)0x41C40000U)
+
+
+/** @addtogroup FACTORYREGION_OPEN
+  @{
+*/
+
+typedef struct {
+  __I  uint32_t TRACEID;                           /* !< (@ 0x41C40000) Defined by TI, during ATE, based on wafer */
+  __I  uint32_t DEVICEID;                          /* !< (@ 0x41C40004) This is the JTAGIDCODE that comes from the Ramp
+                                                      system */
+  __I  uint32_t USERID;                            /* !< (@ 0x41C40008) Defined by TI, depending on device spin */
+  __I  uint32_t BSLPIN_UART;                       /* !< (@ 0x41C4000C) BSL UART Pin Configuration */
+  __I  uint32_t BSLPIN_I2C;                        /* !< (@ 0x41C40010) BSL I2C Pin Configuration */
+  __I  uint32_t BSLPIN_INVOKE;                     /* !< (@ 0x41C40014) BSL Pin Invocation Configuration */
+  __I  uint32_t SRAMFLASH;                         /* !< (@ 0x41C40018) */
+  __I  uint32_t PLLSTARTUP0_4_8MHZ;                /* !< (@ 0x41C4001C) */
+  __I  uint32_t PLLSTARTUP1_4_8MHZ;                /* !< (@ 0x41C40020) System PLL Paramater 1 MMR --- Data from Flash
+                                                      Table Lookup */
+  __I  uint32_t PLLSTARTUP0_8_16MHZ;               /* !< (@ 0x41C40024) */
+  __I  uint32_t PLLSTARTUP1_8_16MHZ;               /* !< (@ 0x41C40028) System PLL Paramater 1 MMR --- Data from Flash
+                                                      Table Lookup */
+  __I  uint32_t PLLSTARTUP0_16_32MHZ;              /* !< (@ 0x41C4002C) */
+  __I  uint32_t PLLSTARTUP1_16_32MHZ;              /* !< (@ 0x41C40030) System PLL Paramater 1 MMR --- Data from Flash
+                                                      Table Lookup */
+  __I  uint32_t PLLSTARTUP0_32_48MHZ;              /* !< (@ 0x41C40034) */
+  __I  uint32_t PLLSTARTUP1_32_48MHZ;              /* !< (@ 0x41C40038) System PLL Paramater 1 MMR --- Data from Flash
+                                                      Table Lookup */
+  __I  uint32_t TEMP_SENSE0;                       /* !< (@ 0x41C4003C) Temperature sensor room temperature calibration
+                                                      code. This is ADC conversion results of temperature sensor output
+                                                      voltage.  Included in BOOTCRC calculation. */
+  __I  uint32_t RESERVED0;                         /* !< (@ 0x41C40040) */
+  __I  uint32_t RESERVED1;                         /* !< (@ 0x41C40044) */
+  __I  uint32_t RESERVED2;                         /* !< (@ 0x41C40048) */
+  __I  uint32_t RESERVED3;                         /* !< (@ 0x41C4004C) */
+  __I  uint32_t RESERVED4;                         /* !< (@ 0x41C40050) */
+  __I  uint32_t RESERVED5;                         /* !< (@ 0x41C40054) */
+  __I  uint32_t RESERVED6;                         /* !< (@ 0x41C40058) */
+  __I  uint32_t RESERVED7;                         /* !< (@ 0x41C4005C) */
+  __I  uint32_t RESERVED8;                         /* !< (@ 0x41C40060) */
+  __I  uint32_t RESERVED9;                         /* !< (@ 0x41C40064) */
+  __I  uint32_t RESERVED10;                        /* !< (@ 0x41C40068) */
+  __I  uint32_t RESERVED11;                        /* !< (@ 0x41C4006C) */
+  __I  uint32_t RESERVED12;                        /* !< (@ 0x41C40070) */
+  __I  uint32_t RESERVED13;                        /* !< (@ 0x41C40074) */
+  __I  uint32_t RESERVED14;                        /* !< (@ 0x41C40078) */
+  __I  uint32_t BOOTCRC;                           /* !< (@ 0x41C4007C) BOOTCRC records the 32-bit CRC of all locations in
+                                                      OPEN including reserved locations. */
+} FACTORYREGION_OPEN_Regs;
+
+/*@}*/ /* end of group FACTORYREGION_OPEN */
+
+/** @addtogroup FACTORYREGION
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[275841024];
+  FACTORYREGION_OPEN_Regs  OPEN;                              /* !< (@ 0x41C40000) Customer-visible data (IDs, PLL trims,...) */
+} FACTORYREGION_Regs;
+
+/*@}*/ /* end of group FACTORYREGION */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* FACTORYREGION Register Control Bits
+******************************************************************************/
+
+/* FACTORYREGION_TRACEID Bits */
+/* FACTORYREGION_TRACEID[DATA] Bits */
+#define FACTORYREGION_TRACEID_DATA_OFS           (0)                             /* !< DATA Offset */
+#define FACTORYREGION_TRACEID_DATA_MASK          ((uint32_t)0xFFFFFFFFU)
+
+/* FACTORYREGION_DEVICEID Bits */
+/* FACTORYREGION_DEVICEID[VERSION] Bits */
+#define FACTORYREGION_DEVICEID_VERSION_OFS       (28)                            /* !< VERSION Offset */
+#define FACTORYREGION_DEVICEID_VERSION_MASK      ((uint32_t)0xF0000000U)         /* !< Revision of the device. This field
+                                                                                    should change each time that the
+                                                                                    logic or mask set of the device is
+                                                                                    revised. */
+/* FACTORYREGION_DEVICEID[PARTNUM] Bits */
+#define FACTORYREGION_DEVICEID_PARTNUM_OFS       (12)                            /* !< PARTNUM Offset */
+#define FACTORYREGION_DEVICEID_PARTNUM_MASK      ((uint32_t)0x0FFFF000U)         /* !< Part number of the device. */
+/* FACTORYREGION_DEVICEID[MANUFACTURER] Bits */
+#define FACTORYREGION_DEVICEID_MANUFACTURER_OFS  (1)                             /* !< MANUFACTURER Offset */
+#define FACTORYREGION_DEVICEID_MANUFACTURER_MASK ((uint32_t)0x00000FFEU)         /* !< TI's JEDEC bank and company code,
+                                                                                    which is: 00000010111b */
+/* FACTORYREGION_DEVICEID[ALWAYS_1] Bits */
+#define FACTORYREGION_DEVICEID_ALWAYS_1_OFS      (0)                             /* !< ALWAYS_1 Offset */
+#define FACTORYREGION_DEVICEID_ALWAYS_1_MASK     ((uint32_t)0x00000001U)         /* !< This is always 1 */
+
+/* FACTORYREGION_USERID Bits */
+/* FACTORYREGION_USERID[PART] Bits */
+#define FACTORYREGION_USERID_PART_OFS            (0)                             /* !< PART Offset */
+#define FACTORYREGION_USERID_PART_MASK           ((uint32_t)0x0000FFFFU)         /* !< Bit pattern that uniquely
+                                                                                    identifying a part. This is used to
+                                                                                    identify the specific part based on
+                                                                                    the die identified in
+                                                                                    DEVICEID.device. This number shall be
+                                                                                    selected at random among the
+                                                                                    remaining numbers for DEVICEID.device
+                                                                                    such that the order of creation
+                                                                                    cannot be inferred by the number.
+                                                                                    This value does not encode the part
+                                                                                    number directly. */
+/* FACTORYREGION_USERID[VARIANT] Bits */
+#define FACTORYREGION_USERID_VARIANT_OFS         (16)                            /* !< VARIANT Offset */
+#define FACTORYREGION_USERID_VARIANT_MASK        ((uint32_t)0x00FF0000U)         /* !< Bit pattern uniquely identifying a
+                                                                                    variant of a part. This is used to
+                                                                                    indicate memory or package variations
+                                                                                    of the same part number. This number
+                                                                                    shall be selected at random among the
+                                                                                    remaining numbers for the relevant
+                                                                                    combination of IDCODE.device and
+                                                                                    USERCODE.part such that the order of
+                                                                                    creation cannot be inferred by the
+                                                                                    number. The variant number does not
+                                                                                    encode specifics of the variant
+                                                                                    directly. */
+/* FACTORYREGION_USERID[MINORREV] Bits */
+#define FACTORYREGION_USERID_MINORREV_OFS        (24)                            /* !< MINORREV Offset */
+#define FACTORYREGION_USERID_MINORREV_MASK       ((uint32_t)0x0F000000U)         /* !< Monotonic increasing value
+                                                                                    indicating a new revision of the SKU
+                                                                                    that preserves compatibility with
+                                                                                    lesser minorrev values. New
+                                                                                    capability may be introduced such
+                                                                                    that lesser minorrev numbers may not
+                                                                                    be compatible with greater if the new
+                                                                                    capability is used. */
+/* FACTORYREGION_USERID[MAJORREV] Bits */
+#define FACTORYREGION_USERID_MAJORREV_OFS        (28)                            /* !< MAJORREV Offset */
+#define FACTORYREGION_USERID_MAJORREV_MASK       ((uint32_t)0x70000000U)         /* !< Monotonic increasing value
+                                                                                    indicating a new revision of the SKU
+                                                                                    significant enough that users of the
+                                                                                    device may have to revise PCB or or
+                                                                                    software design */
+/* FACTORYREGION_USERID[START] Bits */
+#define FACTORYREGION_USERID_START_OFS           (31)                            /* !< START Offset */
+#define FACTORYREGION_USERID_START_MASK          ((uint32_t)0x80000000U)
+
+/* FACTORYREGION_BSLPIN_UART Bits */
+/* FACTORYREGION_BSLPIN_UART[UART_RXD_PAD] Bits */
+#define FACTORYREGION_BSLPIN_UART_UART_RXD_PAD_OFS (0)                             /* !< UART_RXD_PAD Offset */
+#define FACTORYREGION_BSLPIN_UART_UART_RXD_PAD_MASK ((uint32_t)0x000000FFU)         /* !< UART RXD Pad used by BSL */
+/* FACTORYREGION_BSLPIN_UART[UART_RXD_PF] Bits */
+#define FACTORYREGION_BSLPIN_UART_UART_RXD_PF_OFS (8)                             /* !< UART_RXD_PF Offset */
+#define FACTORYREGION_BSLPIN_UART_UART_RXD_PF_MASK ((uint32_t)0x0000FF00U)         /* !< UART RXD Pin Function Selection
+                                                                                    Value */
+/* FACTORYREGION_BSLPIN_UART[UART_TXD_PAD] Bits */
+#define FACTORYREGION_BSLPIN_UART_UART_TXD_PAD_OFS (16)                            /* !< UART_TXD_PAD Offset */
+#define FACTORYREGION_BSLPIN_UART_UART_TXD_PAD_MASK ((uint32_t)0x00FF0000U)         /* !< UART TXD Pin used by BSL */
+/* FACTORYREGION_BSLPIN_UART[UART_TXD_PF] Bits */
+#define FACTORYREGION_BSLPIN_UART_UART_TXD_PF_OFS (24)                            /* !< UART_TXD_PF Offset */
+#define FACTORYREGION_BSLPIN_UART_UART_TXD_PF_MASK ((uint32_t)0xFF000000U)         /* !< UART TXD Pin Function Selection
+                                                                                    Value */
+
+/* FACTORYREGION_BSLPIN_I2C Bits */
+/* FACTORYREGION_BSLPIN_I2C[I2C_SDA_PAD] Bits */
+#define FACTORYREGION_BSLPIN_I2C_I2C_SDA_PAD_OFS (0)                             /* !< I2C_SDA_PAD Offset */
+#define FACTORYREGION_BSLPIN_I2C_I2C_SDA_PAD_MASK ((uint32_t)0x000000FFU)         /* !< I2C SDA Pin used by BSL */
+/* FACTORYREGION_BSLPIN_I2C[I2C_SDA_PF] Bits */
+#define FACTORYREGION_BSLPIN_I2C_I2C_SDA_PF_OFS  (8)                             /* !< I2C_SDA_PF Offset */
+#define FACTORYREGION_BSLPIN_I2C_I2C_SDA_PF_MASK ((uint32_t)0x0000FF00U)         /* !< I2C SDA Pin Function Selection
+                                                                                    Value */
+/* FACTORYREGION_BSLPIN_I2C[I2C_SCL_PAD] Bits */
+#define FACTORYREGION_BSLPIN_I2C_I2C_SCL_PAD_OFS (16)                            /* !< I2C_SCL_PAD Offset */
+#define FACTORYREGION_BSLPIN_I2C_I2C_SCL_PAD_MASK ((uint32_t)0x00FF0000U)         /* !< I2C SCL Pin used by BSL */
+/* FACTORYREGION_BSLPIN_I2C[I2C_SCL_PF] Bits */
+#define FACTORYREGION_BSLPIN_I2C_I2C_SCL_PF_OFS  (24)                            /* !< I2C_SCL_PF Offset */
+#define FACTORYREGION_BSLPIN_I2C_I2C_SCL_PF_MASK ((uint32_t)0xFF000000U)         /* !< I2C SCL Pin Function Selection
+                                                                                    Value */
+
+/* FACTORYREGION_BSLPIN_INVOKE Bits */
+/* FACTORYREGION_BSLPIN_INVOKE[BSL_PAD] Bits */
+#define FACTORYREGION_BSLPIN_INVOKE_BSL_PAD_OFS  (0)                             /* !< BSL_PAD Offset */
+#define FACTORYREGION_BSLPIN_INVOKE_BSL_PAD_MASK ((uint32_t)0x0000007FU)         /* !< BSL Invocation Pin Number */
+/* FACTORYREGION_BSLPIN_INVOKE[GPIO_LEVEL] Bits */
+#define FACTORYREGION_BSLPIN_INVOKE_GPIO_LEVEL_OFS (7)                             /* !< GPIO_LEVEL Offset */
+#define FACTORYREGION_BSLPIN_INVOKE_GPIO_LEVEL_MASK ((uint32_t)0x00000080U)         /* !< GPIO Level Configuration for BSL
+                                                                                    Invocation */
+/* FACTORYREGION_BSLPIN_INVOKE[GPIO_PIN_SEL] Bits */
+#define FACTORYREGION_BSLPIN_INVOKE_GPIO_PIN_SEL_OFS (8)                             /* !< GPIO_PIN_SEL Offset */
+#define FACTORYREGION_BSLPIN_INVOKE_GPIO_PIN_SEL_MASK ((uint32_t)0x00001F00U)         /* !< GPIO Pin Number in GPIO Module */
+/* FACTORYREGION_BSLPIN_INVOKE[GPIO_REG_SEL] Bits */
+#define FACTORYREGION_BSLPIN_INVOKE_GPIO_REG_SEL_OFS (13)                            /* !< GPIO_REG_SEL Offset */
+#define FACTORYREGION_BSLPIN_INVOKE_GPIO_REG_SEL_MASK ((uint32_t)0x00006000U)         /* !< GPIO Module Selection */
+
+/* FACTORYREGION_SRAMFLASH Bits */
+/* FACTORYREGION_SRAMFLASH[MAINFLASH_SZ] Bits */
+#define FACTORYREGION_SRAMFLASH_MAINFLASH_SZ_OFS (0)                             /* !< MAINFLASH_SZ Offset */
+#define FACTORYREGION_SRAMFLASH_MAINFLASH_SZ_MASK ((uint32_t)0x00000FFFU)         /* !< The encoding of the field is that
+                                                                                    the value of the field is an integer
+                                                                                    to be interpreted as number of KBs.
+                                                                                    For eg: if the value of the field id
+                                                                                    4, then it is 4KB, if the value is
+                                                                                    32, then 32KB, and so on. */
+/* FACTORYREGION_SRAMFLASH[SRAM_SZ] Bits */
+#define FACTORYREGION_SRAMFLASH_SRAM_SZ_OFS      (16)                            /* !< SRAM_SZ Offset */
+#define FACTORYREGION_SRAMFLASH_SRAM_SZ_MASK     ((uint32_t)0x03FF0000U)         /* !< The encoding of the field is that
+                                                                                    the value of the field is an integer
+                                                                                    to be interpreted as number of KBs.
+                                                                                    For eg: if the value of the field id
+                                                                                    4, then it is 4KB, if the value is
+                                                                                    32, then 32KB, and so on. */
+/* FACTORYREGION_SRAMFLASH[DATAFLASH_SZ] Bits */
+#define FACTORYREGION_SRAMFLASH_DATAFLASH_SZ_OFS (26)                            /* !< DATAFLASH_SZ Offset */
+#define FACTORYREGION_SRAMFLASH_DATAFLASH_SZ_MASK ((uint32_t)0xFC000000U)         /* !< The encoding of the field is that
+                                                                                    the value of the field is an integer
+                                                                                    to be interpreted as number of KBs.
+                                                                                    For eg: if the value of the field id
+                                                                                    4, then it is 4KB, if the value is
+                                                                                    32, then 32KB, and so on. */
+/* FACTORYREGION_SRAMFLASH[MAINNUMBANKS] Bits */
+#define FACTORYREGION_SRAMFLASH_MAINNUMBANKS_OFS (12)                            /* !< MAINNUMBANKS Offset */
+#define FACTORYREGION_SRAMFLASH_MAINNUMBANKS_MASK ((uint32_t)0x00003000U)
+#define FACTORYREGION_SRAMFLASH_MAINNUMBANKS_ONEBANK ((uint32_t)0x00000000U)
+#define FACTORYREGION_SRAMFLASH_MAINNUMBANKS_TWOBANKS ((uint32_t)0x00001000U)
+#define FACTORYREGION_SRAMFLASH_MAINNUMBANKS_THREEBANKS ((uint32_t)0x00002000U)
+#define FACTORYREGION_SRAMFLASH_MAINNUMBANKS_FOURBANKS ((uint32_t)0x00003000U)
+
+/* FACTORYREGION_PLLSTARTUP0_4_8MHZ Bits */
+/* FACTORYREGION_PLLSTARTUP0_4_8MHZ[STARTTIME] Bits */
+#define FACTORYREGION_PLLSTARTUP0_4_8MHZ_STARTTIME_OFS (0)                             /* !< STARTTIME Offset */
+#define FACTORYREGION_PLLSTARTUP0_4_8MHZ_STARTTIME_MASK ((uint32_t)0x0000003FU)         /* !< Startup time from Enable to Locked
+                                                                                    Clock in resolution of 1usec */
+/* FACTORYREGION_PLLSTARTUP0_4_8MHZ[STARTTIMELP] Bits */
+#define FACTORYREGION_PLLSTARTUP0_4_8MHZ_STARTTIMELP_OFS (8)                             /* !< STARTTIMELP Offset */
+#define FACTORYREGION_PLLSTARTUP0_4_8MHZ_STARTTIMELP_MASK ((uint32_t)0x00003F00U)         /* !< Startup time from Low Power Exit to
+                                                                                    Locked Clock in resolution of 1usec */
+/* FACTORYREGION_PLLSTARTUP0_4_8MHZ[CPCURRENT] Bits */
+#define FACTORYREGION_PLLSTARTUP0_4_8MHZ_CPCURRENT_OFS (16)                            /* !< CPCURRENT Offset */
+#define FACTORYREGION_PLLSTARTUP0_4_8MHZ_CPCURRENT_MASK ((uint32_t)0x003F0000U)         /* !< Charge Pump Current */
+/* FACTORYREGION_PLLSTARTUP0_4_8MHZ[CAPBVAL] Bits */
+#define FACTORYREGION_PLLSTARTUP0_4_8MHZ_CAPBVAL_OFS (24)                            /* !< CAPBVAL Offset */
+#define FACTORYREGION_PLLSTARTUP0_4_8MHZ_CAPBVAL_MASK ((uint32_t)0x1F000000U)         /* !< Override Value for Cap B */
+/* FACTORYREGION_PLLSTARTUP0_4_8MHZ[CAPBOVERRIDE] Bits */
+#define FACTORYREGION_PLLSTARTUP0_4_8MHZ_CAPBOVERRIDE_OFS (31)                            /* !< CAPBOVERRIDE Offset */
+#define FACTORYREGION_PLLSTARTUP0_4_8MHZ_CAPBOVERRIDE_MASK ((uint32_t)0x80000000U)         /* !< Override Enable For Cap B */
+#define FACTORYREGION_PLLSTARTUP0_4_8MHZ_CAPBOVERRIDE_DISABLE ((uint32_t)0x00000000U)
+#define FACTORYREGION_PLLSTARTUP0_4_8MHZ_CAPBOVERRIDE_ENABLE ((uint32_t)0x80000000U)
+
+/* FACTORYREGION_PLLSTARTUP1_4_8MHZ Bits */
+/* FACTORYREGION_PLLSTARTUP1_4_8MHZ[LPFCAPA] Bits */
+#define FACTORYREGION_PLLSTARTUP1_4_8MHZ_LPFCAPA_OFS (0)                             /* !< LPFCAPA Offset */
+#define FACTORYREGION_PLLSTARTUP1_4_8MHZ_LPFCAPA_MASK ((uint32_t)0x0000001FU)         /* !< Loop Filter Cap A */
+/* FACTORYREGION_PLLSTARTUP1_4_8MHZ[LPFRESA] Bits */
+#define FACTORYREGION_PLLSTARTUP1_4_8MHZ_LPFRESA_OFS (8)                             /* !< LPFRESA Offset */
+#define FACTORYREGION_PLLSTARTUP1_4_8MHZ_LPFRESA_MASK ((uint32_t)0x0003FF00U)         /* !< Loop Filter Res A */
+/* FACTORYREGION_PLLSTARTUP1_4_8MHZ[LPFRESC] Bits */
+#define FACTORYREGION_PLLSTARTUP1_4_8MHZ_LPFRESC_OFS (24)                            /* !< LPFRESC Offset */
+#define FACTORYREGION_PLLSTARTUP1_4_8MHZ_LPFRESC_MASK ((uint32_t)0xFF000000U)         /* !< Loop Filter Res C */
+
+/* FACTORYREGION_PLLSTARTUP0_8_16MHZ Bits */
+/* FACTORYREGION_PLLSTARTUP0_8_16MHZ[STARTTIME] Bits */
+#define FACTORYREGION_PLLSTARTUP0_8_16MHZ_STARTTIME_OFS (0)                             /* !< STARTTIME Offset */
+#define FACTORYREGION_PLLSTARTUP0_8_16MHZ_STARTTIME_MASK ((uint32_t)0x0000003FU)         /* !< Startup time from Enable to Locked
+                                                                                    Clock in resolution of 1usec */
+/* FACTORYREGION_PLLSTARTUP0_8_16MHZ[STARTTIMELP] Bits */
+#define FACTORYREGION_PLLSTARTUP0_8_16MHZ_STARTTIMELP_OFS (8)                             /* !< STARTTIMELP Offset */
+#define FACTORYREGION_PLLSTARTUP0_8_16MHZ_STARTTIMELP_MASK ((uint32_t)0x00003F00U)         /* !< Startup time from Low Power Exit to
+                                                                                    Locked Clock in resolution of 1usec */
+/* FACTORYREGION_PLLSTARTUP0_8_16MHZ[CPCURRENT] Bits */
+#define FACTORYREGION_PLLSTARTUP0_8_16MHZ_CPCURRENT_OFS (16)                            /* !< CPCURRENT Offset */
+#define FACTORYREGION_PLLSTARTUP0_8_16MHZ_CPCURRENT_MASK ((uint32_t)0x003F0000U)         /* !< Charge Pump Current */
+/* FACTORYREGION_PLLSTARTUP0_8_16MHZ[CAPBVAL] Bits */
+#define FACTORYREGION_PLLSTARTUP0_8_16MHZ_CAPBVAL_OFS (24)                            /* !< CAPBVAL Offset */
+#define FACTORYREGION_PLLSTARTUP0_8_16MHZ_CAPBVAL_MASK ((uint32_t)0x1F000000U)         /* !< Override Value for Cap B */
+/* FACTORYREGION_PLLSTARTUP0_8_16MHZ[CAPBOVERRIDE] Bits */
+#define FACTORYREGION_PLLSTARTUP0_8_16MHZ_CAPBOVERRIDE_OFS (31)                            /* !< CAPBOVERRIDE Offset */
+#define FACTORYREGION_PLLSTARTUP0_8_16MHZ_CAPBOVERRIDE_MASK ((uint32_t)0x80000000U)         /* !< Override Enable For Cap B */
+#define FACTORYREGION_PLLSTARTUP0_8_16MHZ_CAPBOVERRIDE_DISABLE ((uint32_t)0x00000000U)
+#define FACTORYREGION_PLLSTARTUP0_8_16MHZ_CAPBOVERRIDE_ENABLE ((uint32_t)0x80000000U)
+
+/* FACTORYREGION_PLLSTARTUP1_8_16MHZ Bits */
+/* FACTORYREGION_PLLSTARTUP1_8_16MHZ[LPFCAPA] Bits */
+#define FACTORYREGION_PLLSTARTUP1_8_16MHZ_LPFCAPA_OFS (0)                             /* !< LPFCAPA Offset */
+#define FACTORYREGION_PLLSTARTUP1_8_16MHZ_LPFCAPA_MASK ((uint32_t)0x0000001FU)         /* !< Loop Filter Cap A */
+/* FACTORYREGION_PLLSTARTUP1_8_16MHZ[LPFRESA] Bits */
+#define FACTORYREGION_PLLSTARTUP1_8_16MHZ_LPFRESA_OFS (8)                             /* !< LPFRESA Offset */
+#define FACTORYREGION_PLLSTARTUP1_8_16MHZ_LPFRESA_MASK ((uint32_t)0x0003FF00U)         /* !< Loop Filter Res A */
+/* FACTORYREGION_PLLSTARTUP1_8_16MHZ[LPFRESC] Bits */
+#define FACTORYREGION_PLLSTARTUP1_8_16MHZ_LPFRESC_OFS (24)                            /* !< LPFRESC Offset */
+#define FACTORYREGION_PLLSTARTUP1_8_16MHZ_LPFRESC_MASK ((uint32_t)0xFF000000U)         /* !< Loop Filter Res C */
+
+/* FACTORYREGION_PLLSTARTUP0_16_32MHZ Bits */
+/* FACTORYREGION_PLLSTARTUP0_16_32MHZ[STARTTIME] Bits */
+#define FACTORYREGION_PLLSTARTUP0_16_32MHZ_STARTTIME_OFS (0)                             /* !< STARTTIME Offset */
+#define FACTORYREGION_PLLSTARTUP0_16_32MHZ_STARTTIME_MASK ((uint32_t)0x0000003FU)         /* !< Startup time from Enable to Locked
+                                                                                    Clock in resolution of 1usec */
+/* FACTORYREGION_PLLSTARTUP0_16_32MHZ[STARTTIMELP] Bits */
+#define FACTORYREGION_PLLSTARTUP0_16_32MHZ_STARTTIMELP_OFS (8)                             /* !< STARTTIMELP Offset */
+#define FACTORYREGION_PLLSTARTUP0_16_32MHZ_STARTTIMELP_MASK ((uint32_t)0x00003F00U)         /* !< Startup time from Low Power Exit to
+                                                                                    Locked Clock in resolution of 1usec */
+/* FACTORYREGION_PLLSTARTUP0_16_32MHZ[CPCURRENT] Bits */
+#define FACTORYREGION_PLLSTARTUP0_16_32MHZ_CPCURRENT_OFS (16)                            /* !< CPCURRENT Offset */
+#define FACTORYREGION_PLLSTARTUP0_16_32MHZ_CPCURRENT_MASK ((uint32_t)0x003F0000U)         /* !< Charge Pump Current */
+/* FACTORYREGION_PLLSTARTUP0_16_32MHZ[CAPBVAL] Bits */
+#define FACTORYREGION_PLLSTARTUP0_16_32MHZ_CAPBVAL_OFS (24)                            /* !< CAPBVAL Offset */
+#define FACTORYREGION_PLLSTARTUP0_16_32MHZ_CAPBVAL_MASK ((uint32_t)0x1F000000U)         /* !< Override Value for Cap B */
+/* FACTORYREGION_PLLSTARTUP0_16_32MHZ[CAPBOVERRIDE] Bits */
+#define FACTORYREGION_PLLSTARTUP0_16_32MHZ_CAPBOVERRIDE_OFS (31)                            /* !< CAPBOVERRIDE Offset */
+#define FACTORYREGION_PLLSTARTUP0_16_32MHZ_CAPBOVERRIDE_MASK ((uint32_t)0x80000000U)         /* !< Override Enable For Cap B */
+#define FACTORYREGION_PLLSTARTUP0_16_32MHZ_CAPBOVERRIDE_DISABLE ((uint32_t)0x00000000U)
+#define FACTORYREGION_PLLSTARTUP0_16_32MHZ_CAPBOVERRIDE_ENABLE ((uint32_t)0x80000000U)
+
+/* FACTORYREGION_PLLSTARTUP1_16_32MHZ Bits */
+/* FACTORYREGION_PLLSTARTUP1_16_32MHZ[LPFCAPA] Bits */
+#define FACTORYREGION_PLLSTARTUP1_16_32MHZ_LPFCAPA_OFS (0)                             /* !< LPFCAPA Offset */
+#define FACTORYREGION_PLLSTARTUP1_16_32MHZ_LPFCAPA_MASK ((uint32_t)0x0000001FU)         /* !< Loop Filter Cap A */
+/* FACTORYREGION_PLLSTARTUP1_16_32MHZ[LPFRESA] Bits */
+#define FACTORYREGION_PLLSTARTUP1_16_32MHZ_LPFRESA_OFS (8)                             /* !< LPFRESA Offset */
+#define FACTORYREGION_PLLSTARTUP1_16_32MHZ_LPFRESA_MASK ((uint32_t)0x0003FF00U)         /* !< Loop Filter Res A */
+/* FACTORYREGION_PLLSTARTUP1_16_32MHZ[LPFRESC] Bits */
+#define FACTORYREGION_PLLSTARTUP1_16_32MHZ_LPFRESC_OFS (24)                            /* !< LPFRESC Offset */
+#define FACTORYREGION_PLLSTARTUP1_16_32MHZ_LPFRESC_MASK ((uint32_t)0xFF000000U)         /* !< Loop Filter Res C */
+
+/* FACTORYREGION_PLLSTARTUP0_32_48MHZ Bits */
+/* FACTORYREGION_PLLSTARTUP0_32_48MHZ[STARTTIME] Bits */
+#define FACTORYREGION_PLLSTARTUP0_32_48MHZ_STARTTIME_OFS (0)                             /* !< STARTTIME Offset */
+#define FACTORYREGION_PLLSTARTUP0_32_48MHZ_STARTTIME_MASK ((uint32_t)0x0000003FU)         /* !< Startup time from Enable to Locked
+                                                                                    Clock in resolution of 1usec */
+/* FACTORYREGION_PLLSTARTUP0_32_48MHZ[STARTTIMELP] Bits */
+#define FACTORYREGION_PLLSTARTUP0_32_48MHZ_STARTTIMELP_OFS (8)                             /* !< STARTTIMELP Offset */
+#define FACTORYREGION_PLLSTARTUP0_32_48MHZ_STARTTIMELP_MASK ((uint32_t)0x00003F00U)         /* !< Startup time from Low Power Exit to
+                                                                                    Locked Clock in resolution of 1usec */
+/* FACTORYREGION_PLLSTARTUP0_32_48MHZ[CPCURRENT] Bits */
+#define FACTORYREGION_PLLSTARTUP0_32_48MHZ_CPCURRENT_OFS (16)                            /* !< CPCURRENT Offset */
+#define FACTORYREGION_PLLSTARTUP0_32_48MHZ_CPCURRENT_MASK ((uint32_t)0x003F0000U)         /* !< Charge Pump Current */
+/* FACTORYREGION_PLLSTARTUP0_32_48MHZ[CAPBVAL] Bits */
+#define FACTORYREGION_PLLSTARTUP0_32_48MHZ_CAPBVAL_OFS (24)                            /* !< CAPBVAL Offset */
+#define FACTORYREGION_PLLSTARTUP0_32_48MHZ_CAPBVAL_MASK ((uint32_t)0x1F000000U)         /* !< Override Value for Cap B */
+/* FACTORYREGION_PLLSTARTUP0_32_48MHZ[CAPBOVERRIDE] Bits */
+#define FACTORYREGION_PLLSTARTUP0_32_48MHZ_CAPBOVERRIDE_OFS (31)                            /* !< CAPBOVERRIDE Offset */
+#define FACTORYREGION_PLLSTARTUP0_32_48MHZ_CAPBOVERRIDE_MASK ((uint32_t)0x80000000U)         /* !< Override Enable For Cap B */
+#define FACTORYREGION_PLLSTARTUP0_32_48MHZ_CAPBOVERRIDE_DISABLE ((uint32_t)0x00000000U)
+#define FACTORYREGION_PLLSTARTUP0_32_48MHZ_CAPBOVERRIDE_ENABLE ((uint32_t)0x80000000U)
+
+/* FACTORYREGION_PLLSTARTUP1_32_48MHZ Bits */
+/* FACTORYREGION_PLLSTARTUP1_32_48MHZ[LPFCAPA] Bits */
+#define FACTORYREGION_PLLSTARTUP1_32_48MHZ_LPFCAPA_OFS (0)                             /* !< LPFCAPA Offset */
+#define FACTORYREGION_PLLSTARTUP1_32_48MHZ_LPFCAPA_MASK ((uint32_t)0x0000001FU)         /* !< Loop Filter Cap A */
+/* FACTORYREGION_PLLSTARTUP1_32_48MHZ[LPFRESA] Bits */
+#define FACTORYREGION_PLLSTARTUP1_32_48MHZ_LPFRESA_OFS (8)                             /* !< LPFRESA Offset */
+#define FACTORYREGION_PLLSTARTUP1_32_48MHZ_LPFRESA_MASK ((uint32_t)0x0003FF00U)         /* !< Loop Filter Res A */
+/* FACTORYREGION_PLLSTARTUP1_32_48MHZ[LPFRESC] Bits */
+#define FACTORYREGION_PLLSTARTUP1_32_48MHZ_LPFRESC_OFS (24)                            /* !< LPFRESC Offset */
+#define FACTORYREGION_PLLSTARTUP1_32_48MHZ_LPFRESC_MASK ((uint32_t)0xFF000000U)         /* !< Loop Filter Res C */
+
+/* FACTORYREGION_TEMP_SENSE0 Bits */
+/* FACTORYREGION_TEMP_SENSE0[DATA] Bits */
+#define FACTORYREGION_TEMP_SENSE0_DATA_OFS       (0)                             /* !< DATA Offset */
+#define FACTORYREGION_TEMP_SENSE0_DATA_MASK      ((uint32_t)0xFFFFFFFFU)
+
+/* FACTORYREGION_BOOTCRC Bits */
+/* FACTORYREGION_BOOTCRC[DATA] Bits */
+#define FACTORYREGION_BOOTCRC_DATA_OFS           (0)                             /* !< DATA Offset */
+#define FACTORYREGION_BOOTCRC_DATA_MASK          ((uint32_t)0xFFFFFFFFU)
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_hw_factoryregion__include */

--- a/mspm0/source/ti/devices/msp/peripherals/m0p/hw_sysctl.h
+++ b/mspm0/source/ti/devices/msp/peripherals/m0p/hw_sysctl.h
@@ -1,0 +1,64 @@
+/*****************************************************************************
+
+  Copyright (C) 2020 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+/* This file automatically includes the specific device sysctl header file
+   without the need to include a specific device sysctl header.
+   The device #define is set automatically through the toolchain on basis
+   of the device chosen in the device selection menu (.e.g -D__MICRO1__).      */
+
+#ifndef ti_devices_msp_peripheral_m0p_sysctl__include
+#define ti_devices_msp_peripheral_m0p_sysctl__include
+
+/******************************************************************************
+* MSP devices
+******************************************************************************/
+
+#include <ti/devices/DeviceFamily.h>
+
+#if (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPM0G1X0X_G3X0X)
+#include <ti/devices/msp/peripherals/m0p/sysctl/hw_sysctl_mspm0g1x0x_g3x0x.h>
+#elif (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPM0L11XX_L13XX)
+#include <ti/devices/msp/peripherals/m0p/sysctl/hw_sysctl_mspm0l11xx_l13xx.h>
+#elif (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPM0C110X) || (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPS003FX)
+#include <ti/devices/msp/peripherals/m0p/sysctl/hw_sysctl_mspm0c110x.h>
+#elif (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPM0L122X_L222X)
+#include <ti/devices/msp/peripherals/m0p/sysctl/hw_sysctl_mspm0l122x_l222x.h>
+/********************************************************************
+ *
+ ********************************************************************/
+#else
+#error "Failed to match a default include file"
+#endif
+
+#endif /* ti_devices_msp_peripheral_m0p_sysctl__include */

--- a/mspm0/source/ti/devices/msp/peripherals/m0p/sysctl/hw_sysctl_mspm0g1x0x_g3x0x.h
+++ b/mspm0/source/ti/devices/msp/peripherals/m0p/sysctl/hw_sysctl_mspm0g1x0x_g3x0x.h
@@ -1,0 +1,3736 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_m0p_hw_sysctl_mspm0g1x0x_g3x0x__include
+#define ti_devices_msp_peripherals_m0p_hw_sysctl_mspm0g1x0x_g3x0x__include
+
+/* Filename: hw_sysctl_mspm0g1x0x_g3x0x.h */
+/* Revised: 2023-06-10 20:11:25 */
+/* Revision: 654ee49b8da203f200540fbb92f63e5ecb4fbfe3 */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* SYSCTL Registers
+******************************************************************************/
+#define SYSCTL_MGMT_TMALITE1_OFS                 ((uint32_t)0x00900800U)
+#define SYSCTL_MGMT_GPTIMER32B2CC0_OFS           ((uint32_t)0x00870800U)
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_OFS         ((uint32_t)0x0086A800U)
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_OFS         ((uint32_t)0x00868800U)
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_OFS        ((uint32_t)0x00862800U)
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_OFS        ((uint32_t)0x00860800U)
+#define SYSCTL_MGMT_MCAN0_OFS                    ((uint32_t)0x0050E800U)
+#define SYSCTL_MGMT_UART0_OFS                    ((uint32_t)0x00500800U)
+#define SYSCTL_MGMT_SPI1_OFS                     ((uint32_t)0x0046A800U)
+#define SYSCTL_MGMT_SPI0_OFS                     ((uint32_t)0x00468800U)
+#define SYSCTL_MGMT_TRNG_OFS                     ((uint32_t)0x00444800U)
+#define SYSCTL_MGMT_AES_OFS                      ((uint32_t)0x00442800U)
+#define SYSCTL_MGMT_CRC0_OFS                     ((uint32_t)0x00440800U)
+#define SYSCTL_MGMT_MATHACL_OFS                  ((uint32_t)0x00410800U)
+#define SYSCTL_MGMT_UARTADVLP0_OFS               ((uint32_t)0x00108800U)
+#define SYSCTL_MGMT_UARTLP1_OFS                  ((uint32_t)0x00102800U)
+#define SYSCTL_MGMT_UARTLP0_OFS                  ((uint32_t)0x00100800U)
+#define SYSCTL_MGMT_I2C1_OFS                     ((uint32_t)0x000F2800U)
+#define SYSCTL_MGMT_I2C0_OFS                     ((uint32_t)0x000F0800U)
+#define SYSCTL_MGMT_GPIO1_OFS                    ((uint32_t)0x000A2800U)
+#define SYSCTL_MGMT_GPIO0_OFS                    ((uint32_t)0x000A0800U)
+#define SYSCTL_MGMT_RTC_OFS                      ((uint32_t)0x00094800U)
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_OFS      ((uint32_t)0x00090800U)
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_OFS         ((uint32_t)0x00084800U)
+#define SYSCTL_MGMT_WWDTLP1_OFS                  ((uint32_t)0x00082800U)
+#define SYSCTL_MGMT_WWDTLP0_OFS                  ((uint32_t)0x00080800U)
+#define SYSCTL_MGMT_VREF_OFS                     ((uint32_t)0x00030800U)
+#define SYSCTL_MGMT_OPAMP1_OFS                   ((uint32_t)0x00022800U)
+#define SYSCTL_MGMT_OPAMP0_OFS                   ((uint32_t)0x00020800U)
+#define SYSCTL_MGMT_DAC12B0_OFS                  ((uint32_t)0x00018800U)
+#define SYSCTL_MGMT_ANACOMP2_OFS                 ((uint32_t)0x0000C800U)
+#define SYSCTL_MGMT_ANACOMP1_OFS                 ((uint32_t)0x0000A800U)
+#define SYSCTL_MGMT_ANACOMP0_OFS                 ((uint32_t)0x00008800U)
+#define SYSCTL_MGMT_ADC12B4MSPS1_OFS             ((uint32_t)0x00002800U)
+#define SYSCTL_SOCLOCK_OFS                       ((uint32_t)0x00001000U)
+#define SYSCTL_MGMT_ADC12B4MSPS0_OFS             ((uint32_t)0x00000800U)
+
+
+/** @addtogroup SYSCTL_MGMT_TMALITE1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00900800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00900804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00900814) IP State Register - Read Only */
+} SYSCTL_MGMT_TMALITE1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_TMALITE1 */
+
+/** @addtogroup SYSCTL_MGMT_GPTIMER32B2CC0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00870800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00870804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00870814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPTIMER32B2CC0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPTIMER32B2CC0 */
+
+/** @addtogroup SYSCTL_MGMT_GPTIMER16B2CCSP1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x0086A800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x0086A804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x0086A814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPTIMER16B2CCSP1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPTIMER16B2CCSP1 */
+
+/** @addtogroup SYSCTL_MGMT_GPTIMER16B2CCSP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00868800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00868804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00868814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPTIMER16B2CCSP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPTIMER16B2CCSP0 */
+
+/** @addtogroup SYSCTL_MGMT_GPTIMER16BADV2CC0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00862800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00862804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00862814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPTIMER16BADV2CC0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPTIMER16BADV2CC0 */
+
+/** @addtogroup SYSCTL_MGMT_GPTIMER16BADV4CC0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00860800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00860804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00860814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPTIMER16BADV4CC0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPTIMER16BADV4CC0 */
+
+/** @addtogroup SYSCTL_MGMT_MCAN0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x0050E800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x0050E804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x0050E814) IP State Register - Read Only */
+} SYSCTL_MGMT_MCAN0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_MCAN0 */
+
+/** @addtogroup SYSCTL_MGMT_UART0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00500800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00500804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00500808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00500814) IP State Register - Read Only */
+} SYSCTL_MGMT_UART0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_UART0 */
+
+/** @addtogroup SYSCTL_MGMT_SPI1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x0046A800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x0046A804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x0046A808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x0046A814) IP State Register - Read Only */
+} SYSCTL_MGMT_SPI1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_SPI1 */
+
+/** @addtogroup SYSCTL_MGMT_SPI0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00468800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00468804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00468808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00468814) IP State Register - Read Only */
+} SYSCTL_MGMT_SPI0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_SPI0 */
+
+/** @addtogroup SYSCTL_MGMT_TRNG
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00444800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00444804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00444814) IP State Register - Read Only */
+} SYSCTL_MGMT_TRNG_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_TRNG */
+
+/** @addtogroup SYSCTL_MGMT_AES
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00442800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00442804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00442814) IP State Register - Read Only */
+} SYSCTL_MGMT_AES_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_AES */
+
+/** @addtogroup SYSCTL_MGMT_CRC0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00440800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00440804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00440814) IP State Register - Read Only */
+} SYSCTL_MGMT_CRC0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_CRC0 */
+
+/** @addtogroup SYSCTL_MGMT_MATHACL
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00410800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00410804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00410814) IP State Register - Read Only */
+} SYSCTL_MGMT_MATHACL_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_MATHACL */
+
+/** @addtogroup SYSCTL_MGMT_UARTADVLP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00108800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00108804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00108808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00108814) IP State Register - Read Only */
+} SYSCTL_MGMT_UARTADVLP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_UARTADVLP0 */
+
+/** @addtogroup SYSCTL_MGMT_UARTLP1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00102800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00102804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00102808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00102814) IP State Register - Read Only */
+} SYSCTL_MGMT_UARTLP1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_UARTLP1 */
+
+/** @addtogroup SYSCTL_MGMT_UARTLP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00100800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00100804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00100808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00100814) IP State Register - Read Only */
+} SYSCTL_MGMT_UARTLP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_UARTLP0 */
+
+/** @addtogroup SYSCTL_MGMT_I2C1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x000F2800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x000F2804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x000F2808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x000F2814) IP State Register - Read Only */
+} SYSCTL_MGMT_I2C1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_I2C1 */
+
+/** @addtogroup SYSCTL_MGMT_I2C0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x000F0800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x000F0804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x000F0808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x000F0814) IP State Register - Read Only */
+} SYSCTL_MGMT_I2C0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_I2C0 */
+
+/** @addtogroup SYSCTL_MGMT_GPIO1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x000A2800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x000A2804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x000A2814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPIO1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPIO1 */
+
+/** @addtogroup SYSCTL_MGMT_GPIO0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x000A0800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x000A0804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x000A0814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPIO0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPIO0 */
+
+/** @addtogroup SYSCTL_MGMT_RTC
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00094800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00094804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00094808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00094814) IP State Register - Read Only */
+} SYSCTL_MGMT_RTC_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_RTC */
+
+/** @addtogroup SYSCTL_MGMT_GPTIMER16B2CCQEILP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00090800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00090804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00090814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPTIMER16B2CCQEILP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPTIMER16B2CCQEILP0 */
+
+/** @addtogroup SYSCTL_MGMT_GPTIMER16B2CCLP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00084800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00084804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00084814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPTIMER16B2CCLP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPTIMER16B2CCLP0 */
+
+/** @addtogroup SYSCTL_MGMT_WWDTLP1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00082800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00082804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00082814) IP State Register - Read Only */
+} SYSCTL_MGMT_WWDTLP1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_WWDTLP1 */
+
+/** @addtogroup SYSCTL_MGMT_WWDTLP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00080800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00080804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00080814) IP State Register - Read Only */
+} SYSCTL_MGMT_WWDTLP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_WWDTLP0 */
+
+/** @addtogroup SYSCTL_MGMT_VREF
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00030800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00030804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00030814) IP State Register - Read Only */
+} SYSCTL_MGMT_VREF_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_VREF */
+
+/** @addtogroup SYSCTL_MGMT_OPAMP1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00022800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00022804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00022814) IP State Register - Read Only */
+} SYSCTL_MGMT_OPAMP1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_OPAMP1 */
+
+/** @addtogroup SYSCTL_MGMT_OPAMP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00020800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00020804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00020814) IP State Register - Read Only */
+} SYSCTL_MGMT_OPAMP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_OPAMP0 */
+
+/** @addtogroup SYSCTL_MGMT_DAC12B0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00018800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00018804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00018814) IP State Register - Read Only */
+} SYSCTL_MGMT_DAC12B0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_DAC12B0 */
+
+/** @addtogroup SYSCTL_MGMT_ANACOMP2
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x0000C800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x0000C804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x0000C808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x0000C814) IP State Register - Read Only */
+} SYSCTL_MGMT_ANACOMP2_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_ANACOMP2 */
+
+/** @addtogroup SYSCTL_MGMT_ANACOMP1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x0000A800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x0000A804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x0000A808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x0000A814) IP State Register - Read Only */
+} SYSCTL_MGMT_ANACOMP1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_ANACOMP1 */
+
+/** @addtogroup SYSCTL_MGMT_ANACOMP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00008800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00008804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00008808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00008814) IP State Register - Read Only */
+} SYSCTL_MGMT_ANACOMP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_ANACOMP0 */
+
+/** @addtogroup SYSCTL_MGMT_ADC12B4MSPS1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00002800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00002804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00002808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00002814) IP State Register - Read Only */
+} SYSCTL_MGMT_ADC12B4MSPS1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_ADC12B4MSPS1 */
+
+/** @addtogroup SYSCTL_SOCLOCK
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[8];
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) SYSCTL interrupt index */
+       uint32_t RESERVED1;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) SYSCTL interrupt mask */
+       uint32_t RESERVED2;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) SYSCTL raw interrupt status */
+       uint32_t RESERVED3;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) SYSCTL masked interrupt status */
+       uint32_t RESERVED4;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) SYSCTL interrupt set */
+       uint32_t RESERVED5;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) SYSCTL interrupt clear */
+       uint32_t RESERVED6;
+  __I  uint32_t NMIIIDX;                           /* !< (@ 0x00001050) NMI interrupt index */
+       uint32_t RESERVED7[3];
+  __I  uint32_t NMIRIS;                            /* !< (@ 0x00001060) NMI raw interrupt status */
+       uint32_t RESERVED8[3];
+  __O  uint32_t NMIISET;                           /* !< (@ 0x00001070) NMI interrupt set */
+       uint32_t RESERVED9;
+  __O  uint32_t NMIICLR;                           /* !< (@ 0x00001078) NMI interrupt clear */
+       uint32_t RESERVED10[33];
+  __IO uint32_t SYSOSCCFG;                         /* !< (@ 0x00001100) SYSOSC configuration */
+  __IO uint32_t MCLKCFG;                           /* !< (@ 0x00001104) Main clock (MCLK) configuration */
+  __IO uint32_t HSCLKEN;                           /* !< (@ 0x00001108) High-speed clock (HSCLK) source enable/disable */
+  __IO uint32_t HSCLKCFG;                          /* !< (@ 0x0000110C) High-speed clock (HSCLK) source selection */
+  __IO uint32_t HFCLKCLKCFG;                       /* !< (@ 0x00001110) High-frequency clock (HFCLK) configuration */
+  __IO uint32_t LFCLKCFG;                          /* !< (@ 0x00001114) Low frequency crystal oscillator (LFXT)
+                                                      configuration */
+       uint32_t RESERVED11[2];
+  __IO uint32_t SYSPLLCFG0;                        /* !< (@ 0x00001120) SYSPLL reference and output configuration */
+  __IO uint32_t SYSPLLCFG1;                        /* !< (@ 0x00001124) SYSPLL reference and feedback divider */
+  __IO uint32_t SYSPLLPARAM0;                      /* !< (@ 0x00001128) SYSPLL PARAM0 (load from FACTORY region) */
+  __IO uint32_t SYSPLLPARAM1;                      /* !< (@ 0x0000112C) SYSPLL PARAM1 (load from FACTORY region) */
+       uint32_t RESERVED12[2];
+  __IO uint32_t GENCLKCFG;                         /* !< (@ 0x00001138) General clock configuration */
+  __IO uint32_t GENCLKEN;                          /* !< (@ 0x0000113C) General clock enable control */
+  __IO uint32_t PMODECFG;                          /* !< (@ 0x00001140) Power mode configuration */
+       uint32_t RESERVED13[3];
+  __I  uint32_t FCC;                               /* !< (@ 0x00001150) Frequency clock counter (FCC) count */
+       uint32_t RESERVED14[7];
+  __IO uint32_t SYSOSCTRIMUSER;                    /* !< (@ 0x00001170) SYSOSC user-specified trim */
+       uint32_t RESERVED15;
+  __IO uint32_t SRAMBOUNDARY;                      /* !< (@ 0x00001178) SRAM Write Boundary */
+       uint32_t RESERVED16;
+  __IO uint32_t SYSTEMCFG;                         /* !< (@ 0x00001180) System configuration */
+       uint32_t RESERVED17[31];
+  __IO uint32_t WRITELOCK;                         /* !< (@ 0x00001200) SYSCTL register write lockout */
+  __I  uint32_t CLKSTATUS;                         /* !< (@ 0x00001204) Clock module (CKM) status */
+  __I  uint32_t SYSSTATUS;                         /* !< (@ 0x00001208) System status information */
+  __I  uint32_t DEDERRADDR;                        /* !< (@ 0x0000120C) Memory DED Address */
+       uint32_t RESERVED18[4];
+  __I  uint32_t RSTCAUSE;                          /* !< (@ 0x00001220) Reset cause */
+       uint32_t RESERVED19[55];
+  __IO uint32_t RESETLEVEL;                        /* !< (@ 0x00001300) Reset level for application-triggered reset
+                                                      command */
+  __O  uint32_t RESETCMD;                          /* !< (@ 0x00001304) Execute an application-triggered reset command */
+  __IO uint32_t BORTHRESHOLD;                      /* !< (@ 0x00001308) BOR threshold selection */
+  __O  uint32_t BORCLRCMD;                         /* !< (@ 0x0000130C) Set the BOR threshold */
+  __O  uint32_t SYSOSCFCLCTL;                      /* !< (@ 0x00001310) SYSOSC frequency correction loop (FCL) ROSC enable */
+  __O  uint32_t LFXTCTL;                           /* !< (@ 0x00001314) LFXT and LFCLK control */
+  __O  uint32_t EXLFCTL;                           /* !< (@ 0x00001318) LFCLK_IN and LFCLK control */
+  __O  uint32_t SHDNIOREL;                         /* !< (@ 0x0000131C) SHUTDOWN IO release control */
+  __O  uint32_t EXRSTPIN;                          /* !< (@ 0x00001320) Disable the reset function of the NRST pin */
+  __O  uint32_t SYSSTATUSCLR;                      /* !< (@ 0x00001324) Clear sticky bits of SYSSTATUS */
+  __O  uint32_t SWDCFG;                            /* !< (@ 0x00001328) Disable the SWD function on the SWD pins */
+  __O  uint32_t FCCCMD;                            /* !< (@ 0x0000132C) Frequency clock counter start capture */
+       uint32_t RESERVED20[20];
+  __IO uint32_t PMUOPAMP;                          /* !< (@ 0x00001380) GPAMP control */
+       uint32_t RESERVED21[31];
+  __IO uint32_t SHUTDNSTORE0;                      /* !< (@ 0x00001400) Shutdown storage memory (byte 0) */
+  __IO uint32_t SHUTDNSTORE1;                      /* !< (@ 0x00001404) Shutdown storage memory (byte 1) */
+  __IO uint32_t SHUTDNSTORE2;                      /* !< (@ 0x00001408) Shutdown storage memory (byte 2) */
+  __IO uint32_t SHUTDNSTORE3;                      /* !< (@ 0x0000140C) Shutdown storage memory (byte 3) */
+} SYSCTL_SOCLOCK_Regs;
+
+/*@}*/ /* end of group SYSCTL_SOCLOCK */
+
+/** @addtogroup SYSCTL_MGMT_ADC12B4MSPS0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00000800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00000804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00000808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00000814) IP State Register - Read Only */
+} SYSCTL_MGMT_ADC12B4MSPS0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_ADC12B4MSPS0 */
+
+/** @addtogroup SYSCTL
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[512];
+  SYSCTL_MGMT_ADC12B4MSPS0_Regs  MGMT_ADC12B4MSPS0;                 /* !< (@ 0x00000800) SYSCTL Mgmt sub-region for IPD adc12b4msps0 */
+       uint32_t RESERVED1[506];
+  SYSCTL_SOCLOCK_Regs  SOCLOCK;                           /* !< (@ 0x00001000) SYSCTL SOCLOCK Region */
+       uint32_t RESERVED2[1276];
+  SYSCTL_MGMT_ADC12B4MSPS1_Regs  MGMT_ADC12B4MSPS1;                 /* !< (@ 0x00002800) SYSCTL Mgmt sub-region for IPD adc12b4msps1 */
+       uint32_t RESERVED3[6138];
+  SYSCTL_MGMT_ANACOMP0_Regs  MGMT_ANACOMP0;                     /* !< (@ 0x00008800) SYSCTL Mgmt sub-region for IPD anacomp0 */
+       uint32_t RESERVED4[2042];
+  SYSCTL_MGMT_ANACOMP1_Regs  MGMT_ANACOMP1;                     /* !< (@ 0x0000A800) SYSCTL Mgmt sub-region for IPD anacomp1 */
+       uint32_t RESERVED5[2042];
+  SYSCTL_MGMT_ANACOMP2_Regs  MGMT_ANACOMP2;                     /* !< (@ 0x0000C800) SYSCTL Mgmt sub-region for IPD anacomp2 */
+       uint32_t RESERVED6[12282];
+  SYSCTL_MGMT_DAC12B0_Regs  MGMT_DAC12B0;                      /* !< (@ 0x00018800) SYSCTL Mgmt sub-region for IPD dac12b0 */
+       uint32_t RESERVED7[8186];
+  SYSCTL_MGMT_OPAMP0_Regs  MGMT_OPAMP0;                       /* !< (@ 0x00020800) SYSCTL Mgmt sub-region for IPD opamp0 */
+       uint32_t RESERVED8[2042];
+  SYSCTL_MGMT_OPAMP1_Regs  MGMT_OPAMP1;                       /* !< (@ 0x00022800) SYSCTL Mgmt sub-region for IPD opamp1 */
+       uint32_t RESERVED9[14330];
+  SYSCTL_MGMT_VREF_Regs  MGMT_VREF;                         /* !< (@ 0x00030800) SYSCTL Mgmt sub-region for IPD vref */
+       uint32_t RESERVED10[81914];
+  SYSCTL_MGMT_WWDTLP0_Regs  MGMT_WWDTLP0;                      /* !< (@ 0x00080800) SYSCTL Mgmt sub-region for IPD wwdtlp0 */
+       uint32_t RESERVED11[2042];
+  SYSCTL_MGMT_WWDTLP1_Regs  MGMT_WWDTLP1;                      /* !< (@ 0x00082800) SYSCTL Mgmt sub-region for IPD wwdtlp1 */
+       uint32_t RESERVED12[2042];
+  SYSCTL_MGMT_GPTIMER16B2CCLP0_Regs  MGMT_GPTIMER16B2CCLP0;             /* !< (@ 0x00084800) SYSCTL Mgmt sub-region for IPD gptimer16b2cclp0 */
+       uint32_t RESERVED13[12282];
+  SYSCTL_MGMT_GPTIMER16B2CCQEILP0_Regs  MGMT_GPTIMER16B2CCQEILP0;          /* !< (@ 0x00090800) SYSCTL Mgmt sub-region for IPD gptimer16b2ccqeilp0 */
+       uint32_t RESERVED14[4090];
+  SYSCTL_MGMT_RTC_Regs  MGMT_RTC;                          /* !< (@ 0x00094800) SYSCTL Mgmt sub-region for IPD rtc */
+       uint32_t RESERVED15[12282];
+  SYSCTL_MGMT_GPIO0_Regs  MGMT_GPIO0;                        /* !< (@ 0x000A0800) SYSCTL Mgmt sub-region for IPD gpio0 */
+       uint32_t RESERVED16[2042];
+  SYSCTL_MGMT_GPIO1_Regs  MGMT_GPIO1;                        /* !< (@ 0x000A2800) SYSCTL Mgmt sub-region for IPD gpio1 */
+       uint32_t RESERVED17[79866];
+  SYSCTL_MGMT_I2C0_Regs  MGMT_I2C0;                         /* !< (@ 0x000F0800) SYSCTL Mgmt sub-region for IPD i2c0 */
+       uint32_t RESERVED18[2042];
+  SYSCTL_MGMT_I2C1_Regs  MGMT_I2C1;                         /* !< (@ 0x000F2800) SYSCTL Mgmt sub-region for IPD i2c1 */
+       uint32_t RESERVED19[14330];
+  SYSCTL_MGMT_UARTLP0_Regs  MGMT_UARTLP0;                      /* !< (@ 0x00100800) SYSCTL Mgmt sub-region for IPD uartlp0 */
+       uint32_t RESERVED20[2042];
+  SYSCTL_MGMT_UARTLP1_Regs  MGMT_UARTLP1;                      /* !< (@ 0x00102800) SYSCTL Mgmt sub-region for IPD uartlp1 */
+       uint32_t RESERVED21[6138];
+  SYSCTL_MGMT_UARTADVLP0_Regs  MGMT_UARTADVLP0;                   /* !< (@ 0x00108800) SYSCTL Mgmt sub-region for IPD uartadvlp0 */
+       uint32_t RESERVED22[794618];
+  SYSCTL_MGMT_MATHACL_Regs  MGMT_MATHACL;                      /* !< (@ 0x00410800) SYSCTL Mgmt sub-region for IPD mathacl */
+       uint32_t RESERVED23[49146];
+  SYSCTL_MGMT_CRC0_Regs  MGMT_CRC0;                         /* !< (@ 0x00440800) SYSCTL Mgmt sub-region for IPD crc0 */
+       uint32_t RESERVED24[2042];
+  SYSCTL_MGMT_AES_Regs  MGMT_AES;                          /* !< (@ 0x00442800) SYSCTL Mgmt sub-region for IPD aes */
+       uint32_t RESERVED25[2042];
+  SYSCTL_MGMT_TRNG_Regs  MGMT_TRNG;                         /* !< (@ 0x00444800) SYSCTL Mgmt sub-region for IPD trng */
+       uint32_t RESERVED26[36858];
+  SYSCTL_MGMT_SPI0_Regs  MGMT_SPI0;                         /* !< (@ 0x00468800) SYSCTL Mgmt sub-region for IPD spi0 */
+       uint32_t RESERVED27[2042];
+  SYSCTL_MGMT_SPI1_Regs  MGMT_SPI1;                         /* !< (@ 0x0046A800) SYSCTL Mgmt sub-region for IPD spi1 */
+       uint32_t RESERVED28[153594];
+  SYSCTL_MGMT_UART0_Regs  MGMT_UART0;                        /* !< (@ 0x00500800) SYSCTL Mgmt sub-region for IPD uart0 */
+       uint32_t RESERVED29[14330];
+  SYSCTL_MGMT_MCAN0_Regs  MGMT_MCAN0;                        /* !< (@ 0x0050E800) SYSCTL Mgmt sub-region for IPD mcan0 */
+       uint32_t RESERVED30[870394];
+  SYSCTL_MGMT_GPTIMER16BADV4CC0_Regs  MGMT_GPTIMER16BADV4CC0;            /* !< (@ 0x00860800) SYSCTL Mgmt sub-region for IPD gptimer16badv4cc0 */
+       uint32_t RESERVED31[2042];
+  SYSCTL_MGMT_GPTIMER16BADV2CC0_Regs  MGMT_GPTIMER16BADV2CC0;            /* !< (@ 0x00862800) SYSCTL Mgmt sub-region for IPD gptimer16badv2cc0 */
+       uint32_t RESERVED32[6138];
+  SYSCTL_MGMT_GPTIMER16B2CCSP0_Regs  MGMT_GPTIMER16B2CCSP0;             /* !< (@ 0x00868800) SYSCTL Mgmt sub-region for IPD gptimer16b2ccsp0 */
+       uint32_t RESERVED33[2042];
+  SYSCTL_MGMT_GPTIMER16B2CCSP1_Regs  MGMT_GPTIMER16B2CCSP1;             /* !< (@ 0x0086A800) SYSCTL Mgmt sub-region for IPD gptimer16b2ccsp1 */
+       uint32_t RESERVED34[6138];
+  SYSCTL_MGMT_GPTIMER32B2CC0_Regs  MGMT_GPTIMER32B2CC0;               /* !< (@ 0x00870800) SYSCTL Mgmt sub-region for IPD gptimer32b2cc0 */
+       uint32_t RESERVED35[147450];
+  SYSCTL_MGMT_TMALITE1_Regs  MGMT_TMALITE1;                     /* !< (@ 0x00900800) SYSCTL Mgmt sub-region for IPD tmalite1 */
+} SYSCTL_Regs;
+
+/*@}*/ /* end of group SYSCTL */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* SYSCTL Register Control Bits
+******************************************************************************/
+
+/* SYSCTL_MGMT_TMALITE1_PWREN Bits */
+/* SYSCTL_MGMT_TMALITE1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_TMALITE1_PWREN_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_TMALITE1_PWREN_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_TMALITE1_PWREN_KEY_UNLOCK    ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_TMALITE1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_TMALITE1_PWREN_ENABLE_OFS    (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_TMALITE1_PWREN_ENABLE_MASK   ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_TMALITE1_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_TMALITE1_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_TMALITE1_RSTCTL Bits */
+/* SYSCTL_MGMT_TMALITE1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_TMALITE1_RSTCTL_KEY_OFS      (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_TMALITE1_RSTCTL_KEY_MASK     ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_TMALITE1_RSTCTL_KEY_UNLOCK   ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_TMALITE1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_TMALITE1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_TMALITE1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_TMALITE1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_TMALITE1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_TMALITE1_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_TMALITE1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_TMALITE1_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_TMALITE1_STAT Bits */
+/* SYSCTL_MGMT_TMALITE1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_TMALITE1_STAT_RESETSTKY_OFS  (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_TMALITE1_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_TMALITE1_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_TMALITE1_STAT_RESETSTKY_SET  ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPTIMER32B2CC0_PWREN Bits */
+/* SYSCTL_MGMT_GPTIMER32B2CC0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPTIMER32B2CC0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL Bits */
+/* SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER32B2CC0_STAT Bits */
+/* SYSCTL_MGMT_GPTIMER32B2CC0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER32B2CC0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCSP1_PWREN Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCSP1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_PWREN_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_PWREN_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCSP1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCSP1_RSTCTL Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCSP1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_RSTCTL_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCSP1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPTIMER16B2CCSP1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCSP1_STAT Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCSP1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCSP1_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCSP0_PWREN Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCSP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_PWREN_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_PWREN_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCSP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCSP0_RSTCTL Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCSP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_RSTCTL_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCSP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPTIMER16B2CCSP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCSP0_STAT Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCSP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCSP0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPTIMER16BADV2CC0_PWREN Bits */
+/* SYSCTL_MGMT_GPTIMER16BADV2CC0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_PWREN_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_PWREN_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPTIMER16BADV2CC0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16BADV2CC0_RSTCTL Bits */
+/* SYSCTL_MGMT_GPTIMER16BADV2CC0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_RSTCTL_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPTIMER16BADV2CC0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPTIMER16BADV2CC0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16BADV2CC0_STAT Bits */
+/* SYSCTL_MGMT_GPTIMER16BADV2CC0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16BADV2CC0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN Bits */
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL Bits */
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_STAT Bits */
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_MCAN0_PWREN Bits */
+/* SYSCTL_MGMT_MCAN0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_MCAN0_PWREN_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_MCAN0_PWREN_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_MCAN0_PWREN_KEY_UNLOCK       ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_MCAN0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_MCAN0_PWREN_ENABLE_OFS       (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_MCAN0_PWREN_ENABLE_MASK      ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_MCAN0_PWREN_ENABLE_DISABLE   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_MCAN0_PWREN_ENABLE_ENABLE    ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_MCAN0_RSTCTL Bits */
+/* SYSCTL_MGMT_MCAN0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_MCAN0_RSTCTL_KEY_OFS         (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_MCAN0_RSTCTL_KEY_MASK        ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_MCAN0_RSTCTL_KEY_UNLOCK      ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_MCAN0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_MCAN0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_MCAN0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_MCAN0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_MCAN0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_MCAN0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_MCAN0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_MCAN0_RSTCTL_RESETASSERT_DO  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_MCAN0_STAT Bits */
+/* SYSCTL_MGMT_MCAN0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_MCAN0_STAT_RESETSTKY_OFS     (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_MCAN0_STAT_RESETSTKY_MASK    ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_MCAN0_STAT_RESETSTKY_CLEAR   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_MCAN0_STAT_RESETSTKY_SET     ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_UART0_PWREN Bits */
+/* SYSCTL_MGMT_UART0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_UART0_PWREN_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UART0_PWREN_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_UART0_PWREN_KEY_UNLOCK       ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_UART0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_UART0_PWREN_ENABLE_OFS       (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_UART0_PWREN_ENABLE_MASK      ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_UART0_PWREN_ENABLE_DISABLE   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UART0_PWREN_ENABLE_ENABLE    ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UART0_RSTCTL Bits */
+/* SYSCTL_MGMT_UART0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_UART0_RSTCTL_KEY_OFS         (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UART0_RSTCTL_KEY_MASK        ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_UART0_RSTCTL_KEY_UNLOCK      ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_UART0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_UART0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_UART0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_UART0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_UART0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_UART0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_UART0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_UART0_RSTCTL_RESETASSERT_DO  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UART0_CLKCFG Bits */
+/* SYSCTL_MGMT_UART0_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_UART0_CLKCFG_KEY_OFS         (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UART0_CLKCFG_KEY_MASK        ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_UART0_CLKCFG_KEY_UNLOCK      ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_UART0_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_UART0_CLKCFG_BLOCKASYNC_OFS  (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_UART0_CLKCFG_BLOCKASYNC_MASK ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_UART0_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UART0_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_UART0_STAT Bits */
+/* SYSCTL_MGMT_UART0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_UART0_STAT_RESETSTKY_OFS     (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_UART0_STAT_RESETSTKY_MASK    ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_UART0_STAT_RESETSTKY_CLEAR   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UART0_STAT_RESETSTKY_SET     ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_SPI1_PWREN Bits */
+/* SYSCTL_MGMT_SPI1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_SPI1_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_SPI1_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_SPI1_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_SPI1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_SPI1_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_SPI1_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_SPI1_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_SPI1_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_SPI1_RSTCTL Bits */
+/* SYSCTL_MGMT_SPI1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_SPI1_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_SPI1_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_SPI1_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_SPI1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_SPI1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_SPI1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_SPI1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_SPI1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_SPI1_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_SPI1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_SPI1_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_SPI1_CLKCFG Bits */
+/* SYSCTL_MGMT_SPI1_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_SPI1_CLKCFG_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_SPI1_CLKCFG_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_SPI1_CLKCFG_KEY_UNLOCK       ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_SPI1_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_SPI1_CLKCFG_BLOCKASYNC_OFS   (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_SPI1_CLKCFG_BLOCKASYNC_MASK  ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_SPI1_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_SPI1_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_SPI1_STAT Bits */
+/* SYSCTL_MGMT_SPI1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_SPI1_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_SPI1_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_SPI1_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_SPI1_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_SPI0_PWREN Bits */
+/* SYSCTL_MGMT_SPI0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_SPI0_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_SPI0_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_SPI0_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_SPI0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_SPI0_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_SPI0_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_SPI0_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_SPI0_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_SPI0_RSTCTL Bits */
+/* SYSCTL_MGMT_SPI0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_SPI0_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_SPI0_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_SPI0_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_SPI0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_SPI0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_SPI0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_SPI0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_SPI0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_SPI0_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_SPI0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_SPI0_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_SPI0_CLKCFG Bits */
+/* SYSCTL_MGMT_SPI0_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_SPI0_CLKCFG_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_SPI0_CLKCFG_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_SPI0_CLKCFG_KEY_UNLOCK       ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_SPI0_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_SPI0_CLKCFG_BLOCKASYNC_OFS   (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_SPI0_CLKCFG_BLOCKASYNC_MASK  ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_SPI0_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_SPI0_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_SPI0_STAT Bits */
+/* SYSCTL_MGMT_SPI0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_SPI0_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_SPI0_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_SPI0_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_SPI0_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_TRNG_PWREN Bits */
+/* SYSCTL_MGMT_TRNG_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_TRNG_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_TRNG_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_TRNG_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_TRNG_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_TRNG_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_TRNG_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_TRNG_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_TRNG_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_TRNG_RSTCTL Bits */
+/* SYSCTL_MGMT_TRNG_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_TRNG_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_TRNG_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_TRNG_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_TRNG_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_TRNG_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_TRNG_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_TRNG_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_TRNG_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_TRNG_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_TRNG_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_TRNG_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_TRNG_STAT Bits */
+/* SYSCTL_MGMT_TRNG_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_TRNG_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_TRNG_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_TRNG_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_TRNG_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_AES_PWREN Bits */
+/* SYSCTL_MGMT_AES_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_AES_PWREN_KEY_OFS            (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_AES_PWREN_KEY_MASK           ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_AES_PWREN_KEY_UNLOCK         ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_AES_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_AES_PWREN_ENABLE_OFS         (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_AES_PWREN_ENABLE_MASK        ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_AES_PWREN_ENABLE_DISABLE     ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_AES_PWREN_ENABLE_ENABLE      ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_AES_RSTCTL Bits */
+/* SYSCTL_MGMT_AES_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_AES_RSTCTL_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_AES_RSTCTL_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_AES_RSTCTL_KEY_UNLOCK        ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_AES_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_AES_RSTCTL_RESETSTKYCLR_OFS  (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_AES_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_AES_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_AES_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_AES_RSTCTL_RESETASSERT_OFS   (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_AES_RSTCTL_RESETASSERT_MASK  ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_AES_RSTCTL_RESETASSERT_DO    ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_AES_STAT Bits */
+/* SYSCTL_MGMT_AES_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_AES_STAT_RESETSTKY_OFS       (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_AES_STAT_RESETSTKY_MASK      ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_AES_STAT_RESETSTKY_CLEAR     ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_AES_STAT_RESETSTKY_SET       ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_CRC0_PWREN Bits */
+/* SYSCTL_MGMT_CRC0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_CRC0_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_CRC0_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_CRC0_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_CRC0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_CRC0_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_CRC0_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_CRC0_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_CRC0_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_CRC0_RSTCTL Bits */
+/* SYSCTL_MGMT_CRC0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_CRC0_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_CRC0_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_CRC0_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_CRC0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_CRC0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_CRC0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_CRC0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_CRC0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_CRC0_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_CRC0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_CRC0_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_CRC0_STAT Bits */
+/* SYSCTL_MGMT_CRC0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_CRC0_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_CRC0_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_CRC0_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_CRC0_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_MATHACL_PWREN Bits */
+/* SYSCTL_MGMT_MATHACL_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_MATHACL_PWREN_KEY_OFS        (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_MATHACL_PWREN_KEY_MASK       ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_MATHACL_PWREN_KEY_UNLOCK     ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_MATHACL_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_MATHACL_PWREN_ENABLE_OFS     (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_MATHACL_PWREN_ENABLE_MASK    ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_MATHACL_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_MATHACL_PWREN_ENABLE_ENABLE  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_MATHACL_RSTCTL Bits */
+/* SYSCTL_MGMT_MATHACL_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_MATHACL_RSTCTL_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_MATHACL_RSTCTL_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_MATHACL_RSTCTL_KEY_UNLOCK    ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_MATHACL_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_MATHACL_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_MATHACL_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_MATHACL_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_MATHACL_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_MATHACL_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_MATHACL_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_MATHACL_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_MATHACL_STAT Bits */
+/* SYSCTL_MGMT_MATHACL_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_MATHACL_STAT_RESETSTKY_OFS   (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_MATHACL_STAT_RESETSTKY_MASK  ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_MATHACL_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_MATHACL_STAT_RESETSTKY_SET   ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_UARTADVLP0_PWREN Bits */
+/* SYSCTL_MGMT_UARTADVLP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_KEY_OFS     (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_KEY_MASK    ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_KEY_UNLOCK  ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_UARTADVLP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_ENABLE_OFS  (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTADVLP0_RSTCTL Bits */
+/* SYSCTL_MGMT_UARTADVLP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_KEY_OFS    (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_KEY_MASK   ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_UARTADVLP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_UARTADVLP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTADVLP0_CLKCFG Bits */
+/* SYSCTL_MGMT_UARTADVLP0_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_KEY_OFS    (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_KEY_MASK   ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_KEY_UNLOCK ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_UARTADVLP0_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_BLOCKASYNC_OFS (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_BLOCKASYNC_MASK ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_UARTADVLP0_STAT Bits */
+/* SYSCTL_MGMT_UARTADVLP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_UARTADVLP0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_UARTADVLP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTADVLP0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_UARTLP1_PWREN Bits */
+/* SYSCTL_MGMT_UARTLP1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP1_PWREN_KEY_OFS        (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP1_PWREN_KEY_MASK       ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_UARTLP1_PWREN_KEY_UNLOCK     ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_UARTLP1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_UARTLP1_PWREN_ENABLE_OFS     (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_UARTLP1_PWREN_ENABLE_MASK    ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_UARTLP1_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP1_PWREN_ENABLE_ENABLE  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTLP1_RSTCTL Bits */
+/* SYSCTL_MGMT_UARTLP1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_KEY_UNLOCK    ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_UARTLP1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_UARTLP1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTLP1_CLKCFG Bits */
+/* SYSCTL_MGMT_UARTLP1_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_KEY_UNLOCK    ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_UARTLP1_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_BLOCKASYNC_OFS (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_BLOCKASYNC_MASK ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_UARTLP1_STAT Bits */
+/* SYSCTL_MGMT_UARTLP1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_UARTLP1_STAT_RESETSTKY_OFS   (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_UARTLP1_STAT_RESETSTKY_MASK  ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_UARTLP1_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP1_STAT_RESETSTKY_SET   ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_UARTLP0_PWREN Bits */
+/* SYSCTL_MGMT_UARTLP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP0_PWREN_KEY_OFS        (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP0_PWREN_KEY_MASK       ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_UARTLP0_PWREN_KEY_UNLOCK     ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_UARTLP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_UARTLP0_PWREN_ENABLE_OFS     (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_UARTLP0_PWREN_ENABLE_MASK    ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_UARTLP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP0_PWREN_ENABLE_ENABLE  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTLP0_RSTCTL Bits */
+/* SYSCTL_MGMT_UARTLP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_KEY_UNLOCK    ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_UARTLP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_UARTLP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTLP0_CLKCFG Bits */
+/* SYSCTL_MGMT_UARTLP0_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_KEY_UNLOCK    ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_UARTLP0_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_BLOCKASYNC_OFS (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_BLOCKASYNC_MASK ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_UARTLP0_STAT Bits */
+/* SYSCTL_MGMT_UARTLP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_UARTLP0_STAT_RESETSTKY_OFS   (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_UARTLP0_STAT_RESETSTKY_MASK  ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_UARTLP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP0_STAT_RESETSTKY_SET   ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_I2C1_PWREN Bits */
+/* SYSCTL_MGMT_I2C1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_I2C1_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C1_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_I2C1_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_I2C1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_I2C1_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_I2C1_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_I2C1_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C1_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_I2C1_RSTCTL Bits */
+/* SYSCTL_MGMT_I2C1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_I2C1_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C1_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_I2C1_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_I2C1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_I2C1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_I2C1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_I2C1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_I2C1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_I2C1_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_I2C1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_I2C1_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_I2C1_CLKCFG Bits */
+/* SYSCTL_MGMT_I2C1_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_I2C1_CLKCFG_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C1_CLKCFG_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_I2C1_CLKCFG_KEY_UNLOCK       ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_I2C1_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_I2C1_CLKCFG_BLOCKASYNC_OFS   (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_I2C1_CLKCFG_BLOCKASYNC_MASK  ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_I2C1_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C1_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_I2C1_STAT Bits */
+/* SYSCTL_MGMT_I2C1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_I2C1_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_I2C1_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_I2C1_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C1_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_I2C0_PWREN Bits */
+/* SYSCTL_MGMT_I2C0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_I2C0_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C0_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_I2C0_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_I2C0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_I2C0_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_I2C0_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_I2C0_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C0_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_I2C0_RSTCTL Bits */
+/* SYSCTL_MGMT_I2C0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_I2C0_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C0_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_I2C0_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_I2C0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_I2C0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_I2C0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_I2C0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_I2C0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_I2C0_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_I2C0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_I2C0_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_I2C0_CLKCFG Bits */
+/* SYSCTL_MGMT_I2C0_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_I2C0_CLKCFG_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C0_CLKCFG_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_I2C0_CLKCFG_KEY_UNLOCK       ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_I2C0_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_I2C0_CLKCFG_BLOCKASYNC_OFS   (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_I2C0_CLKCFG_BLOCKASYNC_MASK  ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_I2C0_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C0_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_I2C0_STAT Bits */
+/* SYSCTL_MGMT_I2C0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_I2C0_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_I2C0_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_I2C0_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C0_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPIO1_PWREN Bits */
+/* SYSCTL_MGMT_GPIO1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPIO1_PWREN_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPIO1_PWREN_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPIO1_PWREN_KEY_UNLOCK       ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPIO1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPIO1_PWREN_ENABLE_OFS       (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPIO1_PWREN_ENABLE_MASK      ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPIO1_PWREN_ENABLE_DISABLE   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPIO1_PWREN_ENABLE_ENABLE    ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPIO1_RSTCTL Bits */
+/* SYSCTL_MGMT_GPIO1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_KEY_OFS         (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_KEY_MASK        ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_KEY_UNLOCK      ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPIO1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPIO1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_RESETASSERT_DO  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPIO1_STAT Bits */
+/* SYSCTL_MGMT_GPIO1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPIO1_STAT_RESETSTKY_OFS     (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPIO1_STAT_RESETSTKY_MASK    ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPIO1_STAT_RESETSTKY_CLEAR   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPIO1_STAT_RESETSTKY_SET     ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPIO0_PWREN Bits */
+/* SYSCTL_MGMT_GPIO0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPIO0_PWREN_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPIO0_PWREN_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPIO0_PWREN_KEY_UNLOCK       ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPIO0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPIO0_PWREN_ENABLE_OFS       (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPIO0_PWREN_ENABLE_MASK      ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPIO0_PWREN_ENABLE_DISABLE   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPIO0_PWREN_ENABLE_ENABLE    ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPIO0_RSTCTL Bits */
+/* SYSCTL_MGMT_GPIO0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_KEY_OFS         (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_KEY_MASK        ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_KEY_UNLOCK      ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPIO0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPIO0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_RESETASSERT_DO  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPIO0_STAT Bits */
+/* SYSCTL_MGMT_GPIO0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPIO0_STAT_RESETSTKY_OFS     (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPIO0_STAT_RESETSTKY_MASK    ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPIO0_STAT_RESETSTKY_CLEAR   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPIO0_STAT_RESETSTKY_SET     ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_RTC_PWREN Bits */
+/* SYSCTL_MGMT_RTC_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_RTC_PWREN_KEY_OFS            (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_RTC_PWREN_KEY_MASK           ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_RTC_PWREN_KEY_UNLOCK         ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_RTC_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_RTC_PWREN_ENABLE_OFS         (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_RTC_PWREN_ENABLE_MASK        ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_RTC_PWREN_ENABLE_DISABLE     ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_RTC_PWREN_ENABLE_ENABLE      ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_RTC_RSTCTL Bits */
+/* SYSCTL_MGMT_RTC_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_RTC_RSTCTL_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_RTC_RSTCTL_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_RTC_RSTCTL_KEY_UNLOCK        ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_RTC_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_RTC_RSTCTL_RESETSTKYCLR_OFS  (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_RTC_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_RTC_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_RTC_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_RTC_RSTCTL_RESETASSERT_OFS   (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_RTC_RSTCTL_RESETASSERT_MASK  ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_RTC_RSTCTL_RESETASSERT_DO    ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_RTC_CLKCFG Bits */
+/* SYSCTL_MGMT_RTC_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_RTC_CLKCFG_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_RTC_CLKCFG_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_RTC_CLKCFG_KEY_UNLOCK        ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_RTC_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_RTC_CLKCFG_BLOCKASYNC_OFS    (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_RTC_CLKCFG_BLOCKASYNC_MASK   ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_RTC_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_RTC_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_RTC_STAT Bits */
+/* SYSCTL_MGMT_RTC_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_RTC_STAT_RESETSTKY_OFS       (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_RTC_STAT_RESETSTKY_MASK      ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_RTC_STAT_RESETSTKY_CLEAR     ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_RTC_STAT_RESETSTKY_SET       ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_STAT Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_STAT Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_WWDTLP1_PWREN Bits */
+/* SYSCTL_MGMT_WWDTLP1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_WWDTLP1_PWREN_KEY_OFS        (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_WWDTLP1_PWREN_KEY_MASK       ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_WWDTLP1_PWREN_KEY_UNLOCK     ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_WWDTLP1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_WWDTLP1_PWREN_ENABLE_OFS     (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_WWDTLP1_PWREN_ENABLE_MASK    ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_WWDTLP1_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_WWDTLP1_PWREN_ENABLE_ENABLE  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_WWDTLP1_RSTCTL Bits */
+/* SYSCTL_MGMT_WWDTLP1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_WWDTLP1_RSTCTL_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_WWDTLP1_RSTCTL_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_WWDTLP1_RSTCTL_KEY_UNLOCK    ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_WWDTLP1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_WWDTLP1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_WWDTLP1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_WWDTLP1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_WWDTLP1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_WWDTLP1_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_WWDTLP1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_WWDTLP1_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_WWDTLP1_STAT Bits */
+/* SYSCTL_MGMT_WWDTLP1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_WWDTLP1_STAT_RESETSTKY_OFS   (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_WWDTLP1_STAT_RESETSTKY_MASK  ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_WWDTLP1_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_WWDTLP1_STAT_RESETSTKY_SET   ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_WWDTLP0_PWREN Bits */
+/* SYSCTL_MGMT_WWDTLP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_WWDTLP0_PWREN_KEY_OFS        (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_WWDTLP0_PWREN_KEY_MASK       ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_WWDTLP0_PWREN_KEY_UNLOCK     ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_WWDTLP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_WWDTLP0_PWREN_ENABLE_OFS     (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_WWDTLP0_PWREN_ENABLE_MASK    ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_WWDTLP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_WWDTLP0_PWREN_ENABLE_ENABLE  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_WWDTLP0_RSTCTL Bits */
+/* SYSCTL_MGMT_WWDTLP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_KEY_UNLOCK    ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_WWDTLP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_WWDTLP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_WWDTLP0_STAT Bits */
+/* SYSCTL_MGMT_WWDTLP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_WWDTLP0_STAT_RESETSTKY_OFS   (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_WWDTLP0_STAT_RESETSTKY_MASK  ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_WWDTLP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_WWDTLP0_STAT_RESETSTKY_SET   ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_VREF_PWREN Bits */
+/* SYSCTL_MGMT_VREF_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_VREF_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_VREF_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_VREF_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_VREF_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_VREF_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_VREF_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_VREF_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_VREF_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_VREF_RSTCTL Bits */
+/* SYSCTL_MGMT_VREF_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_VREF_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_VREF_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_VREF_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_VREF_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_VREF_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_VREF_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_VREF_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_VREF_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_VREF_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_VREF_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_VREF_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_VREF_STAT Bits */
+/* SYSCTL_MGMT_VREF_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_VREF_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_VREF_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_VREF_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_VREF_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_OPAMP1_PWREN Bits */
+/* SYSCTL_MGMT_OPAMP1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_OPAMP1_PWREN_KEY_OFS         (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_OPAMP1_PWREN_KEY_MASK        ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_OPAMP1_PWREN_KEY_UNLOCK      ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_OPAMP1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_OPAMP1_PWREN_ENABLE_OFS      (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_OPAMP1_PWREN_ENABLE_MASK     ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_OPAMP1_PWREN_ENABLE_DISABLE  ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_OPAMP1_PWREN_ENABLE_ENABLE   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_OPAMP1_RSTCTL Bits */
+/* SYSCTL_MGMT_OPAMP1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_OPAMP1_RSTCTL_KEY_OFS        (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_OPAMP1_RSTCTL_KEY_MASK       ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_OPAMP1_RSTCTL_KEY_UNLOCK     ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_OPAMP1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_OPAMP1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_OPAMP1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_OPAMP1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_OPAMP1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_OPAMP1_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_OPAMP1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_OPAMP1_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_OPAMP1_STAT Bits */
+/* SYSCTL_MGMT_OPAMP1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_OPAMP1_STAT_RESETSTKY_OFS    (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_OPAMP1_STAT_RESETSTKY_MASK   ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_OPAMP1_STAT_RESETSTKY_CLEAR  ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_OPAMP1_STAT_RESETSTKY_SET    ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_OPAMP0_PWREN Bits */
+/* SYSCTL_MGMT_OPAMP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_OPAMP0_PWREN_KEY_OFS         (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_OPAMP0_PWREN_KEY_MASK        ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_OPAMP0_PWREN_KEY_UNLOCK      ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_OPAMP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_OPAMP0_PWREN_ENABLE_OFS      (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_OPAMP0_PWREN_ENABLE_MASK     ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_OPAMP0_PWREN_ENABLE_DISABLE  ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_OPAMP0_PWREN_ENABLE_ENABLE   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_OPAMP0_RSTCTL Bits */
+/* SYSCTL_MGMT_OPAMP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_OPAMP0_RSTCTL_KEY_OFS        (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_OPAMP0_RSTCTL_KEY_MASK       ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_OPAMP0_RSTCTL_KEY_UNLOCK     ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_OPAMP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_OPAMP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_OPAMP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_OPAMP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_OPAMP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_OPAMP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_OPAMP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_OPAMP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_OPAMP0_STAT Bits */
+/* SYSCTL_MGMT_OPAMP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_OPAMP0_STAT_RESETSTKY_OFS    (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_OPAMP0_STAT_RESETSTKY_MASK   ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_OPAMP0_STAT_RESETSTKY_CLEAR  ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_OPAMP0_STAT_RESETSTKY_SET    ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_DAC12B0_PWREN Bits */
+/* SYSCTL_MGMT_DAC12B0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_DAC12B0_PWREN_KEY_OFS        (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_DAC12B0_PWREN_KEY_MASK       ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_DAC12B0_PWREN_KEY_UNLOCK     ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_DAC12B0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_DAC12B0_PWREN_ENABLE_OFS     (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_DAC12B0_PWREN_ENABLE_MASK    ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_DAC12B0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_DAC12B0_PWREN_ENABLE_ENABLE  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_DAC12B0_RSTCTL Bits */
+/* SYSCTL_MGMT_DAC12B0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_DAC12B0_RSTCTL_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_DAC12B0_RSTCTL_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_DAC12B0_RSTCTL_KEY_UNLOCK    ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_DAC12B0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_DAC12B0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_DAC12B0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_DAC12B0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_DAC12B0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_DAC12B0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_DAC12B0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_DAC12B0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_DAC12B0_STAT Bits */
+/* SYSCTL_MGMT_DAC12B0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_DAC12B0_STAT_RESETSTKY_OFS   (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_DAC12B0_STAT_RESETSTKY_MASK  ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_DAC12B0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_DAC12B0_STAT_RESETSTKY_SET   ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_ANACOMP2_PWREN Bits */
+/* SYSCTL_MGMT_ANACOMP2_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_ANACOMP2_PWREN_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ANACOMP2_PWREN_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_ANACOMP2_PWREN_KEY_UNLOCK    ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_ANACOMP2_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_ANACOMP2_PWREN_ENABLE_OFS    (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_ANACOMP2_PWREN_ENABLE_MASK   ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_ANACOMP2_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ANACOMP2_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ANACOMP2_RSTCTL Bits */
+/* SYSCTL_MGMT_ANACOMP2_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_ANACOMP2_RSTCTL_KEY_OFS      (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ANACOMP2_RSTCTL_KEY_MASK     ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_ANACOMP2_RSTCTL_KEY_UNLOCK   ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_ANACOMP2_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_ANACOMP2_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_ANACOMP2_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_ANACOMP2_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_ANACOMP2_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_ANACOMP2_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_ANACOMP2_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_ANACOMP2_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ANACOMP2_CLKCFG Bits */
+/* SYSCTL_MGMT_ANACOMP2_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_ANACOMP2_CLKCFG_KEY_OFS      (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ANACOMP2_CLKCFG_KEY_MASK     ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_ANACOMP2_CLKCFG_KEY_UNLOCK   ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_ANACOMP2_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_ANACOMP2_CLKCFG_BLOCKASYNC_OFS (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_ANACOMP2_CLKCFG_BLOCKASYNC_MASK ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_ANACOMP2_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ANACOMP2_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_ANACOMP2_STAT Bits */
+/* SYSCTL_MGMT_ANACOMP2_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_ANACOMP2_STAT_RESETSTKY_OFS  (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_ANACOMP2_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_ANACOMP2_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ANACOMP2_STAT_RESETSTKY_SET  ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_ANACOMP1_PWREN Bits */
+/* SYSCTL_MGMT_ANACOMP1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_ANACOMP1_PWREN_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ANACOMP1_PWREN_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_ANACOMP1_PWREN_KEY_UNLOCK    ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_ANACOMP1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_ANACOMP1_PWREN_ENABLE_OFS    (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_ANACOMP1_PWREN_ENABLE_MASK   ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_ANACOMP1_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ANACOMP1_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ANACOMP1_RSTCTL Bits */
+/* SYSCTL_MGMT_ANACOMP1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_ANACOMP1_RSTCTL_KEY_OFS      (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ANACOMP1_RSTCTL_KEY_MASK     ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_ANACOMP1_RSTCTL_KEY_UNLOCK   ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_ANACOMP1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_ANACOMP1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_ANACOMP1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_ANACOMP1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_ANACOMP1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_ANACOMP1_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_ANACOMP1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_ANACOMP1_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ANACOMP1_CLKCFG Bits */
+/* SYSCTL_MGMT_ANACOMP1_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_ANACOMP1_CLKCFG_KEY_OFS      (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ANACOMP1_CLKCFG_KEY_MASK     ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_ANACOMP1_CLKCFG_KEY_UNLOCK   ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_ANACOMP1_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_ANACOMP1_CLKCFG_BLOCKASYNC_OFS (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_ANACOMP1_CLKCFG_BLOCKASYNC_MASK ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_ANACOMP1_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ANACOMP1_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_ANACOMP1_STAT Bits */
+/* SYSCTL_MGMT_ANACOMP1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_ANACOMP1_STAT_RESETSTKY_OFS  (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_ANACOMP1_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_ANACOMP1_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ANACOMP1_STAT_RESETSTKY_SET  ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_ANACOMP0_PWREN Bits */
+/* SYSCTL_MGMT_ANACOMP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_ANACOMP0_PWREN_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ANACOMP0_PWREN_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_ANACOMP0_PWREN_KEY_UNLOCK    ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_ANACOMP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_ANACOMP0_PWREN_ENABLE_OFS    (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_ANACOMP0_PWREN_ENABLE_MASK   ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_ANACOMP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ANACOMP0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ANACOMP0_RSTCTL Bits */
+/* SYSCTL_MGMT_ANACOMP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_KEY_OFS      (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_KEY_MASK     ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_KEY_UNLOCK   ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_ANACOMP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_ANACOMP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ANACOMP0_CLKCFG Bits */
+/* SYSCTL_MGMT_ANACOMP0_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_KEY_OFS      (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_KEY_MASK     ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_KEY_UNLOCK   ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_ANACOMP0_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_BLOCKASYNC_OFS (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_BLOCKASYNC_MASK ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_ANACOMP0_STAT Bits */
+/* SYSCTL_MGMT_ANACOMP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_ANACOMP0_STAT_RESETSTKY_OFS  (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_ANACOMP0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_ANACOMP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ANACOMP0_STAT_RESETSTKY_SET  ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_ADC12B4MSPS1_PWREN Bits */
+/* SYSCTL_MGMT_ADC12B4MSPS1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS1_PWREN_KEY_OFS   (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS1_PWREN_KEY_MASK  ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_ADC12B4MSPS1_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_ADC12B4MSPS1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS1_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS1_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_ADC12B4MSPS1_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B4MSPS1_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ADC12B4MSPS1_RSTCTL Bits */
+/* SYSCTL_MGMT_ADC12B4MSPS1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS1_RSTCTL_KEY_OFS  (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS1_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_ADC12B4MSPS1_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_ADC12B4MSPS1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_ADC12B4MSPS1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_ADC12B4MSPS1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS1_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_ADC12B4MSPS1_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG Bits */
+/* SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_KEY_OFS  (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_KEY_UNLOCK ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG[CCONSTOP] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_CCONSTOP_OFS (5)                             /* !< CCONSTOP Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_CCONSTOP_MASK ((uint32_t)0x00000020U)         /* !< Conversion Clock is ON during STOP
+                                                                                    Mode */
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_CCONSTOP_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_CCONSTOP_ENABLE ((uint32_t)0x00000020U)
+/* SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG[CCONRUN] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_CCONRUN_OFS (4)                             /* !< CCONRUN Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_CCONRUN_MASK ((uint32_t)0x00000010U)         /* !< Conversion Clock is ON during RUN
+                                                                                    Mode */
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_CCONRUN_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_CCONRUN_ENABLE ((uint32_t)0x00000010U)
+/* SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG[SAMPCLK] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_SAMPCLK_OFS (0)                             /* !< SAMPCLK Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_SAMPCLK_MASK ((uint32_t)0x00000003U)         /* !< Sample Window Clock */
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_SAMPCLK_ULPCLK ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_SAMPCLK_SYSOSC ((uint32_t)0x00000001U)
+#define SYSCTL_MGMT_ADC12B4MSPS1_CLKCFG_SAMPCLK_HFCLK ((uint32_t)0x00000002U)
+
+/* SYSCTL_MGMT_ADC12B4MSPS1_STAT Bits */
+/* SYSCTL_MGMT_ADC12B4MSPS1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS1_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS1_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_ADC12B4MSPS1_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B4MSPS1_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_IIDX Bits */
+/* SYSCTL_IIDX[STAT] Bits */
+#define SYSCTL_IIDX_STAT_OFS                     (0)                             /* !< STAT Offset */
+#define SYSCTL_IIDX_STAT_MASK                    ((uint32_t)0x0000000FU)         /* !< The SYSCTL interrupt index (IIDX)
+                                                                                    register generates a value
+                                                                                    corresponding to the highest priority
+                                                                                    pending interrupt source.  This value
+                                                                                    may be used as an address offset for
+                                                                                    fast, deterministic handling in the
+                                                                                    interrupt service routine.  A read of
+                                                                                    the IIDX register will clear the
+                                                                                    corresponding interrupt status in the
+                                                                                    RIS and MIS registers. */
+#define SYSCTL_IIDX_STAT_NO_INTR                 ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define SYSCTL_IIDX_STAT_LFOSCGOOD               ((uint32_t)0x00000001U)         /* !< LFOSCGOOD interrupt pending */
+#define SYSCTL_IIDX_STAT_ANACLKERR               ((uint32_t)0x00000002U)
+#define SYSCTL_IIDX_STAT_FLASHSEC                ((uint32_t)0x00000003U)
+#define SYSCTL_IIDX_STAT_SRAMSEC                 ((uint32_t)0x00000004U)
+#define SYSCTL_IIDX_STAT_LFXTGOOD                ((uint32_t)0x00000005U)
+#define SYSCTL_IIDX_STAT_HFCLKGOOD               ((uint32_t)0x00000006U)
+#define SYSCTL_IIDX_STAT_SYSPLLGOOD              ((uint32_t)0x00000007U)
+#define SYSCTL_IIDX_STAT_HSCLKGOOD               ((uint32_t)0x00000008U)
+
+/* SYSCTL_IMASK Bits */
+/* SYSCTL_IMASK[LFOSCGOOD] Bits */
+#define SYSCTL_IMASK_LFOSCGOOD_OFS               (0)                             /* !< LFOSCGOOD Offset */
+#define SYSCTL_IMASK_LFOSCGOOD_MASK              ((uint32_t)0x00000001U)         /* !< Enable or disable the LFOSCGOOD
+                                                                                    interrupt. LFOSCGOOD indicates that
+                                                                                    the LFOSC has started successfully. */
+#define SYSCTL_IMASK_LFOSCGOOD_DISABLE           ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define SYSCTL_IMASK_LFOSCGOOD_ENABLE            ((uint32_t)0x00000001U)         /* !< Interrupt enabled */
+/* SYSCTL_IMASK[HFCLKGOOD] Bits */
+#define SYSCTL_IMASK_HFCLKGOOD_OFS               (5)                             /* !< HFCLKGOOD Offset */
+#define SYSCTL_IMASK_HFCLKGOOD_MASK              ((uint32_t)0x00000020U)         /* !< HFCLK GOOD */
+#define SYSCTL_IMASK_HFCLKGOOD_DISABLE           ((uint32_t)0x00000000U)
+#define SYSCTL_IMASK_HFCLKGOOD_ENABLE            ((uint32_t)0x00000020U)
+/* SYSCTL_IMASK[SRAMSEC] Bits */
+#define SYSCTL_IMASK_SRAMSEC_OFS                 (3)                             /* !< SRAMSEC Offset */
+#define SYSCTL_IMASK_SRAMSEC_MASK                ((uint32_t)0x00000008U)         /* !< SRAM Single Error Correct */
+#define SYSCTL_IMASK_SRAMSEC_DISABLE             ((uint32_t)0x00000000U)
+#define SYSCTL_IMASK_SRAMSEC_ENABLE              ((uint32_t)0x00000008U)
+/* SYSCTL_IMASK[LFXTGOOD] Bits */
+#define SYSCTL_IMASK_LFXTGOOD_OFS                (4)                             /* !< LFXTGOOD Offset */
+#define SYSCTL_IMASK_LFXTGOOD_MASK               ((uint32_t)0x00000010U)         /* !< LFXT GOOD */
+#define SYSCTL_IMASK_LFXTGOOD_DISABLE            ((uint32_t)0x00000000U)
+#define SYSCTL_IMASK_LFXTGOOD_ENABLE             ((uint32_t)0x00000010U)
+/* SYSCTL_IMASK[HSCLKGOOD] Bits */
+#define SYSCTL_IMASK_HSCLKGOOD_OFS               (7)                             /* !< HSCLKGOOD Offset */
+#define SYSCTL_IMASK_HSCLKGOOD_MASK              ((uint32_t)0x00000080U)         /* !< HSCLK GOOD */
+#define SYSCTL_IMASK_HSCLKGOOD_DISABLE           ((uint32_t)0x00000000U)
+#define SYSCTL_IMASK_HSCLKGOOD_ENABLE            ((uint32_t)0x00000080U)
+/* SYSCTL_IMASK[SYSPLLGOOD] Bits */
+#define SYSCTL_IMASK_SYSPLLGOOD_OFS              (6)                             /* !< SYSPLLGOOD Offset */
+#define SYSCTL_IMASK_SYSPLLGOOD_MASK             ((uint32_t)0x00000040U)         /* !< SYSPLL GOOD */
+#define SYSCTL_IMASK_SYSPLLGOOD_DISABLE          ((uint32_t)0x00000000U)
+#define SYSCTL_IMASK_SYSPLLGOOD_ENABLE           ((uint32_t)0x00000040U)
+/* SYSCTL_IMASK[ANACLKERR] Bits */
+#define SYSCTL_IMASK_ANACLKERR_OFS               (1)                             /* !< ANACLKERR Offset */
+#define SYSCTL_IMASK_ANACLKERR_MASK              ((uint32_t)0x00000002U)         /* !< Analog Clocking Consistency Error */
+#define SYSCTL_IMASK_ANACLKERR_DISABLE           ((uint32_t)0x00000000U)
+#define SYSCTL_IMASK_ANACLKERR_ENABLE            ((uint32_t)0x00000002U)
+/* SYSCTL_IMASK[FLASHSEC] Bits */
+#define SYSCTL_IMASK_FLASHSEC_OFS                (2)                             /* !< FLASHSEC Offset */
+#define SYSCTL_IMASK_FLASHSEC_MASK               ((uint32_t)0x00000004U)         /* !< Flash Single Error Correct */
+#define SYSCTL_IMASK_FLASHSEC_DISABLE            ((uint32_t)0x00000000U)
+#define SYSCTL_IMASK_FLASHSEC_ENABLE             ((uint32_t)0x00000004U)
+
+/* SYSCTL_RIS Bits */
+/* SYSCTL_RIS[LFOSCGOOD] Bits */
+#define SYSCTL_RIS_LFOSCGOOD_OFS                 (0)                             /* !< LFOSCGOOD Offset */
+#define SYSCTL_RIS_LFOSCGOOD_MASK                ((uint32_t)0x00000001U)         /* !< Raw status of the LFOSCGOOD
+                                                                                    interrupt. */
+#define SYSCTL_RIS_LFOSCGOOD_FALSE               ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define SYSCTL_RIS_LFOSCGOOD_TRUE                ((uint32_t)0x00000001U)         /* !< Interrupt pending */
+/* SYSCTL_RIS[HFCLKGOOD] Bits */
+#define SYSCTL_RIS_HFCLKGOOD_OFS                 (5)                             /* !< HFCLKGOOD Offset */
+#define SYSCTL_RIS_HFCLKGOOD_MASK                ((uint32_t)0x00000020U)         /* !< HFCLK GOOD */
+#define SYSCTL_RIS_HFCLKGOOD_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_RIS_HFCLKGOOD_TRUE                ((uint32_t)0x00000020U)
+/* SYSCTL_RIS[SRAMSEC] Bits */
+#define SYSCTL_RIS_SRAMSEC_OFS                   (3)                             /* !< SRAMSEC Offset */
+#define SYSCTL_RIS_SRAMSEC_MASK                  ((uint32_t)0x00000008U)         /* !< SRAM Single Error Correct */
+#define SYSCTL_RIS_SRAMSEC_FALSE                 ((uint32_t)0x00000000U)
+#define SYSCTL_RIS_SRAMSEC_TRUE                  ((uint32_t)0x00000008U)
+/* SYSCTL_RIS[LFXTGOOD] Bits */
+#define SYSCTL_RIS_LFXTGOOD_OFS                  (4)                             /* !< LFXTGOOD Offset */
+#define SYSCTL_RIS_LFXTGOOD_MASK                 ((uint32_t)0x00000010U)         /* !< LFXT GOOD */
+#define SYSCTL_RIS_LFXTGOOD_FALSE                ((uint32_t)0x00000000U)
+#define SYSCTL_RIS_LFXTGOOD_TRUE                 ((uint32_t)0x00000010U)
+/* SYSCTL_RIS[HSCLKGOOD] Bits */
+#define SYSCTL_RIS_HSCLKGOOD_OFS                 (7)                             /* !< HSCLKGOOD Offset */
+#define SYSCTL_RIS_HSCLKGOOD_MASK                ((uint32_t)0x00000080U)         /* !< HSCLK GOOD */
+#define SYSCTL_RIS_HSCLKGOOD_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_RIS_HSCLKGOOD_TRUE                ((uint32_t)0x00000080U)
+/* SYSCTL_RIS[SYSPLLGOOD] Bits */
+#define SYSCTL_RIS_SYSPLLGOOD_OFS                (6)                             /* !< SYSPLLGOOD Offset */
+#define SYSCTL_RIS_SYSPLLGOOD_MASK               ((uint32_t)0x00000040U)         /* !< SYSPLL GOOD */
+#define SYSCTL_RIS_SYSPLLGOOD_FALSE              ((uint32_t)0x00000000U)
+#define SYSCTL_RIS_SYSPLLGOOD_TRUE               ((uint32_t)0x00000040U)
+/* SYSCTL_RIS[ANACLKERR] Bits */
+#define SYSCTL_RIS_ANACLKERR_OFS                 (1)                             /* !< ANACLKERR Offset */
+#define SYSCTL_RIS_ANACLKERR_MASK                ((uint32_t)0x00000002U)         /* !< Analog Clocking Consistency Error */
+#define SYSCTL_RIS_ANACLKERR_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_RIS_ANACLKERR_TRUE                ((uint32_t)0x00000002U)
+/* SYSCTL_RIS[FLASHSEC] Bits */
+#define SYSCTL_RIS_FLASHSEC_OFS                  (2)                             /* !< FLASHSEC Offset */
+#define SYSCTL_RIS_FLASHSEC_MASK                 ((uint32_t)0x00000004U)         /* !< Flash Single Error Correct */
+#define SYSCTL_RIS_FLASHSEC_FALSE                ((uint32_t)0x00000000U)
+#define SYSCTL_RIS_FLASHSEC_TRUE                 ((uint32_t)0x00000004U)
+
+/* SYSCTL_MIS Bits */
+/* SYSCTL_MIS[LFOSCGOOD] Bits */
+#define SYSCTL_MIS_LFOSCGOOD_OFS                 (0)                             /* !< LFOSCGOOD Offset */
+#define SYSCTL_MIS_LFOSCGOOD_MASK                ((uint32_t)0x00000001U)         /* !< Masked status of the LFOSCGOOD
+                                                                                    interrupt. */
+#define SYSCTL_MIS_LFOSCGOOD_FALSE               ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define SYSCTL_MIS_LFOSCGOOD_TRUE                ((uint32_t)0x00000001U)         /* !< Interrupt pending */
+/* SYSCTL_MIS[HFCLKGOOD] Bits */
+#define SYSCTL_MIS_HFCLKGOOD_OFS                 (5)                             /* !< HFCLKGOOD Offset */
+#define SYSCTL_MIS_HFCLKGOOD_MASK                ((uint32_t)0x00000020U)         /* !< HFCLK GOOD */
+#define SYSCTL_MIS_HFCLKGOOD_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_MIS_HFCLKGOOD_TRUE                ((uint32_t)0x00000020U)
+/* SYSCTL_MIS[SRAMSEC] Bits */
+#define SYSCTL_MIS_SRAMSEC_OFS                   (3)                             /* !< SRAMSEC Offset */
+#define SYSCTL_MIS_SRAMSEC_MASK                  ((uint32_t)0x00000008U)         /* !< SRAM Single Error Correct */
+#define SYSCTL_MIS_SRAMSEC_FALSE                 ((uint32_t)0x00000000U)
+#define SYSCTL_MIS_SRAMSEC_TRUE                  ((uint32_t)0x00000008U)
+/* SYSCTL_MIS[LFXTGOOD] Bits */
+#define SYSCTL_MIS_LFXTGOOD_OFS                  (4)                             /* !< LFXTGOOD Offset */
+#define SYSCTL_MIS_LFXTGOOD_MASK                 ((uint32_t)0x00000010U)         /* !< LFXT GOOD */
+#define SYSCTL_MIS_LFXTGOOD_FALSE                ((uint32_t)0x00000000U)
+#define SYSCTL_MIS_LFXTGOOD_TRUE                 ((uint32_t)0x00000010U)
+/* SYSCTL_MIS[HSCLKGOOD] Bits */
+#define SYSCTL_MIS_HSCLKGOOD_OFS                 (7)                             /* !< HSCLKGOOD Offset */
+#define SYSCTL_MIS_HSCLKGOOD_MASK                ((uint32_t)0x00000080U)         /* !< HSCLK GOOD */
+#define SYSCTL_MIS_HSCLKGOOD_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_MIS_HSCLKGOOD_TRUE                ((uint32_t)0x00000080U)
+/* SYSCTL_MIS[SYSPLLGOOD] Bits */
+#define SYSCTL_MIS_SYSPLLGOOD_OFS                (6)                             /* !< SYSPLLGOOD Offset */
+#define SYSCTL_MIS_SYSPLLGOOD_MASK               ((uint32_t)0x00000040U)         /* !< SYSPLL GOOD */
+#define SYSCTL_MIS_SYSPLLGOOD_FALSE              ((uint32_t)0x00000000U)
+#define SYSCTL_MIS_SYSPLLGOOD_TRUE               ((uint32_t)0x00000040U)
+/* SYSCTL_MIS[ANACLKERR] Bits */
+#define SYSCTL_MIS_ANACLKERR_OFS                 (1)                             /* !< ANACLKERR Offset */
+#define SYSCTL_MIS_ANACLKERR_MASK                ((uint32_t)0x00000002U)         /* !< Analog Clocking Consistency Error */
+#define SYSCTL_MIS_ANACLKERR_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_MIS_ANACLKERR_TRUE                ((uint32_t)0x00000002U)
+/* SYSCTL_MIS[FLASHSEC] Bits */
+#define SYSCTL_MIS_FLASHSEC_OFS                  (2)                             /* !< FLASHSEC Offset */
+#define SYSCTL_MIS_FLASHSEC_MASK                 ((uint32_t)0x00000004U)         /* !< Flash Single Error Correct */
+#define SYSCTL_MIS_FLASHSEC_FALSE                ((uint32_t)0x00000000U)
+#define SYSCTL_MIS_FLASHSEC_TRUE                 ((uint32_t)0x00000004U)
+
+/* SYSCTL_ISET Bits */
+/* SYSCTL_ISET[LFOSCGOOD] Bits */
+#define SYSCTL_ISET_LFOSCGOOD_OFS                (0)                             /* !< LFOSCGOOD Offset */
+#define SYSCTL_ISET_LFOSCGOOD_MASK               ((uint32_t)0x00000001U)         /* !< Set the LFOSCGOOD interrupt. */
+#define SYSCTL_ISET_LFOSCGOOD_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0h hs no effect */
+#define SYSCTL_ISET_LFOSCGOOD_SET                ((uint32_t)0x00000001U)         /* !< Set interrupt */
+/* SYSCTL_ISET[HFCLKGOOD] Bits */
+#define SYSCTL_ISET_HFCLKGOOD_OFS                (5)                             /* !< HFCLKGOOD Offset */
+#define SYSCTL_ISET_HFCLKGOOD_MASK               ((uint32_t)0x00000020U)         /* !< HFCLK GOOD */
+#define SYSCTL_ISET_HFCLKGOOD_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_ISET_HFCLKGOOD_SET                ((uint32_t)0x00000020U)
+/* SYSCTL_ISET[SRAMSEC] Bits */
+#define SYSCTL_ISET_SRAMSEC_OFS                  (3)                             /* !< SRAMSEC Offset */
+#define SYSCTL_ISET_SRAMSEC_MASK                 ((uint32_t)0x00000008U)         /* !< SRAM Single Error Correct */
+#define SYSCTL_ISET_SRAMSEC_NO_EFFECT            ((uint32_t)0x00000000U)
+#define SYSCTL_ISET_SRAMSEC_SET                  ((uint32_t)0x00000008U)
+/* SYSCTL_ISET[LFXTGOOD] Bits */
+#define SYSCTL_ISET_LFXTGOOD_OFS                 (4)                             /* !< LFXTGOOD Offset */
+#define SYSCTL_ISET_LFXTGOOD_MASK                ((uint32_t)0x00000010U)         /* !< LFXT GOOD */
+#define SYSCTL_ISET_LFXTGOOD_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_ISET_LFXTGOOD_SET                 ((uint32_t)0x00000010U)
+/* SYSCTL_ISET[HSCLKGOOD] Bits */
+#define SYSCTL_ISET_HSCLKGOOD_OFS                (7)                             /* !< HSCLKGOOD Offset */
+#define SYSCTL_ISET_HSCLKGOOD_MASK               ((uint32_t)0x00000080U)         /* !< HSCLK GOOD */
+#define SYSCTL_ISET_HSCLKGOOD_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_ISET_HSCLKGOOD_SET                ((uint32_t)0x00000080U)
+/* SYSCTL_ISET[SYSPLLGOOD] Bits */
+#define SYSCTL_ISET_SYSPLLGOOD_OFS               (6)                             /* !< SYSPLLGOOD Offset */
+#define SYSCTL_ISET_SYSPLLGOOD_MASK              ((uint32_t)0x00000040U)         /* !< SYSPLL GOOD */
+#define SYSCTL_ISET_SYSPLLGOOD_NO_EFFECT         ((uint32_t)0x00000000U)
+#define SYSCTL_ISET_SYSPLLGOOD_SET               ((uint32_t)0x00000040U)
+/* SYSCTL_ISET[ANACLKERR] Bits */
+#define SYSCTL_ISET_ANACLKERR_OFS                (1)                             /* !< ANACLKERR Offset */
+#define SYSCTL_ISET_ANACLKERR_MASK               ((uint32_t)0x00000002U)         /* !< Analog Clocking Consistency Error */
+#define SYSCTL_ISET_ANACLKERR_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_ISET_ANACLKERR_SET                ((uint32_t)0x00000002U)
+/* SYSCTL_ISET[FLASHSEC] Bits */
+#define SYSCTL_ISET_FLASHSEC_OFS                 (2)                             /* !< FLASHSEC Offset */
+#define SYSCTL_ISET_FLASHSEC_MASK                ((uint32_t)0x00000004U)         /* !< Flash Single Error Correct */
+#define SYSCTL_ISET_FLASHSEC_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_ISET_FLASHSEC_SET                 ((uint32_t)0x00000004U)
+
+/* SYSCTL_ICLR Bits */
+/* SYSCTL_ICLR[LFOSCGOOD] Bits */
+#define SYSCTL_ICLR_LFOSCGOOD_OFS                (0)                             /* !< LFOSCGOOD Offset */
+#define SYSCTL_ICLR_LFOSCGOOD_MASK               ((uint32_t)0x00000001U)         /* !< Clear the LFOSCGOOD interrupt. */
+#define SYSCTL_ICLR_LFOSCGOOD_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0h has no effect */
+#define SYSCTL_ICLR_LFOSCGOOD_CLR                ((uint32_t)0x00000001U)         /* !< Clear interrupt */
+/* SYSCTL_ICLR[HFCLKGOOD] Bits */
+#define SYSCTL_ICLR_HFCLKGOOD_OFS                (5)                             /* !< HFCLKGOOD Offset */
+#define SYSCTL_ICLR_HFCLKGOOD_MASK               ((uint32_t)0x00000020U)         /* !< HFCLK GOOD */
+#define SYSCTL_ICLR_HFCLKGOOD_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_ICLR_HFCLKGOOD_CLR                ((uint32_t)0x00000020U)
+/* SYSCTL_ICLR[SRAMSEC] Bits */
+#define SYSCTL_ICLR_SRAMSEC_OFS                  (3)                             /* !< SRAMSEC Offset */
+#define SYSCTL_ICLR_SRAMSEC_MASK                 ((uint32_t)0x00000008U)         /* !< SRAM Single Error Correct */
+#define SYSCTL_ICLR_SRAMSEC_NO_EFFECT            ((uint32_t)0x00000000U)
+#define SYSCTL_ICLR_SRAMSEC_CLR                  ((uint32_t)0x00000008U)
+/* SYSCTL_ICLR[LFXTGOOD] Bits */
+#define SYSCTL_ICLR_LFXTGOOD_OFS                 (4)                             /* !< LFXTGOOD Offset */
+#define SYSCTL_ICLR_LFXTGOOD_MASK                ((uint32_t)0x00000010U)         /* !< LFXT GOOD */
+#define SYSCTL_ICLR_LFXTGOOD_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_ICLR_LFXTGOOD_CLR                 ((uint32_t)0x00000010U)
+/* SYSCTL_ICLR[HSCLKGOOD] Bits */
+#define SYSCTL_ICLR_HSCLKGOOD_OFS                (7)                             /* !< HSCLKGOOD Offset */
+#define SYSCTL_ICLR_HSCLKGOOD_MASK               ((uint32_t)0x00000080U)         /* !< HSCLK GOOD */
+#define SYSCTL_ICLR_HSCLKGOOD_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_ICLR_HSCLKGOOD_CLR                ((uint32_t)0x00000080U)
+/* SYSCTL_ICLR[SYSPLLGOOD] Bits */
+#define SYSCTL_ICLR_SYSPLLGOOD_OFS               (6)                             /* !< SYSPLLGOOD Offset */
+#define SYSCTL_ICLR_SYSPLLGOOD_MASK              ((uint32_t)0x00000040U)         /* !< SYSPLL GOOD */
+#define SYSCTL_ICLR_SYSPLLGOOD_NO_EFFECT         ((uint32_t)0x00000000U)
+#define SYSCTL_ICLR_SYSPLLGOOD_CLR               ((uint32_t)0x00000040U)
+/* SYSCTL_ICLR[ANACLKERR] Bits */
+#define SYSCTL_ICLR_ANACLKERR_OFS                (1)                             /* !< ANACLKERR Offset */
+#define SYSCTL_ICLR_ANACLKERR_MASK               ((uint32_t)0x00000002U)         /* !< Analog Clocking Consistency Error */
+#define SYSCTL_ICLR_ANACLKERR_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_ICLR_ANACLKERR_CLR                ((uint32_t)0x00000002U)
+/* SYSCTL_ICLR[FLASHSEC] Bits */
+#define SYSCTL_ICLR_FLASHSEC_OFS                 (2)                             /* !< FLASHSEC Offset */
+#define SYSCTL_ICLR_FLASHSEC_MASK                ((uint32_t)0x00000004U)         /* !< Flash Single Error Correct */
+#define SYSCTL_ICLR_FLASHSEC_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_ICLR_FLASHSEC_CLR                 ((uint32_t)0x00000004U)
+
+/* SYSCTL_NMIIIDX Bits */
+/* SYSCTL_NMIIIDX[STAT] Bits */
+#define SYSCTL_NMIIIDX_STAT_OFS                  (0)                             /* !< STAT Offset */
+#define SYSCTL_NMIIIDX_STAT_MASK                 ((uint32_t)0x0000000FU)         /* !< The NMI interrupt index (NMIIIDX)
+                                                                                    register generates a value
+                                                                                    corresponding to the highest priority
+                                                                                    pending NMI source.  This value may
+                                                                                    be used as an address offset for
+                                                                                    fast, deterministic handling in the
+                                                                                    NMI service routine.  A read of the
+                                                                                    NMIIIDX register will clear the
+                                                                                    corresponding interrupt status in the
+                                                                                    NMIRIS register. */
+#define SYSCTL_NMIIIDX_STAT_NO_INTR              ((uint32_t)0x00000000U)         /* !< No NMI pending */
+#define SYSCTL_NMIIIDX_STAT_BORLVL               ((uint32_t)0x00000001U)         /* !< BOR Threshold NMI pending */
+#define SYSCTL_NMIIIDX_STAT_WWDT0                ((uint32_t)0x00000002U)
+#define SYSCTL_NMIIIDX_STAT_WWDT1                ((uint32_t)0x00000003U)
+#define SYSCTL_NMIIIDX_STAT_LFCLKFAIL            ((uint32_t)0x00000004U)
+#define SYSCTL_NMIIIDX_STAT_FLASHDED             ((uint32_t)0x00000005U)
+#define SYSCTL_NMIIIDX_STAT_SRAMDED              ((uint32_t)0x00000006U)
+
+/* SYSCTL_NMIRIS Bits */
+/* SYSCTL_NMIRIS[WWDT1] Bits */
+#define SYSCTL_NMIRIS_WWDT1_OFS                  (2)                             /* !< WWDT1 Offset */
+#define SYSCTL_NMIRIS_WWDT1_MASK                 ((uint32_t)0x00000004U)         /* !< Watch Dog 0 Fault */
+#define SYSCTL_NMIRIS_WWDT1_FALSE                ((uint32_t)0x00000000U)
+#define SYSCTL_NMIRIS_WWDT1_TRUE                 ((uint32_t)0x00000004U)
+/* SYSCTL_NMIRIS[SRAMDED] Bits */
+#define SYSCTL_NMIRIS_SRAMDED_OFS                (5)                             /* !< SRAMDED Offset */
+#define SYSCTL_NMIRIS_SRAMDED_MASK               ((uint32_t)0x00000020U)         /* !< SRAM Double Error Detect */
+#define SYSCTL_NMIRIS_SRAMDED_FALSE              ((uint32_t)0x00000000U)
+#define SYSCTL_NMIRIS_SRAMDED_TRUE               ((uint32_t)0x00000020U)
+/* SYSCTL_NMIRIS[BORLVL] Bits */
+#define SYSCTL_NMIRIS_BORLVL_OFS                 (0)                             /* !< BORLVL Offset */
+#define SYSCTL_NMIRIS_BORLVL_MASK                ((uint32_t)0x00000001U)         /* !< Raw status of the BORLVL NMI */
+#define SYSCTL_NMIRIS_BORLVL_FALSE               ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define SYSCTL_NMIRIS_BORLVL_TRUE                ((uint32_t)0x00000001U)         /* !< Interrupt pending */
+/* SYSCTL_NMIRIS[FLASHDED] Bits */
+#define SYSCTL_NMIRIS_FLASHDED_OFS               (4)                             /* !< FLASHDED Offset */
+#define SYSCTL_NMIRIS_FLASHDED_MASK              ((uint32_t)0x00000010U)         /* !< Flash Double Error Detect */
+#define SYSCTL_NMIRIS_FLASHDED_FALSE             ((uint32_t)0x00000000U)
+#define SYSCTL_NMIRIS_FLASHDED_TRUE              ((uint32_t)0x00000010U)
+/* SYSCTL_NMIRIS[WWDT0] Bits */
+#define SYSCTL_NMIRIS_WWDT0_OFS                  (1)                             /* !< WWDT0 Offset */
+#define SYSCTL_NMIRIS_WWDT0_MASK                 ((uint32_t)0x00000002U)         /* !< Watch Dog 0 Fault */
+#define SYSCTL_NMIRIS_WWDT0_FALSE                ((uint32_t)0x00000000U)
+#define SYSCTL_NMIRIS_WWDT0_TRUE                 ((uint32_t)0x00000002U)
+/* SYSCTL_NMIRIS[LFCLKFAIL] Bits */
+#define SYSCTL_NMIRIS_LFCLKFAIL_OFS              (3)                             /* !< LFCLKFAIL Offset */
+#define SYSCTL_NMIRIS_LFCLKFAIL_MASK             ((uint32_t)0x00000008U)         /* !< LFXT-EXLF Monitor Fail */
+#define SYSCTL_NMIRIS_LFCLKFAIL_FALSE            ((uint32_t)0x00000000U)
+#define SYSCTL_NMIRIS_LFCLKFAIL_TRUE             ((uint32_t)0x00000008U)
+
+/* SYSCTL_NMIISET Bits */
+/* SYSCTL_NMIISET[WWDT1] Bits */
+#define SYSCTL_NMIISET_WWDT1_OFS                 (2)                             /* !< WWDT1 Offset */
+#define SYSCTL_NMIISET_WWDT1_MASK                ((uint32_t)0x00000004U)         /* !< Watch Dog 0 Fault */
+#define SYSCTL_NMIISET_WWDT1_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_NMIISET_WWDT1_SET                 ((uint32_t)0x00000004U)
+/* SYSCTL_NMIISET[SRAMDED] Bits */
+#define SYSCTL_NMIISET_SRAMDED_OFS               (5)                             /* !< SRAMDED Offset */
+#define SYSCTL_NMIISET_SRAMDED_MASK              ((uint32_t)0x00000020U)         /* !< SRAM Double Error Detect */
+#define SYSCTL_NMIISET_SRAMDED_NO_EFFECT         ((uint32_t)0x00000000U)
+#define SYSCTL_NMIISET_SRAMDED_SET               ((uint32_t)0x00000020U)
+/* SYSCTL_NMIISET[BORLVL] Bits */
+#define SYSCTL_NMIISET_BORLVL_OFS                (0)                             /* !< BORLVL Offset */
+#define SYSCTL_NMIISET_BORLVL_MASK               ((uint32_t)0x00000001U)         /* !< Set the BORLVL NMI */
+#define SYSCTL_NMIISET_BORLVL_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0h hs no effect */
+#define SYSCTL_NMIISET_BORLVL_SET                ((uint32_t)0x00000001U)         /* !< Set interrupt */
+/* SYSCTL_NMIISET[FLASHDED] Bits */
+#define SYSCTL_NMIISET_FLASHDED_OFS              (4)                             /* !< FLASHDED Offset */
+#define SYSCTL_NMIISET_FLASHDED_MASK             ((uint32_t)0x00000010U)         /* !< Flash Double Error Detect */
+#define SYSCTL_NMIISET_FLASHDED_NO_EFFECT        ((uint32_t)0x00000000U)
+#define SYSCTL_NMIISET_FLASHDED_SET              ((uint32_t)0x00000010U)
+/* SYSCTL_NMIISET[WWDT0] Bits */
+#define SYSCTL_NMIISET_WWDT0_OFS                 (1)                             /* !< WWDT0 Offset */
+#define SYSCTL_NMIISET_WWDT0_MASK                ((uint32_t)0x00000002U)         /* !< Watch Dog 0 Fault */
+#define SYSCTL_NMIISET_WWDT0_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_NMIISET_WWDT0_SET                 ((uint32_t)0x00000002U)
+/* SYSCTL_NMIISET[LFCLKFAIL] Bits */
+#define SYSCTL_NMIISET_LFCLKFAIL_OFS             (3)                             /* !< LFCLKFAIL Offset */
+#define SYSCTL_NMIISET_LFCLKFAIL_MASK            ((uint32_t)0x00000008U)         /* !< LFXT-EXLF Monitor Fail */
+#define SYSCTL_NMIISET_LFCLKFAIL_NO_EFFECT       ((uint32_t)0x00000000U)
+#define SYSCTL_NMIISET_LFCLKFAIL_SET             ((uint32_t)0x00000008U)
+
+/* SYSCTL_NMIICLR Bits */
+/* SYSCTL_NMIICLR[WWDT1] Bits */
+#define SYSCTL_NMIICLR_WWDT1_OFS                 (2)                             /* !< WWDT1 Offset */
+#define SYSCTL_NMIICLR_WWDT1_MASK                ((uint32_t)0x00000004U)         /* !< Watch Dog 0 Fault */
+#define SYSCTL_NMIICLR_WWDT1_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_NMIICLR_WWDT1_CLR                 ((uint32_t)0x00000004U)
+/* SYSCTL_NMIICLR[SRAMDED] Bits */
+#define SYSCTL_NMIICLR_SRAMDED_OFS               (5)                             /* !< SRAMDED Offset */
+#define SYSCTL_NMIICLR_SRAMDED_MASK              ((uint32_t)0x00000020U)         /* !< SRAM Double Error Detect */
+#define SYSCTL_NMIICLR_SRAMDED_NO_EFFECT         ((uint32_t)0x00000000U)
+#define SYSCTL_NMIICLR_SRAMDED_CLR               ((uint32_t)0x00000020U)
+/* SYSCTL_NMIICLR[BORLVL] Bits */
+#define SYSCTL_NMIICLR_BORLVL_OFS                (0)                             /* !< BORLVL Offset */
+#define SYSCTL_NMIICLR_BORLVL_MASK               ((uint32_t)0x00000001U)         /* !< Clr the BORLVL NMI */
+#define SYSCTL_NMIICLR_BORLVL_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0h hs no effect */
+#define SYSCTL_NMIICLR_BORLVL_CLR                ((uint32_t)0x00000001U)         /* !< Clear interrupt */
+/* SYSCTL_NMIICLR[FLASHDED] Bits */
+#define SYSCTL_NMIICLR_FLASHDED_OFS              (4)                             /* !< FLASHDED Offset */
+#define SYSCTL_NMIICLR_FLASHDED_MASK             ((uint32_t)0x00000010U)         /* !< Flash Double Error Detect */
+#define SYSCTL_NMIICLR_FLASHDED_NO_EFFECT        ((uint32_t)0x00000000U)
+#define SYSCTL_NMIICLR_FLASHDED_CLR              ((uint32_t)0x00000010U)
+/* SYSCTL_NMIICLR[WWDT0] Bits */
+#define SYSCTL_NMIICLR_WWDT0_OFS                 (1)                             /* !< WWDT0 Offset */
+#define SYSCTL_NMIICLR_WWDT0_MASK                ((uint32_t)0x00000002U)         /* !< Watch Dog 0 Fault */
+#define SYSCTL_NMIICLR_WWDT0_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_NMIICLR_WWDT0_CLR                 ((uint32_t)0x00000002U)
+/* SYSCTL_NMIICLR[LFCLKFAIL] Bits */
+#define SYSCTL_NMIICLR_LFCLKFAIL_OFS             (3)                             /* !< LFCLKFAIL Offset */
+#define SYSCTL_NMIICLR_LFCLKFAIL_MASK            ((uint32_t)0x00000008U)         /* !< LFXT-EXLF Monitor Fail */
+#define SYSCTL_NMIICLR_LFCLKFAIL_NO_EFFECT       ((uint32_t)0x00000000U)
+#define SYSCTL_NMIICLR_LFCLKFAIL_CLR             ((uint32_t)0x00000008U)
+
+/* SYSCTL_SYSOSCCFG Bits */
+/* SYSCTL_SYSOSCCFG[USE4MHZSTOP] Bits */
+#define SYSCTL_SYSOSCCFG_USE4MHZSTOP_OFS         (8)                             /* !< USE4MHZSTOP Offset */
+#define SYSCTL_SYSOSCCFG_USE4MHZSTOP_MASK        ((uint32_t)0x00000100U)         /* !< USE4MHZSTOP sets the SYSOSC stop
+                                                                                    mode frequency policy.  When entering
+                                                                                    STOP mode, the SYSOSC frequency may
+                                                                                    be automatically switched to 4MHz to
+                                                                                    reduce SYSOSC power consumption. */
+#define SYSCTL_SYSOSCCFG_USE4MHZSTOP_DISABLE     ((uint32_t)0x00000000U)         /* !< Do not gear shift the SYSOSC to
+                                                                                    4MHz in STOP mode */
+#define SYSCTL_SYSOSCCFG_USE4MHZSTOP_ENABLE      ((uint32_t)0x00000100U)         /* !< Gear shift SYSOSC to 4MHz in STOP
+                                                                                    mode */
+/* SYSCTL_SYSOSCCFG[DISABLESTOP] Bits */
+#define SYSCTL_SYSOSCCFG_DISABLESTOP_OFS         (9)                             /* !< DISABLESTOP Offset */
+#define SYSCTL_SYSOSCCFG_DISABLESTOP_MASK        ((uint32_t)0x00000200U)         /* !< DISABLESTOP sets the SYSOSC stop
+                                                                                    mode enable/disable policy.  When
+                                                                                    operating in STOP mode, the SYSOSC
+                                                                                    may be automatically disabled.  When
+                                                                                    set, ULPCLK will run from LFCLK in
+                                                                                    STOP mode and SYSOSC will be disabled
+                                                                                    to reduce power consumption. */
+#define SYSCTL_SYSOSCCFG_DISABLESTOP_DISABLE     ((uint32_t)0x00000000U)         /* !< Do not disable SYSOSC in STOP mode */
+#define SYSCTL_SYSOSCCFG_DISABLESTOP_ENABLE      ((uint32_t)0x00000200U)         /* !< Disable SYSOSC in STOP mode and
+                                                                                    source ULPCLK from LFCLK */
+/* SYSCTL_SYSOSCCFG[BLOCKASYNCALL] Bits */
+#define SYSCTL_SYSOSCCFG_BLOCKASYNCALL_OFS       (16)                            /* !< BLOCKASYNCALL Offset */
+#define SYSCTL_SYSOSCCFG_BLOCKASYNCALL_MASK      ((uint32_t)0x00010000U)         /* !< BLOCKASYNCALL may be used to mask
+                                                                                    block all asynchronous fast clock
+                                                                                    requests, preventing hardware from
+                                                                                    dynamically changing the active clock
+                                                                                    configuration when operating in a
+                                                                                    given mode. */
+#define SYSCTL_SYSOSCCFG_BLOCKASYNCALL_DISABLE   ((uint32_t)0x00000000U)         /* !< Asynchronous fast clock requests
+                                                                                    are controlled by the requesting
+                                                                                    peripheral */
+#define SYSCTL_SYSOSCCFG_BLOCKASYNCALL_ENABLE    ((uint32_t)0x00010000U)         /* !< All asynchronous fast clock
+                                                                                    requests are blocked */
+/* SYSCTL_SYSOSCCFG[DISABLE] Bits */
+#define SYSCTL_SYSOSCCFG_DISABLE_OFS             (10)                            /* !< DISABLE Offset */
+#define SYSCTL_SYSOSCCFG_DISABLE_MASK            ((uint32_t)0x00000400U)         /* !< DISABLE sets the SYSOSC
+                                                                                    enable/disable policy.  SYSOSC may be
+                                                                                    powered off in RUN, SLEEP, and STOP
+                                                                                    modes to reduce power consumption.
+                                                                                    When SYSOSC is disabled, MCLK and
+                                                                                    ULPCLK are sourced from LFCLK. */
+#define SYSCTL_SYSOSCCFG_DISABLE_DISABLE         ((uint32_t)0x00000000U)         /* !< Do not disable SYSOSC */
+#define SYSCTL_SYSOSCCFG_DISABLE_ENABLE          ((uint32_t)0x00000400U)         /* !< Disable SYSOSC immediately and
+                                                                                    source MCLK and ULPCLK from LFCLK */
+/* SYSCTL_SYSOSCCFG[FASTCPUEVENT] Bits */
+#define SYSCTL_SYSOSCCFG_FASTCPUEVENT_OFS        (17)                            /* !< FASTCPUEVENT Offset */
+#define SYSCTL_SYSOSCCFG_FASTCPUEVENT_MASK       ((uint32_t)0x00020000U)         /* !< FASTCPUEVENT may be used to assert
+                                                                                    a fast clock request when an
+                                                                                    interrupt is asserted to the CPU,
+                                                                                    reducing interrupt latency. */
+#define SYSCTL_SYSOSCCFG_FASTCPUEVENT_DISABLE    ((uint32_t)0x00000000U)         /* !< An interrupt to the CPU will not
+                                                                                    assert a fast clock request */
+#define SYSCTL_SYSOSCCFG_FASTCPUEVENT_ENABLE     ((uint32_t)0x00020000U)         /* !< An interrupt to the CPU will assert
+                                                                                    a fast clock request */
+/* SYSCTL_SYSOSCCFG[FREQ] Bits */
+#define SYSCTL_SYSOSCCFG_FREQ_OFS                (0)                             /* !< FREQ Offset */
+#define SYSCTL_SYSOSCCFG_FREQ_MASK               ((uint32_t)0x00000003U)         /* !< Target operating frequency for the
+                                                                                    system oscillator (SYSOSC) */
+#define SYSCTL_SYSOSCCFG_FREQ_SYSOSCBASE         ((uint32_t)0x00000000U)         /* !< Base frequency (32MHz) */
+#define SYSCTL_SYSOSCCFG_FREQ_SYSOSC4M           ((uint32_t)0x00000001U)         /* !< Low frequency (4MHz) */
+#define SYSCTL_SYSOSCCFG_FREQ_SYSOSCUSER         ((uint32_t)0x00000002U)         /* !< User-trimmed frequency (16 or 24
+                                                                                    MHz) */
+
+/* SYSCTL_MCLKCFG Bits */
+/* SYSCTL_MCLKCFG[USEMFTICK] Bits */
+#define SYSCTL_MCLKCFG_USEMFTICK_OFS             (12)                            /* !< USEMFTICK Offset */
+#define SYSCTL_MCLKCFG_USEMFTICK_MASK            ((uint32_t)0x00001000U)         /* !< USEMFTICK specifies whether the
+                                                                                    4MHz constant-rate clock (MFCLK) to
+                                                                                    peripherals is enabled or disabled.
+                                                                                    When enabled, MDIV must be disabled
+                                                                                    (set to 0h=/1). */
+#define SYSCTL_MCLKCFG_USEMFTICK_DISABLE         ((uint32_t)0x00000000U)         /* !< The 4MHz rate MFCLK to peripherals
+                                                                                    is enabled */
+#define SYSCTL_MCLKCFG_USEMFTICK_ENABLE          ((uint32_t)0x00001000U)         /* !< The 4MHz rate MFCLK to peripherals
+                                                                                    is enabled. */
+/* SYSCTL_MCLKCFG[MDIV] Bits */
+#define SYSCTL_MCLKCFG_MDIV_OFS                  (0)                             /* !< MDIV Offset */
+#define SYSCTL_MCLKCFG_MDIV_MASK                 ((uint32_t)0x0000000FU)         /* !< MDIV may be used to divide the MCLK
+                                                                                    frequency when MCLK is sourced from
+                                                                                    SYSOSC.  MDIV=0h corresponds to /1
+                                                                                    (no divider).  MDIV=1h corresponds to
+                                                                                    /2 (divide-by-2).  MDIV=Fh
+                                                                                    corresponds to /16 (divide-by-16).
+                                                                                    MDIV may be set between /1 and /16 on
+                                                                                    an integer basis. */
+/* SYSCTL_MCLKCFG[USEHSCLK] Bits */
+#define SYSCTL_MCLKCFG_USEHSCLK_OFS              (16)                            /* !< USEHSCLK Offset */
+#define SYSCTL_MCLKCFG_USEHSCLK_MASK             ((uint32_t)0x00010000U)         /* !< USEHSCLK, together with USELFCLK,
+                                                                                    sets the MCLK source policy.  Set
+                                                                                    USEHSCLK to use HSCLK (HFCLK or
+                                                                                    SYSPLL) as the MCLK source in RUN and
+                                                                                    SLEEP modes. */
+#define SYSCTL_MCLKCFG_USEHSCLK_DISABLE          ((uint32_t)0x00000000U)         /* !< MCLK will not use the high speed
+                                                                                    clock (HSCLK) */
+#define SYSCTL_MCLKCFG_USEHSCLK_ENABLE           ((uint32_t)0x00010000U)         /* !< MCLK will use the high speed clock
+                                                                                    (HSCLK) in RUN and SLEEP mode */
+/* SYSCTL_MCLKCFG[USELFCLK] Bits */
+#define SYSCTL_MCLKCFG_USELFCLK_OFS              (20)                            /* !< USELFCLK Offset */
+#define SYSCTL_MCLKCFG_USELFCLK_MASK             ((uint32_t)0x00100000U)         /* !< USELFCLK sets the MCLK source
+                                                                                    policy.  Set USELFCLK to use LFCLK as
+                                                                                    the MCLK source.  Note that setting
+                                                                                    USELFCLK does not disable SYSOSC, and
+                                                                                    SYSOSC remains available for direct
+                                                                                    use by analog modules. */
+#define SYSCTL_MCLKCFG_USELFCLK_DISABLE          ((uint32_t)0x00000000U)         /* !< MCLK will not use the low frequency
+                                                                                    clock (LFCLK) */
+#define SYSCTL_MCLKCFG_USELFCLK_ENABLE           ((uint32_t)0x00100000U)         /* !< MCLK will use the low frequency
+                                                                                    clock (LFCLK) */
+/* SYSCTL_MCLKCFG[STOPCLKSTBY] Bits */
+#define SYSCTL_MCLKCFG_STOPCLKSTBY_OFS           (21)                            /* !< STOPCLKSTBY Offset */
+#define SYSCTL_MCLKCFG_STOPCLKSTBY_MASK          ((uint32_t)0x00200000U)         /* !< STOPCLKSTBY sets the STANDBY mode
+                                                                                    policy (STANDBY0 or STANDBY1).  When
+                                                                                    set, ULPCLK and LFCLK are disabled to
+                                                                                    all peripherals in STANDBY mode, with
+                                                                                    the exception of TIMG0 and TIMG1
+                                                                                    which continue to run.  Wake-up is
+                                                                                    only possible via an asynchronous
+                                                                                    fast clock request. */
+#define SYSCTL_MCLKCFG_STOPCLKSTBY_DISABLE       ((uint32_t)0x00000000U)         /* !< ULPCLK/LFCLK runs to all PD0
+                                                                                    peripherals in STANDBY mode */
+#define SYSCTL_MCLKCFG_STOPCLKSTBY_ENABLE        ((uint32_t)0x00200000U)         /* !< ULPCLK/LFCLK is disabled to all
+                                                                                    peripherals in STANDBY mode except
+                                                                                    TIMG0 and TIMG1 */
+/* SYSCTL_MCLKCFG[FLASHWAIT] Bits */
+#define SYSCTL_MCLKCFG_FLASHWAIT_OFS             (8)                             /* !< FLASHWAIT Offset */
+#define SYSCTL_MCLKCFG_FLASHWAIT_MASK            ((uint32_t)0x00000F00U)         /* !< FLASHWAIT specifies the number of
+                                                                                    flash wait states when MCLK is
+                                                                                    sourced from HSCLK.  FLASHWAIT has no
+                                                                                    effect when MCLK is sourced from
+                                                                                    SYSOSC or LFCLK. */
+#define SYSCTL_MCLKCFG_FLASHWAIT_WAIT0           ((uint32_t)0x00000000U)         /* !< No flash wait states are applied */
+#define SYSCTL_MCLKCFG_FLASHWAIT_WAIT1           ((uint32_t)0x00000100U)         /* !< One flash wait state is applied */
+#define SYSCTL_MCLKCFG_FLASHWAIT_WAIT2           ((uint32_t)0x00000200U)         /* !< 2 flash wait states are applied */
+/* SYSCTL_MCLKCFG[MCLKDEADCHK] Bits */
+#define SYSCTL_MCLKCFG_MCLKDEADCHK_OFS           (22)                            /* !< MCLKDEADCHK Offset */
+#define SYSCTL_MCLKCFG_MCLKDEADCHK_MASK          ((uint32_t)0x00400000U)         /* !< MCLKDEADCHK enables or disables the
+                                                                                    continuous MCLK dead check monitor.
+                                                                                    LFCLK must be running before
+                                                                                    MCLKDEADCHK is enabled. */
+#define SYSCTL_MCLKCFG_MCLKDEADCHK_DISABLE       ((uint32_t)0x00000000U)         /* !< The MCLK dead check monitor is
+                                                                                    disabled */
+#define SYSCTL_MCLKCFG_MCLKDEADCHK_ENABLE        ((uint32_t)0x00400000U)         /* !< The MCLK dead check monitor is
+                                                                                    enabled */
+/* SYSCTL_MCLKCFG[UDIV] Bits */
+#define SYSCTL_MCLKCFG_UDIV_OFS                  (4)                             /* !< UDIV Offset */
+#define SYSCTL_MCLKCFG_UDIV_MASK                 ((uint32_t)0x00000030U)         /* !< UDIV specifies the ULPCLK divider
+                                                                                    when MCLK is sourced from HSCLK.
+                                                                                    UDIV has no effect when MCLK is
+                                                                                    sourced from SYSOSC or LFCLK. */
+#define SYSCTL_MCLKCFG_UDIV_NODIVIDE             ((uint32_t)0x00000000U)         /* !< ULPCLK is not divided and is equal
+                                                                                    to MCLK */
+#define SYSCTL_MCLKCFG_UDIV_DIVIDE2              ((uint32_t)0x00000010U)         /* !< ULPCLK is MCLK/2 (divided-by-2) */
+#define SYSCTL_MCLKCFG_UDIV_DIVIDE3              ((uint32_t)0x00000020U)         /* !< ULPCLK is MCLK/3 (divided-by-3) */
+
+/* SYSCTL_HSCLKEN Bits */
+/* SYSCTL_HSCLKEN[HFXTEN] Bits */
+#define SYSCTL_HSCLKEN_HFXTEN_OFS                (0)                             /* !< HFXTEN Offset */
+#define SYSCTL_HSCLKEN_HFXTEN_MASK               ((uint32_t)0x00000001U)         /* !< HFXTEN enables or disables the high
+                                                                                    frequency crystal oscillator (HFXT). */
+#define SYSCTL_HSCLKEN_HFXTEN_DISABLE            ((uint32_t)0x00000000U)         /* !< Disable the HFXT */
+#define SYSCTL_HSCLKEN_HFXTEN_ENABLE             ((uint32_t)0x00000001U)         /* !< Enable the HFXT */
+/* SYSCTL_HSCLKEN[USEEXTHFCLK] Bits */
+#define SYSCTL_HSCLKEN_USEEXTHFCLK_OFS           (16)                            /* !< USEEXTHFCLK Offset */
+#define SYSCTL_HSCLKEN_USEEXTHFCLK_MASK          ((uint32_t)0x00010000U)         /* !< USEEXTHFCLK selects the HFCLK_IN
+                                                                                    digital clock input to be the source
+                                                                                    for HFCLK.  When disabled, HFXT is
+                                                                                    the HFCLK source and HFXTEN may be
+                                                                                    set.  Do not set HFXTEN and
+                                                                                    USEEXTHFCLK simultaneously. */
+#define SYSCTL_HSCLKEN_USEEXTHFCLK_DISABLE       ((uint32_t)0x00000000U)         /* !< Use HFXT as the HFCLK source */
+#define SYSCTL_HSCLKEN_USEEXTHFCLK_ENABLE        ((uint32_t)0x00010000U)         /* !< Use the HFCLK_IN digital clock
+                                                                                    input as the HFCLK source */
+/* SYSCTL_HSCLKEN[SYSPLLEN] Bits */
+#define SYSCTL_HSCLKEN_SYSPLLEN_OFS              (8)                             /* !< SYSPLLEN Offset */
+#define SYSCTL_HSCLKEN_SYSPLLEN_MASK             ((uint32_t)0x00000100U)         /* !< SYSPLLEN enables or disables the
+                                                                                    system phase-lock loop (SYSPLL). */
+#define SYSCTL_HSCLKEN_SYSPLLEN_DISABLE          ((uint32_t)0x00000000U)         /* !< Disable the SYSPLL */
+#define SYSCTL_HSCLKEN_SYSPLLEN_ENABLE           ((uint32_t)0x00000100U)         /* !< Enable the SYSPLL */
+
+/* SYSCTL_HSCLKCFG Bits */
+/* SYSCTL_HSCLKCFG[HSCLKSEL] Bits */
+#define SYSCTL_HSCLKCFG_HSCLKSEL_OFS             (0)                             /* !< HSCLKSEL Offset */
+#define SYSCTL_HSCLKCFG_HSCLKSEL_MASK            ((uint32_t)0x00000001U)         /* !< HSCLKSEL selects the HSCLK source
+                                                                                    (SYSPLL or HFCLK). */
+#define SYSCTL_HSCLKCFG_HSCLKSEL_SYSPLL          ((uint32_t)0x00000000U)         /* !< HSCLK is sourced from the SYSPLL */
+#define SYSCTL_HSCLKCFG_HSCLKSEL_HFCLKCLK        ((uint32_t)0x00000001U)         /* !< HSCLK is sourced from the HFCLK */
+
+/* SYSCTL_HFCLKCLKCFG Bits */
+/* SYSCTL_HFCLKCLKCFG[HFXTTIME] Bits */
+#define SYSCTL_HFCLKCLKCFG_HFXTTIME_OFS          (0)                             /* !< HFXTTIME Offset */
+#define SYSCTL_HFCLKCLKCFG_HFXTTIME_MASK         ((uint32_t)0x000000FFU)         /* !< HFXTTIME specifies the HFXT startup
+                                                                                    time in 64us resolution.  If the
+                                                                                    HFCLK startup monitor is enabled
+                                                                                    (HFCLKFLTCHK), HFXT will be checked
+                                                                                    after this time expires. */
+#define SYSCTL_HFCLKCLKCFG_HFXTTIME_MINSTARTTIME ((uint32_t)0x00000000U)         /* !< Minimum startup time (approximatly
+                                                                                    zero) */
+#define SYSCTL_HFCLKCLKCFG_HFXTTIME_MAXSTARTTIME ((uint32_t)0x000000FFU)         /* !< Maximum startup time (approximatly
+                                                                                    16.32ms) */
+/* SYSCTL_HFCLKCLKCFG[HFCLKFLTCHK] Bits */
+#define SYSCTL_HFCLKCLKCFG_HFCLKFLTCHK_OFS       (28)                            /* !< HFCLKFLTCHK Offset */
+#define SYSCTL_HFCLKCLKCFG_HFCLKFLTCHK_MASK      ((uint32_t)0x10000000U)         /* !< HFCLKFLTCHK enables or disables the
+                                                                                    HFCLK startup monitor. */
+#define SYSCTL_HFCLKCLKCFG_HFCLKFLTCHK_DISABLE   ((uint32_t)0x00000000U)         /* !< HFCLK startup is not checked */
+#define SYSCTL_HFCLKCLKCFG_HFCLKFLTCHK_ENABLE    ((uint32_t)0x10000000U)         /* !< HFCLK startup is checked */
+/* SYSCTL_HFCLKCLKCFG[HFXTRSEL] Bits */
+#define SYSCTL_HFCLKCLKCFG_HFXTRSEL_OFS          (12)                            /* !< HFXTRSEL Offset */
+#define SYSCTL_HFCLKCLKCFG_HFXTRSEL_MASK         ((uint32_t)0x00003000U)         /* !< HFXT Range Select */
+#define SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE4TO8    ((uint32_t)0x00000000U)         /* !< 4MHz &lt;= HFXT frequency &lt;=
+                                                                                    8MHz */
+#define SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE8TO16   ((uint32_t)0x00001000U)         /* !< 8MHz &lt; HFXT frequency &lt;=
+                                                                                    16MHz */
+#define SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE16TO32  ((uint32_t)0x00002000U)         /* !< 16MHz &lt; HFXT frequency &lt;=
+                                                                                    32MHz */
+#define SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE32TO48  ((uint32_t)0x00003000U)         /* !< 32MHz &lt; HFXT frequency &lt;=
+                                                                                    48MHz */
+
+/* SYSCTL_LFCLKCFG Bits */
+/* SYSCTL_LFCLKCFG[XT1DRIVE] Bits */
+#define SYSCTL_LFCLKCFG_XT1DRIVE_OFS             (0)                             /* !< XT1DRIVE Offset */
+#define SYSCTL_LFCLKCFG_XT1DRIVE_MASK            ((uint32_t)0x00000003U)         /* !< XT1DRIVE selects the low frequency
+                                                                                    crystal oscillator (LFXT) drive
+                                                                                    strength. */
+#define SYSCTL_LFCLKCFG_XT1DRIVE_LOWESTDRV       ((uint32_t)0x00000000U)         /* !< Lowest drive and current */
+#define SYSCTL_LFCLKCFG_XT1DRIVE_LOWERDRV        ((uint32_t)0x00000001U)         /* !< Lower drive and current */
+#define SYSCTL_LFCLKCFG_XT1DRIVE_HIGHERDRV       ((uint32_t)0x00000002U)         /* !< Higher drive and current */
+#define SYSCTL_LFCLKCFG_XT1DRIVE_HIGHESTDRV      ((uint32_t)0x00000003U)         /* !< Highest drive and current */
+/* SYSCTL_LFCLKCFG[MONITOR] Bits */
+#define SYSCTL_LFCLKCFG_MONITOR_OFS              (4)                             /* !< MONITOR Offset */
+#define SYSCTL_LFCLKCFG_MONITOR_MASK             ((uint32_t)0x00000010U)         /* !< MONITOR enables or disables the
+                                                                                    LFCLK monitor, which continuously
+                                                                                    checks LFXT or LFCLK_IN for a clock
+                                                                                    stuck fault. */
+#define SYSCTL_LFCLKCFG_MONITOR_DISABLE          ((uint32_t)0x00000000U)         /* !< Clock monitor is disabled */
+#define SYSCTL_LFCLKCFG_MONITOR_ENABLE           ((uint32_t)0x00000010U)         /* !< Clock monitor is enabled */
+/* SYSCTL_LFCLKCFG[LOWCAP] Bits */
+#define SYSCTL_LFCLKCFG_LOWCAP_OFS               (8)                             /* !< LOWCAP Offset */
+#define SYSCTL_LFCLKCFG_LOWCAP_MASK              ((uint32_t)0x00000100U)         /* !< LOWCAP controls the low-power LFXT
+                                                                                    mode.  When the LFXT load capacitance
+                                                                                    is less than 3pf, LOWCAP may be set
+                                                                                    for reduced power consumption. */
+#define SYSCTL_LFCLKCFG_LOWCAP_DISABLE           ((uint32_t)0x00000000U)         /* !< LFXT low capacitance mode is
+                                                                                    disabled */
+#define SYSCTL_LFCLKCFG_LOWCAP_ENABLE            ((uint32_t)0x00000100U)         /* !< LFXT low capacitance mode is
+                                                                                    enabled */
+
+/* SYSCTL_SYSPLLCFG0 Bits */
+/* SYSCTL_SYSPLLCFG0[ENABLECLK0] Bits */
+#define SYSCTL_SYSPLLCFG0_ENABLECLK0_OFS         (4)                             /* !< ENABLECLK0 Offset */
+#define SYSCTL_SYSPLLCFG0_ENABLECLK0_MASK        ((uint32_t)0x00000010U)         /* !< ENABLECLK0 enables or disables the
+                                                                                    SYSPLLCLK0 output. */
+#define SYSCTL_SYSPLLCFG0_ENABLECLK0_DISABLE     ((uint32_t)0x00000000U)         /* !< SYSPLLCLK0 is disabled */
+#define SYSCTL_SYSPLLCFG0_ENABLECLK0_ENABLE      ((uint32_t)0x00000010U)         /* !< SYSPLLCLK0 is enabled */
+/* SYSCTL_SYSPLLCFG0[ENABLECLK1] Bits */
+#define SYSCTL_SYSPLLCFG0_ENABLECLK1_OFS         (5)                             /* !< ENABLECLK1 Offset */
+#define SYSCTL_SYSPLLCFG0_ENABLECLK1_MASK        ((uint32_t)0x00000020U)         /* !< ENABLECLK1 enables or disables the
+                                                                                    SYSPLLCLK1 output. */
+#define SYSCTL_SYSPLLCFG0_ENABLECLK1_DISABLE     ((uint32_t)0x00000000U)         /* !< SYSPLLCLK1 is disabled */
+#define SYSCTL_SYSPLLCFG0_ENABLECLK1_ENABLE      ((uint32_t)0x00000020U)         /* !< SYSPLLCLK1 is enabled */
+/* SYSCTL_SYSPLLCFG0[RDIVCLK1] Bits */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_OFS           (12)                            /* !< RDIVCLK1 Offset */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_MASK          ((uint32_t)0x0000F000U)         /* !< RDIVCLK1 sets the final divider for
+                                                                                    the SYSPLLCLK1 output. */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV2      ((uint32_t)0x00000000U)         /* !< SYSPLLCLK1 is divided by 2 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV4      ((uint32_t)0x00001000U)         /* !< SYSPLLCLK1 is divided by 4 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV6      ((uint32_t)0x00002000U)         /* !< SYSPLLCLK1 is divided by 6 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV8      ((uint32_t)0x00003000U)         /* !< SYSPLLCLK1 is divided by 8 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV10     ((uint32_t)0x00004000U)         /* !< SYSPLLCLK1 is divided by 10 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV12     ((uint32_t)0x00005000U)         /* !< SYSPLLCLK1 is divided by 12 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV14     ((uint32_t)0x00006000U)         /* !< SYSPLLCLK1 is divided by 14 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV16     ((uint32_t)0x00007000U)         /* !< SYSPLLCLK1 is divided by 16 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV18     ((uint32_t)0x00008000U)         /* !< SYSPLLCLK1 is divided by 18 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV20     ((uint32_t)0x00009000U)         /* !< SYSPLLCLK1 is divided by 20 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV22     ((uint32_t)0x0000A000U)         /* !< SYSPLLCLK1 is divided by 22 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV24     ((uint32_t)0x0000B000U)         /* !< SYSPLLCLK1 is divided by 24 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV26     ((uint32_t)0x0000C000U)         /* !< SYSPLLCLK1 is divided by 26 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV28     ((uint32_t)0x0000D000U)         /* !< SYSPLLCLK1 is divided by 28 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV30     ((uint32_t)0x0000E000U)         /* !< SYSPLLCLK1 is divided by 30 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK1_CLK1DIV32     ((uint32_t)0x0000F000U)         /* !< SYSPLLCLK1 is divided by 32 */
+/* SYSCTL_SYSPLLCFG0[MCLK2XVCO] Bits */
+#define SYSCTL_SYSPLLCFG0_MCLK2XVCO_OFS          (1)                             /* !< MCLK2XVCO Offset */
+#define SYSCTL_SYSPLLCFG0_MCLK2XVCO_MASK         ((uint32_t)0x00000002U)         /* !< MCLK2XVCO selects the SYSPLL output
+                                                                                    which is sent to the HSCLK mux for
+                                                                                    use by MCLK. */
+#define SYSCTL_SYSPLLCFG0_MCLK2XVCO_DISABLE      ((uint32_t)0x00000000U)         /* !< The SYSPLLCLK0 output is sent to
+                                                                                    the HSCLK mux */
+#define SYSCTL_SYSPLLCFG0_MCLK2XVCO_ENABLE       ((uint32_t)0x00000002U)         /* !< The SYSPLLCLK2X output is sent to
+                                                                                    the HSCLK mux */
+/* SYSCTL_SYSPLLCFG0[RDIVCLK2X] Bits */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_OFS          (16)                            /* !< RDIVCLK2X Offset */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_MASK         ((uint32_t)0x000F0000U)         /* !< RDIVCLK2X sets the final divider
+                                                                                    for the SYSPLLCLK2X output. */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV1    ((uint32_t)0x00000000U)         /* !< SYSPLLCLK1 is divided by 1 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV2    ((uint32_t)0x00010000U)         /* !< SYSPLLCLK1 is divided by 2 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV3    ((uint32_t)0x00020000U)         /* !< SYSPLLCLK1 is divided by 3 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV4    ((uint32_t)0x00030000U)         /* !< SYSPLLCLK1 is divided by 4 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV5    ((uint32_t)0x00040000U)         /* !< SYSPLLCLK1 is divided by 5 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV6    ((uint32_t)0x00050000U)         /* !< SYSPLLCLK1 is divided by 6 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV7    ((uint32_t)0x00060000U)         /* !< SYSPLLCLK1 is divided by 7 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV8    ((uint32_t)0x00070000U)         /* !< SYSPLLCLK1 is divided by 8 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV9    ((uint32_t)0x00080000U)         /* !< SYSPLLCLK1 is divided by 9 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV10   ((uint32_t)0x00090000U)         /* !< SYSPLLCLK1 is divided by 10 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV11   ((uint32_t)0x000A0000U)         /* !< SYSPLLCLK1 is divided by 11 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV12   ((uint32_t)0x000B0000U)         /* !< SYSPLLCLK1 is divided by 12 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV13   ((uint32_t)0x000C0000U)         /* !< SYSPLLCLK1 is divided by 13 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV14   ((uint32_t)0x000D0000U)         /* !< SYSPLLCLK1 is divided by 14 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV15   ((uint32_t)0x000E0000U)         /* !< SYSPLLCLK1 is divided by 15 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK2X_CLK2XDIV16   ((uint32_t)0x000F0000U)         /* !< SYSPLLCLK1 is divided by 16 */
+/* SYSCTL_SYSPLLCFG0[RDIVCLK0] Bits */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_OFS           (8)                             /* !< RDIVCLK0 Offset */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_MASK          ((uint32_t)0x00000F00U)         /* !< RDIVCLK0 sets the final divider for
+                                                                                    the SYSPLLCLK0 output. */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV2      ((uint32_t)0x00000000U)         /* !< SYSPLLCLK0 is divided by 2 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV4      ((uint32_t)0x00000100U)         /* !< SYSPLLCLK0 is divided by 4 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV6      ((uint32_t)0x00000200U)         /* !< SYSPLLCLK0 is divided by 6 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV8      ((uint32_t)0x00000300U)         /* !< SYSPLLCLK0 is divided by 8 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV10     ((uint32_t)0x00000400U)         /* !< SYSPLLCLK0 is divided by 10 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV12     ((uint32_t)0x00000500U)         /* !< SYSPLLCLK0 is divided by 12 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV14     ((uint32_t)0x00000600U)         /* !< SYSPLLCLK0 is divided by 14 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV16     ((uint32_t)0x00000700U)         /* !< SYSPLLCLK0 is divided by 16 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV18     ((uint32_t)0x00000800U)         /* !< SYSPLLCLK0 is divided by 18 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV20     ((uint32_t)0x00000900U)         /* !< SYSPLLCLK0 is divided by 20 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV22     ((uint32_t)0x00000A00U)         /* !< SYSPLLCLK0 is divided by 22 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV24     ((uint32_t)0x00000B00U)         /* !< SYSPLLCLK0 is divided by 24 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV26     ((uint32_t)0x00000C00U)         /* !< SYSPLLCLK0 is divided by 26 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV28     ((uint32_t)0x00000D00U)         /* !< SYSPLLCLK0 is divided by 28 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV30     ((uint32_t)0x00000E00U)         /* !< SYSPLLCLK0 is divided by 30 */
+#define SYSCTL_SYSPLLCFG0_RDIVCLK0_CLK0DIV32     ((uint32_t)0x00000F00U)         /* !< SYSPLLCLK0 is divided by 32 */
+/* SYSCTL_SYSPLLCFG0[SYSPLLREF] Bits */
+#define SYSCTL_SYSPLLCFG0_SYSPLLREF_OFS          (0)                             /* !< SYSPLLREF Offset */
+#define SYSCTL_SYSPLLCFG0_SYSPLLREF_MASK         ((uint32_t)0x00000001U)         /* !< SYSPLLREF selects the system PLL
+                                                                                    (SYSPLL) reference clock source. */
+#define SYSCTL_SYSPLLCFG0_SYSPLLREF_SYSOSC       ((uint32_t)0x00000000U)         /* !< SYSPLL reference is SYSOSC */
+#define SYSCTL_SYSPLLCFG0_SYSPLLREF_HFCLK        ((uint32_t)0x00000001U)         /* !< SYSPLL reference is HFCLK */
+/* SYSCTL_SYSPLLCFG0[ENABLECLK2X] Bits */
+#define SYSCTL_SYSPLLCFG0_ENABLECLK2X_OFS        (6)                             /* !< ENABLECLK2X Offset */
+#define SYSCTL_SYSPLLCFG0_ENABLECLK2X_MASK       ((uint32_t)0x00000040U)         /* !< ENABLECLK2X enables or disables the
+                                                                                    SYSPLLCLK2X output. */
+#define SYSCTL_SYSPLLCFG0_ENABLECLK2X_DISABLE    ((uint32_t)0x00000000U)         /* !< SYSPLLCLK2X is disabled */
+#define SYSCTL_SYSPLLCFG0_ENABLECLK2X_ENABLE     ((uint32_t)0x00000040U)         /* !< SYSPLLCLK2X is enabled */
+
+/* SYSCTL_SYSPLLCFG1 Bits */
+/* SYSCTL_SYSPLLCFG1[PDIV] Bits */
+#define SYSCTL_SYSPLLCFG1_PDIV_OFS               (0)                             /* !< PDIV Offset */
+#define SYSCTL_SYSPLLCFG1_PDIV_MASK              ((uint32_t)0x00000003U)         /* !< PDIV selects the SYSPLL reference
+                                                                                    clock prescale divider. */
+#define SYSCTL_SYSPLLCFG1_PDIV_REFDIV1           ((uint32_t)0x00000000U)         /* !< SYSPLLREF is not divided */
+#define SYSCTL_SYSPLLCFG1_PDIV_REFDIV2           ((uint32_t)0x00000001U)         /* !< SYSPLLREF is divided by 2 */
+#define SYSCTL_SYSPLLCFG1_PDIV_REFDIV4           ((uint32_t)0x00000002U)         /* !< SYSPLLREF is divided by 4 */
+#define SYSCTL_SYSPLLCFG1_PDIV_REFDIV8           ((uint32_t)0x00000003U)         /* !< SYSPLLREF is divided by 8 */
+/* SYSCTL_SYSPLLCFG1[QDIV] Bits */
+#define SYSCTL_SYSPLLCFG1_QDIV_OFS               (8)                             /* !< QDIV Offset */
+#define SYSCTL_SYSPLLCFG1_QDIV_MASK              ((uint32_t)0x00007F00U)         /* !< QDIV selects the SYSPLL feedback
+                                                                                    path divider. */
+#define SYSCTL_SYSPLLCFG1_QDIV_INVALID           ((uint32_t)0x00000000U)         /* !< Divide-by-one is not a valid QDIV
+                                                                                    option */
+#define SYSCTL_SYSPLLCFG1_QDIV_QDIVMIN           ((uint32_t)0x00000100U)         /* !< Feedback path is divided by 2 */
+#define SYSCTL_SYSPLLCFG1_QDIV_QDIVMAX           ((uint32_t)0x00007E00U)         /* !< Feedback path is divided by 127
+                                                                                    (0x7E) */
+
+/* SYSCTL_SYSPLLPARAM0 Bits */
+/* SYSCTL_SYSPLLPARAM0[CPCURRENT] Bits */
+#define SYSCTL_SYSPLLPARAM0_CPCURRENT_OFS        (16)                            /* !< CPCURRENT Offset */
+#define SYSCTL_SYSPLLPARAM0_CPCURRENT_MASK       ((uint32_t)0x003F0000U)         /* !< Charge pump current */
+/* SYSCTL_SYSPLLPARAM0[CAPBOVERRIDE] Bits */
+#define SYSCTL_SYSPLLPARAM0_CAPBOVERRIDE_OFS     (31)                            /* !< CAPBOVERRIDE Offset */
+#define SYSCTL_SYSPLLPARAM0_CAPBOVERRIDE_MASK    ((uint32_t)0x80000000U)         /* !< CAPBOVERRIDE controls the override
+                                                                                    for Cap B */
+#define SYSCTL_SYSPLLPARAM0_CAPBOVERRIDE_DISABLE ((uint32_t)0x00000000U)         /* !< Cap B override disabled */
+#define SYSCTL_SYSPLLPARAM0_CAPBOVERRIDE_ENABLE  ((uint32_t)0x80000000U)         /* !< Cap B override enabled */
+/* SYSCTL_SYSPLLPARAM0[STARTTIME] Bits */
+#define SYSCTL_SYSPLLPARAM0_STARTTIME_OFS        (0)                             /* !< STARTTIME Offset */
+#define SYSCTL_SYSPLLPARAM0_STARTTIME_MASK       ((uint32_t)0x0000003FU)         /* !< Startup time from enable to locked
+                                                                                    clock, in 1us resolution */
+/* SYSCTL_SYSPLLPARAM0[CAPBVAL] Bits */
+#define SYSCTL_SYSPLLPARAM0_CAPBVAL_OFS          (24)                            /* !< CAPBVAL Offset */
+#define SYSCTL_SYSPLLPARAM0_CAPBVAL_MASK         ((uint32_t)0x1F000000U)         /* !< Override value for Cap B */
+/* SYSCTL_SYSPLLPARAM0[STARTTIMELP] Bits */
+#define SYSCTL_SYSPLLPARAM0_STARTTIMELP_OFS      (8)                             /* !< STARTTIMELP Offset */
+#define SYSCTL_SYSPLLPARAM0_STARTTIMELP_MASK     ((uint32_t)0x00003F00U)         /* !< Startup time from low power mode
+                                                                                    exit to locked clock, in 1us
+                                                                                    resolution */
+
+/* SYSCTL_SYSPLLPARAM1 Bits */
+/* SYSCTL_SYSPLLPARAM1[LPFCAPA] Bits */
+#define SYSCTL_SYSPLLPARAM1_LPFCAPA_OFS          (0)                             /* !< LPFCAPA Offset */
+#define SYSCTL_SYSPLLPARAM1_LPFCAPA_MASK         ((uint32_t)0x0000001FU)         /* !< Loop filter Cap A */
+/* SYSCTL_SYSPLLPARAM1[LPFRESC] Bits */
+#define SYSCTL_SYSPLLPARAM1_LPFRESC_OFS          (24)                            /* !< LPFRESC Offset */
+#define SYSCTL_SYSPLLPARAM1_LPFRESC_MASK         ((uint32_t)0xFF000000U)         /* !< Loop filter Res C */
+/* SYSCTL_SYSPLLPARAM1[LPFRESA] Bits */
+#define SYSCTL_SYSPLLPARAM1_LPFRESA_OFS          (8)                             /* !< LPFRESA Offset */
+#define SYSCTL_SYSPLLPARAM1_LPFRESA_MASK         ((uint32_t)0x0003FF00U)         /* !< Loop filter Res A */
+
+/* SYSCTL_GENCLKCFG Bits */
+/* SYSCTL_GENCLKCFG[HFCLK4MFPCLKDIV] Bits */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_OFS     (12)                            /* !< HFCLK4MFPCLKDIV Offset */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_MASK    ((uint32_t)0x0000F000U)         /* !< HFCLK4MFPCLKDIV selects the divider
+                                                                                    applied to HFCLK when HFCLK is used
+                                                                                    as the MFPCLK source.  Integer
+                                                                                    dividers from /1 to /16 may be
+                                                                                    selected. */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV1    ((uint32_t)0x00000000U)         /* !< HFCLK is not divided before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV2    ((uint32_t)0x00001000U)         /* !< HFCLK is divided by 2 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV3    ((uint32_t)0x00002000U)         /* !< HFCLK is divided by 3 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV4    ((uint32_t)0x00003000U)         /* !< HFCLK is divided by 4 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV5    ((uint32_t)0x00004000U)         /* !< HFCLK is divided by 5 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV6    ((uint32_t)0x00005000U)         /* !< HFCLK is divided by 6 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV7    ((uint32_t)0x00006000U)         /* !< HFCLK is divided by 7 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV8    ((uint32_t)0x00007000U)         /* !< HFCLK is divided by 8 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV9    ((uint32_t)0x00008000U)         /* !< HFCLK is divided by 9 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV10   ((uint32_t)0x00009000U)         /* !< HFCLK is divided by 10 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV11   ((uint32_t)0x0000A000U)         /* !< HFCLK is divided by 11 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV12   ((uint32_t)0x0000B000U)         /* !< HFCLK is divided by 12 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV13   ((uint32_t)0x0000C000U)         /* !< HFCLK is divided by 13 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV14   ((uint32_t)0x0000D000U)         /* !< HFCLK is divided by 14 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV15   ((uint32_t)0x0000E000U)         /* !< HFCLK is divided by 15 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV16   ((uint32_t)0x0000F000U)         /* !< HFCLK is divided by 16 before being
+                                                                                    used for MFPCLK */
+/* SYSCTL_GENCLKCFG[MFPCLKSRC] Bits */
+#define SYSCTL_GENCLKCFG_MFPCLKSRC_OFS           (9)                             /* !< MFPCLKSRC Offset */
+#define SYSCTL_GENCLKCFG_MFPCLKSRC_MASK          ((uint32_t)0x00000200U)         /* !< MFPCLKSRC selects the MFPCLK
+                                                                                    (middle frequency precision clock)
+                                                                                    source. */
+#define SYSCTL_GENCLKCFG_MFPCLKSRC_SYSOSC        ((uint32_t)0x00000000U)         /* !< MFPCLK is sourced from SYSOSC */
+#define SYSCTL_GENCLKCFG_MFPCLKSRC_HFCLK         ((uint32_t)0x00000200U)         /* !< MFPCLK is sourced from HFCLK */
+/* SYSCTL_GENCLKCFG[CANCLKSRC] Bits */
+#define SYSCTL_GENCLKCFG_CANCLKSRC_OFS           (8)                             /* !< CANCLKSRC Offset */
+#define SYSCTL_GENCLKCFG_CANCLKSRC_MASK          ((uint32_t)0x00000100U)         /* !< CANCLKSRC selects the CANCLK
+                                                                                    source. */
+#define SYSCTL_GENCLKCFG_CANCLKSRC_HFCLK         ((uint32_t)0x00000000U)         /* !< CANCLK source is HFCLK */
+#define SYSCTL_GENCLKCFG_CANCLKSRC_SYSPLLOUT1    ((uint32_t)0x00000100U)         /* !< CANCLK source is SYSPLLCLK1 */
+/* SYSCTL_GENCLKCFG[FCCTRIGCNT] Bits */
+#define SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS          (24)                            /* !< FCCTRIGCNT Offset */
+#define SYSCTL_GENCLKCFG_FCCTRIGCNT_MASK         ((uint32_t)0x1F000000U)         /* !< FCCTRIGCNT specifies the number of
+                                                                                    trigger clock periods in the trigger
+                                                                                    window. FCCTRIGCNT=0h (one trigger
+                                                                                    clock period) up to 1Fh (32 trigger
+                                                                                    clock periods) may be specified. */
+/* SYSCTL_GENCLKCFG[ANACPUMPCFG] Bits */
+#define SYSCTL_GENCLKCFG_ANACPUMPCFG_OFS         (22)                            /* !< ANACPUMPCFG Offset */
+#define SYSCTL_GENCLKCFG_ANACPUMPCFG_MASK        ((uint32_t)0x00C00000U)         /* !< ANACPUMPCFG selects the analog mux
+                                                                                    charge pump (VBOOST) enable method. */
+#define SYSCTL_GENCLKCFG_ANACPUMPCFG_ONDEMAND    ((uint32_t)0x00000000U)         /* !< VBOOST is enabled on request from a
+                                                                                    COMP, GPAMP, or OPA */
+#define SYSCTL_GENCLKCFG_ANACPUMPCFG_ONACTIVE    ((uint32_t)0x00400000U)         /* !< VBOOST is enabled when the device
+                                                                                    is in RUN or SLEEP mode, or when a
+                                                                                    COMP/GPAMP/OPA is enabled */
+#define SYSCTL_GENCLKCFG_ANACPUMPCFG_ONALWAYS    ((uint32_t)0x00800000U)         /* !< VBOOST is always enabled */
+/* SYSCTL_GENCLKCFG[FCCSELCLK] Bits */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_OFS           (16)                            /* !< FCCSELCLK Offset */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_MASK          ((uint32_t)0x000F0000U)         /* !< FCCSELCLK selectes the frequency
+                                                                                    clock counter (FCC) clock source. */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_MCLK          ((uint32_t)0x00000000U)         /* !< FCC clock is MCLK */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_SYSOSC        ((uint32_t)0x00010000U)         /* !< FCC clock is SYSOSC */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_HFCLK         ((uint32_t)0x00020000U)         /* !< FCC clock is HFCLK */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_EXTCLK        ((uint32_t)0x00030000U)         /* !< FCC clock is the CLK_OUT selection */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_SYSPLLCLK0    ((uint32_t)0x00040000U)         /* !< FCC clock is SYSPLLCLK0 */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_SYSPLLCLK1    ((uint32_t)0x00050000U)         /* !< FCC clock is SYSPLLCLK1 */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_SYSPLLCLK2X   ((uint32_t)0x00060000U)         /* !< FCC clock is SYSPLLCLK2X */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_FCCIN         ((uint32_t)0x00070000U)         /* !< FCC clock is the FCCIN external
+                                                                                    input */
+/* SYSCTL_GENCLKCFG[FCCTRIGSRC] Bits */
+#define SYSCTL_GENCLKCFG_FCCTRIGSRC_OFS          (20)                            /* !< FCCTRIGSRC Offset */
+#define SYSCTL_GENCLKCFG_FCCTRIGSRC_MASK         ((uint32_t)0x00100000U)         /* !< FCCTRIGSRC selects the frequency
+                                                                                    clock counter (FCC) trigger source. */
+#define SYSCTL_GENCLKCFG_FCCTRIGSRC_EXTPIN       ((uint32_t)0x00000000U)         /* !< FCC trigger is the external pin */
+#define SYSCTL_GENCLKCFG_FCCTRIGSRC_LFCLK        ((uint32_t)0x00100000U)         /* !< FCC trigger is the LFCLK */
+/* SYSCTL_GENCLKCFG[FCCLVLTRIG] Bits */
+#define SYSCTL_GENCLKCFG_FCCLVLTRIG_OFS          (21)                            /* !< FCCLVLTRIG Offset */
+#define SYSCTL_GENCLKCFG_FCCLVLTRIG_MASK         ((uint32_t)0x00200000U)         /* !< FCCLVLTRIG selects the frequency
+                                                                                    clock counter (FCC) trigger mode. */
+#define SYSCTL_GENCLKCFG_FCCLVLTRIG_RISE2RISE    ((uint32_t)0x00000000U)         /* !< Rising edge to rising edge
+                                                                                    triggered */
+#define SYSCTL_GENCLKCFG_FCCLVLTRIG_LEVEL        ((uint32_t)0x00200000U)         /* !< Level triggered */
+/* SYSCTL_GENCLKCFG[EXCLKSRC] Bits */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_OFS            (0)                             /* !< EXCLKSRC Offset */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_MASK           ((uint32_t)0x00000007U)         /* !< EXCLKSRC selects the source for the
+                                                                                    CLK_OUT external clock output block.
+                                                                                    ULPCLK and MFPCLK require the CLK_OUT
+                                                                                    divider (EXCLKDIVEN) to be enabled */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_SYSOSC         ((uint32_t)0x00000000U)         /* !< CLK_OUT is SYSOSC */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_ULPCLK         ((uint32_t)0x00000001U)         /* !< CLK_OUT is ULPCLK (EXCLKDIVEN must
+                                                                                    be enabled) */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_LFCLK          ((uint32_t)0x00000002U)         /* !< CLK_OUT is LFCLK */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_MFPCLK         ((uint32_t)0x00000003U)         /* !< CLK_OUT is MFPCLK (EXCLKDIVEN must
+                                                                                    be enabled) */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_HFCLK          ((uint32_t)0x00000004U)         /* !< CLK_OUT is HFCLK */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_SYSPLLOUT1     ((uint32_t)0x00000005U)         /* !< CLK_OUT is SYSPLLCLK1 (SYSPLLCLK1
+                                                                                    must be &lt;=48MHz) */
+/* SYSCTL_GENCLKCFG[EXCLKDIVVAL] Bits */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_OFS         (4)                             /* !< EXCLKDIVVAL Offset */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_MASK        ((uint32_t)0x00000070U)         /* !< EXCLKDIVVAL selects the divider
+                                                                                    value for the divider in the CLK_OUT
+                                                                                    external clock output block. */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV2        ((uint32_t)0x00000000U)         /* !< CLK_OUT source is divided by 2 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV4        ((uint32_t)0x00000010U)         /* !< CLK_OUT source is divided by 4 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV6        ((uint32_t)0x00000020U)         /* !< CLK_OUT source is divided by 6 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV8        ((uint32_t)0x00000030U)         /* !< CLK_OUT source is divided by 8 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV10       ((uint32_t)0x00000040U)         /* !< CLK_OUT source is divided by 10 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV12       ((uint32_t)0x00000050U)         /* !< CLK_OUT source is divided by 12 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV14       ((uint32_t)0x00000060U)         /* !< CLK_OUT source is divided by 14 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV16       ((uint32_t)0x00000070U)         /* !< CLK_OUT source is divided by 16 */
+/* SYSCTL_GENCLKCFG[EXCLKDIVEN] Bits */
+#define SYSCTL_GENCLKCFG_EXCLKDIVEN_OFS          (7)                             /* !< EXCLKDIVEN Offset */
+#define SYSCTL_GENCLKCFG_EXCLKDIVEN_MASK         ((uint32_t)0x00000080U)         /* !< EXCLKDIVEN enables or disables the
+                                                                                    divider function of the CLK_OUT
+                                                                                    external clock output block. */
+#define SYSCTL_GENCLKCFG_EXCLKDIVEN_PASSTHRU     ((uint32_t)0x00000000U)         /* !< CLock divider is disabled
+                                                                                    (passthrough, EXCLKDIVVAL is not
+                                                                                    applied) */
+#define SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE       ((uint32_t)0x00000080U)         /* !< Clock divider is enabled
+                                                                                    (EXCLKDIVVAL is applied) */
+
+/* SYSCTL_GENCLKEN Bits */
+/* SYSCTL_GENCLKEN[EXCLKEN] Bits */
+#define SYSCTL_GENCLKEN_EXCLKEN_OFS              (0)                             /* !< EXCLKEN Offset */
+#define SYSCTL_GENCLKEN_EXCLKEN_MASK             ((uint32_t)0x00000001U)         /* !< EXCLKEN enables the CLK_OUT
+                                                                                    external clock output block. */
+#define SYSCTL_GENCLKEN_EXCLKEN_DISABLE          ((uint32_t)0x00000000U)         /* !< CLK_OUT block is disabled */
+#define SYSCTL_GENCLKEN_EXCLKEN_ENABLE           ((uint32_t)0x00000001U)         /* !< CLK_OUT block is enabled */
+/* SYSCTL_GENCLKEN[MFPCLKEN] Bits */
+#define SYSCTL_GENCLKEN_MFPCLKEN_OFS             (4)                             /* !< MFPCLKEN Offset */
+#define SYSCTL_GENCLKEN_MFPCLKEN_MASK            ((uint32_t)0x00000010U)         /* !< MFPCLKEN enables the middle
+                                                                                    frequency precision clock (MFPCLK). */
+#define SYSCTL_GENCLKEN_MFPCLKEN_DISABLE         ((uint32_t)0x00000000U)         /* !< MFPCLK is disabled */
+#define SYSCTL_GENCLKEN_MFPCLKEN_ENABLE          ((uint32_t)0x00000010U)         /* !< MFPCLK is enabled */
+
+/* SYSCTL_PMODECFG Bits */
+/* SYSCTL_PMODECFG[DSLEEP] Bits */
+#define SYSCTL_PMODECFG_DSLEEP_OFS               (0)                             /* !< DSLEEP Offset */
+#define SYSCTL_PMODECFG_DSLEEP_MASK              ((uint32_t)0x00000003U)         /* !< DSLEEP selects the operating mode
+                                                                                    to enter upon a DEEPSLEEP request
+                                                                                    from the CPU. */
+#define SYSCTL_PMODECFG_DSLEEP_STOP              ((uint32_t)0x00000000U)         /* !< STOP mode is entered */
+#define SYSCTL_PMODECFG_DSLEEP_STANDBY           ((uint32_t)0x00000001U)         /* !< STANDBY mode is entered */
+#define SYSCTL_PMODECFG_DSLEEP_SHUTDOWN          ((uint32_t)0x00000002U)         /* !< SHUTDOWN mode is entered */
+
+/* SYSCTL_FCC Bits */
+/* SYSCTL_FCC[DATA] Bits */
+#define SYSCTL_FCC_DATA_OFS                      (0)                             /* !< DATA Offset */
+#define SYSCTL_FCC_DATA_MASK                     ((uint32_t)0x003FFFFFU)         /* !< Frequency clock counter (FCC) count
+                                                                                    value. */
+
+/* SYSCTL_SYSOSCTRIMUSER Bits */
+/* SYSCTL_SYSOSCTRIMUSER[RESCOARSE] Bits */
+#define SYSCTL_SYSOSCTRIMUSER_RESCOARSE_OFS      (8)                             /* !< RESCOARSE Offset */
+#define SYSCTL_SYSOSCTRIMUSER_RESCOARSE_MASK     ((uint32_t)0x00003F00U)         /* !< RESCOARSE specifies the resister
+                                                                                    coarse trim.  This value changes with
+                                                                                    the target frequency. */
+/* SYSCTL_SYSOSCTRIMUSER[RESFINE] Bits */
+#define SYSCTL_SYSOSCTRIMUSER_RESFINE_OFS        (16)                            /* !< RESFINE Offset */
+#define SYSCTL_SYSOSCTRIMUSER_RESFINE_MASK       ((uint32_t)0x000F0000U)         /* !< RESFINE specifies the resister fine
+                                                                                    trim.  This value changes with the
+                                                                                    target frequency. */
+/* SYSCTL_SYSOSCTRIMUSER[RDIV] Bits */
+#define SYSCTL_SYSOSCTRIMUSER_RDIV_OFS           (20)                            /* !< RDIV Offset */
+#define SYSCTL_SYSOSCTRIMUSER_RDIV_MASK          ((uint32_t)0x1FF00000U)         /* !< RDIV specifies the frequency
+                                                                                    correction loop (FCL) resistor trim.
+                                                                                    This value changes with the target
+                                                                                    frequency. */
+/* SYSCTL_SYSOSCTRIMUSER[FREQ] Bits */
+#define SYSCTL_SYSOSCTRIMUSER_FREQ_OFS           (0)                             /* !< FREQ Offset */
+#define SYSCTL_SYSOSCTRIMUSER_FREQ_MASK          ((uint32_t)0x00000003U)         /* !< FREQ specifies the target
+                                                                                    user-trimmed frequency for SYSOSC. */
+#define SYSCTL_SYSOSCTRIMUSER_FREQ_SYSOSC16M     ((uint32_t)0x00000001U)         /* !< 16MHz user frequency */
+#define SYSCTL_SYSOSCTRIMUSER_FREQ_SYSOSC24M     ((uint32_t)0x00000002U)         /* !< 24MHz user frequency */
+/* SYSCTL_SYSOSCTRIMUSER[CAP] Bits */
+#define SYSCTL_SYSOSCTRIMUSER_CAP_OFS            (4)                             /* !< CAP Offset */
+#define SYSCTL_SYSOSCTRIMUSER_CAP_MASK           ((uint32_t)0x00000070U)         /* !< CAP specifies the SYSOSC capacitor
+                                                                                    trim.  This value changes with the
+                                                                                    target frequency. */
+
+/* SYSCTL_SRAMBOUNDARY Bits */
+/* SYSCTL_SRAMBOUNDARY[ADDR] Bits */
+#define SYSCTL_SRAMBOUNDARY_ADDR_OFS             (5)                             /* !< ADDR Offset */
+#define SYSCTL_SRAMBOUNDARY_ADDR_MASK            ((uint32_t)0x000FFFE0U)         /* !< SRAM boundary configuration. The
+                                                                                    value configured into this acts such
+                                                                                    that: SRAM accesses to addresses less
+                                                                                    than or equal value will be RW only.
+                                                                                    SRAM accesses to addresses greater
+                                                                                    than value will be RX only. Value of
+                                                                                    0 is not valid (system will have no
+                                                                                    stack). If set to 0, the system acts
+                                                                                    as if the entire SRAM is RWX.  Any
+                                                                                    non-zero value can be configured,
+                                                                                    including a value = SRAM size. */
+
+/* SYSCTL_SYSTEMCFG Bits */
+/* SYSCTL_SYSTEMCFG[KEY] Bits */
+#define SYSCTL_SYSTEMCFG_KEY_OFS                 (24)                            /* !< KEY Offset */
+#define SYSCTL_SYSTEMCFG_KEY_MASK                ((uint32_t)0xFF000000U)         /* !< The key value of 1Bh (27) must be
+                                                                                    written to KEY together with contents
+                                                                                    to be updated. Reads as 0 */
+#define SYSCTL_SYSTEMCFG_KEY_VALUE               ((uint32_t)0x1B000000U)         /* !< Issue write */
+/* SYSCTL_SYSTEMCFG[FLASHECCRSTDIS] Bits */
+#define SYSCTL_SYSTEMCFG_FLASHECCRSTDIS_OFS      (2)                             /* !< FLASHECCRSTDIS Offset */
+#define SYSCTL_SYSTEMCFG_FLASHECCRSTDIS_MASK     ((uint32_t)0x00000004U)         /* !< FLASHECCRSTDIS specifies whether a
+                                                                                    flash ECC double error detect (DED)
+                                                                                    will trigger a SYSRST or an NMI. */
+#define SYSCTL_SYSTEMCFG_FLASHECCRSTDIS_FALSE    ((uint32_t)0x00000000U)         /* !< Flash ECC DED will trigger a SYSRST */
+#define SYSCTL_SYSTEMCFG_FLASHECCRSTDIS_TRUE     ((uint32_t)0x00000004U)         /* !< Flash ECC DED will trigger a NMI */
+/* SYSCTL_SYSTEMCFG[WWDTLP0RSTDIS] Bits */
+#define SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_OFS       (0)                             /* !< WWDTLP0RSTDIS Offset */
+#define SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_MASK      ((uint32_t)0x00000001U)         /* !< WWDTLP0RSTDIS specifies whether a
+                                                                                    WWDT Error Event will trigger a
+                                                                                    BOOTRST or an NMI. */
+#define SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_FALSE     ((uint32_t)0x00000000U)         /* !< WWDTLP0 Error Event will trigger a
+                                                                                    BOOTRST */
+#define SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_TRUE      ((uint32_t)0x00000001U)         /* !< WWDTLP0 Error Event will trigger an
+                                                                                    NMI */
+/* SYSCTL_SYSTEMCFG[WWDTLP1RSTDIS] Bits */
+#define SYSCTL_SYSTEMCFG_WWDTLP1RSTDIS_OFS       (1)                             /* !< WWDTLP1RSTDIS Offset */
+#define SYSCTL_SYSTEMCFG_WWDTLP1RSTDIS_MASK      ((uint32_t)0x00000002U)         /* !< WWDTLP1RSTDIS specifies whether a
+                                                                                    WWDT Error Event will trigger a
+                                                                                    SYSRST or an NMI. */
+#define SYSCTL_SYSTEMCFG_WWDTLP1RSTDIS_FALSE     ((uint32_t)0x00000000U)         /* !< WWDTLP1 Error Event will trigger a
+                                                                                    SYSRST */
+#define SYSCTL_SYSTEMCFG_WWDTLP1RSTDIS_TRUE      ((uint32_t)0x00000002U)         /* !< WWDTLP1 Error Event will trigger an
+                                                                                    NMI */
+
+/* SYSCTL_WRITELOCK Bits */
+/* SYSCTL_WRITELOCK[ACTIVE] Bits */
+#define SYSCTL_WRITELOCK_ACTIVE_OFS              (0)                             /* !< ACTIVE Offset */
+#define SYSCTL_WRITELOCK_ACTIVE_MASK             ((uint32_t)0x00000001U)         /* !< ACTIVE controls whether critical
+                                                                                    SYSCTL registers are write protected
+                                                                                    or not. */
+#define SYSCTL_WRITELOCK_ACTIVE_DISABLE          ((uint32_t)0x00000000U)         /* !< Allow writes to lockable registers */
+#define SYSCTL_WRITELOCK_ACTIVE_ENABLE           ((uint32_t)0x00000001U)         /* !< Disallow writes to lockable
+                                                                                    registers */
+
+/* SYSCTL_CLKSTATUS Bits */
+/* SYSCTL_CLKSTATUS[OPAMPCLKERR] Bits */
+#define SYSCTL_CLKSTATUS_OPAMPCLKERR_OFS         (30)                            /* !< OPAMPCLKERR Offset */
+#define SYSCTL_CLKSTATUS_OPAMPCLKERR_MASK        ((uint32_t)0x40000000U)         /* !< OPAMPCLKERR is set when the device
+                                                                                    clock configuration does not support
+                                                                                    an enabled OPA mode and the OPA may
+                                                                                    not be functioning as expected. */
+#define SYSCTL_CLKSTATUS_OPAMPCLKERR_FALSE       ((uint32_t)0x00000000U)         /* !< No OPA clock generation errors
+                                                                                    detected */
+#define SYSCTL_CLKSTATUS_OPAMPCLKERR_TRUE        ((uint32_t)0x40000000U)         /* !< OPA clock generation error detected */
+/* SYSCTL_CLKSTATUS[LFOSCGOOD] Bits */
+#define SYSCTL_CLKSTATUS_LFOSCGOOD_OFS           (11)                            /* !< LFOSCGOOD Offset */
+#define SYSCTL_CLKSTATUS_LFOSCGOOD_MASK          ((uint32_t)0x00000800U)         /* !< LFOSCGOOD indicates when the LFOSC
+                                                                                    startup has completed and the LFOSC
+                                                                                    is ready for use. */
+#define SYSCTL_CLKSTATUS_LFOSCGOOD_FALSE         ((uint32_t)0x00000000U)         /* !< LFOSC is not ready */
+#define SYSCTL_CLKSTATUS_LFOSCGOOD_TRUE          ((uint32_t)0x00000800U)         /* !< LFOSC is ready */
+/* SYSCTL_CLKSTATUS[HFCLKGOOD] Bits */
+#define SYSCTL_CLKSTATUS_HFCLKGOOD_OFS           (8)                             /* !< HFCLKGOOD Offset */
+#define SYSCTL_CLKSTATUS_HFCLKGOOD_MASK          ((uint32_t)0x00000100U)         /* !< HFCLKGOOD indicates that the HFCLK
+                                                                                    started correctly.  When the HFXT is
+                                                                                    started or HFCLK_IN is selected as
+                                                                                    the HFCLK source,  this bit will be
+                                                                                    set by hardware if a valid HFCLK is
+                                                                                    detected, and cleared if HFCLK is not
+                                                                                    operating within the expected range. */
+#define SYSCTL_CLKSTATUS_HFCLKGOOD_FALSE         ((uint32_t)0x00000000U)         /* !< HFCLK did not start correctly */
+#define SYSCTL_CLKSTATUS_HFCLKGOOD_TRUE          ((uint32_t)0x00000100U)         /* !< HFCLK started correctly */
+/* SYSCTL_CLKSTATUS[HSCLKDEAD] Bits */
+#define SYSCTL_CLKSTATUS_HSCLKDEAD_OFS           (20)                            /* !< HSCLKDEAD Offset */
+#define SYSCTL_CLKSTATUS_HSCLKDEAD_MASK          ((uint32_t)0x00100000U)         /* !< HSCLKDEAD is set by hardware if the
+                                                                                    selected source for HSCLK was started
+                                                                                    but did not start successfully. */
+#define SYSCTL_CLKSTATUS_HSCLKDEAD_FALSE         ((uint32_t)0x00000000U)         /* !< The HSCLK source was not started or
+                                                                                    started correctly */
+#define SYSCTL_CLKSTATUS_HSCLKDEAD_TRUE          ((uint32_t)0x00100000U)         /* !< The HSCLK source did not start
+                                                                                    correctly */
+/* SYSCTL_CLKSTATUS[SYSPLLBLKUPD] Bits */
+#define SYSCTL_CLKSTATUS_SYSPLLBLKUPD_OFS        (29)                            /* !< SYSPLLBLKUPD Offset */
+#define SYSCTL_CLKSTATUS_SYSPLLBLKUPD_MASK       ((uint32_t)0x20000000U)         /* !< SYSPLLBLKUPD indicates when writes
+                                                                                    to SYSPLLCFG0/1 and SYSPLLPARAM0/1
+                                                                                    are blocked. */
+#define SYSCTL_CLKSTATUS_SYSPLLBLKUPD_FALSE      ((uint32_t)0x00000000U)         /* !< writes to SYSPLLCFG0/1 and
+                                                                                    SYSPLLPARAM0/1 are allowed */
+#define SYSCTL_CLKSTATUS_SYSPLLBLKUPD_TRUE       ((uint32_t)0x20000000U)         /* !< writes to SYSPLLCFG0/1 and
+                                                                                    SYSPLLPARAM0/1 are blocked */
+/* SYSCTL_CLKSTATUS[HFCLKOFF] Bits */
+#define SYSCTL_CLKSTATUS_HFCLKOFF_OFS            (13)                            /* !< HFCLKOFF Offset */
+#define SYSCTL_CLKSTATUS_HFCLKOFF_MASK           ((uint32_t)0x00002000U)         /* !< HFCLKOFF indicates if the HFCLK is
+                                                                                    disabled or was dead at startup.
+                                                                                    When the HFCLK is started, HFCLKOFF
+                                                                                    is cleared by hardware.  Following
+                                                                                    startup of the HFCLK, if the HFCLK
+                                                                                    startup monitor determines that the
+                                                                                    HFCLK was not started correctly,
+                                                                                    HFCLKOFF is set. */
+#define SYSCTL_CLKSTATUS_HFCLKOFF_FALSE          ((uint32_t)0x00000000U)         /* !< HFCLK started correctly and is
+                                                                                    enabled */
+#define SYSCTL_CLKSTATUS_HFCLKOFF_TRUE           ((uint32_t)0x00002000U)         /* !< HFCLK is disabled or was dead at
+                                                                                    startup */
+/* SYSCTL_CLKSTATUS[HFCLKBLKUPD] Bits */
+#define SYSCTL_CLKSTATUS_HFCLKBLKUPD_OFS         (28)                            /* !< HFCLKBLKUPD Offset */
+#define SYSCTL_CLKSTATUS_HFCLKBLKUPD_MASK        ((uint32_t)0x10000000U)         /* !< HFCLKBLKUPD indicates when writes
+                                                                                    to the HFCLKCLKCFG register are
+                                                                                    blocked. */
+#define SYSCTL_CLKSTATUS_HFCLKBLKUPD_FALSE       ((uint32_t)0x00000000U)         /* !< Writes to HFCLKCLKCFG are allowed */
+#define SYSCTL_CLKSTATUS_HFCLKBLKUPD_TRUE        ((uint32_t)0x10000000U)         /* !< Writes to HFCLKCLKCFG are blocked */
+/* SYSCTL_CLKSTATUS[HSCLKGOOD] Bits */
+#define SYSCTL_CLKSTATUS_HSCLKGOOD_OFS           (21)                            /* !< HSCLKGOOD Offset */
+#define SYSCTL_CLKSTATUS_HSCLKGOOD_MASK          ((uint32_t)0x00200000U)         /* !< HSCLKGOOD is set by hardware if the
+                                                                                    selected clock source for HSCLK
+                                                                                    started successfully. */
+#define SYSCTL_CLKSTATUS_HSCLKGOOD_FALSE         ((uint32_t)0x00000000U)         /* !< The HSCLK source did not start
+                                                                                    correctly */
+#define SYSCTL_CLKSTATUS_HSCLKGOOD_TRUE          ((uint32_t)0x00200000U)         /* !< The HSCLK source started correctly */
+/* SYSCTL_CLKSTATUS[SYSPLLGOOD] Bits */
+#define SYSCTL_CLKSTATUS_SYSPLLGOOD_OFS          (9)                             /* !< SYSPLLGOOD Offset */
+#define SYSCTL_CLKSTATUS_SYSPLLGOOD_MASK         ((uint32_t)0x00000200U)         /* !< SYSPLLGOOD indicates if the SYSPLL
+                                                                                    started correctly.  When the SYSPLL
+                                                                                    is started, SYSPLLGOOD is cleared by
+                                                                                    hardware.  After the startup settling
+                                                                                    time has expired, the SYSPLL status
+                                                                                    is tested.  If the SYSPLL started
+                                                                                    successfully the SYSPLLGOOD bit is
+                                                                                    set, else it is left cleared. */
+#define SYSCTL_CLKSTATUS_SYSPLLGOOD_FALSE        ((uint32_t)0x00000000U)         /* !< SYSPLL did not start correctly */
+#define SYSCTL_CLKSTATUS_SYSPLLGOOD_TRUE         ((uint32_t)0x00000200U)         /* !< SYSPLL started correctly */
+/* SYSCTL_CLKSTATUS[ANACLKERR] Bits */
+#define SYSCTL_CLKSTATUS_ANACLKERR_OFS           (31)                            /* !< ANACLKERR Offset */
+#define SYSCTL_CLKSTATUS_ANACLKERR_MASK          ((uint32_t)0x80000000U)         /* !< ANACLKERR is set when the device
+                                                                                    clock configuration does not support
+                                                                                    an enabled analog peripheral mode and
+                                                                                    the analog peripheral may not be
+                                                                                    functioning as expected. */
+#define SYSCTL_CLKSTATUS_ANACLKERR_FALSE         ((uint32_t)0x00000000U)         /* !< No analog clock errors detected */
+#define SYSCTL_CLKSTATUS_ANACLKERR_TRUE          ((uint32_t)0x80000000U)         /* !< Analog clock error detected */
+/* SYSCTL_CLKSTATUS[HSCLKMUX] Bits */
+#define SYSCTL_CLKSTATUS_HSCLKMUX_OFS            (4)                             /* !< HSCLKMUX Offset */
+#define SYSCTL_CLKSTATUS_HSCLKMUX_MASK           ((uint32_t)0x00000010U)         /* !< HSCLKMUX indicates if MCLK is
+                                                                                    currently sourced from the high-speed
+                                                                                    clock (HSCLK). */
+#define SYSCTL_CLKSTATUS_HSCLKMUX_SYSOSC         ((uint32_t)0x00000000U)         /* !< MCLK is not sourced from HSCLK */
+#define SYSCTL_CLKSTATUS_HSCLKMUX_HSCLK          ((uint32_t)0x00000010U)         /* !< MCLK is sourced from HSCLK */
+/* SYSCTL_CLKSTATUS[LFCLKMUX] Bits */
+#define SYSCTL_CLKSTATUS_LFCLKMUX_OFS            (6)                             /* !< LFCLKMUX Offset */
+#define SYSCTL_CLKSTATUS_LFCLKMUX_MASK           ((uint32_t)0x000000C0U)         /* !< LFCLKMUX indicates if LFCLK is
+                                                                                    sourced from the internal LFOSC, the
+                                                                                    low frequency crystal (LFXT), or the
+                                                                                    LFCLK_IN digital clock input. */
+#define SYSCTL_CLKSTATUS_LFCLKMUX_LFOSC          ((uint32_t)0x00000000U)         /* !< LFCLK is sourced from the internal
+                                                                                    LFOSC */
+#define SYSCTL_CLKSTATUS_LFCLKMUX_LFXT           ((uint32_t)0x00000040U)         /* !< LFCLK is sourced from the LFXT
+                                                                                    (crystal) */
+#define SYSCTL_CLKSTATUS_LFCLKMUX_EXLF           ((uint32_t)0x00000080U)         /* !< LFCLK is sourced from LFCLK_IN
+                                                                                    (external digital clock  input) */
+/* SYSCTL_CLKSTATUS[SYSOSCFREQ] Bits */
+#define SYSCTL_CLKSTATUS_SYSOSCFREQ_OFS          (0)                             /* !< SYSOSCFREQ Offset */
+#define SYSCTL_CLKSTATUS_SYSOSCFREQ_MASK         ((uint32_t)0x00000003U)         /* !< SYSOSCFREQ indicates the current
+                                                                                    SYSOSC operating frequency. */
+#define SYSCTL_CLKSTATUS_SYSOSCFREQ_SYSOSC32M    ((uint32_t)0x00000000U)         /* !< SYSOSC is at base frequency (32MHz) */
+#define SYSCTL_CLKSTATUS_SYSOSCFREQ_SYSOSC4M     ((uint32_t)0x00000001U)         /* !< SYSOSC is at low frequency (4MHz) */
+#define SYSCTL_CLKSTATUS_SYSOSCFREQ_SYSOSCUSER   ((uint32_t)0x00000002U)         /* !< SYSOSC is at the user-trimmed
+                                                                                    frequency (16 or 24MHz) */
+#define SYSCTL_CLKSTATUS_SYSOSCFREQ_SYSOSCTURBO  ((uint32_t)0x00000003U)         /* !< Reserved */
+/* SYSCTL_CLKSTATUS[LFXTGOOD] Bits */
+#define SYSCTL_CLKSTATUS_LFXTGOOD_OFS            (10)                            /* !< LFXTGOOD Offset */
+#define SYSCTL_CLKSTATUS_LFXTGOOD_MASK           ((uint32_t)0x00000400U)         /* !< LFXTGOOD indicates if the LFXT
+                                                                                    started correctly.  When the LFXT is
+                                                                                    started, LFXTGOOD is cleared by
+                                                                                    hardware.  After the startup settling
+                                                                                    time has expired, the LFXT status is
+                                                                                    tested.  If the LFXT started
+                                                                                    successfully the LFXTGOOD bit is set,
+                                                                                    else it is left cleared. */
+#define SYSCTL_CLKSTATUS_LFXTGOOD_FALSE          ((uint32_t)0x00000000U)         /* !< LFXT did not start correctly */
+#define SYSCTL_CLKSTATUS_LFXTGOOD_TRUE           ((uint32_t)0x00000400U)         /* !< LFXT started correctly */
+/* SYSCTL_CLKSTATUS[HSCLKSOFF] Bits */
+#define SYSCTL_CLKSTATUS_HSCLKSOFF_OFS           (12)                            /* !< HSCLKSOFF Offset */
+#define SYSCTL_CLKSTATUS_HSCLKSOFF_MASK          ((uint32_t)0x00001000U)         /* !< HSCLKSOFF is set when the high
+                                                                                    speed clock sources (SYSPLL, HFCLK)
+                                                                                    are disabled or dead.  It is the
+                                                                                    logical AND of HFCLKOFF and
+                                                                                    SYSPLLOFF. */
+#define SYSCTL_CLKSTATUS_HSCLKSOFF_FALSE         ((uint32_t)0x00000000U)         /* !< SYSPLL, HFCLK, or both were started
+                                                                                    correctly and remain enabled */
+#define SYSCTL_CLKSTATUS_HSCLKSOFF_TRUE          ((uint32_t)0x00001000U)         /* !< SYSPLL and HFCLK are both either
+                                                                                    off or dead */
+/* SYSCTL_CLKSTATUS[FCLMODE] Bits */
+#define SYSCTL_CLKSTATUS_FCLMODE_OFS             (24)                            /* !< FCLMODE Offset */
+#define SYSCTL_CLKSTATUS_FCLMODE_MASK            ((uint32_t)0x01000000U)         /* !< FCLMODE indicates if the SYSOSC
+                                                                                    frequency correction loop (FCL) is
+                                                                                    enabled. */
+#define SYSCTL_CLKSTATUS_FCLMODE_DISABLED        ((uint32_t)0x00000000U)         /* !< SYSOSC FCL is disabled */
+#define SYSCTL_CLKSTATUS_FCLMODE_ENABLED         ((uint32_t)0x01000000U)         /* !< SYSOSC FCL is enabled */
+/* SYSCTL_CLKSTATUS[CURHSCLKSEL] Bits */
+#define SYSCTL_CLKSTATUS_CURHSCLKSEL_OFS         (16)                            /* !< CURHSCLKSEL Offset */
+#define SYSCTL_CLKSTATUS_CURHSCLKSEL_MASK        ((uint32_t)0x00010000U)         /* !< CURHSCLKSEL indicates the current
+                                                                                    clock source for HSCLK. */
+#define SYSCTL_CLKSTATUS_CURHSCLKSEL_SYSPLL      ((uint32_t)0x00000000U)         /* !< HSCLK is currently sourced from the
+                                                                                    SYSPLL */
+#define SYSCTL_CLKSTATUS_CURHSCLKSEL_HFCLK       ((uint32_t)0x00010000U)         /* !< HSCLK is currently sourced from the
+                                                                                    HFCLK */
+/* SYSCTL_CLKSTATUS[CURMCLKSEL] Bits */
+#define SYSCTL_CLKSTATUS_CURMCLKSEL_OFS          (17)                            /* !< CURMCLKSEL Offset */
+#define SYSCTL_CLKSTATUS_CURMCLKSEL_MASK         ((uint32_t)0x00020000U)         /* !< CURMCLKSEL indicates if MCLK is
+                                                                                    currently sourced from LFCLK. */
+#define SYSCTL_CLKSTATUS_CURMCLKSEL_NOTLFCLK     ((uint32_t)0x00000000U)         /* !< MCLK is not sourced from LFCLK */
+#define SYSCTL_CLKSTATUS_CURMCLKSEL_LFCLK        ((uint32_t)0x00020000U)         /* !< MCLK is sourced from LFCLK */
+/* SYSCTL_CLKSTATUS[FCCDONE] Bits */
+#define SYSCTL_CLKSTATUS_FCCDONE_OFS             (25)                            /* !< FCCDONE Offset */
+#define SYSCTL_CLKSTATUS_FCCDONE_MASK            ((uint32_t)0x02000000U)         /* !< FCCDONE indicates when a frequency
+                                                                                    clock counter capture is complete. */
+#define SYSCTL_CLKSTATUS_FCCDONE_NOTDONE         ((uint32_t)0x00000000U)         /* !< FCC capture is not done */
+#define SYSCTL_CLKSTATUS_FCCDONE_DONE            ((uint32_t)0x02000000U)         /* !< FCC capture is done */
+/* SYSCTL_CLKSTATUS[SYSPLLOFF] Bits */
+#define SYSCTL_CLKSTATUS_SYSPLLOFF_OFS           (14)                            /* !< SYSPLLOFF Offset */
+#define SYSCTL_CLKSTATUS_SYSPLLOFF_MASK          ((uint32_t)0x00004000U)         /* !< SYSPLLOFF indicates if the SYSPLL
+                                                                                    is disabled or was dead at startup.
+                                                                                    When the SYSPLL is started, SYSPLLOFF
+                                                                                    is cleared by hardware.  Following
+                                                                                    startup of the SYSPLL, if the SYSPLL
+                                                                                    startup monitor determines that the
+                                                                                    SYSPLL was not started correctly,
+                                                                                    SYSPLLOFF is set. */
+#define SYSCTL_CLKSTATUS_SYSPLLOFF_FALSE         ((uint32_t)0x00000000U)         /* !< SYSPLL started correctly and is
+                                                                                    enabled */
+#define SYSCTL_CLKSTATUS_SYSPLLOFF_TRUE          ((uint32_t)0x00004000U)         /* !< SYSPLL is disabled or was dead
+                                                                                    startup */
+/* SYSCTL_CLKSTATUS[LFCLKFAIL] Bits */
+#define SYSCTL_CLKSTATUS_LFCLKFAIL_OFS           (23)                            /* !< LFCLKFAIL Offset */
+#define SYSCTL_CLKSTATUS_LFCLKFAIL_MASK          ((uint32_t)0x00800000U)         /* !< LFCLKFAIL indicates when the
+                                                                                    continous LFCLK monitor detects a
+                                                                                    LFXT or LFCLK_IN clock stuck failure. */
+#define SYSCTL_CLKSTATUS_LFCLKFAIL_FALSE         ((uint32_t)0x00000000U)         /* !< No LFCLK fault detected */
+#define SYSCTL_CLKSTATUS_LFCLKFAIL_TRUE          ((uint32_t)0x00800000U)         /* !< LFCLK stuck fault detected */
+
+/* SYSCTL_SYSSTATUS Bits */
+/* SYSCTL_SYSSTATUS[SHDNIOLOCK] Bits */
+#define SYSCTL_SYSSTATUS_SHDNIOLOCK_OFS          (14)                            /* !< SHDNIOLOCK Offset */
+#define SYSCTL_SYSSTATUS_SHDNIOLOCK_MASK         ((uint32_t)0x00004000U)         /* !< SHDNIOLOCK indicates when IO is
+                                                                                    locked due to SHUTDOWN */
+#define SYSCTL_SYSSTATUS_SHDNIOLOCK_FALSE        ((uint32_t)0x00000000U)         /* !< IO IS NOT Locked due to SHUTDOWN */
+#define SYSCTL_SYSSTATUS_SHDNIOLOCK_TRUE         ((uint32_t)0x00004000U)         /* !< IO IS Locked due to SHUTDOWN */
+/* SYSCTL_SYSSTATUS[EXTRSTPINDIS] Bits */
+#define SYSCTL_SYSSTATUS_EXTRSTPINDIS_OFS        (12)                            /* !< EXTRSTPINDIS Offset */
+#define SYSCTL_SYSSTATUS_EXTRSTPINDIS_MASK       ((uint32_t)0x00001000U)         /* !< EXTRSTPINDIS indicates when user
+                                                                                    has disabled the use of external
+                                                                                    reset pin */
+#define SYSCTL_SYSSTATUS_EXTRSTPINDIS_FALSE      ((uint32_t)0x00000000U)         /* !< External Reset Pin Enabled */
+#define SYSCTL_SYSSTATUS_EXTRSTPINDIS_TRUE       ((uint32_t)0x00001000U)         /* !< External Reset Pin Disabled */
+/* SYSCTL_SYSSTATUS[PMUIREFGOOD] Bits */
+#define SYSCTL_SYSSTATUS_PMUIREFGOOD_OFS         (6)                             /* !< PMUIREFGOOD Offset */
+#define SYSCTL_SYSSTATUS_PMUIREFGOOD_MASK        ((uint32_t)0x00000040U)         /* !< PMUIREFGOOD is set by hardware when
+                                                                                    the PMU current reference is ready. */
+#define SYSCTL_SYSSTATUS_PMUIREFGOOD_FALSE       ((uint32_t)0x00000000U)         /* !< IREF is not ready */
+#define SYSCTL_SYSSTATUS_PMUIREFGOOD_TRUE        ((uint32_t)0x00000040U)         /* !< IREF is ready */
+/* SYSCTL_SYSSTATUS[SWDCFGDIS] Bits */
+#define SYSCTL_SYSSTATUS_SWDCFGDIS_OFS           (13)                            /* !< SWDCFGDIS Offset */
+#define SYSCTL_SYSSTATUS_SWDCFGDIS_MASK          ((uint32_t)0x00002000U)         /* !< SWDCFGDIS indicates when user has
+                                                                                    disabled the use of SWD Port */
+#define SYSCTL_SYSSTATUS_SWDCFGDIS_FALSE         ((uint32_t)0x00000000U)         /* !< SWD Port Enabled */
+#define SYSCTL_SYSSTATUS_SWDCFGDIS_TRUE          ((uint32_t)0x00002000U)         /* !< SWD Port Disabled */
+/* SYSCTL_SYSSTATUS[ANACPUMPGOOD] Bits */
+#define SYSCTL_SYSSTATUS_ANACPUMPGOOD_OFS        (5)                             /* !< ANACPUMPGOOD Offset */
+#define SYSCTL_SYSSTATUS_ANACPUMPGOOD_MASK       ((uint32_t)0x00000020U)         /* !< ANACPUMPGOOD is set by hardware
+                                                                                    when the VBOOST analog mux charge
+                                                                                    pump is ready. */
+#define SYSCTL_SYSSTATUS_ANACPUMPGOOD_FALSE      ((uint32_t)0x00000000U)         /* !< VBOOST is not ready */
+#define SYSCTL_SYSSTATUS_ANACPUMPGOOD_TRUE       ((uint32_t)0x00000020U)         /* !< VBOOST is ready */
+/* SYSCTL_SYSSTATUS[REBOOTATTEMPTS] Bits */
+#define SYSCTL_SYSSTATUS_REBOOTATTEMPTS_OFS      (30)                            /* !< REBOOTATTEMPTS Offset */
+#define SYSCTL_SYSSTATUS_REBOOTATTEMPTS_MASK     ((uint32_t)0xC0000000U)         /* !< REBOOTATTEMPTS indicates the number
+                                                                                    of boot attempts taken before the
+                                                                                    user application starts. */
+/* SYSCTL_SYSSTATUS[BORLVL] Bits */
+#define SYSCTL_SYSSTATUS_BORLVL_OFS              (4)                             /* !< BORLVL Offset */
+#define SYSCTL_SYSSTATUS_BORLVL_MASK             ((uint32_t)0x00000010U)         /* !< BORLVL indicates if a BOR event
+                                                                                    occured and the BOR threshold was
+                                                                                    switched to BOR0 by hardware. */
+#define SYSCTL_SYSSTATUS_BORLVL_FALSE            ((uint32_t)0x00000000U)         /* !< No BOR violation occured */
+#define SYSCTL_SYSSTATUS_BORLVL_TRUE             ((uint32_t)0x00000010U)         /* !< A BOR violation occured and the BOR
+                                                                                    threshold was switched to BOR0 */
+/* SYSCTL_SYSSTATUS[MCAN0READY] Bits */
+#define SYSCTL_SYSSTATUS_MCAN0READY_OFS          (8)                             /* !< MCAN0READY Offset */
+#define SYSCTL_SYSSTATUS_MCAN0READY_MASK         ((uint32_t)0x00000100U)         /* !< MCAN0READY indicates when the MCAN0
+                                                                                    peripheral is ready. */
+#define SYSCTL_SYSSTATUS_MCAN0READY_FALSE        ((uint32_t)0x00000000U)         /* !< MCAN0 is not ready */
+#define SYSCTL_SYSSTATUS_MCAN0READY_TRUE         ((uint32_t)0x00000100U)         /* !< MCAN0 is ready */
+/* SYSCTL_SYSSTATUS[FLASHDED] Bits */
+#define SYSCTL_SYSSTATUS_FLASHDED_OFS            (0)                             /* !< FLASHDED Offset */
+#define SYSCTL_SYSSTATUS_FLASHDED_MASK           ((uint32_t)0x00000001U)         /* !< FLASHDED indicates if a flash ECC
+                                                                                    double bit error was detected (DED). */
+#define SYSCTL_SYSSTATUS_FLASHDED_FALSE          ((uint32_t)0x00000000U)         /* !< No flash ECC double bit error
+                                                                                    detected */
+#define SYSCTL_SYSSTATUS_FLASHDED_TRUE           ((uint32_t)0x00000001U)         /* !< Flash ECC double bit error detected */
+/* SYSCTL_SYSSTATUS[FLASHSEC] Bits */
+#define SYSCTL_SYSSTATUS_FLASHSEC_OFS            (1)                             /* !< FLASHSEC Offset */
+#define SYSCTL_SYSSTATUS_FLASHSEC_MASK           ((uint32_t)0x00000002U)         /* !< FLASHSEC indicates if a flash ECC
+                                                                                    single bit error was detected and
+                                                                                    corrected (SEC). */
+#define SYSCTL_SYSSTATUS_FLASHSEC_FALSE          ((uint32_t)0x00000000U)         /* !< No flash ECC single bit error
+                                                                                    detected */
+#define SYSCTL_SYSSTATUS_FLASHSEC_TRUE           ((uint32_t)0x00000002U)         /* !< Flash ECC single bit error was
+                                                                                    detected and corrected */
+/* SYSCTL_SYSSTATUS[BORCURTHRESHOLD] Bits */
+#define SYSCTL_SYSSTATUS_BORCURTHRESHOLD_OFS     (2)                             /* !< BORCURTHRESHOLD Offset */
+#define SYSCTL_SYSSTATUS_BORCURTHRESHOLD_MASK    ((uint32_t)0x0000000CU)         /* !< BORCURTHRESHOLD indicates the
+                                                                                    active brown-out reset supply monitor
+                                                                                    configuration. */
+#define SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORMIN  ((uint32_t)0x00000000U)         /* !< Default minimum threshold; a BOR0-
+                                                                                    violation triggers a BOR */
+#define SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVEL1 ((uint32_t)0x00000004U)         /* !< A BOR1- violation generates a
+                                                                                    BORLVL interrupt */
+#define SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVEL2 ((uint32_t)0x00000008U)         /* !< A BOR2- violation generates a
+                                                                                    BORLVL interrupt */
+#define SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVEL3 ((uint32_t)0x0000000CU)         /* !< A BOR3- violation generates a
+                                                                                    BORLVL interrupt */
+
+/* SYSCTL_DEDERRADDR Bits */
+/* SYSCTL_DEDERRADDR[ADDR] Bits */
+#define SYSCTL_DEDERRADDR_ADDR_OFS               (0)                             /* !< ADDR Offset */
+#define SYSCTL_DEDERRADDR_ADDR_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< Address of MEMORY DED Error. */
+
+/* SYSCTL_RSTCAUSE Bits */
+/* SYSCTL_RSTCAUSE[ID] Bits */
+#define SYSCTL_RSTCAUSE_ID_OFS                   (0)                             /* !< ID Offset */
+#define SYSCTL_RSTCAUSE_ID_MASK                  ((uint32_t)0x0000001FU)         /* !< ID is a read-to-clear field which
+                                                                                    indicates the lowest level reset
+                                                                                    cause since the last read. */
+#define SYSCTL_RSTCAUSE_ID_NORST                 ((uint32_t)0x00000000U)         /* !< No reset since last read */
+#define SYSCTL_RSTCAUSE_ID_PORHWFAIL             ((uint32_t)0x00000001U)         /* !< POR- violation, SHUTDNSTOREx or PMU
+                                                                                    trim parity fault */
+#define SYSCTL_RSTCAUSE_ID_POREXNRST             ((uint32_t)0x00000002U)         /* !< NRST triggered POR (>1s hold) */
+#define SYSCTL_RSTCAUSE_ID_PORSW                 ((uint32_t)0x00000003U)         /* !< Software triggered POR */
+#define SYSCTL_RSTCAUSE_ID_BORSUPPLY             ((uint32_t)0x00000004U)         /* !< BOR0- violation */
+#define SYSCTL_RSTCAUSE_ID_BORWAKESHUTDN         ((uint32_t)0x00000005U)         /* !< SHUTDOWN mode exit */
+#define SYSCTL_RSTCAUSE_ID_BOOTNONPMUPARITY      ((uint32_t)0x00000008U)         /* !< Non-PMU trim parity fault */
+#define SYSCTL_RSTCAUSE_ID_BOOTCLKFAIL           ((uint32_t)0x00000009U)         /* !< Fatal clock failure */
+#define SYSCTL_RSTCAUSE_ID_BOOTEXNRST            ((uint32_t)0x0000000CU)         /* !< NRST triggered BOOTRST (<1s hold) */
+#define SYSCTL_RSTCAUSE_ID_BOOTSW                ((uint32_t)0x0000000DU)         /* !< Software triggered BOOTRST */
+#define SYSCTL_RSTCAUSE_ID_SYSWWDT0              ((uint32_t)0x0000000EU)         /* !< WWDT0 violation */
+#define SYSCTL_RSTCAUSE_ID_SYSBSLEXIT            ((uint32_t)0x00000010U)         /* !< BSL exit */
+#define SYSCTL_RSTCAUSE_ID_SYSBSLENTRY           ((uint32_t)0x00000011U)         /* !< BSL entry */
+#define SYSCTL_RSTCAUSE_ID_SYSWWDT1              ((uint32_t)0x00000013U)         /* !< WWDT1 violation */
+#define SYSCTL_RSTCAUSE_ID_SYSFLASHECC           ((uint32_t)0x00000014U)         /* !< Flash uncorrectable ECC error */
+#define SYSCTL_RSTCAUSE_ID_SYSCPULOCK            ((uint32_t)0x00000015U)         /* !< CPULOCK violation */
+#define SYSCTL_RSTCAUSE_ID_SYSDBG                ((uint32_t)0x0000001AU)         /* !< Debug triggered SYSRST */
+#define SYSCTL_RSTCAUSE_ID_SYSSW                 ((uint32_t)0x0000001BU)         /* !< Software triggered SYSRST */
+#define SYSCTL_RSTCAUSE_ID_CPUDBG                ((uint32_t)0x0000001CU)         /* !< Debug triggered CPURST */
+#define SYSCTL_RSTCAUSE_ID_CPUSW                 ((uint32_t)0x0000001DU)         /* !< Software triggered CPURST */
+
+/* SYSCTL_RESETLEVEL Bits */
+/* SYSCTL_RESETLEVEL[LEVEL] Bits */
+#define SYSCTL_RESETLEVEL_LEVEL_OFS              (0)                             /* !< LEVEL Offset */
+#define SYSCTL_RESETLEVEL_LEVEL_MASK             ((uint32_t)0x00000007U)         /* !< LEVEL is used to specify the type
+                                                                                    of reset to be issued when RESETCMD
+                                                                                    is set to generate a software
+                                                                                    triggered reset. */
+#define SYSCTL_RESETLEVEL_LEVEL_CPU              ((uint32_t)0x00000000U)         /* !< Issue a SYSRST (CPU plus
+                                                                                    peripherals only) */
+#define SYSCTL_RESETLEVEL_LEVEL_BOOT             ((uint32_t)0x00000001U)         /* !< Issue a BOOTRST (CPU, peripherals,
+                                                                                    and boot configuration routine) */
+#define SYSCTL_RESETLEVEL_LEVEL_BOOTLOADERENTRY  ((uint32_t)0x00000002U)         /* !< Issue a SYSRST and enter the boot
+                                                                                    strap loader (BSL) */
+#define SYSCTL_RESETLEVEL_LEVEL_POR              ((uint32_t)0x00000003U)         /* !< Issue a power-on reset (POR) */
+#define SYSCTL_RESETLEVEL_LEVEL_BOOTLOADEREXIT   ((uint32_t)0x00000004U)         /* !< Issue a SYSRST and exit the boot
+                                                                                    strap loader (BSL) */
+
+/* SYSCTL_RESETCMD Bits */
+/* SYSCTL_RESETCMD[KEY] Bits */
+#define SYSCTL_RESETCMD_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define SYSCTL_RESETCMD_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< The key value of E4h (228) must be
+                                                                                    written to KEY together with GO to
+                                                                                    trigger the reset. */
+#define SYSCTL_RESETCMD_KEY_VALUE                ((uint32_t)0xE4000000U)         /* !< Issue reset */
+/* SYSCTL_RESETCMD[GO] Bits */
+#define SYSCTL_RESETCMD_GO_OFS                   (0)                             /* !< GO Offset */
+#define SYSCTL_RESETCMD_GO_MASK                  ((uint32_t)0x00000001U)         /* !< Execute the reset specified in
+                                                                                    RESETLEVEL.LEVEL.  Must be written
+                                                                                    together with the KEY. */
+#define SYSCTL_RESETCMD_GO_TRUE                  ((uint32_t)0x00000001U)         /* !< Issue reset */
+
+/* SYSCTL_BORTHRESHOLD Bits */
+/* SYSCTL_BORTHRESHOLD[LEVEL] Bits */
+#define SYSCTL_BORTHRESHOLD_LEVEL_OFS            (0)                             /* !< LEVEL Offset */
+#define SYSCTL_BORTHRESHOLD_LEVEL_MASK           ((uint32_t)0x00000003U)         /* !< LEVEL specifies the desired BOR
+                                                                                    threshold and BOR mode. */
+#define SYSCTL_BORTHRESHOLD_LEVEL_BORMIN         ((uint32_t)0x00000000U)         /* !< Default minimum threshold; a BOR0-
+                                                                                    violation triggers a BOR */
+#define SYSCTL_BORTHRESHOLD_LEVEL_BORLEVEL1      ((uint32_t)0x00000001U)         /* !< A BOR1- violation generates a
+                                                                                    BORLVL interrupt */
+#define SYSCTL_BORTHRESHOLD_LEVEL_BORLEVEL2      ((uint32_t)0x00000002U)         /* !< A BOR2- violation generates a
+                                                                                    BORLVL interrupt */
+#define SYSCTL_BORTHRESHOLD_LEVEL_BORLEVEL3      ((uint32_t)0x00000003U)         /* !< A BOR3- violation generates a
+                                                                                    BORLVL interrupt */
+
+/* SYSCTL_BORCLRCMD Bits */
+/* SYSCTL_BORCLRCMD[KEY] Bits */
+#define SYSCTL_BORCLRCMD_KEY_OFS                 (24)                            /* !< KEY Offset */
+#define SYSCTL_BORCLRCMD_KEY_MASK                ((uint32_t)0xFF000000U)         /* !< The key value of C7h (199) must be
+                                                                                    written to KEY together with GO to
+                                                                                    trigger the clear and BOR threshold
+                                                                                    change. */
+#define SYSCTL_BORCLRCMD_KEY_VALUE               ((uint32_t)0xC7000000U)         /* !< Issue clear */
+/* SYSCTL_BORCLRCMD[GO] Bits */
+#define SYSCTL_BORCLRCMD_GO_OFS                  (0)                             /* !< GO Offset */
+#define SYSCTL_BORCLRCMD_GO_MASK                 ((uint32_t)0x00000001U)         /* !< GO clears any prior BOR violation
+                                                                                    status indications and attempts to
+                                                                                    change the active BOR mode to that
+                                                                                    specified in the LEVEL field of the
+                                                                                    BORTHRESHOLD register. */
+#define SYSCTL_BORCLRCMD_GO_TRUE                 ((uint32_t)0x00000001U)         /* !< Issue clear */
+
+/* SYSCTL_SYSOSCFCLCTL Bits */
+/* SYSCTL_SYSOSCFCLCTL[KEY] Bits */
+#define SYSCTL_SYSOSCFCLCTL_KEY_OFS              (24)                            /* !< KEY Offset */
+#define SYSCTL_SYSOSCFCLCTL_KEY_MASK             ((uint32_t)0xFF000000U)         /* !< The key value of 2Ah (42) must be
+                                                                                    written to KEY together with
+                                                                                    SETUSEFCL to enable the FCL. */
+#define SYSCTL_SYSOSCFCLCTL_KEY_VALUE            ((uint32_t)0x2A000000U)         /* !< Issue Command */
+/* SYSCTL_SYSOSCFCLCTL[SETUSEFCL] Bits */
+#define SYSCTL_SYSOSCFCLCTL_SETUSEFCL_OFS        (0)                             /* !< SETUSEFCL Offset */
+#define SYSCTL_SYSOSCFCLCTL_SETUSEFCL_MASK       ((uint32_t)0x00000001U)         /* !< Set SETUSEFCL to enable the
+                                                                                    frequency correction loop in SYSOSC.
+                                                                                    Once enabled, this state is locked
+                                                                                    until the next BOOTRST. */
+#define SYSCTL_SYSOSCFCLCTL_SETUSEFCL_TRUE       ((uint32_t)0x00000001U)         /* !< Enable the SYSOSC FCL */
+/* SYSCTL_SYSOSCFCLCTL[SETUSEEXRES] Bits */
+#define SYSCTL_SYSOSCFCLCTL_SETUSEEXRES_OFS      (1)                             /* !< SETUSEEXRES Offset */
+#define SYSCTL_SYSOSCFCLCTL_SETUSEEXRES_MASK     ((uint32_t)0x00000002U)         /* !< Set SETUSEEXRES to specify that an
+                                                                                    external resistor will be used for
+                                                                                    the FCL.  An appropriate resistor
+                                                                                    must be populated on the ROSC pin.
+                                                                                    This state is locked until the next
+                                                                                    BOOTRST. */
+#define SYSCTL_SYSOSCFCLCTL_SETUSEEXRES_TRUE     ((uint32_t)0x00000002U)         /* !< Enable the SYSOSC external Resistor */
+
+/* SYSCTL_LFXTCTL Bits */
+/* SYSCTL_LFXTCTL[KEY] Bits */
+#define SYSCTL_LFXTCTL_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define SYSCTL_LFXTCTL_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< The key value of 91h (145) must be
+                                                                                    written to KEY together with either
+                                                                                    STARTLFXT or SETUSELFXT to set the
+                                                                                    corresponding bit. */
+#define SYSCTL_LFXTCTL_KEY_VALUE                 ((uint32_t)0x91000000U)         /* !< Issue command */
+/* SYSCTL_LFXTCTL[SETUSELFXT] Bits */
+#define SYSCTL_LFXTCTL_SETUSELFXT_OFS            (1)                             /* !< SETUSELFXT Offset */
+#define SYSCTL_LFXTCTL_SETUSELFXT_MASK           ((uint32_t)0x00000002U)         /* !< Set SETUSELFXT to switch LFCLK to
+                                                                                    LFXT.  Once set, SETUSELFXT remains
+                                                                                    set until the next BOOTRST. */
+#define SYSCTL_LFXTCTL_SETUSELFXT_FALSE          ((uint32_t)0x00000000U)
+#define SYSCTL_LFXTCTL_SETUSELFXT_TRUE           ((uint32_t)0x00000002U)         /* !< Use LFXT as the LFCLK source */
+/* SYSCTL_LFXTCTL[STARTLFXT] Bits */
+#define SYSCTL_LFXTCTL_STARTLFXT_OFS             (0)                             /* !< STARTLFXT Offset */
+#define SYSCTL_LFXTCTL_STARTLFXT_MASK            ((uint32_t)0x00000001U)         /* !< Set STARTLFXT to start the low
+                                                                                    frequency crystal oscillator (LFXT).
+                                                                                    Once set, STARTLFXT remains set until
+                                                                                    the next BOOTRST. */
+#define SYSCTL_LFXTCTL_STARTLFXT_FALSE           ((uint32_t)0x00000000U)         /* !< LFXT not started */
+#define SYSCTL_LFXTCTL_STARTLFXT_TRUE            ((uint32_t)0x00000001U)         /* !< Start LFXT */
+
+/* SYSCTL_EXLFCTL Bits */
+/* SYSCTL_EXLFCTL[KEY] Bits */
+#define SYSCTL_EXLFCTL_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define SYSCTL_EXLFCTL_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< The key value of 36h (54) must be
+                                                                                    written to KEY together with
+                                                                                    SETUSEEXLF to set SETUSEEXLF. */
+#define SYSCTL_EXLFCTL_KEY_VALUE                 ((uint32_t)0x36000000U)         /* !< Issue command */
+/* SYSCTL_EXLFCTL[SETUSEEXLF] Bits */
+#define SYSCTL_EXLFCTL_SETUSEEXLF_OFS            (0)                             /* !< SETUSEEXLF Offset */
+#define SYSCTL_EXLFCTL_SETUSEEXLF_MASK           ((uint32_t)0x00000001U)         /* !< Set SETUSEEXLF to switch LFCLK to
+                                                                                    the LFCLK_IN digital clock input.
+                                                                                    Once set, SETUSEEXLF remains set
+                                                                                    until the next BOOTRST. */
+#define SYSCTL_EXLFCTL_SETUSEEXLF_TRUE           ((uint32_t)0x00000001U)         /* !< Use LFCLK_IN as the LFCLK source */
+
+/* SYSCTL_SHDNIOREL Bits */
+/* SYSCTL_SHDNIOREL[KEY] Bits */
+#define SYSCTL_SHDNIOREL_KEY_OFS                 (24)                            /* !< KEY Offset */
+#define SYSCTL_SHDNIOREL_KEY_MASK                ((uint32_t)0xFF000000U)         /* !< The key value 91h must be written
+                                                                                    to KEY together with RELEASE to set
+                                                                                    RELEASE. */
+#define SYSCTL_SHDNIOREL_KEY_VALUE               ((uint32_t)0x91000000U)         /* !< Issue command */
+/* SYSCTL_SHDNIOREL[RELEASE] Bits */
+#define SYSCTL_SHDNIOREL_RELEASE_OFS             (0)                             /* !< RELEASE Offset */
+#define SYSCTL_SHDNIOREL_RELEASE_MASK            ((uint32_t)0x00000001U)         /* !< Set RELEASE to release the IO after
+                                                                                    a SHUTDOWN mode exit. */
+#define SYSCTL_SHDNIOREL_RELEASE_TRUE            ((uint32_t)0x00000001U)         /* !< Release IO */
+
+/* SYSCTL_EXRSTPIN Bits */
+/* SYSCTL_EXRSTPIN[KEY] Bits */
+#define SYSCTL_EXRSTPIN_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define SYSCTL_EXRSTPIN_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< The key value 1Eh must be written
+                                                                                    together with DISABLE to disable the
+                                                                                    reset function. */
+#define SYSCTL_EXRSTPIN_KEY_VALUE                ((uint32_t)0x1E000000U)         /* !< Issue command */
+/* SYSCTL_EXRSTPIN[DISABLE] Bits */
+#define SYSCTL_EXRSTPIN_DISABLE_OFS              (0)                             /* !< DISABLE Offset */
+#define SYSCTL_EXRSTPIN_DISABLE_MASK             ((uint32_t)0x00000001U)         /* !< Set DISABLE to disable the reset
+                                                                                    function of the NRST pin.  Once set,
+                                                                                    this configuration is locked until
+                                                                                    the next POR. */
+#define SYSCTL_EXRSTPIN_DISABLE_FALSE            ((uint32_t)0x00000000U)         /* !< Reset function of NRST pin is
+                                                                                    enabled */
+#define SYSCTL_EXRSTPIN_DISABLE_TRUE             ((uint32_t)0x00000001U)         /* !< Reset function of NRST pin is
+                                                                                    disabled */
+
+/* SYSCTL_SYSSTATUSCLR Bits */
+/* SYSCTL_SYSSTATUSCLR[KEY] Bits */
+#define SYSCTL_SYSSTATUSCLR_KEY_OFS              (24)                            /* !< KEY Offset */
+#define SYSCTL_SYSSTATUSCLR_KEY_MASK             ((uint32_t)0xFF000000U)         /* !< The key value CEh (206) must be
+                                                                                    written to KEY together with ALLECC
+                                                                                    to clear the ECC state. */
+#define SYSCTL_SYSSTATUSCLR_KEY_VALUE            ((uint32_t)0xCE000000U)         /* !< Issue command */
+/* SYSCTL_SYSSTATUSCLR[ALLECC] Bits */
+#define SYSCTL_SYSSTATUSCLR_ALLECC_OFS           (0)                             /* !< ALLECC Offset */
+#define SYSCTL_SYSSTATUSCLR_ALLECC_MASK          ((uint32_t)0x00000001U)         /* !< Set ALLECC to clear all ECC related
+                                                                                    SYSSTATUS indicators. */
+#define SYSCTL_SYSSTATUSCLR_ALLECC_CLEAR         ((uint32_t)0x00000001U)         /* !< Clear ECC error state */
+
+/* SYSCTL_SWDCFG Bits */
+/* SYSCTL_SWDCFG[KEY] Bits */
+#define SYSCTL_SWDCFG_KEY_OFS                    (24)                            /* !< KEY Offset */
+#define SYSCTL_SWDCFG_KEY_MASK                   ((uint32_t)0xFF000000U)         /* !< The key value 62h (98) must be
+                                                                                    written to KEY together with DISBALE
+                                                                                    to disable the SWD functions. */
+#define SYSCTL_SWDCFG_KEY_VALUE                  ((uint32_t)0x62000000U)         /* !< Issue command */
+/* SYSCTL_SWDCFG[DISABLE] Bits */
+#define SYSCTL_SWDCFG_DISABLE_OFS                (0)                             /* !< DISABLE Offset */
+#define SYSCTL_SWDCFG_DISABLE_MASK               ((uint32_t)0x00000001U)         /* !< Set DISABLE to disable the SWD
+                                                                                    function on SWD pins, allowing the
+                                                                                    SWD pins to be used as GPIO. */
+#define SYSCTL_SWDCFG_DISABLE_TRUE               ((uint32_t)0x00000001U)         /* !< Disable SWD function on SWD pins */
+
+/* SYSCTL_FCCCMD Bits */
+/* SYSCTL_FCCCMD[KEY] Bits */
+#define SYSCTL_FCCCMD_KEY_OFS                    (24)                            /* !< KEY Offset */
+#define SYSCTL_FCCCMD_KEY_MASK                   ((uint32_t)0xFF000000U)         /* !< The key value 0Eh (14) must be
+                                                                                    written with GO to start a capture. */
+#define SYSCTL_FCCCMD_KEY_VALUE                  ((uint32_t)0x0E000000U)         /* !< Issue command */
+/* SYSCTL_FCCCMD[GO] Bits */
+#define SYSCTL_FCCCMD_GO_OFS                     (0)                             /* !< GO Offset */
+#define SYSCTL_FCCCMD_GO_MASK                    ((uint32_t)0x00000001U)         /* !< Set GO to start a capture with the
+                                                                                    frequency clock counter (FCC). */
+#define SYSCTL_FCCCMD_GO_TRUE                    ((uint32_t)0x00000001U)
+
+/* SYSCTL_PMUOPAMP Bits */
+/* SYSCTL_PMUOPAMP[RRI] Bits */
+#define SYSCTL_PMUOPAMP_RRI_OFS                  (4)                             /* !< RRI Offset */
+#define SYSCTL_PMUOPAMP_RRI_MASK                 ((uint32_t)0x00000030U)         /* !< RRI selects the rail-to-rail input
+                                                                                    mode. */
+#define SYSCTL_PMUOPAMP_RRI_MODE0                ((uint32_t)0x00000000U)         /* !< PMOS input pairs */
+#define SYSCTL_PMUOPAMP_RRI_MODE1                ((uint32_t)0x00000010U)         /* !< NMOS input pairs */
+#define SYSCTL_PMUOPAMP_RRI_MODE2                ((uint32_t)0x00000020U)         /* !< Rail-to-rail mode */
+#define SYSCTL_PMUOPAMP_RRI_MODE3                ((uint32_t)0x00000030U)         /* !< Rail-to-rail mode */
+/* SYSCTL_PMUOPAMP[NSEL] Bits */
+#define SYSCTL_PMUOPAMP_NSEL_OFS                 (2)                             /* !< NSEL Offset */
+#define SYSCTL_PMUOPAMP_NSEL_MASK                ((uint32_t)0x0000000CU)         /* !< NSEL selects the GPAMP negative
+                                                                                    channel input. */
+#define SYSCTL_PMUOPAMP_NSEL_SEL0                ((uint32_t)0x00000000U)         /* !< GPAMP_OUT pin connected to negative
+                                                                                    channel */
+#define SYSCTL_PMUOPAMP_NSEL_SEL1                ((uint32_t)0x00000004U)         /* !< GPAMP_IN- pin connected to negative
+                                                                                    channel */
+#define SYSCTL_PMUOPAMP_NSEL_SEL2                ((uint32_t)0x00000008U)         /* !< GPAMP_OUT signal connected to
+                                                                                    negative channel */
+#define SYSCTL_PMUOPAMP_NSEL_SEL3                ((uint32_t)0x0000000CU)         /* !< No channel selected */
+/* SYSCTL_PMUOPAMP[CHOPCLKMODE] Bits */
+#define SYSCTL_PMUOPAMP_CHOPCLKMODE_OFS          (10)                            /* !< CHOPCLKMODE Offset */
+#define SYSCTL_PMUOPAMP_CHOPCLKMODE_MASK         ((uint32_t)0x00000C00U)         /* !< CHOPCLKMODE selects the GPAMP
+                                                                                    chopping mode. */
+#define SYSCTL_PMUOPAMP_CHOPCLKMODE_CHOPDISABLED ((uint32_t)0x00000000U)         /* !< Chopping disabled */
+#define SYSCTL_PMUOPAMP_CHOPCLKMODE_REGCHOP      ((uint32_t)0x00000400U)         /* !< Normal chopping */
+#define SYSCTL_PMUOPAMP_CHOPCLKMODE_ADCASSIST    ((uint32_t)0x00000800U)         /* !< ADC Assisted chopping */
+/* SYSCTL_PMUOPAMP[OUTENABLE] Bits */
+#define SYSCTL_PMUOPAMP_OUTENABLE_OFS            (6)                             /* !< OUTENABLE Offset */
+#define SYSCTL_PMUOPAMP_OUTENABLE_MASK           ((uint32_t)0x00000040U)         /* !< Set OUTENABLE to connect the GPAMP
+                                                                                    output signal to the GPAMP_OUT pin */
+#define SYSCTL_PMUOPAMP_OUTENABLE_FALSE          ((uint32_t)0x00000000U)         /* !< GPAMP_OUT signal is not connected
+                                                                                    to the GPAMP_OUT pin */
+#define SYSCTL_PMUOPAMP_OUTENABLE_TRUE           ((uint32_t)0x00000040U)         /* !< GPAMP_OUT signal is connected to
+                                                                                    the GPAMP_OUT pin */
+/* SYSCTL_PMUOPAMP[ENABLE] Bits */
+#define SYSCTL_PMUOPAMP_ENABLE_OFS               (0)                             /* !< ENABLE Offset */
+#define SYSCTL_PMUOPAMP_ENABLE_MASK              ((uint32_t)0x00000001U)         /* !< Set ENABLE to turn on the GPAMP. */
+#define SYSCTL_PMUOPAMP_ENABLE_FALSE             ((uint32_t)0x00000000U)         /* !< GPAMP is disabled */
+#define SYSCTL_PMUOPAMP_ENABLE_TRUE              ((uint32_t)0x00000001U)         /* !< GPAMP is enabled */
+/* SYSCTL_PMUOPAMP[CHOPCLKFREQ] Bits */
+#define SYSCTL_PMUOPAMP_CHOPCLKFREQ_OFS          (8)                             /* !< CHOPCLKFREQ Offset */
+#define SYSCTL_PMUOPAMP_CHOPCLKFREQ_MASK         ((uint32_t)0x00000300U)         /* !< CHOPCLKFREQ selects the GPAMP
+                                                                                    chopping clock frequency */
+#define SYSCTL_PMUOPAMP_CHOPCLKFREQ_CLK16KHZ     ((uint32_t)0x00000000U)         /* !< 16kHz */
+#define SYSCTL_PMUOPAMP_CHOPCLKFREQ_CLK8KHZ      ((uint32_t)0x00000100U)         /* !< 8kHz */
+#define SYSCTL_PMUOPAMP_CHOPCLKFREQ_CLK4KHZ      ((uint32_t)0x00000200U)         /* !< 4kHz */
+#define SYSCTL_PMUOPAMP_CHOPCLKFREQ_CLK2KHZ      ((uint32_t)0x00000300U)         /* !< 2kHz */
+/* SYSCTL_PMUOPAMP[PCHENABLE] Bits */
+#define SYSCTL_PMUOPAMP_PCHENABLE_OFS            (1)                             /* !< PCHENABLE Offset */
+#define SYSCTL_PMUOPAMP_PCHENABLE_MASK           ((uint32_t)0x00000002U)         /* !< Set PCHENABLE to enable the
+                                                                                    positive channel input. */
+#define SYSCTL_PMUOPAMP_PCHENABLE_FALSE          ((uint32_t)0x00000000U)         /* !< Positive channel disabled */
+#define SYSCTL_PMUOPAMP_PCHENABLE_TRUE           ((uint32_t)0x00000002U)         /* !< GPAMP_IN+ connected to positive
+                                                                                    channel */
+
+/* SYSCTL_SHUTDNSTORE0 Bits */
+/* SYSCTL_SHUTDNSTORE0[DATA] Bits */
+#define SYSCTL_SHUTDNSTORE0_DATA_OFS             (0)                             /* !< DATA Offset */
+#define SYSCTL_SHUTDNSTORE0_DATA_MASK            ((uint32_t)0x000000FFU)         /* !< Shutdown storage byte 0 */
+
+/* SYSCTL_SHUTDNSTORE1 Bits */
+/* SYSCTL_SHUTDNSTORE1[DATA] Bits */
+#define SYSCTL_SHUTDNSTORE1_DATA_OFS             (0)                             /* !< DATA Offset */
+#define SYSCTL_SHUTDNSTORE1_DATA_MASK            ((uint32_t)0x000000FFU)         /* !< Shutdown storage byte 1 */
+
+/* SYSCTL_SHUTDNSTORE2 Bits */
+/* SYSCTL_SHUTDNSTORE2[DATA] Bits */
+#define SYSCTL_SHUTDNSTORE2_DATA_OFS             (0)                             /* !< DATA Offset */
+#define SYSCTL_SHUTDNSTORE2_DATA_MASK            ((uint32_t)0x000000FFU)         /* !< Shutdown storage byte 2 */
+
+/* SYSCTL_SHUTDNSTORE3 Bits */
+/* SYSCTL_SHUTDNSTORE3[DATA] Bits */
+#define SYSCTL_SHUTDNSTORE3_DATA_OFS             (0)                             /* !< DATA Offset */
+#define SYSCTL_SHUTDNSTORE3_DATA_MASK            ((uint32_t)0x000000FFU)         /* !< Shutdown storage byte 3 */
+
+/* SYSCTL_MGMT_ADC12B4MSPS0_PWREN Bits */
+/* SYSCTL_MGMT_ADC12B4MSPS0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS0_PWREN_KEY_OFS   (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS0_PWREN_KEY_MASK  ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_ADC12B4MSPS0_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_ADC12B4MSPS0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS0_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_ADC12B4MSPS0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B4MSPS0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ADC12B4MSPS0_RSTCTL Bits */
+/* SYSCTL_MGMT_ADC12B4MSPS0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS0_RSTCTL_KEY_OFS  (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS0_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_ADC12B4MSPS0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_ADC12B4MSPS0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_ADC12B4MSPS0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_ADC12B4MSPS0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_ADC12B4MSPS0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG Bits */
+/* SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_KEY_OFS  (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_KEY_UNLOCK ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG[CCONSTOP] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_CCONSTOP_OFS (5)                             /* !< CCONSTOP Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_CCONSTOP_MASK ((uint32_t)0x00000020U)         /* !< Conversion Clock is ON during STOP
+                                                                                    Mode */
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_CCONSTOP_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_CCONSTOP_ENABLE ((uint32_t)0x00000020U)
+/* SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG[CCONRUN] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_CCONRUN_OFS (4)                             /* !< CCONRUN Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_CCONRUN_MASK ((uint32_t)0x00000010U)         /* !< Conversion Clock is ON during RUN
+                                                                                    Mode */
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_CCONRUN_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_CCONRUN_ENABLE ((uint32_t)0x00000010U)
+/* SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG[SAMPCLK] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_SAMPCLK_OFS (0)                             /* !< SAMPCLK Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_SAMPCLK_MASK ((uint32_t)0x00000003U)         /* !< Sample Window Clock */
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_SAMPCLK_ULPCLK ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_SAMPCLK_SYSOSC ((uint32_t)0x00000001U)
+#define SYSCTL_MGMT_ADC12B4MSPS0_CLKCFG_SAMPCLK_HFCLK ((uint32_t)0x00000002U)
+
+/* SYSCTL_MGMT_ADC12B4MSPS0_STAT Bits */
+/* SYSCTL_MGMT_ADC12B4MSPS0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_ADC12B4MSPS0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_ADC12B4MSPS0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_ADC12B4MSPS0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B4MSPS0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_m0p_hw_sysctl_mspm0g1x0x_g3x0x__include */

--- a/mspm0/source/ti/devices/msp/peripherals/m0p/sysctl/hw_sysctl_mspm0l122x_l222x.h
+++ b/mspm0/source/ti/devices/msp/peripherals/m0p/sysctl/hw_sysctl_mspm0l122x_l222x.h
@@ -1,0 +1,3185 @@
+/*****************************************************************************
+
+  Copyright (C) 2023 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ti_devices_msp_peripherals_m0p_hw_sysctl_mspm0l122x_l222x__include
+#define ti_devices_msp_peripherals_m0p_hw_sysctl_mspm0l122x_l222x__include
+
+/* This preliminary header file does not have a version number */
+/* MMR repo: https://bitbucket.itg.ti.com/projects/cmcu_msp65soc/repos/a2lcd */
+/* MMR revision: 23572d7fd2920103d261ffc0f6a29182e49c1f54 */
+/* Generator revision: c98c4ac511e2bd0d918c5d427bd46b7a359dacf1
+   (MInT: b82a4aedc3ad14af13277adb74bf98dc8019011e) */
+
+#ifndef __CORTEX_M
+  #ifdef __cplusplus
+    #define __I  volatile        /*!< Defines 'read only' permissions */
+  #else
+    #define __I  volatile const  /*!< Defines 'read only' permissions */
+  #endif
+  #define __O  volatile          /*!< Defines 'write only' permissions */
+  #define __IO  volatile         /*!< Defines 'read / write' permissions */
+
+  /* following defines should be used for structure members */
+  #define __IM  volatile const   /*! Defines 'read only' structure member permissions */
+  #define __OM  volatile         /*! Defines 'write only' structure member permissions */
+  #define __IOM  volatile        /*! Defines 'read / write' structure member permissions */
+#endif
+
+/* Use standard integer types with explicit width */
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined ( __CC_ARM )
+#pragma anon_unions
+#endif
+
+/******************************************************************************
+* SYSCTL Registers
+******************************************************************************/
+#define SYSCTL_MGMT_GPTIMER32B2CC0_OFS           ((uint32_t)0x00870800U)
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_OFS        ((uint32_t)0x00860800U)
+#define SYSCTL_MGMT_SPI1_OFS                     ((uint32_t)0x0046A800U)
+#define SYSCTL_MGMT_SPI0_OFS                     ((uint32_t)0x00468800U)
+#define SYSCTL_MGMT_TRNG_OFS                     ((uint32_t)0x00444800U)
+#define SYSCTL_MGMT_AES_OFS                      ((uint32_t)0x00442800U)
+#define SYSCTL_MGMT_CRC0_OFS                     ((uint32_t)0x00440800U)
+#define SYSCTL_MGMT_UARTADVLP1_OFS               ((uint32_t)0x0010A800U)
+#define SYSCTL_MGMT_UARTADVLP0_OFS               ((uint32_t)0x00108800U)
+#define SYSCTL_MGMT_UARTLP2_OFS                  ((uint32_t)0x00104800U)
+#define SYSCTL_MGMT_UARTLP1_OFS                  ((uint32_t)0x00102800U)
+#define SYSCTL_MGMT_UARTLP0_OFS                  ((uint32_t)0x00100800U)
+#define SYSCTL_MGMT_I2C2_OFS                     ((uint32_t)0x000F4800U)
+#define SYSCTL_MGMT_I2C1_OFS                     ((uint32_t)0x000F2800U)
+#define SYSCTL_MGMT_I2C0_OFS                     ((uint32_t)0x000F0800U)
+#define SYSCTL_MGMT_GPIO2_OFS                    ((uint32_t)0x000A4800U)
+#define SYSCTL_MGMT_GPIO1_OFS                    ((uint32_t)0x000A2800U)
+#define SYSCTL_MGMT_GPIO0_OFS                    ((uint32_t)0x000A0800U)
+#define SYSCTL_MGMT_RTC_OFS                      ((uint32_t)0x00094800U)
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_OFS      ((uint32_t)0x00090800U)
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_OFS       ((uint32_t)0x0008E800U)
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_OFS       ((uint32_t)0x0008C800U)
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_OFS         ((uint32_t)0x00084800U)
+#define SYSCTL_MGMT_WWDTLP0_OFS                  ((uint32_t)0x00080800U)
+#define SYSCTL_MGMT_LCD_OFS                      ((uint32_t)0x00070800U)
+#define SYSCTL_MGMT_VREF_OFS                     ((uint32_t)0x00030800U)
+#define SYSCTL_MGMT_ANACOMP0_OFS                 ((uint32_t)0x00008800U)
+#define SYSCTL_MGMT_ADC12B1MSPS0_OFS             ((uint32_t)0x00004800U)
+#define SYSCTL_SECCFG_OFS                        ((uint32_t)0x00003000U)
+#define SYSCTL_SOCLOCK_OFS                       ((uint32_t)0x00001000U)
+
+
+/** @addtogroup SYSCTL_MGMT_GPTIMER32B2CC0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00870800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00870804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00870814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPTIMER32B2CC0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPTIMER32B2CC0 */
+
+/** @addtogroup SYSCTL_MGMT_GPTIMER16BADV4CC0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00860800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00860804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00860814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPTIMER16BADV4CC0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPTIMER16BADV4CC0 */
+
+/** @addtogroup SYSCTL_MGMT_SPI1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x0046A800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x0046A804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x0046A808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x0046A814) IP State Register - Read Only */
+} SYSCTL_MGMT_SPI1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_SPI1 */
+
+/** @addtogroup SYSCTL_MGMT_SPI0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00468800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00468804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00468808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00468814) IP State Register - Read Only */
+} SYSCTL_MGMT_SPI0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_SPI0 */
+
+/** @addtogroup SYSCTL_MGMT_TRNG
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00444800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00444804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00444814) IP State Register - Read Only */
+} SYSCTL_MGMT_TRNG_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_TRNG */
+
+/** @addtogroup SYSCTL_MGMT_AES
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00442800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00442804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00442814) IP State Register - Read Only */
+} SYSCTL_MGMT_AES_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_AES */
+
+/** @addtogroup SYSCTL_MGMT_CRC0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00440800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00440804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00440814) IP State Register - Read Only */
+} SYSCTL_MGMT_CRC0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_CRC0 */
+
+/** @addtogroup SYSCTL_MGMT_UARTADVLP1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x0010A800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x0010A804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x0010A808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x0010A814) IP State Register - Read Only */
+} SYSCTL_MGMT_UARTADVLP1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_UARTADVLP1 */
+
+/** @addtogroup SYSCTL_MGMT_UARTADVLP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00108800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00108804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00108808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00108814) IP State Register - Read Only */
+} SYSCTL_MGMT_UARTADVLP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_UARTADVLP0 */
+
+/** @addtogroup SYSCTL_MGMT_UARTLP2
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00104800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00104804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00104808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00104814) IP State Register - Read Only */
+} SYSCTL_MGMT_UARTLP2_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_UARTLP2 */
+
+/** @addtogroup SYSCTL_MGMT_UARTLP1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00102800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00102804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00102808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00102814) IP State Register - Read Only */
+} SYSCTL_MGMT_UARTLP1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_UARTLP1 */
+
+/** @addtogroup SYSCTL_MGMT_UARTLP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00100800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00100804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00100808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00100814) IP State Register - Read Only */
+} SYSCTL_MGMT_UARTLP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_UARTLP0 */
+
+/** @addtogroup SYSCTL_MGMT_I2C2
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x000F4800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x000F4804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x000F4808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x000F4814) IP State Register - Read Only */
+} SYSCTL_MGMT_I2C2_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_I2C2 */
+
+/** @addtogroup SYSCTL_MGMT_I2C1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x000F2800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x000F2804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x000F2808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x000F2814) IP State Register - Read Only */
+} SYSCTL_MGMT_I2C1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_I2C1 */
+
+/** @addtogroup SYSCTL_MGMT_I2C0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x000F0800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x000F0804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x000F0808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x000F0814) IP State Register - Read Only */
+} SYSCTL_MGMT_I2C0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_I2C0 */
+
+/** @addtogroup SYSCTL_MGMT_GPIO2
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x000A4800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x000A4804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x000A4814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPIO2_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPIO2 */
+
+/** @addtogroup SYSCTL_MGMT_GPIO1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x000A2800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x000A2804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x000A2814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPIO1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPIO1 */
+
+/** @addtogroup SYSCTL_MGMT_GPIO0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x000A0800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x000A0804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x000A0814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPIO0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPIO0 */
+
+/** @addtogroup SYSCTL_MGMT_RTC
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[2];
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00094808) IP Clock Configuration Register */
+} SYSCTL_MGMT_RTC_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_RTC */
+
+/** @addtogroup SYSCTL_MGMT_GPTIMER16B2CCQEILP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00090800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00090804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00090814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPTIMER16B2CCQEILP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPTIMER16B2CCQEILP0 */
+
+/** @addtogroup SYSCTL_MGMT_GPTIMER16B2CCSPLP1
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x0008E800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x0008E804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x0008E814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPTIMER16B2CCSPLP1_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPTIMER16B2CCSPLP1 */
+
+/** @addtogroup SYSCTL_MGMT_GPTIMER16B2CCSPLP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x0008C800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x0008C804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x0008C814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPTIMER16B2CCSPLP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPTIMER16B2CCSPLP0 */
+
+/** @addtogroup SYSCTL_MGMT_GPTIMER16B2CCLP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00084800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00084804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00084814) IP State Register - Read Only */
+} SYSCTL_MGMT_GPTIMER16B2CCLP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_GPTIMER16B2CCLP0 */
+
+/** @addtogroup SYSCTL_MGMT_WWDTLP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00080800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00080804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00080814) IP State Register - Read Only */
+} SYSCTL_MGMT_WWDTLP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_WWDTLP0 */
+
+/** @addtogroup SYSCTL_MGMT_LCD
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00070800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00070804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00070814) IP State Register - Read Only */
+} SYSCTL_MGMT_LCD_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_LCD */
+
+/** @addtogroup SYSCTL_MGMT_VREF
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00030800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00030804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+       uint32_t RESERVED0[3];
+  __I  uint32_t STAT;                              /* !< (@ 0x00030814) IP State Register - Read Only */
+} SYSCTL_MGMT_VREF_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_VREF */
+
+/** @addtogroup SYSCTL_MGMT_ANACOMP0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00008800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00008804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00008808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00008814) IP State Register - Read Only */
+} SYSCTL_MGMT_ANACOMP0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_ANACOMP0 */
+
+/** @addtogroup SYSCTL_MGMT_ADC12B1MSPS0
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t PWREN;                             /* !< (@ 0x00004800) IP Enable Register */
+  __O  uint32_t RSTCTL;                            /* !< (@ 0x00004804) Power Control Register - Write Only Register,
+                                                      Always Read as 0 */
+  __IO uint32_t CLKCFG;                            /* !< (@ 0x00004808) IP Clock Configuration Register */
+       uint32_t RESERVED0[2];
+  __I  uint32_t STAT;                              /* !< (@ 0x00004814) IP State Register - Read Only */
+} SYSCTL_MGMT_ADC12B1MSPS0_Regs;
+
+/*@}*/ /* end of group SYSCTL_MGMT_ADC12B1MSPS0 */
+
+/** @addtogroup SYSCTL_SECCFG
+  @{
+*/
+
+typedef struct {
+  __IO uint32_t FWEPROTMAIN;                       /* !< (@ 0x00003000) 1 Sector Write-Erase per bit starting at address
+                                                      0x0 of flash */
+       uint32_t RESERVED0[5];
+  __IO uint32_t FRXPROTMAINSTART;                  /* !< (@ 0x00003018) Flash RX Protection Start Address */
+  __IO uint32_t FRXPROTMAINEND;                    /* !< (@ 0x0000301C) Flash RX Protection End Address */
+  __IO uint32_t FIPPROTMAINSTART;                  /* !< (@ 0x00003020) Flash IP Protection Start Address */
+  __IO uint32_t FIPPROTMAINEND;                    /* !< (@ 0x00003024) Flash IP Protection End Address */
+       uint32_t RESERVED1[4];
+  __O  uint32_t FLBANKSWPPOLICY;                   /* !< (@ 0x00003038) Flash Bank Swap Policy */
+  __O  uint32_t FLBANKSWP;                         /* !< (@ 0x0000303C) Flash MAIN bank address swap */
+       uint32_t RESERVED2;
+  __O  uint32_t FWENABLE;                          /* !< (@ 0x00003044) Security Firewall Enable Register */
+  __I  uint32_t SECSTATUS;                         /* !< (@ 0x00003048) Security Configuration  status */
+       uint32_t RESERVED3[5];
+  __O  uint32_t INITDONE;                          /* !< (@ 0x00003060) INITCODE PASS */
+} SYSCTL_SECCFG_Regs;
+
+/*@}*/ /* end of group SYSCTL_SECCFG */
+
+/** @addtogroup SYSCTL_SOCLOCK
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[8];
+  __I  uint32_t IIDX;                              /* !< (@ 0x00001020) SYSCTL interrupt index */
+       uint32_t RESERVED1;
+  __IO uint32_t IMASK;                             /* !< (@ 0x00001028) SYSCTL interrupt mask */
+       uint32_t RESERVED2;
+  __I  uint32_t RIS;                               /* !< (@ 0x00001030) SYSCTL raw interrupt status */
+       uint32_t RESERVED3;
+  __I  uint32_t MIS;                               /* !< (@ 0x00001038) SYSCTL masked interrupt status */
+       uint32_t RESERVED4;
+  __O  uint32_t ISET;                              /* !< (@ 0x00001040) SYSCTL interrupt set */
+       uint32_t RESERVED5;
+  __O  uint32_t ICLR;                              /* !< (@ 0x00001048) SYSCTL interrupt clear */
+       uint32_t RESERVED6;
+  __I  uint32_t NMIIIDX;                           /* !< (@ 0x00001050) NMI interrupt index */
+       uint32_t RESERVED7[3];
+  __I  uint32_t NMIRIS;                            /* !< (@ 0x00001060) NMI raw interrupt status */
+       uint32_t RESERVED8[3];
+  __O  uint32_t NMIISET;                           /* !< (@ 0x00001070) NMI interrupt set */
+       uint32_t RESERVED9;
+  __O  uint32_t NMIICLR;                           /* !< (@ 0x00001078) NMI interrupt clear */
+       uint32_t RESERVED10[33];
+  __IO uint32_t SYSOSCCFG;                         /* !< (@ 0x00001100) SYSOSC configuration */
+  __IO uint32_t MCLKCFG;                           /* !< (@ 0x00001104) Main clock (MCLK) configuration */
+  __IO uint32_t HSCLKEN;                           /* !< (@ 0x00001108) High-speed clock (HSCLK) source enable/disable */
+  __IO uint32_t HSCLKCFG;                          /* !< (@ 0x0000110C) High-speed clock (HSCLK) source selection */
+  __IO uint32_t HFCLKCLKCFG;                       /* !< (@ 0x00001110) High-frequency clock (HFCLK) configuration */
+  __IO uint32_t LFCLKCFG;                          /* !< (@ 0x00001114) Low frequency crystal oscillator (LFXT)
+                                                      configuration */
+       uint32_t RESERVED11[8];
+  __IO uint32_t GENCLKCFG;                         /* !< (@ 0x00001138) General clock configuration */
+  __IO uint32_t GENCLKEN;                          /* !< (@ 0x0000113C) General clock enable control */
+  __IO uint32_t PMODECFG;                          /* !< (@ 0x00001140) Power mode configuration */
+       uint32_t RESERVED12[3];
+  __I  uint32_t FCC;                               /* !< (@ 0x00001150) Frequency clock counter (FCC) count */
+       uint32_t RESERVED13[7];
+  __IO uint32_t SYSOSCTRIMUSER;                    /* !< (@ 0x00001170) SYSOSC user-specified trim */
+       uint32_t RESERVED14;
+  __IO uint32_t SRAMBOUNDARY;                      /* !< (@ 0x00001178) SRAM Write Boundary */
+       uint32_t RESERVED15;
+  __IO uint32_t SYSTEMCFG;                         /* !< (@ 0x00001180) System configuration */
+       uint32_t RESERVED16[31];
+  __IO uint32_t WRITELOCK;                         /* !< (@ 0x00001200) SYSCTL register write lockout */
+  __I  uint32_t CLKSTATUS;                         /* !< (@ 0x00001204) Clock module (CKM) status */
+  __I  uint32_t SYSSTATUS;                         /* !< (@ 0x00001208) System status information */
+  __I  uint32_t DEDERRADDR;                        /* !< (@ 0x0000120C) Memory DED Address */
+       uint32_t RESERVED17[4];
+  __I  uint32_t RSTCAUSE;                          /* !< (@ 0x00001220) Reset cause */
+       uint32_t RESERVED18[55];
+  __IO uint32_t RESETLEVEL;                        /* !< (@ 0x00001300) Reset level for application-triggered reset
+                                                      command */
+  __O  uint32_t RESETCMD;                          /* !< (@ 0x00001304) Execute an application-triggered reset command */
+  __IO uint32_t BORTHRESHOLD;                      /* !< (@ 0x00001308) BOR threshold selection */
+  __O  uint32_t BORCLRCMD;                         /* !< (@ 0x0000130C) Set the BOR threshold */
+  __O  uint32_t SYSOSCFCLCTL;                      /* !< (@ 0x00001310) SYSOSC frequency correction loop (FCL) ROSC enable */
+  __O  uint32_t LFXTCTL;                           /* !< (@ 0x00001314) LFXT and LFCLK control */
+  __O  uint32_t EXLFCTL;                           /* !< (@ 0x00001318) LFCLK_IN and LFCLK control */
+  __O  uint32_t SHDNIOREL;                         /* !< (@ 0x0000131C) SHUTDOWN IO release control */
+  __O  uint32_t EXRSTPIN;                          /* !< (@ 0x00001320) Disable the reset function of the NRST pin */
+  __O  uint32_t SYSSTATUSCLR;                      /* !< (@ 0x00001324) Clear sticky bits of SYSSTATUS */
+  __O  uint32_t SWDCFG;                            /* !< (@ 0x00001328) Disable the SWD function on the SWD pins */
+  __O  uint32_t FCCCMD;                            /* !< (@ 0x0000132C) Frequency clock counter start capture */
+       uint32_t RESERVED19[52];
+  __IO uint32_t SHUTDNSTORE0;                      /* !< (@ 0x00001400) Shutdown storage memory (byte 0) */
+  __IO uint32_t SHUTDNSTORE1;                      /* !< (@ 0x00001404) Shutdown storage memory (byte 1) */
+  __IO uint32_t SHUTDNSTORE2;                      /* !< (@ 0x00001408) Shutdown storage memory (byte 2) */
+  __IO uint32_t SHUTDNSTORE3;                      /* !< (@ 0x0000140C) Shutdown storage memory (byte 3) */
+} SYSCTL_SOCLOCK_Regs;
+
+/*@}*/ /* end of group SYSCTL_SOCLOCK */
+
+/** @addtogroup SYSCTL
+  @{
+*/
+
+typedef struct {
+       uint32_t RESERVED0[1024];
+  SYSCTL_SOCLOCK_Regs  SOCLOCK;                           /* !< (@ 0x00001000) SYSCTL SOCLOCK Region */
+       uint32_t RESERVED1[1788];
+  SYSCTL_SECCFG_Regs  SECCFG;                            /* !< (@ 0x00003000) SYSCTL SECCFG Region */
+       uint32_t RESERVED2[1511];
+  SYSCTL_MGMT_ADC12B1MSPS0_Regs  MGMT_ADC12B1MSPS0;                 /* !< (@ 0x00004800) SYSCTL Mgmt sub-region for IPD adc12b1msps0 */
+       uint32_t RESERVED3[4090];
+  SYSCTL_MGMT_ANACOMP0_Regs  MGMT_ANACOMP0;                     /* !< (@ 0x00008800) SYSCTL Mgmt sub-region for IPD anacomp0 */
+       uint32_t RESERVED4[40954];
+  SYSCTL_MGMT_VREF_Regs  MGMT_VREF;                         /* !< (@ 0x00030800) SYSCTL Mgmt sub-region for IPD vref */
+       uint32_t RESERVED5[65530];
+  SYSCTL_MGMT_LCD_Regs  MGMT_LCD;                          /* !< (@ 0x00070800) SYSCTL Mgmt sub-region for IPD lcd */
+       uint32_t RESERVED6[16378];
+  SYSCTL_MGMT_WWDTLP0_Regs  MGMT_WWDTLP0;                      /* !< (@ 0x00080800) SYSCTL Mgmt sub-region for IPD wwdtlp0 */
+       uint32_t RESERVED7[4090];
+  SYSCTL_MGMT_GPTIMER16B2CCLP0_Regs  MGMT_GPTIMER16B2CCLP0;             /* !< (@ 0x00084800) SYSCTL Mgmt sub-region for IPD gptimer16b2cclp0 */
+       uint32_t RESERVED8[8186];
+  SYSCTL_MGMT_GPTIMER16B2CCSPLP0_Regs  MGMT_GPTIMER16B2CCSPLP0;           /* !< (@ 0x0008C800) SYSCTL Mgmt sub-region for IPD gptimer16b2ccsplp0 */
+       uint32_t RESERVED9[2042];
+  SYSCTL_MGMT_GPTIMER16B2CCSPLP1_Regs  MGMT_GPTIMER16B2CCSPLP1;           /* !< (@ 0x0008E800) SYSCTL Mgmt sub-region for IPD gptimer16b2ccsplp1 */
+       uint32_t RESERVED10[2042];
+  SYSCTL_MGMT_GPTIMER16B2CCQEILP0_Regs  MGMT_GPTIMER16B2CCQEILP0;          /* !< (@ 0x00090800) SYSCTL Mgmt sub-region for IPD gptimer16b2ccqeilp0 */
+       uint32_t RESERVED11[4090];
+  SYSCTL_MGMT_RTC_Regs  MGMT_RTC;                          /* !< (@ 0x00094800) SYSCTL Mgmt sub-region for IPD rtc */
+       uint32_t RESERVED12[12285];
+  SYSCTL_MGMT_GPIO0_Regs  MGMT_GPIO0;                        /* !< (@ 0x000A0800) SYSCTL Mgmt sub-region for IPD gpio0 */
+       uint32_t RESERVED13[2042];
+  SYSCTL_MGMT_GPIO1_Regs  MGMT_GPIO1;                        /* !< (@ 0x000A2800) SYSCTL Mgmt sub-region for IPD gpio1 */
+       uint32_t RESERVED14[2042];
+  SYSCTL_MGMT_GPIO2_Regs  MGMT_GPIO2;                        /* !< (@ 0x000A4800) SYSCTL Mgmt sub-region for IPD gpio2 */
+       uint32_t RESERVED15[77818];
+  SYSCTL_MGMT_I2C0_Regs  MGMT_I2C0;                         /* !< (@ 0x000F0800) SYSCTL Mgmt sub-region for IPD i2c0 */
+       uint32_t RESERVED16[2042];
+  SYSCTL_MGMT_I2C1_Regs  MGMT_I2C1;                         /* !< (@ 0x000F2800) SYSCTL Mgmt sub-region for IPD i2c1 */
+       uint32_t RESERVED17[2042];
+  SYSCTL_MGMT_I2C2_Regs  MGMT_I2C2;                         /* !< (@ 0x000F4800) SYSCTL Mgmt sub-region for IPD i2c2 */
+       uint32_t RESERVED18[12282];
+  SYSCTL_MGMT_UARTLP0_Regs  MGMT_UARTLP0;                      /* !< (@ 0x00100800) SYSCTL Mgmt sub-region for IPD uartlp0 */
+       uint32_t RESERVED19[2042];
+  SYSCTL_MGMT_UARTLP1_Regs  MGMT_UARTLP1;                      /* !< (@ 0x00102800) SYSCTL Mgmt sub-region for IPD uartlp1 */
+       uint32_t RESERVED20[2042];
+  SYSCTL_MGMT_UARTLP2_Regs  MGMT_UARTLP2;                      /* !< (@ 0x00104800) SYSCTL Mgmt sub-region for IPD uartlp2 */
+       uint32_t RESERVED21[4090];
+  SYSCTL_MGMT_UARTADVLP0_Regs  MGMT_UARTADVLP0;                   /* !< (@ 0x00108800) SYSCTL Mgmt sub-region for IPD uartadvlp0 */
+       uint32_t RESERVED22[2042];
+  SYSCTL_MGMT_UARTADVLP1_Regs  MGMT_UARTADVLP1;                   /* !< (@ 0x0010A800) SYSCTL Mgmt sub-region for IPD uartadvlp1 */
+       uint32_t RESERVED23[841722];
+  SYSCTL_MGMT_CRC0_Regs  MGMT_CRC0;                         /* !< (@ 0x00440800) SYSCTL Mgmt sub-region for IPD crc0 */
+       uint32_t RESERVED24[2042];
+  SYSCTL_MGMT_AES_Regs  MGMT_AES;                          /* !< (@ 0x00442800) SYSCTL Mgmt sub-region for IPD aes */
+       uint32_t RESERVED25[2042];
+  SYSCTL_MGMT_TRNG_Regs  MGMT_TRNG;                         /* !< (@ 0x00444800) SYSCTL Mgmt sub-region for IPD trng */
+       uint32_t RESERVED26[36858];
+  SYSCTL_MGMT_SPI0_Regs  MGMT_SPI0;                         /* !< (@ 0x00468800) SYSCTL Mgmt sub-region for IPD spi0 */
+       uint32_t RESERVED27[2042];
+  SYSCTL_MGMT_SPI1_Regs  MGMT_SPI1;                         /* !< (@ 0x0046A800) SYSCTL Mgmt sub-region for IPD spi1 */
+       uint32_t RESERVED28[1038330];
+  SYSCTL_MGMT_GPTIMER16BADV4CC0_Regs  MGMT_GPTIMER16BADV4CC0;            /* !< (@ 0x00860800) SYSCTL Mgmt sub-region for IPD gptimer16badv4cc0 */
+       uint32_t RESERVED29[16378];
+  SYSCTL_MGMT_GPTIMER32B2CC0_Regs  MGMT_GPTIMER32B2CC0;               /* !< (@ 0x00870800) SYSCTL Mgmt sub-region for IPD gptimer32b2cc0 */
+} SYSCTL_Regs;
+
+/*@}*/ /* end of group SYSCTL */
+
+
+
+#if defined ( __CC_ARM )
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************
+* SYSCTL Register Control Bits
+******************************************************************************/
+
+/* SYSCTL_MGMT_GPTIMER32B2CC0_PWREN Bits */
+/* SYSCTL_MGMT_GPTIMER32B2CC0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPTIMER32B2CC0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER32B2CC0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL Bits */
+/* SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER32B2CC0_STAT Bits */
+/* SYSCTL_MGMT_GPTIMER32B2CC0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPTIMER32B2CC0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER32B2CC0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN Bits */
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL Bits */
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_STAT Bits */
+/* SYSCTL_MGMT_GPTIMER16BADV4CC0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16BADV4CC0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_SPI1_PWREN Bits */
+/* SYSCTL_MGMT_SPI1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_SPI1_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_SPI1_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_SPI1_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_SPI1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_SPI1_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_SPI1_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_SPI1_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_SPI1_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_SPI1_RSTCTL Bits */
+/* SYSCTL_MGMT_SPI1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_SPI1_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_SPI1_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_SPI1_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_SPI1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_SPI1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_SPI1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_SPI1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_SPI1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_SPI1_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_SPI1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_SPI1_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_SPI1_CLKCFG Bits */
+/* SYSCTL_MGMT_SPI1_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_SPI1_CLKCFG_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_SPI1_CLKCFG_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_SPI1_CLKCFG_KEY_UNLOCK       ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_SPI1_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_SPI1_CLKCFG_BLOCKASYNC_OFS   (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_SPI1_CLKCFG_BLOCKASYNC_MASK  ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_SPI1_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_SPI1_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_SPI1_STAT Bits */
+/* SYSCTL_MGMT_SPI1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_SPI1_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_SPI1_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_SPI1_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_SPI1_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_SPI0_PWREN Bits */
+/* SYSCTL_MGMT_SPI0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_SPI0_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_SPI0_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_SPI0_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_SPI0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_SPI0_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_SPI0_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_SPI0_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_SPI0_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_SPI0_RSTCTL Bits */
+/* SYSCTL_MGMT_SPI0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_SPI0_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_SPI0_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_SPI0_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_SPI0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_SPI0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_SPI0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_SPI0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_SPI0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_SPI0_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_SPI0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_SPI0_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_SPI0_CLKCFG Bits */
+/* SYSCTL_MGMT_SPI0_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_SPI0_CLKCFG_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_SPI0_CLKCFG_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_SPI0_CLKCFG_KEY_UNLOCK       ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_SPI0_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_SPI0_CLKCFG_BLOCKASYNC_OFS   (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_SPI0_CLKCFG_BLOCKASYNC_MASK  ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_SPI0_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_SPI0_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_SPI0_STAT Bits */
+/* SYSCTL_MGMT_SPI0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_SPI0_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_SPI0_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_SPI0_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_SPI0_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_TRNG_PWREN Bits */
+/* SYSCTL_MGMT_TRNG_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_TRNG_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_TRNG_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_TRNG_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_TRNG_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_TRNG_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_TRNG_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_TRNG_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_TRNG_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_TRNG_RSTCTL Bits */
+/* SYSCTL_MGMT_TRNG_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_TRNG_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_TRNG_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_TRNG_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_TRNG_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_TRNG_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_TRNG_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_TRNG_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_TRNG_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_TRNG_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_TRNG_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_TRNG_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_TRNG_STAT Bits */
+/* SYSCTL_MGMT_TRNG_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_TRNG_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_TRNG_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_TRNG_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_TRNG_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_AES_PWREN Bits */
+/* SYSCTL_MGMT_AES_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_AES_PWREN_KEY_OFS            (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_AES_PWREN_KEY_MASK           ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_AES_PWREN_KEY_UNLOCK         ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_AES_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_AES_PWREN_ENABLE_OFS         (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_AES_PWREN_ENABLE_MASK        ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_AES_PWREN_ENABLE_DISABLE     ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_AES_PWREN_ENABLE_ENABLE      ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_AES_RSTCTL Bits */
+/* SYSCTL_MGMT_AES_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_AES_RSTCTL_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_AES_RSTCTL_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_AES_RSTCTL_KEY_UNLOCK        ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_AES_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_AES_RSTCTL_RESETSTKYCLR_OFS  (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_AES_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_AES_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_AES_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_AES_RSTCTL_RESETASSERT_OFS   (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_AES_RSTCTL_RESETASSERT_MASK  ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_AES_RSTCTL_RESETASSERT_DO    ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_AES_STAT Bits */
+/* SYSCTL_MGMT_AES_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_AES_STAT_RESETSTKY_OFS       (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_AES_STAT_RESETSTKY_MASK      ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_AES_STAT_RESETSTKY_CLEAR     ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_AES_STAT_RESETSTKY_SET       ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_CRC0_PWREN Bits */
+/* SYSCTL_MGMT_CRC0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_CRC0_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_CRC0_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_CRC0_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_CRC0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_CRC0_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_CRC0_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_CRC0_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_CRC0_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_CRC0_RSTCTL Bits */
+/* SYSCTL_MGMT_CRC0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_CRC0_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_CRC0_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_CRC0_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_CRC0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_CRC0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_CRC0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_CRC0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_CRC0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_CRC0_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_CRC0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_CRC0_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_CRC0_STAT Bits */
+/* SYSCTL_MGMT_CRC0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_CRC0_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_CRC0_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_CRC0_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_CRC0_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_UARTADVLP1_PWREN Bits */
+/* SYSCTL_MGMT_UARTADVLP1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_UARTADVLP1_PWREN_KEY_OFS     (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTADVLP1_PWREN_KEY_MASK    ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_UARTADVLP1_PWREN_KEY_UNLOCK  ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_UARTADVLP1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_UARTADVLP1_PWREN_ENABLE_OFS  (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_UARTADVLP1_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_UARTADVLP1_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTADVLP1_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTADVLP1_RSTCTL Bits */
+/* SYSCTL_MGMT_UARTADVLP1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_UARTADVLP1_RSTCTL_KEY_OFS    (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTADVLP1_RSTCTL_KEY_MASK   ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_UARTADVLP1_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_UARTADVLP1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_UARTADVLP1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_UARTADVLP1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_UARTADVLP1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_UARTADVLP1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_UARTADVLP1_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_UARTADVLP1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_UARTADVLP1_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTADVLP1_CLKCFG Bits */
+/* SYSCTL_MGMT_UARTADVLP1_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_UARTADVLP1_CLKCFG_KEY_OFS    (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTADVLP1_CLKCFG_KEY_MASK   ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_UARTADVLP1_CLKCFG_KEY_UNLOCK ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_UARTADVLP1_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_UARTADVLP1_CLKCFG_BLOCKASYNC_OFS (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_UARTADVLP1_CLKCFG_BLOCKASYNC_MASK ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_UARTADVLP1_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTADVLP1_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_UARTADVLP1_STAT Bits */
+/* SYSCTL_MGMT_UARTADVLP1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_UARTADVLP1_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_UARTADVLP1_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_UARTADVLP1_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTADVLP1_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_UARTADVLP0_PWREN Bits */
+/* SYSCTL_MGMT_UARTADVLP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_KEY_OFS     (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_KEY_MASK    ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_KEY_UNLOCK  ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_UARTADVLP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_ENABLE_OFS  (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTADVLP0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTADVLP0_RSTCTL Bits */
+/* SYSCTL_MGMT_UARTADVLP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_KEY_OFS    (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_KEY_MASK   ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_UARTADVLP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_UARTADVLP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_UARTADVLP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTADVLP0_CLKCFG Bits */
+/* SYSCTL_MGMT_UARTADVLP0_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_KEY_OFS    (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_KEY_MASK   ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_KEY_UNLOCK ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_UARTADVLP0_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_BLOCKASYNC_OFS (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_BLOCKASYNC_MASK ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTADVLP0_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_UARTADVLP0_STAT Bits */
+/* SYSCTL_MGMT_UARTADVLP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_UARTADVLP0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_UARTADVLP0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_UARTADVLP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTADVLP0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_UARTLP2_PWREN Bits */
+/* SYSCTL_MGMT_UARTLP2_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP2_PWREN_KEY_OFS        (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP2_PWREN_KEY_MASK       ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_UARTLP2_PWREN_KEY_UNLOCK     ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_UARTLP2_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_UARTLP2_PWREN_ENABLE_OFS     (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_UARTLP2_PWREN_ENABLE_MASK    ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_UARTLP2_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP2_PWREN_ENABLE_ENABLE  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTLP2_RSTCTL Bits */
+/* SYSCTL_MGMT_UARTLP2_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP2_RSTCTL_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP2_RSTCTL_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_UARTLP2_RSTCTL_KEY_UNLOCK    ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_UARTLP2_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_UARTLP2_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_UARTLP2_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_UARTLP2_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_UARTLP2_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_UARTLP2_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_UARTLP2_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_UARTLP2_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTLP2_CLKCFG Bits */
+/* SYSCTL_MGMT_UARTLP2_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP2_CLKCFG_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP2_CLKCFG_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_UARTLP2_CLKCFG_KEY_UNLOCK    ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_UARTLP2_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_UARTLP2_CLKCFG_BLOCKASYNC_OFS (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_UARTLP2_CLKCFG_BLOCKASYNC_MASK ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_UARTLP2_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP2_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_UARTLP2_STAT Bits */
+/* SYSCTL_MGMT_UARTLP2_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_UARTLP2_STAT_RESETSTKY_OFS   (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_UARTLP2_STAT_RESETSTKY_MASK  ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_UARTLP2_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP2_STAT_RESETSTKY_SET   ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_UARTLP1_PWREN Bits */
+/* SYSCTL_MGMT_UARTLP1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP1_PWREN_KEY_OFS        (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP1_PWREN_KEY_MASK       ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_UARTLP1_PWREN_KEY_UNLOCK     ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_UARTLP1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_UARTLP1_PWREN_ENABLE_OFS     (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_UARTLP1_PWREN_ENABLE_MASK    ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_UARTLP1_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP1_PWREN_ENABLE_ENABLE  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTLP1_RSTCTL Bits */
+/* SYSCTL_MGMT_UARTLP1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_KEY_UNLOCK    ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_UARTLP1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_UARTLP1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_UARTLP1_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTLP1_CLKCFG Bits */
+/* SYSCTL_MGMT_UARTLP1_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_KEY_UNLOCK    ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_UARTLP1_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_BLOCKASYNC_OFS (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_BLOCKASYNC_MASK ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP1_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_UARTLP1_STAT Bits */
+/* SYSCTL_MGMT_UARTLP1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_UARTLP1_STAT_RESETSTKY_OFS   (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_UARTLP1_STAT_RESETSTKY_MASK  ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_UARTLP1_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP1_STAT_RESETSTKY_SET   ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_UARTLP0_PWREN Bits */
+/* SYSCTL_MGMT_UARTLP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP0_PWREN_KEY_OFS        (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP0_PWREN_KEY_MASK       ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_UARTLP0_PWREN_KEY_UNLOCK     ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_UARTLP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_UARTLP0_PWREN_ENABLE_OFS     (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_UARTLP0_PWREN_ENABLE_MASK    ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_UARTLP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP0_PWREN_ENABLE_ENABLE  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTLP0_RSTCTL Bits */
+/* SYSCTL_MGMT_UARTLP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_KEY_UNLOCK    ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_UARTLP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_UARTLP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_UARTLP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_UARTLP0_CLKCFG Bits */
+/* SYSCTL_MGMT_UARTLP0_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_KEY_UNLOCK    ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_UARTLP0_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_BLOCKASYNC_OFS (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_BLOCKASYNC_MASK ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP0_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_UARTLP0_STAT Bits */
+/* SYSCTL_MGMT_UARTLP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_UARTLP0_STAT_RESETSTKY_OFS   (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_UARTLP0_STAT_RESETSTKY_MASK  ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_UARTLP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_UARTLP0_STAT_RESETSTKY_SET   ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_I2C2_PWREN Bits */
+/* SYSCTL_MGMT_I2C2_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_I2C2_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C2_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_I2C2_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_I2C2_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_I2C2_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_I2C2_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_I2C2_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C2_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_I2C2_RSTCTL Bits */
+/* SYSCTL_MGMT_I2C2_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_I2C2_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C2_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_I2C2_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_I2C2_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_I2C2_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_I2C2_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_I2C2_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_I2C2_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_I2C2_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_I2C2_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_I2C2_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_I2C2_CLKCFG Bits */
+/* SYSCTL_MGMT_I2C2_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_I2C2_CLKCFG_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C2_CLKCFG_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_I2C2_CLKCFG_KEY_UNLOCK       ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_I2C2_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_I2C2_CLKCFG_BLOCKASYNC_OFS   (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_I2C2_CLKCFG_BLOCKASYNC_MASK  ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_I2C2_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C2_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_I2C2_STAT Bits */
+/* SYSCTL_MGMT_I2C2_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_I2C2_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_I2C2_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_I2C2_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C2_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_I2C1_PWREN Bits */
+/* SYSCTL_MGMT_I2C1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_I2C1_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C1_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_I2C1_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_I2C1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_I2C1_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_I2C1_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_I2C1_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C1_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_I2C1_RSTCTL Bits */
+/* SYSCTL_MGMT_I2C1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_I2C1_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C1_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_I2C1_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_I2C1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_I2C1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_I2C1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_I2C1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_I2C1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_I2C1_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_I2C1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_I2C1_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_I2C1_CLKCFG Bits */
+/* SYSCTL_MGMT_I2C1_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_I2C1_CLKCFG_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C1_CLKCFG_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_I2C1_CLKCFG_KEY_UNLOCK       ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_I2C1_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_I2C1_CLKCFG_BLOCKASYNC_OFS   (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_I2C1_CLKCFG_BLOCKASYNC_MASK  ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_I2C1_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C1_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_I2C1_STAT Bits */
+/* SYSCTL_MGMT_I2C1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_I2C1_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_I2C1_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_I2C1_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C1_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_I2C0_PWREN Bits */
+/* SYSCTL_MGMT_I2C0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_I2C0_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C0_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_I2C0_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_I2C0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_I2C0_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_I2C0_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_I2C0_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C0_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_I2C0_RSTCTL Bits */
+/* SYSCTL_MGMT_I2C0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_I2C0_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C0_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_I2C0_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_I2C0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_I2C0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_I2C0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_I2C0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_I2C0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_I2C0_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_I2C0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_I2C0_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_I2C0_CLKCFG Bits */
+/* SYSCTL_MGMT_I2C0_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_I2C0_CLKCFG_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_I2C0_CLKCFG_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_I2C0_CLKCFG_KEY_UNLOCK       ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_I2C0_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_I2C0_CLKCFG_BLOCKASYNC_OFS   (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_I2C0_CLKCFG_BLOCKASYNC_MASK  ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_I2C0_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C0_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_I2C0_STAT Bits */
+/* SYSCTL_MGMT_I2C0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_I2C0_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_I2C0_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_I2C0_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_I2C0_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPIO2_PWREN Bits */
+/* SYSCTL_MGMT_GPIO2_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPIO2_PWREN_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPIO2_PWREN_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPIO2_PWREN_KEY_UNLOCK       ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPIO2_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPIO2_PWREN_ENABLE_OFS       (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPIO2_PWREN_ENABLE_MASK      ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPIO2_PWREN_ENABLE_DISABLE   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPIO2_PWREN_ENABLE_ENABLE    ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPIO2_RSTCTL Bits */
+/* SYSCTL_MGMT_GPIO2_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPIO2_RSTCTL_KEY_OFS         (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPIO2_RSTCTL_KEY_MASK        ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPIO2_RSTCTL_KEY_UNLOCK      ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPIO2_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPIO2_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPIO2_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPIO2_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPIO2_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPIO2_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPIO2_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPIO2_RSTCTL_RESETASSERT_DO  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPIO2_STAT Bits */
+/* SYSCTL_MGMT_GPIO2_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPIO2_STAT_RESETSTKY_OFS     (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPIO2_STAT_RESETSTKY_MASK    ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPIO2_STAT_RESETSTKY_CLEAR   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPIO2_STAT_RESETSTKY_SET     ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPIO1_PWREN Bits */
+/* SYSCTL_MGMT_GPIO1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPIO1_PWREN_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPIO1_PWREN_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPIO1_PWREN_KEY_UNLOCK       ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPIO1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPIO1_PWREN_ENABLE_OFS       (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPIO1_PWREN_ENABLE_MASK      ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPIO1_PWREN_ENABLE_DISABLE   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPIO1_PWREN_ENABLE_ENABLE    ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPIO1_RSTCTL Bits */
+/* SYSCTL_MGMT_GPIO1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_KEY_OFS         (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_KEY_MASK        ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_KEY_UNLOCK      ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPIO1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPIO1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPIO1_RSTCTL_RESETASSERT_DO  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPIO1_STAT Bits */
+/* SYSCTL_MGMT_GPIO1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPIO1_STAT_RESETSTKY_OFS     (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPIO1_STAT_RESETSTKY_MASK    ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPIO1_STAT_RESETSTKY_CLEAR   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPIO1_STAT_RESETSTKY_SET     ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPIO0_PWREN Bits */
+/* SYSCTL_MGMT_GPIO0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPIO0_PWREN_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPIO0_PWREN_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPIO0_PWREN_KEY_UNLOCK       ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPIO0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPIO0_PWREN_ENABLE_OFS       (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPIO0_PWREN_ENABLE_MASK      ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPIO0_PWREN_ENABLE_DISABLE   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPIO0_PWREN_ENABLE_ENABLE    ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPIO0_RSTCTL Bits */
+/* SYSCTL_MGMT_GPIO0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_KEY_OFS         (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_KEY_MASK        ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_KEY_UNLOCK      ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPIO0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPIO0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPIO0_RSTCTL_RESETASSERT_DO  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPIO0_STAT Bits */
+/* SYSCTL_MGMT_GPIO0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPIO0_STAT_RESETSTKY_OFS     (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPIO0_STAT_RESETSTKY_MASK    ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPIO0_STAT_RESETSTKY_CLEAR   ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPIO0_STAT_RESETSTKY_SET     ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_RTC_CLKCFG Bits */
+/* SYSCTL_MGMT_RTC_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_RTC_CLKCFG_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_RTC_CLKCFG_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_RTC_CLKCFG_KEY_UNLOCK        ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_RTC_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_RTC_CLKCFG_BLOCKASYNC_OFS    (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_RTC_CLKCFG_BLOCKASYNC_MASK   ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_RTC_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_RTC_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_STAT Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCQEILP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCQEILP0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP1_PWREN Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP1_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_PWREN_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_PWREN_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP1_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP1_RSTCTL Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP1_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_RSTCTL_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP1_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP1_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP1_STAT Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP1_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP1_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP0_PWREN Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_PWREN_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_PWREN_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP0_RSTCTL Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_RSTCTL_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP0_STAT Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCSPLP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCSPLP0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_KEY_OFS (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_STAT Bits */
+/* SYSCTL_MGMT_GPTIMER16B2CCLP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_GPTIMER16B2CCLP0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_WWDTLP0_PWREN Bits */
+/* SYSCTL_MGMT_WWDTLP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_WWDTLP0_PWREN_KEY_OFS        (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_WWDTLP0_PWREN_KEY_MASK       ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_WWDTLP0_PWREN_KEY_UNLOCK     ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_WWDTLP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_WWDTLP0_PWREN_ENABLE_OFS     (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_WWDTLP0_PWREN_ENABLE_MASK    ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_WWDTLP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_WWDTLP0_PWREN_ENABLE_ENABLE  ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_WWDTLP0_RSTCTL Bits */
+/* SYSCTL_MGMT_WWDTLP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_KEY_UNLOCK    ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_WWDTLP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_WWDTLP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_WWDTLP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_WWDTLP0_STAT Bits */
+/* SYSCTL_MGMT_WWDTLP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_WWDTLP0_STAT_RESETSTKY_OFS   (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_WWDTLP0_STAT_RESETSTKY_MASK  ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_WWDTLP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_WWDTLP0_STAT_RESETSTKY_SET   ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_LCD_PWREN Bits */
+/* SYSCTL_MGMT_LCD_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_LCD_PWREN_KEY_OFS            (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_LCD_PWREN_KEY_MASK           ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_LCD_PWREN_KEY_UNLOCK         ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_LCD_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_LCD_PWREN_ENABLE_OFS         (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_LCD_PWREN_ENABLE_MASK        ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_LCD_PWREN_ENABLE_DISABLE     ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_LCD_PWREN_ENABLE_ENABLE      ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_LCD_RSTCTL Bits */
+/* SYSCTL_MGMT_LCD_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_LCD_RSTCTL_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_LCD_RSTCTL_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_LCD_RSTCTL_KEY_UNLOCK        ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_LCD_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_LCD_RSTCTL_RESETSTKYCLR_OFS  (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_LCD_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_LCD_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_LCD_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_LCD_RSTCTL_RESETASSERT_OFS   (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_LCD_RSTCTL_RESETASSERT_MASK  ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_LCD_RSTCTL_RESETASSERT_DO    ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_LCD_STAT Bits */
+/* SYSCTL_MGMT_LCD_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_LCD_STAT_RESETSTKY_OFS       (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_LCD_STAT_RESETSTKY_MASK      ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_LCD_STAT_RESETSTKY_CLEAR     ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_LCD_STAT_RESETSTKY_SET       ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_VREF_PWREN Bits */
+/* SYSCTL_MGMT_VREF_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_VREF_PWREN_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_VREF_PWREN_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_VREF_PWREN_KEY_UNLOCK        ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_VREF_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_VREF_PWREN_ENABLE_OFS        (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_VREF_PWREN_ENABLE_MASK       ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_VREF_PWREN_ENABLE_DISABLE    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_VREF_PWREN_ENABLE_ENABLE     ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_VREF_RSTCTL Bits */
+/* SYSCTL_MGMT_VREF_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_VREF_RSTCTL_KEY_OFS          (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_VREF_RSTCTL_KEY_MASK         ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_VREF_RSTCTL_KEY_UNLOCK       ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_VREF_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_VREF_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_VREF_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_VREF_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_VREF_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_VREF_RSTCTL_RESETASSERT_OFS  (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_VREF_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_VREF_RSTCTL_RESETASSERT_DO   ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_VREF_STAT Bits */
+/* SYSCTL_MGMT_VREF_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_VREF_STAT_RESETSTKY_OFS      (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_VREF_STAT_RESETSTKY_MASK     ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_VREF_STAT_RESETSTKY_CLEAR    ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_VREF_STAT_RESETSTKY_SET      ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_ANACOMP0_PWREN Bits */
+/* SYSCTL_MGMT_ANACOMP0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_ANACOMP0_PWREN_KEY_OFS       (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ANACOMP0_PWREN_KEY_MASK      ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_ANACOMP0_PWREN_KEY_UNLOCK    ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_ANACOMP0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_ANACOMP0_PWREN_ENABLE_OFS    (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_ANACOMP0_PWREN_ENABLE_MASK   ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_ANACOMP0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ANACOMP0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ANACOMP0_RSTCTL Bits */
+/* SYSCTL_MGMT_ANACOMP0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_KEY_OFS      (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_KEY_MASK     ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_KEY_UNLOCK   ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_ANACOMP0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_ANACOMP0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_ANACOMP0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ANACOMP0_CLKCFG Bits */
+/* SYSCTL_MGMT_ANACOMP0_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_KEY_OFS      (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_KEY_MASK     ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_KEY_UNLOCK   ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_ANACOMP0_CLKCFG[BLOCKASYNC] Bits */
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_BLOCKASYNC_OFS (8)                             /* !< BLOCKASYNC Offset */
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_BLOCKASYNC_MASK ((uint32_t)0x00000100U)         /* !< Async Clock Request is blocked from
+                                                                                    starting SYSOSC or forcing bus clock
+                                                                                    to 32MHz */
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_BLOCKASYNC_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ANACOMP0_CLKCFG_BLOCKASYNC_ENABLE ((uint32_t)0x00000100U)
+
+/* SYSCTL_MGMT_ANACOMP0_STAT Bits */
+/* SYSCTL_MGMT_ANACOMP0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_ANACOMP0_STAT_RESETSTKY_OFS  (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_ANACOMP0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_ANACOMP0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ANACOMP0_STAT_RESETSTKY_SET  ((uint32_t)0x00010000U)
+
+/* SYSCTL_MGMT_ADC12B1MSPS0_PWREN Bits */
+/* SYSCTL_MGMT_ADC12B1MSPS0_PWREN[KEY] Bits */
+#define SYSCTL_MGMT_ADC12B1MSPS0_PWREN_KEY_OFS   (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ADC12B1MSPS0_PWREN_KEY_MASK  ((uint32_t)0xFF000000U)         /* !< KEY to Allow Enable State Change --
+                                                                                    0x26 */
+#define SYSCTL_MGMT_ADC12B1MSPS0_PWREN_KEY_UNLOCK ((uint32_t)0x26000000U)
+/* SYSCTL_MGMT_ADC12B1MSPS0_PWREN[ENABLE] Bits */
+#define SYSCTL_MGMT_ADC12B1MSPS0_PWREN_ENABLE_OFS (0)                             /* !< ENABLE Offset */
+#define SYSCTL_MGMT_ADC12B1MSPS0_PWREN_ENABLE_MASK ((uint32_t)0x00000001U)         /* !< IP Enable */
+#define SYSCTL_MGMT_ADC12B1MSPS0_PWREN_ENABLE_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B1MSPS0_PWREN_ENABLE_ENABLE ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ADC12B1MSPS0_RSTCTL Bits */
+/* SYSCTL_MGMT_ADC12B1MSPS0_RSTCTL[KEY] Bits */
+#define SYSCTL_MGMT_ADC12B1MSPS0_RSTCTL_KEY_OFS  (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ADC12B1MSPS0_RSTCTL_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow Reset -- 0xb1 */
+#define SYSCTL_MGMT_ADC12B1MSPS0_RSTCTL_KEY_UNLOCK ((uint32_t)0xB1000000U)
+/* SYSCTL_MGMT_ADC12B1MSPS0_RSTCTL[RESETSTKYCLR] Bits */
+#define SYSCTL_MGMT_ADC12B1MSPS0_RSTCTL_RESETSTKYCLR_OFS (1)                             /* !< RESETSTKYCLR Offset */
+#define SYSCTL_MGMT_ADC12B1MSPS0_RSTCTL_RESETSTKYCLR_MASK ((uint32_t)0x00000002U)         /* !< Clear the RESET STICKY Bit */
+#define SYSCTL_MGMT_ADC12B1MSPS0_RSTCTL_RESETSTKYCLR_CLEAR ((uint32_t)0x00000002U)
+/* SYSCTL_MGMT_ADC12B1MSPS0_RSTCTL[RESETASSERT] Bits */
+#define SYSCTL_MGMT_ADC12B1MSPS0_RSTCTL_RESETASSERT_OFS (0)                             /* !< RESETASSERT Offset */
+#define SYSCTL_MGMT_ADC12B1MSPS0_RSTCTL_RESETASSERT_MASK ((uint32_t)0x00000001U)         /* !< Assert Reset to IP Domain. */
+#define SYSCTL_MGMT_ADC12B1MSPS0_RSTCTL_RESETASSERT_DO ((uint32_t)0x00000001U)
+
+/* SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG Bits */
+/* SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG[KEY] Bits */
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_KEY_OFS  (24)                            /* !< KEY Offset */
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_KEY_MASK ((uint32_t)0xFF000000U)         /* !< KEY to Allow State Change -- 0xA9 */
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_KEY_UNLOCK ((uint32_t)0xA9000000U)
+/* SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG[CCONSTOP] Bits */
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_CCONSTOP_OFS (5)                             /* !< CCONSTOP Offset */
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_CCONSTOP_MASK ((uint32_t)0x00000020U)         /* !< Conversion Clock is ON during STOP
+                                                                                    Mode */
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_CCONSTOP_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_CCONSTOP_ENABLE ((uint32_t)0x00000020U)
+/* SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG[CCONRUN] Bits */
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_CCONRUN_OFS (4)                             /* !< CCONRUN Offset */
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_CCONRUN_MASK ((uint32_t)0x00000010U)         /* !< Conversion Clock is ON during RUN
+                                                                                    Mode */
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_CCONRUN_DISABLE ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_CCONRUN_ENABLE ((uint32_t)0x00000010U)
+/* SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG[SAMPCLK] Bits */
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_SAMPCLK_OFS (0)                             /* !< SAMPCLK Offset */
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_SAMPCLK_MASK ((uint32_t)0x00000003U)         /* !< Sample Window Clock */
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_SAMPCLK_ULPCLK ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_SAMPCLK_SYSOSC ((uint32_t)0x00000001U)
+#define SYSCTL_MGMT_ADC12B1MSPS0_CLKCFG_SAMPCLK_HFCLK ((uint32_t)0x00000002U)
+
+/* SYSCTL_MGMT_ADC12B1MSPS0_STAT Bits */
+/* SYSCTL_MGMT_ADC12B1MSPS0_STAT[RESETSTKY] Bits */
+#define SYSCTL_MGMT_ADC12B1MSPS0_STAT_RESETSTKY_OFS (16)                            /* !< RESETSTKY Offset */
+#define SYSCTL_MGMT_ADC12B1MSPS0_STAT_RESETSTKY_MASK ((uint32_t)0x00010000U)         /* !< IP has been Reset */
+#define SYSCTL_MGMT_ADC12B1MSPS0_STAT_RESETSTKY_CLEAR ((uint32_t)0x00000000U)
+#define SYSCTL_MGMT_ADC12B1MSPS0_STAT_RESETSTKY_SET ((uint32_t)0x00010000U)
+
+/* SYSCTL_FWEPROTMAIN Bits */
+/* SYSCTL_FWEPROTMAIN[DATA] Bits */
+#define SYSCTL_FWEPROTMAIN_DATA_OFS              (0)                             /* !< DATA Offset */
+#define SYSCTL_FWEPROTMAIN_DATA_MASK             ((uint32_t)0xFFFFFFFFU)         /* !< 1 Sector Write Erase protection 1:
+                                                                                    prohibits write-erase, 0: allows */
+
+/* SYSCTL_FRXPROTMAINSTART Bits */
+/* SYSCTL_FRXPROTMAINSTART[ADDR] Bits */
+#define SYSCTL_FRXPROTMAINSTART_ADDR_OFS         (6)                             /* !< ADDR Offset */
+#define SYSCTL_FRXPROTMAINSTART_ADDR_MASK        ((uint32_t)0x003FFFC0U)         /* !< Flash RX Protection Start Address
+                                                                                    64B granularity */
+
+/* SYSCTL_FRXPROTMAINEND Bits */
+/* SYSCTL_FRXPROTMAINEND[ADDR] Bits */
+#define SYSCTL_FRXPROTMAINEND_ADDR_OFS           (6)                             /* !< ADDR Offset */
+#define SYSCTL_FRXPROTMAINEND_ADDR_MASK          ((uint32_t)0x003FFFC0U)         /* !< Flash RX Protection End Address 64B
+                                                                                    granularity */
+
+/* SYSCTL_FIPPROTMAINSTART Bits */
+/* SYSCTL_FIPPROTMAINSTART[ADDR] Bits */
+#define SYSCTL_FIPPROTMAINSTART_ADDR_OFS         (6)                             /* !< ADDR Offset */
+#define SYSCTL_FIPPROTMAINSTART_ADDR_MASK        ((uint32_t)0x003FFFC0U)         /* !< Flash IP Protection Start Address
+                                                                                    64B granularity */
+
+/* SYSCTL_FIPPROTMAINEND Bits */
+/* SYSCTL_FIPPROTMAINEND[ADDR] Bits */
+#define SYSCTL_FIPPROTMAINEND_ADDR_OFS           (6)                             /* !< ADDR Offset */
+#define SYSCTL_FIPPROTMAINEND_ADDR_MASK          ((uint32_t)0x003FFFC0U)         /* !< Flash IP Protection End Address 64B
+                                                                                    granularity */
+
+/* SYSCTL_FLBANKSWPPOLICY Bits */
+/* SYSCTL_FLBANKSWPPOLICY[KEY] Bits */
+#define SYSCTL_FLBANKSWPPOLICY_KEY_OFS           (24)                            /* !< KEY Offset */
+#define SYSCTL_FLBANKSWPPOLICY_KEY_MASK          ((uint32_t)0xFF000000U)         /* !< Must have KEY==0xCA(202) for write */
+#define SYSCTL_FLBANKSWPPOLICY_KEY_VALUE         ((uint32_t)0xCA000000U)         /* !< Write Key */
+/* SYSCTL_FLBANKSWPPOLICY[DISABLE] Bits */
+#define SYSCTL_FLBANKSWPPOLICY_DISABLE_OFS       (0)                             /* !< DISABLE Offset */
+#define SYSCTL_FLBANKSWPPOLICY_DISABLE_MASK      ((uint32_t)0x00000001U)         /* !< 1: Disables Policy To Allow Flash
+                                                                                    Bank Swapping */
+#define SYSCTL_FLBANKSWPPOLICY_DISABLE_TRUE      ((uint32_t)0x00000001U)         /* !< Disallow Bank Swap */
+
+/* SYSCTL_FLBANKSWP Bits */
+/* SYSCTL_FLBANKSWP[KEY] Bits */
+#define SYSCTL_FLBANKSWP_KEY_OFS                 (24)                            /* !< KEY Offset */
+#define SYSCTL_FLBANKSWP_KEY_MASK                ((uint32_t)0xFF000000U)         /* !< The key value of 58h (88) must be
+                                                                                    written with USEUPPER to change the
+                                                                                    bank swap configuration. */
+#define SYSCTL_FLBANKSWP_KEY_VALUE               ((uint32_t)0x58000000U)         /* !< Issue write */
+/* SYSCTL_FLBANKSWP[USEUPPER] Bits */
+#define SYSCTL_FLBANKSWP_USEUPPER_OFS            (0)                             /* !< USEUPPER Offset */
+#define SYSCTL_FLBANKSWP_USEUPPER_MASK           ((uint32_t)0x00000001U)         /* !< 1: Use Upper Bank as Logical 0 */
+#define SYSCTL_FLBANKSWP_USEUPPER_DISABLE        ((uint32_t)0x00000000U)         /* !< Normal (default) memory map
+                                                                                    addressing scheme */
+#define SYSCTL_FLBANKSWP_USEUPPER_ENABLE         ((uint32_t)0x00000001U)         /* !< Flash upper region address space
+                                                                                    swapped with lower region */
+
+/* SYSCTL_FWENABLE Bits */
+/* SYSCTL_FWENABLE[KEY] Bits */
+#define SYSCTL_FWENABLE_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define SYSCTL_FWENABLE_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< Must have KEY==0x76(118) for write */
+#define SYSCTL_FWENABLE_KEY_VALUE                ((uint32_t)0x76000000U)         /* !< Write Key */
+/* SYSCTL_FWENABLE[FLIPPROT] Bits */
+#define SYSCTL_FWENABLE_FLIPPROT_OFS             (6)                             /* !< FLIPPROT Offset */
+#define SYSCTL_FWENABLE_FLIPPROT_MASK            ((uint32_t)0x00000040U)         /* !< 1: Flash Read IP ProtectionActive */
+#define SYSCTL_FWENABLE_FLIPPROT_ENABLE          ((uint32_t)0x00000040U)         /* !< Turn On Flash IP Protection */
+/* SYSCTL_FWENABLE[SRAMBOUNDARYLOCK] Bits */
+#define SYSCTL_FWENABLE_SRAMBOUNDARYLOCK_OFS     (8)                             /* !< SRAMBOUNDARYLOCK Offset */
+#define SYSCTL_FWENABLE_SRAMBOUNDARYLOCK_MASK    ((uint32_t)0x00000100U)         /* !< 1: Blocks Writes from Changing
+                                                                                    SRAMBOUNDARY MMR */
+#define SYSCTL_FWENABLE_SRAMBOUNDARYLOCK_ENABLE  ((uint32_t)0x00000100U)         /* !< SRAMBOUNDARY MMR Locked */
+/* SYSCTL_FWENABLE[FLRXPROT] Bits */
+#define SYSCTL_FWENABLE_FLRXPROT_OFS             (4)                             /* !< FLRXPROT Offset */
+#define SYSCTL_FWENABLE_FLRXPROT_MASK            ((uint32_t)0x00000010U)         /* !< 1: Flash Read Execute Protection
+                                                                                    Active */
+#define SYSCTL_FWENABLE_FLRXPROT_ENABLE          ((uint32_t)0x00000010U)         /* !< Turn On Flash Read-eXecute
+                                                                                    Protection */
+
+/* SYSCTL_SECSTATUS Bits */
+/* SYSCTL_SECSTATUS[FLBANKSWPPOLICY] Bits */
+#define SYSCTL_SECSTATUS_FLBANKSWPPOLICY_OFS     (10)                            /* !< FLBANKSWPPOLICY Offset */
+#define SYSCTL_SECSTATUS_FLBANKSWPPOLICY_MASK    ((uint32_t)0x00000400U)         /* !< 1: Upper and Lower Banks allowed to
+                                                                                    be swapped */
+#define SYSCTL_SECSTATUS_FLBANKSWPPOLICY_DISABLED ((uint32_t)0x00000000U)
+#define SYSCTL_SECSTATUS_FLBANKSWPPOLICY_ENABLED ((uint32_t)0x00000400U)
+/* SYSCTL_SECSTATUS[FLIPPROT] Bits */
+#define SYSCTL_SECSTATUS_FLIPPROT_OFS            (6)                             /* !< FLIPPROT Offset */
+#define SYSCTL_SECSTATUS_FLIPPROT_MASK           ((uint32_t)0x00000040U)         /* !< 1: Flash IP Protection Active */
+#define SYSCTL_SECSTATUS_FLIPPROT_DISABLED       ((uint32_t)0x00000000U)
+#define SYSCTL_SECSTATUS_FLIPPROT_ENABLED        ((uint32_t)0x00000040U)
+/* SYSCTL_SECSTATUS[FLBANKSWP] Bits */
+#define SYSCTL_SECSTATUS_FLBANKSWP_OFS           (12)                            /* !< FLBANKSWP Offset */
+#define SYSCTL_SECSTATUS_FLBANKSWP_MASK          ((uint32_t)0x00001000U)         /* !< 1: Upper and Lower Banks have been
+                                                                                    swapped */
+/* SYSCTL_SECSTATUS[SRAMBOUNDARYLOCK] Bits */
+#define SYSCTL_SECSTATUS_SRAMBOUNDARYLOCK_OFS    (8)                             /* !< SRAMBOUNDARYLOCK Offset */
+#define SYSCTL_SECSTATUS_SRAMBOUNDARYLOCK_MASK   ((uint32_t)0x00000100U)         /* !< 1: SRAM Boundary MMR Locked */
+#define SYSCTL_SECSTATUS_SRAMBOUNDARYLOCK_DISABLED ((uint32_t)0x00000000U)
+#define SYSCTL_SECSTATUS_SRAMBOUNDARYLOCK_ENABLED ((uint32_t)0x00000100U)
+/* SYSCTL_SECSTATUS[FLRXPROT] Bits */
+#define SYSCTL_SECSTATUS_FLRXPROT_OFS            (4)                             /* !< FLRXPROT Offset */
+#define SYSCTL_SECSTATUS_FLRXPROT_MASK           ((uint32_t)0x00000010U)         /* !< 1: Flash Read Execute Protection
+                                                                                    Active */
+#define SYSCTL_SECSTATUS_FLRXPROT_DISABLED       ((uint32_t)0x00000000U)
+#define SYSCTL_SECSTATUS_FLRXPROT_ENABLED        ((uint32_t)0x00000010U)
+/* SYSCTL_SECSTATUS[INITDONE] Bits */
+#define SYSCTL_SECSTATUS_INITDONE_OFS            (0)                             /* !< INITDONE Offset */
+#define SYSCTL_SECSTATUS_INITDONE_MASK           ((uint32_t)0x00000001U)         /* !< 1: CSC has been completed */
+#define SYSCTL_SECSTATUS_INITDONE_NO             ((uint32_t)0x00000000U)         /* !< INIT is not yet done */
+#define SYSCTL_SECSTATUS_INITDONE_YES            ((uint32_t)0x00000001U)         /* !< INIT is done */
+/* SYSCTL_SECSTATUS[CSCEXISTS] Bits */
+#define SYSCTL_SECSTATUS_CSCEXISTS_OFS           (2)                             /* !< CSCEXISTS Offset */
+#define SYSCTL_SECSTATUS_CSCEXISTS_MASK          ((uint32_t)0x00000004U)         /* !< 1: CSC Exists in the system */
+#define SYSCTL_SECSTATUS_CSCEXISTS_NO            ((uint32_t)0x00000000U)         /* !< System does not have a CSC */
+#define SYSCTL_SECSTATUS_CSCEXISTS_YES           ((uint32_t)0x00000004U)         /* !< System does have a CSC */
+
+/* SYSCTL_INITDONE Bits */
+/* SYSCTL_INITDONE[KEY] Bits */
+#define SYSCTL_INITDONE_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define SYSCTL_INITDONE_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< Must have KEY==0x9D(157) for write */
+#define SYSCTL_INITDONE_KEY_VALUE                ((uint32_t)0x9D000000U)         /* !< Issue Reset */
+/* SYSCTL_INITDONE[PASS] Bits */
+#define SYSCTL_INITDONE_PASS_OFS                 (0)                             /* !< PASS Offset */
+#define SYSCTL_INITDONE_PASS_MASK                ((uint32_t)0x00000001U)         /* !< INITCODE writes 1 for PASS, left
+                                                                                    unwritten a timeout will occur if not
+                                                                                    blocked */
+#define SYSCTL_INITDONE_PASS_TRUE                ((uint32_t)0x00000001U)         /* !< INITCODE PASS */
+
+/* SYSCTL_IIDX Bits */
+/* SYSCTL_IIDX[STAT] Bits */
+#define SYSCTL_IIDX_STAT_OFS                     (0)                             /* !< STAT Offset */
+#define SYSCTL_IIDX_STAT_MASK                    ((uint32_t)0x00000007U)         /* !< The SYSCTL interrupt index (IIDX)
+                                                                                    register generates a value
+                                                                                    corresponding to the highest priority
+                                                                                    pending interrupt source.  This value
+                                                                                    may be used as an address offset for
+                                                                                    fast, deterministic handling in the
+                                                                                    interrupt service routine.  A read of
+                                                                                    the IIDX register will clear the
+                                                                                    corresponding interrupt status in the
+                                                                                    RIS and MIS registers. */
+#define SYSCTL_IIDX_STAT_NO_INTR                 ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define SYSCTL_IIDX_STAT_LFOSCGOOD               ((uint32_t)0x00000001U)         /* !< LFOSCGOOD interrupt pending */
+#define SYSCTL_IIDX_STAT_ANACLKERR               ((uint32_t)0x00000002U)
+#define SYSCTL_IIDX_STAT_FLASHSEC                ((uint32_t)0x00000003U)
+#define SYSCTL_IIDX_STAT_SRAMSEC                 ((uint32_t)0x00000004U)
+#define SYSCTL_IIDX_STAT_LFXTGOOD                ((uint32_t)0x00000005U)
+#define SYSCTL_IIDX_STAT_HFCLKGOOD               ((uint32_t)0x00000006U)
+#define SYSCTL_IIDX_STAT_HSCLKGOOD               ((uint32_t)0x00000007U)
+
+/* SYSCTL_IMASK Bits */
+/* SYSCTL_IMASK[LFOSCGOOD] Bits */
+#define SYSCTL_IMASK_LFOSCGOOD_OFS               (0)                             /* !< LFOSCGOOD Offset */
+#define SYSCTL_IMASK_LFOSCGOOD_MASK              ((uint32_t)0x00000001U)         /* !< Enable or disable the LFOSCGOOD
+                                                                                    interrupt. LFOSCGOOD indicates that
+                                                                                    the LFOSC has started successfully. */
+#define SYSCTL_IMASK_LFOSCGOOD_DISABLE           ((uint32_t)0x00000000U)         /* !< Interrupt disabled */
+#define SYSCTL_IMASK_LFOSCGOOD_ENABLE            ((uint32_t)0x00000001U)         /* !< Interrupt enabled */
+/* SYSCTL_IMASK[HFCLKGOOD] Bits */
+#define SYSCTL_IMASK_HFCLKGOOD_OFS               (5)                             /* !< HFCLKGOOD Offset */
+#define SYSCTL_IMASK_HFCLKGOOD_MASK              ((uint32_t)0x00000020U)         /* !< HFCLK GOOD */
+#define SYSCTL_IMASK_HFCLKGOOD_DISABLE           ((uint32_t)0x00000000U)
+#define SYSCTL_IMASK_HFCLKGOOD_ENABLE            ((uint32_t)0x00000020U)
+/* SYSCTL_IMASK[SRAMSEC] Bits */
+#define SYSCTL_IMASK_SRAMSEC_OFS                 (3)                             /* !< SRAMSEC Offset */
+#define SYSCTL_IMASK_SRAMSEC_MASK                ((uint32_t)0x00000008U)         /* !< SRAM Single Error Correct */
+#define SYSCTL_IMASK_SRAMSEC_DISABLE             ((uint32_t)0x00000000U)
+#define SYSCTL_IMASK_SRAMSEC_ENABLE              ((uint32_t)0x00000008U)
+/* SYSCTL_IMASK[HSCLKGOOD] Bits */
+#define SYSCTL_IMASK_HSCLKGOOD_OFS               (6)                             /* !< HSCLKGOOD Offset */
+#define SYSCTL_IMASK_HSCLKGOOD_MASK              ((uint32_t)0x00000040U)         /* !< HSCLK GOOD */
+#define SYSCTL_IMASK_HSCLKGOOD_DISABLE           ((uint32_t)0x00000000U)
+#define SYSCTL_IMASK_HSCLKGOOD_ENABLE            ((uint32_t)0x00000040U)
+/* SYSCTL_IMASK[ANACLKERR] Bits */
+#define SYSCTL_IMASK_ANACLKERR_OFS               (1)                             /* !< ANACLKERR Offset */
+#define SYSCTL_IMASK_ANACLKERR_MASK              ((uint32_t)0x00000002U)         /* !< Analog Clocking Consistency Error */
+#define SYSCTL_IMASK_ANACLKERR_DISABLE           ((uint32_t)0x00000000U)
+#define SYSCTL_IMASK_ANACLKERR_ENABLE            ((uint32_t)0x00000002U)
+/* SYSCTL_IMASK[FLASHSEC] Bits */
+#define SYSCTL_IMASK_FLASHSEC_OFS                (2)                             /* !< FLASHSEC Offset */
+#define SYSCTL_IMASK_FLASHSEC_MASK               ((uint32_t)0x00000004U)         /* !< Flash Single Error Correct */
+#define SYSCTL_IMASK_FLASHSEC_DISABLE            ((uint32_t)0x00000000U)
+#define SYSCTL_IMASK_FLASHSEC_ENABLE             ((uint32_t)0x00000004U)
+/* SYSCTL_IMASK[LFXTGOOD] Bits */
+#define SYSCTL_IMASK_LFXTGOOD_OFS                (4)                             /* !< LFXTGOOD Offset */
+#define SYSCTL_IMASK_LFXTGOOD_MASK               ((uint32_t)0x00000010U)         /* !< LFXT GOOD */
+#define SYSCTL_IMASK_LFXTGOOD_DISABLE            ((uint32_t)0x00000000U)
+#define SYSCTL_IMASK_LFXTGOOD_ENABLE             ((uint32_t)0x00000010U)
+
+/* SYSCTL_RIS Bits */
+/* SYSCTL_RIS[LFOSCGOOD] Bits */
+#define SYSCTL_RIS_LFOSCGOOD_OFS                 (0)                             /* !< LFOSCGOOD Offset */
+#define SYSCTL_RIS_LFOSCGOOD_MASK                ((uint32_t)0x00000001U)         /* !< Raw status of the LFOSCGOOD
+                                                                                    interrupt. */
+#define SYSCTL_RIS_LFOSCGOOD_FALSE               ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define SYSCTL_RIS_LFOSCGOOD_TRUE                ((uint32_t)0x00000001U)         /* !< Interrupt pending */
+/* SYSCTL_RIS[HFCLKGOOD] Bits */
+#define SYSCTL_RIS_HFCLKGOOD_OFS                 (5)                             /* !< HFCLKGOOD Offset */
+#define SYSCTL_RIS_HFCLKGOOD_MASK                ((uint32_t)0x00000020U)         /* !< HFCLK GOOD */
+#define SYSCTL_RIS_HFCLKGOOD_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_RIS_HFCLKGOOD_TRUE                ((uint32_t)0x00000020U)
+/* SYSCTL_RIS[SRAMSEC] Bits */
+#define SYSCTL_RIS_SRAMSEC_OFS                   (3)                             /* !< SRAMSEC Offset */
+#define SYSCTL_RIS_SRAMSEC_MASK                  ((uint32_t)0x00000008U)         /* !< SRAM Single Error Correct */
+#define SYSCTL_RIS_SRAMSEC_FALSE                 ((uint32_t)0x00000000U)
+#define SYSCTL_RIS_SRAMSEC_TRUE                  ((uint32_t)0x00000008U)
+/* SYSCTL_RIS[HSCLKGOOD] Bits */
+#define SYSCTL_RIS_HSCLKGOOD_OFS                 (6)                             /* !< HSCLKGOOD Offset */
+#define SYSCTL_RIS_HSCLKGOOD_MASK                ((uint32_t)0x00000040U)         /* !< HSCLK GOOD */
+#define SYSCTL_RIS_HSCLKGOOD_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_RIS_HSCLKGOOD_TRUE                ((uint32_t)0x00000040U)
+/* SYSCTL_RIS[ANACLKERR] Bits */
+#define SYSCTL_RIS_ANACLKERR_OFS                 (1)                             /* !< ANACLKERR Offset */
+#define SYSCTL_RIS_ANACLKERR_MASK                ((uint32_t)0x00000002U)         /* !< Analog Clocking Consistency Error */
+#define SYSCTL_RIS_ANACLKERR_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_RIS_ANACLKERR_TRUE                ((uint32_t)0x00000002U)
+/* SYSCTL_RIS[FLASHSEC] Bits */
+#define SYSCTL_RIS_FLASHSEC_OFS                  (2)                             /* !< FLASHSEC Offset */
+#define SYSCTL_RIS_FLASHSEC_MASK                 ((uint32_t)0x00000004U)         /* !< Flash Single Error Correct */
+#define SYSCTL_RIS_FLASHSEC_FALSE                ((uint32_t)0x00000000U)
+#define SYSCTL_RIS_FLASHSEC_TRUE                 ((uint32_t)0x00000004U)
+/* SYSCTL_RIS[LFXTGOOD] Bits */
+#define SYSCTL_RIS_LFXTGOOD_OFS                  (4)                             /* !< LFXTGOOD Offset */
+#define SYSCTL_RIS_LFXTGOOD_MASK                 ((uint32_t)0x00000010U)         /* !< LFXT GOOD */
+#define SYSCTL_RIS_LFXTGOOD_FALSE                ((uint32_t)0x00000000U)
+#define SYSCTL_RIS_LFXTGOOD_TRUE                 ((uint32_t)0x00000010U)
+
+/* SYSCTL_MIS Bits */
+/* SYSCTL_MIS[LFOSCGOOD] Bits */
+#define SYSCTL_MIS_LFOSCGOOD_OFS                 (0)                             /* !< LFOSCGOOD Offset */
+#define SYSCTL_MIS_LFOSCGOOD_MASK                ((uint32_t)0x00000001U)         /* !< Masked status of the LFOSCGOOD
+                                                                                    interrupt. */
+#define SYSCTL_MIS_LFOSCGOOD_FALSE               ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define SYSCTL_MIS_LFOSCGOOD_TRUE                ((uint32_t)0x00000001U)         /* !< Interrupt pending */
+/* SYSCTL_MIS[HFCLKGOOD] Bits */
+#define SYSCTL_MIS_HFCLKGOOD_OFS                 (5)                             /* !< HFCLKGOOD Offset */
+#define SYSCTL_MIS_HFCLKGOOD_MASK                ((uint32_t)0x00000020U)         /* !< HFCLK GOOD */
+#define SYSCTL_MIS_HFCLKGOOD_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_MIS_HFCLKGOOD_TRUE                ((uint32_t)0x00000020U)
+/* SYSCTL_MIS[SRAMSEC] Bits */
+#define SYSCTL_MIS_SRAMSEC_OFS                   (3)                             /* !< SRAMSEC Offset */
+#define SYSCTL_MIS_SRAMSEC_MASK                  ((uint32_t)0x00000008U)         /* !< SRAM Single Error Correct */
+#define SYSCTL_MIS_SRAMSEC_FALSE                 ((uint32_t)0x00000000U)
+#define SYSCTL_MIS_SRAMSEC_TRUE                  ((uint32_t)0x00000008U)
+/* SYSCTL_MIS[HSCLKGOOD] Bits */
+#define SYSCTL_MIS_HSCLKGOOD_OFS                 (6)                             /* !< HSCLKGOOD Offset */
+#define SYSCTL_MIS_HSCLKGOOD_MASK                ((uint32_t)0x00000040U)         /* !< HSCLK GOOD */
+#define SYSCTL_MIS_HSCLKGOOD_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_MIS_HSCLKGOOD_TRUE                ((uint32_t)0x00000040U)
+/* SYSCTL_MIS[ANACLKERR] Bits */
+#define SYSCTL_MIS_ANACLKERR_OFS                 (1)                             /* !< ANACLKERR Offset */
+#define SYSCTL_MIS_ANACLKERR_MASK                ((uint32_t)0x00000002U)         /* !< Analog Clocking Consistency Error */
+#define SYSCTL_MIS_ANACLKERR_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_MIS_ANACLKERR_TRUE                ((uint32_t)0x00000002U)
+/* SYSCTL_MIS[FLASHSEC] Bits */
+#define SYSCTL_MIS_FLASHSEC_OFS                  (2)                             /* !< FLASHSEC Offset */
+#define SYSCTL_MIS_FLASHSEC_MASK                 ((uint32_t)0x00000004U)         /* !< Flash Single Error Correct */
+#define SYSCTL_MIS_FLASHSEC_FALSE                ((uint32_t)0x00000000U)
+#define SYSCTL_MIS_FLASHSEC_TRUE                 ((uint32_t)0x00000004U)
+/* SYSCTL_MIS[LFXTGOOD] Bits */
+#define SYSCTL_MIS_LFXTGOOD_OFS                  (4)                             /* !< LFXTGOOD Offset */
+#define SYSCTL_MIS_LFXTGOOD_MASK                 ((uint32_t)0x00000010U)         /* !< LFXT GOOD */
+#define SYSCTL_MIS_LFXTGOOD_FALSE                ((uint32_t)0x00000000U)
+#define SYSCTL_MIS_LFXTGOOD_TRUE                 ((uint32_t)0x00000010U)
+
+/* SYSCTL_ISET Bits */
+/* SYSCTL_ISET[LFOSCGOOD] Bits */
+#define SYSCTL_ISET_LFOSCGOOD_OFS                (0)                             /* !< LFOSCGOOD Offset */
+#define SYSCTL_ISET_LFOSCGOOD_MASK               ((uint32_t)0x00000001U)         /* !< Set the LFOSCGOOD interrupt. */
+#define SYSCTL_ISET_LFOSCGOOD_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0h hs no effect */
+#define SYSCTL_ISET_LFOSCGOOD_SET                ((uint32_t)0x00000001U)         /* !< Set interrupt */
+/* SYSCTL_ISET[HFCLKGOOD] Bits */
+#define SYSCTL_ISET_HFCLKGOOD_OFS                (5)                             /* !< HFCLKGOOD Offset */
+#define SYSCTL_ISET_HFCLKGOOD_MASK               ((uint32_t)0x00000020U)         /* !< HFCLK GOOD */
+#define SYSCTL_ISET_HFCLKGOOD_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_ISET_HFCLKGOOD_SET                ((uint32_t)0x00000020U)
+/* SYSCTL_ISET[SRAMSEC] Bits */
+#define SYSCTL_ISET_SRAMSEC_OFS                  (3)                             /* !< SRAMSEC Offset */
+#define SYSCTL_ISET_SRAMSEC_MASK                 ((uint32_t)0x00000008U)         /* !< SRAM Single Error Correct */
+#define SYSCTL_ISET_SRAMSEC_NO_EFFECT            ((uint32_t)0x00000000U)
+#define SYSCTL_ISET_SRAMSEC_SET                  ((uint32_t)0x00000008U)
+/* SYSCTL_ISET[HSCLKGOOD] Bits */
+#define SYSCTL_ISET_HSCLKGOOD_OFS                (6)                             /* !< HSCLKGOOD Offset */
+#define SYSCTL_ISET_HSCLKGOOD_MASK               ((uint32_t)0x00000040U)         /* !< HSCLK GOOD */
+#define SYSCTL_ISET_HSCLKGOOD_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_ISET_HSCLKGOOD_SET                ((uint32_t)0x00000040U)
+/* SYSCTL_ISET[ANACLKERR] Bits */
+#define SYSCTL_ISET_ANACLKERR_OFS                (1)                             /* !< ANACLKERR Offset */
+#define SYSCTL_ISET_ANACLKERR_MASK               ((uint32_t)0x00000002U)         /* !< Analog Clocking Consistency Error */
+#define SYSCTL_ISET_ANACLKERR_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_ISET_ANACLKERR_SET                ((uint32_t)0x00000002U)
+/* SYSCTL_ISET[FLASHSEC] Bits */
+#define SYSCTL_ISET_FLASHSEC_OFS                 (2)                             /* !< FLASHSEC Offset */
+#define SYSCTL_ISET_FLASHSEC_MASK                ((uint32_t)0x00000004U)         /* !< Flash Single Error Correct */
+#define SYSCTL_ISET_FLASHSEC_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_ISET_FLASHSEC_SET                 ((uint32_t)0x00000004U)
+/* SYSCTL_ISET[LFXTGOOD] Bits */
+#define SYSCTL_ISET_LFXTGOOD_OFS                 (4)                             /* !< LFXTGOOD Offset */
+#define SYSCTL_ISET_LFXTGOOD_MASK                ((uint32_t)0x00000010U)         /* !< LFXT GOOD */
+#define SYSCTL_ISET_LFXTGOOD_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_ISET_LFXTGOOD_SET                 ((uint32_t)0x00000010U)
+
+/* SYSCTL_ICLR Bits */
+/* SYSCTL_ICLR[LFOSCGOOD] Bits */
+#define SYSCTL_ICLR_LFOSCGOOD_OFS                (0)                             /* !< LFOSCGOOD Offset */
+#define SYSCTL_ICLR_LFOSCGOOD_MASK               ((uint32_t)0x00000001U)         /* !< Clear the LFOSCGOOD interrupt. */
+#define SYSCTL_ICLR_LFOSCGOOD_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0h has no effect */
+#define SYSCTL_ICLR_LFOSCGOOD_CLR                ((uint32_t)0x00000001U)         /* !< Clear interrupt */
+/* SYSCTL_ICLR[HFCLKGOOD] Bits */
+#define SYSCTL_ICLR_HFCLKGOOD_OFS                (5)                             /* !< HFCLKGOOD Offset */
+#define SYSCTL_ICLR_HFCLKGOOD_MASK               ((uint32_t)0x00000020U)         /* !< HFCLK GOOD */
+#define SYSCTL_ICLR_HFCLKGOOD_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_ICLR_HFCLKGOOD_CLR                ((uint32_t)0x00000020U)
+/* SYSCTL_ICLR[SRAMSEC] Bits */
+#define SYSCTL_ICLR_SRAMSEC_OFS                  (3)                             /* !< SRAMSEC Offset */
+#define SYSCTL_ICLR_SRAMSEC_MASK                 ((uint32_t)0x00000008U)         /* !< SRAM Single Error Correct */
+#define SYSCTL_ICLR_SRAMSEC_NO_EFFECT            ((uint32_t)0x00000000U)
+#define SYSCTL_ICLR_SRAMSEC_CLR                  ((uint32_t)0x00000008U)
+/* SYSCTL_ICLR[HSCLKGOOD] Bits */
+#define SYSCTL_ICLR_HSCLKGOOD_OFS                (6)                             /* !< HSCLKGOOD Offset */
+#define SYSCTL_ICLR_HSCLKGOOD_MASK               ((uint32_t)0x00000040U)         /* !< HSCLK GOOD */
+#define SYSCTL_ICLR_HSCLKGOOD_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_ICLR_HSCLKGOOD_CLR                ((uint32_t)0x00000040U)
+/* SYSCTL_ICLR[ANACLKERR] Bits */
+#define SYSCTL_ICLR_ANACLKERR_OFS                (1)                             /* !< ANACLKERR Offset */
+#define SYSCTL_ICLR_ANACLKERR_MASK               ((uint32_t)0x00000002U)         /* !< Analog Clocking Consistency Error */
+#define SYSCTL_ICLR_ANACLKERR_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_ICLR_ANACLKERR_CLR                ((uint32_t)0x00000002U)
+/* SYSCTL_ICLR[FLASHSEC] Bits */
+#define SYSCTL_ICLR_FLASHSEC_OFS                 (2)                             /* !< FLASHSEC Offset */
+#define SYSCTL_ICLR_FLASHSEC_MASK                ((uint32_t)0x00000004U)         /* !< Flash Single Error Correct */
+#define SYSCTL_ICLR_FLASHSEC_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_ICLR_FLASHSEC_CLR                 ((uint32_t)0x00000004U)
+/* SYSCTL_ICLR[LFXTGOOD] Bits */
+#define SYSCTL_ICLR_LFXTGOOD_OFS                 (4)                             /* !< LFXTGOOD Offset */
+#define SYSCTL_ICLR_LFXTGOOD_MASK                ((uint32_t)0x00000010U)         /* !< LFXT GOOD */
+#define SYSCTL_ICLR_LFXTGOOD_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_ICLR_LFXTGOOD_CLR                 ((uint32_t)0x00000010U)
+
+/* SYSCTL_NMIIIDX Bits */
+/* SYSCTL_NMIIIDX[STAT] Bits */
+#define SYSCTL_NMIIIDX_STAT_OFS                  (0)                             /* !< STAT Offset */
+#define SYSCTL_NMIIIDX_STAT_MASK                 ((uint32_t)0x00000007U)         /* !< The NMI interrupt index (NMIIIDX)
+                                                                                    register generates a value
+                                                                                    corresponding to the highest priority
+                                                                                    pending NMI source.  This value may
+                                                                                    be used as an address offset for
+                                                                                    fast, deterministic handling in the
+                                                                                    NMI service routine.  A read of the
+                                                                                    NMIIIDX register will clear the
+                                                                                    corresponding interrupt status in the
+                                                                                    NMIRIS register. */
+#define SYSCTL_NMIIIDX_STAT_NO_INTR              ((uint32_t)0x00000000U)         /* !< No NMI pending */
+#define SYSCTL_NMIIIDX_STAT_BORLVL               ((uint32_t)0x00000001U)         /* !< BOR Threshold NMI pending */
+#define SYSCTL_NMIIIDX_STAT_WWDT0                ((uint32_t)0x00000002U)
+#define SYSCTL_NMIIIDX_STAT_LFCLKFAIL            ((uint32_t)0x00000003U)
+#define SYSCTL_NMIIIDX_STAT_FLASHDED             ((uint32_t)0x00000004U)
+#define SYSCTL_NMIIIDX_STAT_SRAMDED              ((uint32_t)0x00000005U)
+#define SYSCTL_NMIIIDX_STAT_VBATDN               ((uint32_t)0x00000006U)
+#define SYSCTL_NMIIIDX_STAT_VBATUP               ((uint32_t)0x00000007U)
+
+/* SYSCTL_NMIRIS Bits */
+/* SYSCTL_NMIRIS[SRAMDED] Bits */
+#define SYSCTL_NMIRIS_SRAMDED_OFS                (4)                             /* !< SRAMDED Offset */
+#define SYSCTL_NMIRIS_SRAMDED_MASK               ((uint32_t)0x00000010U)         /* !< SRAM Double Error Detect */
+#define SYSCTL_NMIRIS_SRAMDED_FALSE              ((uint32_t)0x00000000U)
+#define SYSCTL_NMIRIS_SRAMDED_TRUE               ((uint32_t)0x00000010U)
+/* SYSCTL_NMIRIS[BORLVL] Bits */
+#define SYSCTL_NMIRIS_BORLVL_OFS                 (0)                             /* !< BORLVL Offset */
+#define SYSCTL_NMIRIS_BORLVL_MASK                ((uint32_t)0x00000001U)         /* !< Raw status of the BORLVL NMI */
+#define SYSCTL_NMIRIS_BORLVL_FALSE               ((uint32_t)0x00000000U)         /* !< No interrupt pending */
+#define SYSCTL_NMIRIS_BORLVL_TRUE                ((uint32_t)0x00000001U)         /* !< Interrupt pending */
+/* SYSCTL_NMIRIS[VBATDN] Bits */
+#define SYSCTL_NMIRIS_VBATDN_OFS                 (5)                             /* !< VBATDN Offset */
+#define SYSCTL_NMIRIS_VBATDN_MASK                ((uint32_t)0x00000020U)         /* !< VBAT Power Off */
+#define SYSCTL_NMIRIS_VBATDN_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_NMIRIS_VBATDN_TRUE                ((uint32_t)0x00000020U)
+/* SYSCTL_NMIRIS[FLASHDED] Bits */
+#define SYSCTL_NMIRIS_FLASHDED_OFS               (3)                             /* !< FLASHDED Offset */
+#define SYSCTL_NMIRIS_FLASHDED_MASK              ((uint32_t)0x00000008U)         /* !< Flash Double Error Detect */
+#define SYSCTL_NMIRIS_FLASHDED_FALSE             ((uint32_t)0x00000000U)
+#define SYSCTL_NMIRIS_FLASHDED_TRUE              ((uint32_t)0x00000008U)
+/* SYSCTL_NMIRIS[WWDT0] Bits */
+#define SYSCTL_NMIRIS_WWDT0_OFS                  (1)                             /* !< WWDT0 Offset */
+#define SYSCTL_NMIRIS_WWDT0_MASK                 ((uint32_t)0x00000002U)         /* !< Watch Dog 0 Fault */
+#define SYSCTL_NMIRIS_WWDT0_FALSE                ((uint32_t)0x00000000U)
+#define SYSCTL_NMIRIS_WWDT0_TRUE                 ((uint32_t)0x00000002U)
+/* SYSCTL_NMIRIS[VBATUP] Bits */
+#define SYSCTL_NMIRIS_VBATUP_OFS                 (6)                             /* !< VBATUP Offset */
+#define SYSCTL_NMIRIS_VBATUP_MASK                ((uint32_t)0x00000040U)         /* !< VBAT Power On */
+#define SYSCTL_NMIRIS_VBATUP_FALSE               ((uint32_t)0x00000000U)
+#define SYSCTL_NMIRIS_VBATUP_TRUE                ((uint32_t)0x00000040U)
+/* SYSCTL_NMIRIS[LFCLKFAIL] Bits */
+#define SYSCTL_NMIRIS_LFCLKFAIL_OFS              (2)                             /* !< LFCLKFAIL Offset */
+#define SYSCTL_NMIRIS_LFCLKFAIL_MASK             ((uint32_t)0x00000004U)         /* !< LFXT-EXLF Monitor Fail */
+#define SYSCTL_NMIRIS_LFCLKFAIL_FALSE            ((uint32_t)0x00000000U)
+#define SYSCTL_NMIRIS_LFCLKFAIL_TRUE             ((uint32_t)0x00000004U)
+
+/* SYSCTL_NMIISET Bits */
+/* SYSCTL_NMIISET[SRAMDED] Bits */
+#define SYSCTL_NMIISET_SRAMDED_OFS               (4)                             /* !< SRAMDED Offset */
+#define SYSCTL_NMIISET_SRAMDED_MASK              ((uint32_t)0x00000010U)         /* !< SRAM Double Error Detect */
+#define SYSCTL_NMIISET_SRAMDED_NO_EFFECT         ((uint32_t)0x00000000U)
+#define SYSCTL_NMIISET_SRAMDED_SET               ((uint32_t)0x00000010U)
+/* SYSCTL_NMIISET[BORLVL] Bits */
+#define SYSCTL_NMIISET_BORLVL_OFS                (0)                             /* !< BORLVL Offset */
+#define SYSCTL_NMIISET_BORLVL_MASK               ((uint32_t)0x00000001U)         /* !< Set the BORLVL NMI */
+#define SYSCTL_NMIISET_BORLVL_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0h hs no effect */
+#define SYSCTL_NMIISET_BORLVL_SET                ((uint32_t)0x00000001U)         /* !< Set interrupt */
+/* SYSCTL_NMIISET[VBATDN] Bits */
+#define SYSCTL_NMIISET_VBATDN_OFS                (5)                             /* !< VBATDN Offset */
+#define SYSCTL_NMIISET_VBATDN_MASK               ((uint32_t)0x00000020U)         /* !< VBAT Power Off */
+#define SYSCTL_NMIISET_VBATDN_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_NMIISET_VBATDN_SET                ((uint32_t)0x00000020U)
+/* SYSCTL_NMIISET[FLASHDED] Bits */
+#define SYSCTL_NMIISET_FLASHDED_OFS              (3)                             /* !< FLASHDED Offset */
+#define SYSCTL_NMIISET_FLASHDED_MASK             ((uint32_t)0x00000008U)         /* !< Flash Double Error Detect */
+#define SYSCTL_NMIISET_FLASHDED_NO_EFFECT        ((uint32_t)0x00000000U)
+#define SYSCTL_NMIISET_FLASHDED_SET              ((uint32_t)0x00000008U)
+/* SYSCTL_NMIISET[WWDT0] Bits */
+#define SYSCTL_NMIISET_WWDT0_OFS                 (1)                             /* !< WWDT0 Offset */
+#define SYSCTL_NMIISET_WWDT0_MASK                ((uint32_t)0x00000002U)         /* !< Watch Dog 0 Fault */
+#define SYSCTL_NMIISET_WWDT0_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_NMIISET_WWDT0_SET                 ((uint32_t)0x00000002U)
+/* SYSCTL_NMIISET[VBATUP] Bits */
+#define SYSCTL_NMIISET_VBATUP_OFS                (6)                             /* !< VBATUP Offset */
+#define SYSCTL_NMIISET_VBATUP_MASK               ((uint32_t)0x00000040U)         /* !< VBAT Power On */
+#define SYSCTL_NMIISET_VBATUP_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_NMIISET_VBATUP_SET                ((uint32_t)0x00000040U)
+/* SYSCTL_NMIISET[LFCLKFAIL] Bits */
+#define SYSCTL_NMIISET_LFCLKFAIL_OFS             (2)                             /* !< LFCLKFAIL Offset */
+#define SYSCTL_NMIISET_LFCLKFAIL_MASK            ((uint32_t)0x00000004U)         /* !< LFXT-EXLF Monitor Fail */
+#define SYSCTL_NMIISET_LFCLKFAIL_NO_EFFECT       ((uint32_t)0x00000000U)
+#define SYSCTL_NMIISET_LFCLKFAIL_SET             ((uint32_t)0x00000004U)
+
+/* SYSCTL_NMIICLR Bits */
+/* SYSCTL_NMIICLR[SRAMDED] Bits */
+#define SYSCTL_NMIICLR_SRAMDED_OFS               (4)                             /* !< SRAMDED Offset */
+#define SYSCTL_NMIICLR_SRAMDED_MASK              ((uint32_t)0x00000010U)         /* !< SRAM Double Error Detect */
+#define SYSCTL_NMIICLR_SRAMDED_NO_EFFECT         ((uint32_t)0x00000000U)
+#define SYSCTL_NMIICLR_SRAMDED_CLR               ((uint32_t)0x00000010U)
+/* SYSCTL_NMIICLR[BORLVL] Bits */
+#define SYSCTL_NMIICLR_BORLVL_OFS                (0)                             /* !< BORLVL Offset */
+#define SYSCTL_NMIICLR_BORLVL_MASK               ((uint32_t)0x00000001U)         /* !< Clr the BORLVL NMI */
+#define SYSCTL_NMIICLR_BORLVL_NO_EFFECT          ((uint32_t)0x00000000U)         /* !< Writing 0h hs no effect */
+#define SYSCTL_NMIICLR_BORLVL_CLR                ((uint32_t)0x00000001U)         /* !< Clear interrupt */
+/* SYSCTL_NMIICLR[VBATDN] Bits */
+#define SYSCTL_NMIICLR_VBATDN_OFS                (5)                             /* !< VBATDN Offset */
+#define SYSCTL_NMIICLR_VBATDN_MASK               ((uint32_t)0x00000020U)         /* !< VBAT Power Off */
+#define SYSCTL_NMIICLR_VBATDN_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_NMIICLR_VBATDN_CLR                ((uint32_t)0x00000020U)
+/* SYSCTL_NMIICLR[FLASHDED] Bits */
+#define SYSCTL_NMIICLR_FLASHDED_OFS              (3)                             /* !< FLASHDED Offset */
+#define SYSCTL_NMIICLR_FLASHDED_MASK             ((uint32_t)0x00000008U)         /* !< Flash Double Error Detect */
+#define SYSCTL_NMIICLR_FLASHDED_NO_EFFECT        ((uint32_t)0x00000000U)
+#define SYSCTL_NMIICLR_FLASHDED_CLR              ((uint32_t)0x00000008U)
+/* SYSCTL_NMIICLR[WWDT0] Bits */
+#define SYSCTL_NMIICLR_WWDT0_OFS                 (1)                             /* !< WWDT0 Offset */
+#define SYSCTL_NMIICLR_WWDT0_MASK                ((uint32_t)0x00000002U)         /* !< Watch Dog 0 Fault */
+#define SYSCTL_NMIICLR_WWDT0_NO_EFFECT           ((uint32_t)0x00000000U)
+#define SYSCTL_NMIICLR_WWDT0_CLR                 ((uint32_t)0x00000002U)
+/* SYSCTL_NMIICLR[VBATUP] Bits */
+#define SYSCTL_NMIICLR_VBATUP_OFS                (6)                             /* !< VBATUP Offset */
+#define SYSCTL_NMIICLR_VBATUP_MASK               ((uint32_t)0x00000040U)         /* !< VBAT Power On */
+#define SYSCTL_NMIICLR_VBATUP_NO_EFFECT          ((uint32_t)0x00000000U)
+#define SYSCTL_NMIICLR_VBATUP_CLR                ((uint32_t)0x00000040U)
+/* SYSCTL_NMIICLR[LFCLKFAIL] Bits */
+#define SYSCTL_NMIICLR_LFCLKFAIL_OFS             (2)                             /* !< LFCLKFAIL Offset */
+#define SYSCTL_NMIICLR_LFCLKFAIL_MASK            ((uint32_t)0x00000004U)         /* !< LFXT-EXLF Monitor Fail */
+#define SYSCTL_NMIICLR_LFCLKFAIL_NO_EFFECT       ((uint32_t)0x00000000U)
+#define SYSCTL_NMIICLR_LFCLKFAIL_CLR             ((uint32_t)0x00000004U)
+
+/* SYSCTL_SYSOSCCFG Bits */
+/* SYSCTL_SYSOSCCFG[USE4MHZSTOP] Bits */
+#define SYSCTL_SYSOSCCFG_USE4MHZSTOP_OFS         (8)                             /* !< USE4MHZSTOP Offset */
+#define SYSCTL_SYSOSCCFG_USE4MHZSTOP_MASK        ((uint32_t)0x00000100U)         /* !< USE4MHZSTOP sets the SYSOSC stop
+                                                                                    mode frequency policy.  When entering
+                                                                                    STOP mode, the SYSOSC frequency may
+                                                                                    be automatically switched to 4MHz to
+                                                                                    reduce SYSOSC power consumption. */
+#define SYSCTL_SYSOSCCFG_USE4MHZSTOP_DISABLE     ((uint32_t)0x00000000U)         /* !< Do not gear shift the SYSOSC to
+                                                                                    4MHz in STOP mode */
+#define SYSCTL_SYSOSCCFG_USE4MHZSTOP_ENABLE      ((uint32_t)0x00000100U)         /* !< Gear shift SYSOSC to 4MHz in STOP
+                                                                                    mode */
+/* SYSCTL_SYSOSCCFG[DISABLESTOP] Bits */
+#define SYSCTL_SYSOSCCFG_DISABLESTOP_OFS         (9)                             /* !< DISABLESTOP Offset */
+#define SYSCTL_SYSOSCCFG_DISABLESTOP_MASK        ((uint32_t)0x00000200U)         /* !< DISABLESTOP sets the SYSOSC stop
+                                                                                    mode enable/disable policy.  When
+                                                                                    operating in STOP mode, the SYSOSC
+                                                                                    may be automatically disabled.  When
+                                                                                    set, ULPCLK will run from LFCLK in
+                                                                                    STOP mode and SYSOSC will be disabled
+                                                                                    to reduce power consumption. */
+#define SYSCTL_SYSOSCCFG_DISABLESTOP_DISABLE     ((uint32_t)0x00000000U)         /* !< Do not disable SYSOSC in STOP mode */
+#define SYSCTL_SYSOSCCFG_DISABLESTOP_ENABLE      ((uint32_t)0x00000200U)         /* !< Disable SYSOSC in STOP mode and
+                                                                                    source ULPCLK from LFCLK */
+/* SYSCTL_SYSOSCCFG[BLOCKASYNCALL] Bits */
+#define SYSCTL_SYSOSCCFG_BLOCKASYNCALL_OFS       (16)                            /* !< BLOCKASYNCALL Offset */
+#define SYSCTL_SYSOSCCFG_BLOCKASYNCALL_MASK      ((uint32_t)0x00010000U)         /* !< BLOCKASYNCALL may be used to mask
+                                                                                    block all asynchronous fast clock
+                                                                                    requests, preventing hardware from
+                                                                                    dynamically changing the active clock
+                                                                                    configuration when operating in a
+                                                                                    given mode. */
+#define SYSCTL_SYSOSCCFG_BLOCKASYNCALL_DISABLE   ((uint32_t)0x00000000U)         /* !< Asynchronous fast clock requests
+                                                                                    are controlled by the requesting
+                                                                                    peripheral */
+#define SYSCTL_SYSOSCCFG_BLOCKASYNCALL_ENABLE    ((uint32_t)0x00010000U)         /* !< All asynchronous fast clock
+                                                                                    requests are blocked */
+/* SYSCTL_SYSOSCCFG[DISABLE] Bits */
+#define SYSCTL_SYSOSCCFG_DISABLE_OFS             (10)                            /* !< DISABLE Offset */
+#define SYSCTL_SYSOSCCFG_DISABLE_MASK            ((uint32_t)0x00000400U)         /* !< DISABLE sets the SYSOSC
+                                                                                    enable/disable policy.  SYSOSC may be
+                                                                                    powered off in RUN, SLEEP, and STOP
+                                                                                    modes to reduce power consumption.
+                                                                                    When SYSOSC is disabled, MCLK and
+                                                                                    ULPCLK are sourced from LFCLK. */
+#define SYSCTL_SYSOSCCFG_DISABLE_DISABLE         ((uint32_t)0x00000000U)         /* !< Do not disable SYSOSC */
+#define SYSCTL_SYSOSCCFG_DISABLE_ENABLE          ((uint32_t)0x00000400U)         /* !< Disable SYSOSC immediately and
+                                                                                    source MCLK and ULPCLK from LFCLK */
+/* SYSCTL_SYSOSCCFG[FASTCPUEVENT] Bits */
+#define SYSCTL_SYSOSCCFG_FASTCPUEVENT_OFS        (17)                            /* !< FASTCPUEVENT Offset */
+#define SYSCTL_SYSOSCCFG_FASTCPUEVENT_MASK       ((uint32_t)0x00020000U)         /* !< FASTCPUEVENT may be used to assert
+                                                                                    a fast clock request when an
+                                                                                    interrupt is asserted to the CPU,
+                                                                                    reducing interrupt latency. */
+#define SYSCTL_SYSOSCCFG_FASTCPUEVENT_DISABLE    ((uint32_t)0x00000000U)         /* !< An interrupt to the CPU will not
+                                                                                    assert a fast clock request */
+#define SYSCTL_SYSOSCCFG_FASTCPUEVENT_ENABLE     ((uint32_t)0x00020000U)         /* !< An interrupt to the CPU will assert
+                                                                                    a fast clock request */
+/* SYSCTL_SYSOSCCFG[FREQ] Bits */
+#define SYSCTL_SYSOSCCFG_FREQ_OFS                (0)                             /* !< FREQ Offset */
+#define SYSCTL_SYSOSCCFG_FREQ_MASK               ((uint32_t)0x00000003U)         /* !< Target operating frequency for the
+                                                                                    system oscillator (SYSOSC) */
+#define SYSCTL_SYSOSCCFG_FREQ_SYSOSCBASE         ((uint32_t)0x00000000U)         /* !< Base frequency (32MHz) */
+#define SYSCTL_SYSOSCCFG_FREQ_SYSOSC4M           ((uint32_t)0x00000001U)         /* !< Low frequency (4MHz) */
+#define SYSCTL_SYSOSCCFG_FREQ_SYSOSCUSER         ((uint32_t)0x00000002U)         /* !< User-trimmed frequency (16 or 24
+                                                                                    MHz) */
+
+/* SYSCTL_MCLKCFG Bits */
+/* SYSCTL_MCLKCFG[USEMFTICK] Bits */
+#define SYSCTL_MCLKCFG_USEMFTICK_OFS             (12)                            /* !< USEMFTICK Offset */
+#define SYSCTL_MCLKCFG_USEMFTICK_MASK            ((uint32_t)0x00001000U)         /* !< USEMFTICK specifies whether the
+                                                                                    4MHz constant-rate clock (MFCLK) to
+                                                                                    peripherals is enabled or disabled.
+                                                                                    When enabled, MDIV must be disabled
+                                                                                    (set to 0h=/1). */
+#define SYSCTL_MCLKCFG_USEMFTICK_DISABLE         ((uint32_t)0x00000000U)         /* !< The 4MHz rate MFCLK to peripherals
+                                                                                    is enabled */
+#define SYSCTL_MCLKCFG_USEMFTICK_ENABLE          ((uint32_t)0x00001000U)         /* !< The 4MHz rate MFCLK to peripherals
+                                                                                    is enabled. */
+/* SYSCTL_MCLKCFG[MDIV] Bits */
+#define SYSCTL_MCLKCFG_MDIV_OFS                  (0)                             /* !< MDIV Offset */
+#define SYSCTL_MCLKCFG_MDIV_MASK                 ((uint32_t)0x0000000FU)         /* !< MDIV may be used to divide the MCLK
+                                                                                    frequency when MCLK is sourced from
+                                                                                    SYSOSC.  MDIV=0h corresponds to /1
+                                                                                    (no divider).  MDIV=1h corresponds to
+                                                                                    /2 (divide-by-2).  MDIV=Fh
+                                                                                    corresponds to /16 (divide-by-16).
+                                                                                    MDIV may be set between /1 and /16 on
+                                                                                    an integer basis. */
+/* SYSCTL_MCLKCFG[USEHSCLK] Bits */
+#define SYSCTL_MCLKCFG_USEHSCLK_OFS              (16)                            /* !< USEHSCLK Offset */
+#define SYSCTL_MCLKCFG_USEHSCLK_MASK             ((uint32_t)0x00010000U)         /* !< USEHSCLK, together with USELFCLK,
+                                                                                    sets the MCLK source policy.  Set
+                                                                                    USEHSCLK to use HSCLK (HFCLK or
+                                                                                    SYSPLL) as the MCLK source in RUN and
+                                                                                    SLEEP modes. */
+#define SYSCTL_MCLKCFG_USEHSCLK_DISABLE          ((uint32_t)0x00000000U)         /* !< MCLK will not use the high speed
+                                                                                    clock (HSCLK) */
+#define SYSCTL_MCLKCFG_USEHSCLK_ENABLE           ((uint32_t)0x00010000U)         /* !< MCLK will use the high speed clock
+                                                                                    (HSCLK) in RUN and SLEEP mode */
+/* SYSCTL_MCLKCFG[USELFCLK] Bits */
+#define SYSCTL_MCLKCFG_USELFCLK_OFS              (20)                            /* !< USELFCLK Offset */
+#define SYSCTL_MCLKCFG_USELFCLK_MASK             ((uint32_t)0x00100000U)         /* !< USELFCLK sets the MCLK source
+                                                                                    policy.  Set USELFCLK to use LFCLK as
+                                                                                    the MCLK source.  Note that setting
+                                                                                    USELFCLK does not disable SYSOSC, and
+                                                                                    SYSOSC remains available for direct
+                                                                                    use by analog modules. */
+#define SYSCTL_MCLKCFG_USELFCLK_DISABLE          ((uint32_t)0x00000000U)         /* !< MCLK will not use the low frequency
+                                                                                    clock (LFCLK) */
+#define SYSCTL_MCLKCFG_USELFCLK_ENABLE           ((uint32_t)0x00100000U)         /* !< MCLK will use the low frequency
+                                                                                    clock (LFCLK) */
+/* SYSCTL_MCLKCFG[STOPCLKSTBY] Bits */
+#define SYSCTL_MCLKCFG_STOPCLKSTBY_OFS           (21)                            /* !< STOPCLKSTBY Offset */
+#define SYSCTL_MCLKCFG_STOPCLKSTBY_MASK          ((uint32_t)0x00200000U)         /* !< STOPCLKSTBY sets the STANDBY mode
+                                                                                    policy (STANDBY0 or STANDBY1).  When
+                                                                                    set, ULPCLK and LFCLK are disabled to
+                                                                                    all peripherals in STANDBY mode, with
+                                                                                    the exception of TIMG0 and TIMG1
+                                                                                    which continue to run.  Wake-up is
+                                                                                    only possible via an asynchronous
+                                                                                    fast clock request. */
+#define SYSCTL_MCLKCFG_STOPCLKSTBY_DISABLE       ((uint32_t)0x00000000U)         /* !< ULPCLK/LFCLK runs to all PD0
+                                                                                    peripherals in STANDBY mode */
+#define SYSCTL_MCLKCFG_STOPCLKSTBY_ENABLE        ((uint32_t)0x00200000U)         /* !< ULPCLK/LFCLK is disabled to all
+                                                                                    peripherals in STANDBY mode except
+                                                                                    TIMG0 and TIMG1 */
+/* SYSCTL_MCLKCFG[FLASHWAIT] Bits */
+#define SYSCTL_MCLKCFG_FLASHWAIT_OFS             (8)                             /* !< FLASHWAIT Offset */
+#define SYSCTL_MCLKCFG_FLASHWAIT_MASK            ((uint32_t)0x00000F00U)         /* !< FLASHWAIT specifies the number of
+                                                                                    flash wait states when MCLK is
+                                                                                    sourced from HSCLK.  FLASHWAIT has no
+                                                                                    effect when MCLK is sourced from
+                                                                                    SYSOSC or LFCLK. */
+#define SYSCTL_MCLKCFG_FLASHWAIT_WAIT0           ((uint32_t)0x00000000U)         /* !< No flash wait states are applied */
+#define SYSCTL_MCLKCFG_FLASHWAIT_WAIT1           ((uint32_t)0x00000100U)         /* !< One flash wait state is applied */
+#define SYSCTL_MCLKCFG_FLASHWAIT_WAIT2           ((uint32_t)0x00000200U)         /* !< 2 flash wait states are applied */
+/* SYSCTL_MCLKCFG[MCLKDEADCHK] Bits */
+#define SYSCTL_MCLKCFG_MCLKDEADCHK_OFS           (22)                            /* !< MCLKDEADCHK Offset */
+#define SYSCTL_MCLKCFG_MCLKDEADCHK_MASK          ((uint32_t)0x00400000U)         /* !< MCLKDEADCHK enables or disables the
+                                                                                    continuous MCLK dead check monitor.
+                                                                                    LFCLK must be running before
+                                                                                    MCLKDEADCHK is enabled. */
+#define SYSCTL_MCLKCFG_MCLKDEADCHK_DISABLE       ((uint32_t)0x00000000U)         /* !< The MCLK dead check monitor is
+                                                                                    disabled */
+#define SYSCTL_MCLKCFG_MCLKDEADCHK_ENABLE        ((uint32_t)0x00400000U)         /* !< The MCLK dead check monitor is
+                                                                                    enabled */
+
+/* SYSCTL_HSCLKEN Bits */
+/* SYSCTL_HSCLKEN[HFXTEN] Bits */
+#define SYSCTL_HSCLKEN_HFXTEN_OFS                (0)                             /* !< HFXTEN Offset */
+#define SYSCTL_HSCLKEN_HFXTEN_MASK               ((uint32_t)0x00000001U)         /* !< HFXTEN enables or disables the high
+                                                                                    frequency crystal oscillator (HFXT). */
+#define SYSCTL_HSCLKEN_HFXTEN_DISABLE            ((uint32_t)0x00000000U)         /* !< Disable the HFXT */
+#define SYSCTL_HSCLKEN_HFXTEN_ENABLE             ((uint32_t)0x00000001U)         /* !< Enable the HFXT */
+/* SYSCTL_HSCLKEN[USEEXTHFCLK] Bits */
+#define SYSCTL_HSCLKEN_USEEXTHFCLK_OFS           (16)                            /* !< USEEXTHFCLK Offset */
+#define SYSCTL_HSCLKEN_USEEXTHFCLK_MASK          ((uint32_t)0x00010000U)         /* !< USEEXTHFCLK selects the HFCLK_IN
+                                                                                    digital clock input to be the source
+                                                                                    for HFCLK.  When disabled, HFXT is
+                                                                                    the HFCLK source and HFXTEN may be
+                                                                                    set.  Do not set HFXTEN and
+                                                                                    USEEXTHFCLK simultaneously. */
+#define SYSCTL_HSCLKEN_USEEXTHFCLK_DISABLE       ((uint32_t)0x00000000U)         /* !< Use HFXT as the HFCLK source */
+#define SYSCTL_HSCLKEN_USEEXTHFCLK_ENABLE        ((uint32_t)0x00010000U)         /* !< Use the HFCLK_IN digital clock
+                                                                                    input as the HFCLK source */
+
+/* SYSCTL_HSCLKCFG Bits */
+/* SYSCTL_HSCLKCFG[HSCLKSEL] Bits */
+#define SYSCTL_HSCLKCFG_HSCLKSEL_OFS             (0)                             /* !< HSCLKSEL Offset */
+#define SYSCTL_HSCLKCFG_HSCLKSEL_MASK            ((uint32_t)0x00000001U)         /* !< HSCLKSEL selects the HSCLK source
+                                                                                    (SYSPLL or HFCLK). */
+#define SYSCTL_HSCLKCFG_HSCLKSEL_HFCLKCLK        ((uint32_t)0x00000001U)         /* !< HSCLK is sourced from the HFCLK */
+
+/* SYSCTL_HFCLKCLKCFG Bits */
+/* SYSCTL_HFCLKCLKCFG[HFXTTIME] Bits */
+#define SYSCTL_HFCLKCLKCFG_HFXTTIME_OFS          (0)                             /* !< HFXTTIME Offset */
+#define SYSCTL_HFCLKCLKCFG_HFXTTIME_MASK         ((uint32_t)0x000000FFU)         /* !< HFXTTIME specifies the HFXT startup
+                                                                                    time in 64us resolution.  If the
+                                                                                    HFCLK startup monitor is enabled
+                                                                                    (HFCLKFLTCHK), HFXT will be checked
+                                                                                    after this time expires. */
+#define SYSCTL_HFCLKCLKCFG_HFXTTIME_MINSTARTTIME ((uint32_t)0x00000000U)         /* !< Minimum startup time (approximatly
+                                                                                    zero) */
+#define SYSCTL_HFCLKCLKCFG_HFXTTIME_MAXSTARTTIME ((uint32_t)0x000000FFU)         /* !< Maximum startup time (approximatly
+                                                                                    16.32ms) */
+/* SYSCTL_HFCLKCLKCFG[HFCLKFLTCHK] Bits */
+#define SYSCTL_HFCLKCLKCFG_HFCLKFLTCHK_OFS       (28)                            /* !< HFCLKFLTCHK Offset */
+#define SYSCTL_HFCLKCLKCFG_HFCLKFLTCHK_MASK      ((uint32_t)0x10000000U)         /* !< HFCLKFLTCHK enables or disables the
+                                                                                    HFCLK startup monitor. */
+#define SYSCTL_HFCLKCLKCFG_HFCLKFLTCHK_DISABLE   ((uint32_t)0x00000000U)         /* !< HFCLK startup is not checked */
+#define SYSCTL_HFCLKCLKCFG_HFCLKFLTCHK_ENABLE    ((uint32_t)0x10000000U)         /* !< HFCLK startup is checked */
+/* SYSCTL_HFCLKCLKCFG[HFXTRSEL] Bits */
+#define SYSCTL_HFCLKCLKCFG_HFXTRSEL_OFS          (12)                            /* !< HFXTRSEL Offset */
+#define SYSCTL_HFCLKCLKCFG_HFXTRSEL_MASK         ((uint32_t)0x00003000U)         /* !< HFXT Range Select */
+#define SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE4TO8    ((uint32_t)0x00000000U)         /* !< 4MHz &lt;= HFXT frequency &lt;=
+                                                                                    8MHz */
+#define SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE8TO16   ((uint32_t)0x00001000U)         /* !< 8MHz &lt; HFXT frequency &lt;=
+                                                                                    16MHz */
+#define SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE16TO32  ((uint32_t)0x00002000U)         /* !< 16MHz &lt; HFXT frequency &lt;=
+                                                                                    32MHz */
+#define SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE32TO48  ((uint32_t)0x00003000U)         /* !< 32MHz &lt; HFXT frequency &lt;=
+                                                                                    48MHz */
+
+/* SYSCTL_LFCLKCFG Bits */
+/* SYSCTL_LFCLKCFG[XT1DRIVE] Bits */
+#define SYSCTL_LFCLKCFG_XT1DRIVE_OFS             (0)                             /* !< XT1DRIVE Offset */
+#define SYSCTL_LFCLKCFG_XT1DRIVE_MASK            ((uint32_t)0x00000003U)         /* !< XT1DRIVE selects the low frequency
+                                                                                    crystal oscillator (LFXT) drive
+                                                                                    strength. */
+#define SYSCTL_LFCLKCFG_XT1DRIVE_LOWESTDRV       ((uint32_t)0x00000000U)         /* !< Lowest drive and current */
+#define SYSCTL_LFCLKCFG_XT1DRIVE_LOWERDRV        ((uint32_t)0x00000001U)         /* !< Lower drive and current */
+#define SYSCTL_LFCLKCFG_XT1DRIVE_HIGHERDRV       ((uint32_t)0x00000002U)         /* !< Higher drive and current */
+#define SYSCTL_LFCLKCFG_XT1DRIVE_HIGHESTDRV      ((uint32_t)0x00000003U)         /* !< Highest drive and current */
+/* SYSCTL_LFCLKCFG[MONITOR] Bits */
+#define SYSCTL_LFCLKCFG_MONITOR_OFS              (4)                             /* !< MONITOR Offset */
+#define SYSCTL_LFCLKCFG_MONITOR_MASK             ((uint32_t)0x00000010U)         /* !< MONITOR enables or disables the
+                                                                                    LFCLK monitor, which continuously
+                                                                                    checks LFXT or LFCLK_IN for a clock
+                                                                                    stuck fault. */
+#define SYSCTL_LFCLKCFG_MONITOR_DISABLE          ((uint32_t)0x00000000U)         /* !< Clock monitor is disabled */
+#define SYSCTL_LFCLKCFG_MONITOR_ENABLE           ((uint32_t)0x00000010U)         /* !< Clock monitor is enabled */
+/* SYSCTL_LFCLKCFG[LOWCAP] Bits */
+#define SYSCTL_LFCLKCFG_LOWCAP_OFS               (8)                             /* !< LOWCAP Offset */
+#define SYSCTL_LFCLKCFG_LOWCAP_MASK              ((uint32_t)0x00000100U)         /* !< LOWCAP controls the low-power LFXT
+                                                                                    mode.  When the LFXT load capacitance
+                                                                                    is less than 3pf, LOWCAP may be set
+                                                                                    for reduced power consumption. */
+#define SYSCTL_LFCLKCFG_LOWCAP_DISABLE           ((uint32_t)0x00000000U)         /* !< LFXT low capacitance mode is
+                                                                                    disabled */
+#define SYSCTL_LFCLKCFG_LOWCAP_ENABLE            ((uint32_t)0x00000100U)         /* !< LFXT low capacitance mode is
+                                                                                    enabled */
+
+/* SYSCTL_GENCLKCFG Bits */
+/* SYSCTL_GENCLKCFG[HFCLK4MFPCLKDIV] Bits */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_OFS     (12)                            /* !< HFCLK4MFPCLKDIV Offset */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_MASK    ((uint32_t)0x0000F000U)         /* !< HFCLK4MFPCLKDIV selects the divider
+                                                                                    applied to HFCLK when HFCLK is used
+                                                                                    as the MFPCLK source.  Integer
+                                                                                    dividers from /1 to /16 may be
+                                                                                    selected. */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV1    ((uint32_t)0x00000000U)         /* !< HFCLK is not divided before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV2    ((uint32_t)0x00001000U)         /* !< HFCLK is divided by 2 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV3    ((uint32_t)0x00002000U)         /* !< HFCLK is divided by 3 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV4    ((uint32_t)0x00003000U)         /* !< HFCLK is divided by 4 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV5    ((uint32_t)0x00004000U)         /* !< HFCLK is divided by 5 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV6    ((uint32_t)0x00005000U)         /* !< HFCLK is divided by 6 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV7    ((uint32_t)0x00006000U)         /* !< HFCLK is divided by 7 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV8    ((uint32_t)0x00007000U)         /* !< HFCLK is divided by 8 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV9    ((uint32_t)0x00008000U)         /* !< HFCLK is divided by 9 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV10   ((uint32_t)0x00009000U)         /* !< HFCLK is divided by 10 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV11   ((uint32_t)0x0000A000U)         /* !< HFCLK is divided by 11 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV12   ((uint32_t)0x0000B000U)         /* !< HFCLK is divided by 12 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV13   ((uint32_t)0x0000C000U)         /* !< HFCLK is divided by 13 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV14   ((uint32_t)0x0000D000U)         /* !< HFCLK is divided by 14 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV15   ((uint32_t)0x0000E000U)         /* !< HFCLK is divided by 15 before being
+                                                                                    used for MFPCLK */
+#define SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_DIV16   ((uint32_t)0x0000F000U)         /* !< HFCLK is divided by 16 before being
+                                                                                    used for MFPCLK */
+/* SYSCTL_GENCLKCFG[MFPCLKSRC] Bits */
+#define SYSCTL_GENCLKCFG_MFPCLKSRC_OFS           (9)                             /* !< MFPCLKSRC Offset */
+#define SYSCTL_GENCLKCFG_MFPCLKSRC_MASK          ((uint32_t)0x00000200U)         /* !< MFPCLKSRC selects the MFPCLK
+                                                                                    (middle frequency precision clock)
+                                                                                    source. */
+#define SYSCTL_GENCLKCFG_MFPCLKSRC_SYSOSC        ((uint32_t)0x00000000U)         /* !< MFPCLK is sourced from SYSOSC */
+#define SYSCTL_GENCLKCFG_MFPCLKSRC_HFCLK         ((uint32_t)0x00000200U)         /* !< MFPCLK is sourced from HFCLK */
+/* SYSCTL_GENCLKCFG[FCCTRIGCNT] Bits */
+#define SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS          (24)                            /* !< FCCTRIGCNT Offset */
+#define SYSCTL_GENCLKCFG_FCCTRIGCNT_MASK         ((uint32_t)0x1F000000U)         /* !< FCCTRIGCNT specifies the number of
+                                                                                    trigger clock periods in the trigger
+                                                                                    window. FCCTRIGCNT=0h (one trigger
+                                                                                    clock period) up to 1Fh (32 trigger
+                                                                                    clock periods) may be specified. */
+/* SYSCTL_GENCLKCFG[ANACPUMPCFG] Bits */
+#define SYSCTL_GENCLKCFG_ANACPUMPCFG_OFS         (22)                            /* !< ANACPUMPCFG Offset */
+#define SYSCTL_GENCLKCFG_ANACPUMPCFG_MASK        ((uint32_t)0x00C00000U)         /* !< ANACPUMPCFG selects the analog mux
+                                                                                    charge pump (VBOOST) enable method. */
+#define SYSCTL_GENCLKCFG_ANACPUMPCFG_ONDEMAND    ((uint32_t)0x00000000U)         /* !< VBOOST is enabled on request from a
+                                                                                    COMP, GPAMP, or OPA */
+#define SYSCTL_GENCLKCFG_ANACPUMPCFG_ONACTIVE    ((uint32_t)0x00400000U)         /* !< VBOOST is enabled when the device
+                                                                                    is in RUN or SLEEP mode, or when a
+                                                                                    COMP/GPAMP/OPA is enabled */
+#define SYSCTL_GENCLKCFG_ANACPUMPCFG_ONALWAYS    ((uint32_t)0x00800000U)         /* !< VBOOST is always enabled */
+/* SYSCTL_GENCLKCFG[FCCSELCLK] Bits */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_OFS           (16)                            /* !< FCCSELCLK Offset */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_MASK          ((uint32_t)0x000F0000U)         /* !< FCCSELCLK selectes the frequency
+                                                                                    clock counter (FCC) clock source. */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_MCLK          ((uint32_t)0x00000000U)         /* !< FCC clock is MCLK */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_SYSOSC        ((uint32_t)0x00010000U)         /* !< FCC clock is SYSOSC */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_HFCLK         ((uint32_t)0x00020000U)         /* !< FCC clock is HFCLK */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_EXTCLK        ((uint32_t)0x00030000U)         /* !< FCC clock is the CLK_OUT selection */
+#define SYSCTL_GENCLKCFG_FCCSELCLK_FCCIN         ((uint32_t)0x00070000U)         /* !< FCC clock is the FCCIN external
+                                                                                    input */
+/* SYSCTL_GENCLKCFG[FCCTRIGSRC] Bits */
+#define SYSCTL_GENCLKCFG_FCCTRIGSRC_OFS          (20)                            /* !< FCCTRIGSRC Offset */
+#define SYSCTL_GENCLKCFG_FCCTRIGSRC_MASK         ((uint32_t)0x00100000U)         /* !< FCCTRIGSRC selects the frequency
+                                                                                    clock counter (FCC) trigger source. */
+#define SYSCTL_GENCLKCFG_FCCTRIGSRC_EXTPIN       ((uint32_t)0x00000000U)         /* !< FCC trigger is the external pin */
+#define SYSCTL_GENCLKCFG_FCCTRIGSRC_LFCLK        ((uint32_t)0x00100000U)         /* !< FCC trigger is the LFCLK */
+/* SYSCTL_GENCLKCFG[FCCLVLTRIG] Bits */
+#define SYSCTL_GENCLKCFG_FCCLVLTRIG_OFS          (21)                            /* !< FCCLVLTRIG Offset */
+#define SYSCTL_GENCLKCFG_FCCLVLTRIG_MASK         ((uint32_t)0x00200000U)         /* !< FCCLVLTRIG selects the frequency
+                                                                                    clock counter (FCC) trigger mode. */
+#define SYSCTL_GENCLKCFG_FCCLVLTRIG_RISE2RISE    ((uint32_t)0x00000000U)         /* !< Rising edge to rising edge
+                                                                                    triggered */
+#define SYSCTL_GENCLKCFG_FCCLVLTRIG_LEVEL        ((uint32_t)0x00200000U)         /* !< Level triggered */
+/* SYSCTL_GENCLKCFG[EXCLKSRC] Bits */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_OFS            (0)                             /* !< EXCLKSRC Offset */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_MASK           ((uint32_t)0x00000007U)         /* !< EXCLKSRC selects the source for the
+                                                                                    CLK_OUT external clock output block.
+                                                                                    ULPCLK and MFPCLK require the CLK_OUT
+                                                                                    divider (EXCLKDIVEN) to be enabled */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_SYSOSC         ((uint32_t)0x00000000U)         /* !< CLK_OUT is SYSOSC */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_ULPCLK         ((uint32_t)0x00000001U)         /* !< CLK_OUT is ULPCLK (EXCLKDIVEN must
+                                                                                    be enabled) */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_LFCLK          ((uint32_t)0x00000002U)         /* !< CLK_OUT is LFCLK */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_MFPCLK         ((uint32_t)0x00000003U)         /* !< CLK_OUT is MFPCLK (EXCLKDIVEN must
+                                                                                    be enabled) */
+#define SYSCTL_GENCLKCFG_EXCLKSRC_HFCLK          ((uint32_t)0x00000004U)         /* !< CLK_OUT is HFCLK */
+/* SYSCTL_GENCLKCFG[EXCLKDIVVAL] Bits */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_OFS         (4)                             /* !< EXCLKDIVVAL Offset */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_MASK        ((uint32_t)0x00000070U)         /* !< EXCLKDIVVAL selects the divider
+                                                                                    value for the divider in the CLK_OUT
+                                                                                    external clock output block. */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV2        ((uint32_t)0x00000000U)         /* !< CLK_OUT source is divided by 2 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV4        ((uint32_t)0x00000010U)         /* !< CLK_OUT source is divided by 4 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV6        ((uint32_t)0x00000020U)         /* !< CLK_OUT source is divided by 6 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV8        ((uint32_t)0x00000030U)         /* !< CLK_OUT source is divided by 8 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV10       ((uint32_t)0x00000040U)         /* !< CLK_OUT source is divided by 10 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV12       ((uint32_t)0x00000050U)         /* !< CLK_OUT source is divided by 12 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV14       ((uint32_t)0x00000060U)         /* !< CLK_OUT source is divided by 14 */
+#define SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV16       ((uint32_t)0x00000070U)         /* !< CLK_OUT source is divided by 16 */
+/* SYSCTL_GENCLKCFG[EXCLKDIVEN] Bits */
+#define SYSCTL_GENCLKCFG_EXCLKDIVEN_OFS          (7)                             /* !< EXCLKDIVEN Offset */
+#define SYSCTL_GENCLKCFG_EXCLKDIVEN_MASK         ((uint32_t)0x00000080U)         /* !< EXCLKDIVEN enables or disables the
+                                                                                    divider function of the CLK_OUT
+                                                                                    external clock output block. */
+#define SYSCTL_GENCLKCFG_EXCLKDIVEN_PASSTHRU     ((uint32_t)0x00000000U)         /* !< CLock divider is disabled
+                                                                                    (passthrough, EXCLKDIVVAL is not
+                                                                                    applied) */
+#define SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE       ((uint32_t)0x00000080U)         /* !< Clock divider is enabled
+                                                                                    (EXCLKDIVVAL is applied) */
+
+/* SYSCTL_GENCLKEN Bits */
+/* SYSCTL_GENCLKEN[EXCLKEN] Bits */
+#define SYSCTL_GENCLKEN_EXCLKEN_OFS              (0)                             /* !< EXCLKEN Offset */
+#define SYSCTL_GENCLKEN_EXCLKEN_MASK             ((uint32_t)0x00000001U)         /* !< EXCLKEN enables the CLK_OUT
+                                                                                    external clock output block. */
+#define SYSCTL_GENCLKEN_EXCLKEN_DISABLE          ((uint32_t)0x00000000U)         /* !< CLK_OUT block is disabled */
+#define SYSCTL_GENCLKEN_EXCLKEN_ENABLE           ((uint32_t)0x00000001U)         /* !< CLK_OUT block is enabled */
+/* SYSCTL_GENCLKEN[MFPCLKEN] Bits */
+#define SYSCTL_GENCLKEN_MFPCLKEN_OFS             (4)                             /* !< MFPCLKEN Offset */
+#define SYSCTL_GENCLKEN_MFPCLKEN_MASK            ((uint32_t)0x00000010U)         /* !< MFPCLKEN enables the middle
+                                                                                    frequency precision clock (MFPCLK). */
+#define SYSCTL_GENCLKEN_MFPCLKEN_DISABLE         ((uint32_t)0x00000000U)         /* !< MFPCLK is disabled */
+#define SYSCTL_GENCLKEN_MFPCLKEN_ENABLE          ((uint32_t)0x00000010U)         /* !< MFPCLK is enabled */
+
+/* SYSCTL_PMODECFG Bits */
+/* SYSCTL_PMODECFG[DSLEEP] Bits */
+#define SYSCTL_PMODECFG_DSLEEP_OFS               (0)                             /* !< DSLEEP Offset */
+#define SYSCTL_PMODECFG_DSLEEP_MASK              ((uint32_t)0x00000003U)         /* !< DSLEEP selects the operating mode
+                                                                                    to enter upon a DEEPSLEEP request
+                                                                                    from the CPU. */
+#define SYSCTL_PMODECFG_DSLEEP_STOP              ((uint32_t)0x00000000U)         /* !< STOP mode is entered */
+#define SYSCTL_PMODECFG_DSLEEP_STANDBY           ((uint32_t)0x00000001U)         /* !< STANDBY mode is entered */
+#define SYSCTL_PMODECFG_DSLEEP_SHUTDOWN          ((uint32_t)0x00000002U)         /* !< SHUTDOWN mode is entered */
+
+/* SYSCTL_FCC Bits */
+/* SYSCTL_FCC[DATA] Bits */
+#define SYSCTL_FCC_DATA_OFS                      (0)                             /* !< DATA Offset */
+#define SYSCTL_FCC_DATA_MASK                     ((uint32_t)0x003FFFFFU)         /* !< Frequency clock counter (FCC) count
+                                                                                    value. */
+
+/* SYSCTL_SYSOSCTRIMUSER Bits */
+/* SYSCTL_SYSOSCTRIMUSER[RESCOARSE] Bits */
+#define SYSCTL_SYSOSCTRIMUSER_RESCOARSE_OFS      (8)                             /* !< RESCOARSE Offset */
+#define SYSCTL_SYSOSCTRIMUSER_RESCOARSE_MASK     ((uint32_t)0x00003F00U)         /* !< RESCOARSE specifies the resister
+                                                                                    coarse trim.  This value changes with
+                                                                                    the target frequency. */
+/* SYSCTL_SYSOSCTRIMUSER[RESFINE] Bits */
+#define SYSCTL_SYSOSCTRIMUSER_RESFINE_OFS        (16)                            /* !< RESFINE Offset */
+#define SYSCTL_SYSOSCTRIMUSER_RESFINE_MASK       ((uint32_t)0x000F0000U)         /* !< RESFINE specifies the resister fine
+                                                                                    trim.  This value changes with the
+                                                                                    target frequency. */
+/* SYSCTL_SYSOSCTRIMUSER[RDIV] Bits */
+#define SYSCTL_SYSOSCTRIMUSER_RDIV_OFS           (20)                            /* !< RDIV Offset */
+#define SYSCTL_SYSOSCTRIMUSER_RDIV_MASK          ((uint32_t)0x1FF00000U)         /* !< RDIV specifies the frequency
+                                                                                    correction loop (FCL) resistor trim.
+                                                                                    This value changes with the target
+                                                                                    frequency. */
+/* SYSCTL_SYSOSCTRIMUSER[FREQ] Bits */
+#define SYSCTL_SYSOSCTRIMUSER_FREQ_OFS           (0)                             /* !< FREQ Offset */
+#define SYSCTL_SYSOSCTRIMUSER_FREQ_MASK          ((uint32_t)0x00000003U)         /* !< FREQ specifies the target
+                                                                                    user-trimmed frequency for SYSOSC. */
+#define SYSCTL_SYSOSCTRIMUSER_FREQ_SYSOSC16M     ((uint32_t)0x00000001U)         /* !< 16MHz user frequency */
+#define SYSCTL_SYSOSCTRIMUSER_FREQ_SYSOSC24M     ((uint32_t)0x00000002U)         /* !< 24MHz user frequency */
+/* SYSCTL_SYSOSCTRIMUSER[CAP] Bits */
+#define SYSCTL_SYSOSCTRIMUSER_CAP_OFS            (4)                             /* !< CAP Offset */
+#define SYSCTL_SYSOSCTRIMUSER_CAP_MASK           ((uint32_t)0x00000070U)         /* !< CAP specifies the SYSOSC capacitor
+                                                                                    trim.  This value changes with the
+                                                                                    target frequency. */
+
+/* SYSCTL_SRAMBOUNDARY Bits */
+/* SYSCTL_SRAMBOUNDARY[ADDR] Bits */
+#define SYSCTL_SRAMBOUNDARY_ADDR_OFS             (5)                             /* !< ADDR Offset */
+#define SYSCTL_SRAMBOUNDARY_ADDR_MASK            ((uint32_t)0x000FFFE0U)         /* !< SRAM boundary configuration. The
+                                                                                    value configured into this acts such
+                                                                                    that: SRAM accesses to addresses less
+                                                                                    than or equal value will be RW only.
+                                                                                    SRAM accesses to addresses greater
+                                                                                    than value will be RX only. Value of
+                                                                                    0 is not valid (system will have no
+                                                                                    stack). If set to 0, the system acts
+                                                                                    as if the entire SRAM is RWX.  Any
+                                                                                    non-zero value can be configured,
+                                                                                    including a value = SRAM size. */
+
+/* SYSCTL_SYSTEMCFG Bits */
+/* SYSCTL_SYSTEMCFG[KEY] Bits */
+#define SYSCTL_SYSTEMCFG_KEY_OFS                 (24)                            /* !< KEY Offset */
+#define SYSCTL_SYSTEMCFG_KEY_MASK                ((uint32_t)0xFF000000U)         /* !< The key value of 1Bh (27) must be
+                                                                                    written to KEY together with contents
+                                                                                    to be updated. Reads as 0 */
+#define SYSCTL_SYSTEMCFG_KEY_VALUE               ((uint32_t)0x1B000000U)         /* !< Issue write */
+/* SYSCTL_SYSTEMCFG[FLASHECCRSTDIS] Bits */
+#define SYSCTL_SYSTEMCFG_FLASHECCRSTDIS_OFS      (2)                             /* !< FLASHECCRSTDIS Offset */
+#define SYSCTL_SYSTEMCFG_FLASHECCRSTDIS_MASK     ((uint32_t)0x00000004U)         /* !< FLASHECCRSTDIS specifies whether a
+                                                                                    flash ECC double error detect (DED)
+                                                                                    will trigger a SYSRST or an NMI. */
+#define SYSCTL_SYSTEMCFG_FLASHECCRSTDIS_FALSE    ((uint32_t)0x00000000U)         /* !< Flash ECC DED will trigger a SYSRST */
+#define SYSCTL_SYSTEMCFG_FLASHECCRSTDIS_TRUE     ((uint32_t)0x00000004U)         /* !< Flash ECC DED will trigger a NMI */
+/* SYSCTL_SYSTEMCFG[WWDTLP0RSTDIS] Bits */
+#define SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_OFS       (0)                             /* !< WWDTLP0RSTDIS Offset */
+#define SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_MASK      ((uint32_t)0x00000001U)         /* !< WWDTLP0RSTDIS specifies whether a
+                                                                                    WWDT Error Event will trigger a
+                                                                                    BOOTRST or an NMI. */
+#define SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_FALSE     ((uint32_t)0x00000000U)         /* !< WWDTLP0 Error Event will trigger a
+                                                                                    BOOTRST */
+#define SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_TRUE      ((uint32_t)0x00000001U)         /* !< WWDTLP0 Error Event will trigger an
+                                                                                    NMI */
+#define SYSCTL_SYSTEMCFG_SUPERCAPEN_OFS          (8)                             /* !< SUPERCAPEN Offset */
+#define SYSCTL_SYSTEMCFG_SUPERCAPEN_MASK         ((uint32_t)0x00000100U)         /* !< SUPERCAP specifies whether the
+                                                                                    battery backup system can be powered
+                                                                                    by a SUPERCAP */
+#define SYSCTL_SYSTEMCFG_SUPERCAPEN_FALSE        ((uint32_t)0x00000000U)         /* !< SUPERCAP Function is not enabled */
+#define SYSCTL_SYSTEMCFG_SUPERCAPEN_TRUE         ((uint32_t)0x00000100U)         /* !< SUPERCAP Function is not enabled */
+
+/* SYSCTL_WRITELOCK Bits */
+/* SYSCTL_WRITELOCK[ACTIVE] Bits */
+#define SYSCTL_WRITELOCK_ACTIVE_OFS              (0)                             /* !< ACTIVE Offset */
+#define SYSCTL_WRITELOCK_ACTIVE_MASK             ((uint32_t)0x00000001U)         /* !< ACTIVE controls whether critical
+                                                                                    SYSCTL registers are write protected
+                                                                                    or not. */
+#define SYSCTL_WRITELOCK_ACTIVE_DISABLE          ((uint32_t)0x00000000U)         /* !< Allow writes to lockable registers */
+#define SYSCTL_WRITELOCK_ACTIVE_ENABLE           ((uint32_t)0x00000001U)         /* !< Disallow writes to lockable
+                                                                                    registers */
+
+/* SYSCTL_CLKSTATUS Bits */
+/* SYSCTL_CLKSTATUS[LFOSCGOOD] Bits */
+#define SYSCTL_CLKSTATUS_LFOSCGOOD_OFS           (11)                            /* !< LFOSCGOOD Offset */
+#define SYSCTL_CLKSTATUS_LFOSCGOOD_MASK          ((uint32_t)0x00000800U)         /* !< LFOSCGOOD indicates when the LFOSC
+                                                                                    startup has completed and the LFOSC
+                                                                                    is ready for use. */
+#define SYSCTL_CLKSTATUS_LFOSCGOOD_FALSE         ((uint32_t)0x00000000U)         /* !< LFOSC is not ready */
+#define SYSCTL_CLKSTATUS_LFOSCGOOD_TRUE          ((uint32_t)0x00000800U)         /* !< LFOSC is ready */
+/* SYSCTL_CLKSTATUS[HFCLKGOOD] Bits */
+#define SYSCTL_CLKSTATUS_HFCLKGOOD_OFS           (8)                             /* !< HFCLKGOOD Offset */
+#define SYSCTL_CLKSTATUS_HFCLKGOOD_MASK          ((uint32_t)0x00000100U)         /* !< HFCLKGOOD indicates that the HFCLK
+                                                                                    started correctly.  When the HFXT is
+                                                                                    started or HFCLK_IN is selected as
+                                                                                    the HFCLK source,  this bit will be
+                                                                                    set by hardware if a valid HFCLK is
+                                                                                    detected, and cleared if HFCLK is not
+                                                                                    operating within the expected range. */
+#define SYSCTL_CLKSTATUS_HFCLKGOOD_FALSE         ((uint32_t)0x00000000U)         /* !< HFCLK did not start correctly */
+#define SYSCTL_CLKSTATUS_HFCLKGOOD_TRUE          ((uint32_t)0x00000100U)         /* !< HFCLK started correctly */
+/* SYSCTL_CLKSTATUS[HSCLKDEAD] Bits */
+#define SYSCTL_CLKSTATUS_HSCLKDEAD_OFS           (20)                            /* !< HSCLKDEAD Offset */
+#define SYSCTL_CLKSTATUS_HSCLKDEAD_MASK          ((uint32_t)0x00100000U)         /* !< HSCLKDEAD is set by hardware if the
+                                                                                    selected source for HSCLK was started
+                                                                                    but did not start successfully. */
+#define SYSCTL_CLKSTATUS_HSCLKDEAD_FALSE         ((uint32_t)0x00000000U)         /* !< The HSCLK source was not started or
+                                                                                    started correctly */
+#define SYSCTL_CLKSTATUS_HSCLKDEAD_TRUE          ((uint32_t)0x00100000U)         /* !< The HSCLK source did not start
+                                                                                    correctly */
+/* SYSCTL_CLKSTATUS[HFCLKOFF] Bits */
+#define SYSCTL_CLKSTATUS_HFCLKOFF_OFS            (13)                            /* !< HFCLKOFF Offset */
+#define SYSCTL_CLKSTATUS_HFCLKOFF_MASK           ((uint32_t)0x00002000U)         /* !< HFCLKOFF indicates if the HFCLK is
+                                                                                    disabled or was dead at startup.
+                                                                                    When the HFCLK is started, HFCLKOFF
+                                                                                    is cleared by hardware.  Following
+                                                                                    startup of the HFCLK, if the HFCLK
+                                                                                    startup monitor determines that the
+                                                                                    HFCLK was not started correctly,
+                                                                                    HFCLKOFF is set. */
+#define SYSCTL_CLKSTATUS_HFCLKOFF_FALSE          ((uint32_t)0x00000000U)         /* !< HFCLK started correctly and is
+                                                                                    enabled */
+#define SYSCTL_CLKSTATUS_HFCLKOFF_TRUE           ((uint32_t)0x00002000U)         /* !< HFCLK is disabled or was dead at
+                                                                                    startup */
+/* SYSCTL_CLKSTATUS[HFCLKBLKUPD] Bits */
+#define SYSCTL_CLKSTATUS_HFCLKBLKUPD_OFS         (28)                            /* !< HFCLKBLKUPD Offset */
+#define SYSCTL_CLKSTATUS_HFCLKBLKUPD_MASK        ((uint32_t)0x10000000U)         /* !< HFCLKBLKUPD indicates when writes
+                                                                                    to the HFCLKCLKCFG register are
+                                                                                    blocked. */
+#define SYSCTL_CLKSTATUS_HFCLKBLKUPD_FALSE       ((uint32_t)0x00000000U)         /* !< Writes to HFCLKCLKCFG are allowed */
+#define SYSCTL_CLKSTATUS_HFCLKBLKUPD_TRUE        ((uint32_t)0x10000000U)         /* !< Writes to HFCLKCLKCFG are blocked */
+/* SYSCTL_CLKSTATUS[HSCLKGOOD] Bits */
+#define SYSCTL_CLKSTATUS_HSCLKGOOD_OFS           (21)                            /* !< HSCLKGOOD Offset */
+#define SYSCTL_CLKSTATUS_HSCLKGOOD_MASK          ((uint32_t)0x00200000U)         /* !< HSCLKGOOD is set by hardware if the
+                                                                                    selected clock source for HSCLK
+                                                                                    started successfully. */
+#define SYSCTL_CLKSTATUS_HSCLKGOOD_FALSE         ((uint32_t)0x00000000U)         /* !< The HSCLK source did not start
+                                                                                    correctly */
+#define SYSCTL_CLKSTATUS_HSCLKGOOD_TRUE          ((uint32_t)0x00200000U)         /* !< The HSCLK source started correctly */
+/* SYSCTL_CLKSTATUS[ANACLKERR] Bits */
+#define SYSCTL_CLKSTATUS_ANACLKERR_OFS           (31)                            /* !< ANACLKERR Offset */
+#define SYSCTL_CLKSTATUS_ANACLKERR_MASK          ((uint32_t)0x80000000U)         /* !< ANACLKERR is set when the device
+                                                                                    clock configuration does not support
+                                                                                    an enabled analog peripheral mode and
+                                                                                    the analog peripheral may not be
+                                                                                    functioning as expected. */
+#define SYSCTL_CLKSTATUS_ANACLKERR_FALSE         ((uint32_t)0x00000000U)         /* !< No analog clock errors detected */
+#define SYSCTL_CLKSTATUS_ANACLKERR_TRUE          ((uint32_t)0x80000000U)         /* !< Analog clock error detected */
+/* SYSCTL_CLKSTATUS[HSCLKMUX] Bits */
+#define SYSCTL_CLKSTATUS_HSCLKMUX_OFS            (4)                             /* !< HSCLKMUX Offset */
+#define SYSCTL_CLKSTATUS_HSCLKMUX_MASK           ((uint32_t)0x00000010U)         /* !< HSCLKMUX indicates if MCLK is
+                                                                                    currently sourced from the high-speed
+                                                                                    clock (HSCLK). */
+#define SYSCTL_CLKSTATUS_HSCLKMUX_SYSOSC         ((uint32_t)0x00000000U)         /* !< MCLK is not sourced from HSCLK */
+#define SYSCTL_CLKSTATUS_HSCLKMUX_HSCLK          ((uint32_t)0x00000010U)         /* !< MCLK is sourced from HSCLK */
+/* SYSCTL_CLKSTATUS[LFCLKMUX] Bits */
+#define SYSCTL_CLKSTATUS_LFCLKMUX_OFS            (6)                             /* !< LFCLKMUX Offset */
+#define SYSCTL_CLKSTATUS_LFCLKMUX_MASK           ((uint32_t)0x000000C0U)         /* !< LFCLKMUX indicates if LFCLK is
+                                                                                    sourced from the internal LFOSC, the
+                                                                                    low frequency crystal (LFXT), or the
+                                                                                    LFCLK_IN digital clock input. */
+#define SYSCTL_CLKSTATUS_LFCLKMUX_LFOSC          ((uint32_t)0x00000000U)         /* !< LFCLK is sourced from the internal
+                                                                                    LFOSC */
+#define SYSCTL_CLKSTATUS_LFCLKMUX_LFXT           ((uint32_t)0x00000040U)         /* !< LFCLK is sourced from the LFXT
+                                                                                    (crystal) */
+#define SYSCTL_CLKSTATUS_LFCLKMUX_EXLF           ((uint32_t)0x00000080U)         /* !< LFCLK is sourced from LFCLK_IN
+                                                                                    (external digital clock  input) */
+/* SYSCTL_CLKSTATUS[SYSOSCFREQ] Bits */
+#define SYSCTL_CLKSTATUS_SYSOSCFREQ_OFS          (0)                             /* !< SYSOSCFREQ Offset */
+#define SYSCTL_CLKSTATUS_SYSOSCFREQ_MASK         ((uint32_t)0x00000003U)         /* !< SYSOSCFREQ indicates the current
+                                                                                    SYSOSC operating frequency. */
+#define SYSCTL_CLKSTATUS_SYSOSCFREQ_SYSOSC32M    ((uint32_t)0x00000000U)         /* !< SYSOSC is at base frequency (32MHz) */
+#define SYSCTL_CLKSTATUS_SYSOSCFREQ_SYSOSC4M     ((uint32_t)0x00000001U)         /* !< SYSOSC is at low frequency (4MHz) */
+#define SYSCTL_CLKSTATUS_SYSOSCFREQ_SYSOSCUSER   ((uint32_t)0x00000002U)         /* !< SYSOSC is at the user-trimmed
+                                                                                    frequency (16 or 24MHz) */
+#define SYSCTL_CLKSTATUS_SYSOSCFREQ_SYSOSCTURBO  ((uint32_t)0x00000003U)         /* !< Reserved */
+/* SYSCTL_CLKSTATUS[LFXTGOOD] Bits */
+#define SYSCTL_CLKSTATUS_LFXTGOOD_OFS            (10)                            /* !< LFXTGOOD Offset */
+#define SYSCTL_CLKSTATUS_LFXTGOOD_MASK           ((uint32_t)0x00000400U)         /* !< LFXTGOOD indicates if the LFXT
+                                                                                    started correctly.  When the LFXT is
+                                                                                    started, LFXTGOOD is cleared by
+                                                                                    hardware.  After the startup settling
+                                                                                    time has expired, the LFXT status is
+                                                                                    tested.  If the LFXT started
+                                                                                    successfully the LFXTGOOD bit is set,
+                                                                                    else it is left cleared. */
+#define SYSCTL_CLKSTATUS_LFXTGOOD_FALSE          ((uint32_t)0x00000000U)         /* !< LFXT did not start correctly */
+#define SYSCTL_CLKSTATUS_LFXTGOOD_TRUE           ((uint32_t)0x00000400U)         /* !< LFXT started correctly */
+/* SYSCTL_CLKSTATUS[HSCLKSOFF] Bits */
+#define SYSCTL_CLKSTATUS_HSCLKSOFF_OFS           (12)                            /* !< HSCLKSOFF Offset */
+#define SYSCTL_CLKSTATUS_HSCLKSOFF_MASK          ((uint32_t)0x00001000U)         /* !< HSCLKSOFF is set when the high
+                                                                                    speed clock sources (SYSPLL, HFCLK)
+                                                                                    are disabled or dead.  It is the
+                                                                                    logical AND of HFCLKOFF and
+                                                                                    SYSPLLOFF. */
+#define SYSCTL_CLKSTATUS_HSCLKSOFF_FALSE         ((uint32_t)0x00000000U)         /* !< SYSPLL, HFCLK, or both were started
+                                                                                    correctly and remain enabled */
+#define SYSCTL_CLKSTATUS_HSCLKSOFF_TRUE          ((uint32_t)0x00001000U)         /* !< SYSPLL and HFCLK are both either
+                                                                                    off or dead */
+/* SYSCTL_CLKSTATUS[FCLMODE] Bits */
+#define SYSCTL_CLKSTATUS_FCLMODE_OFS             (24)                            /* !< FCLMODE Offset */
+#define SYSCTL_CLKSTATUS_FCLMODE_MASK            ((uint32_t)0x01000000U)         /* !< FCLMODE indicates if the SYSOSC
+                                                                                    frequency correction loop (FCL) is
+                                                                                    enabled. */
+#define SYSCTL_CLKSTATUS_FCLMODE_DISABLED        ((uint32_t)0x00000000U)         /* !< SYSOSC FCL is disabled */
+#define SYSCTL_CLKSTATUS_FCLMODE_ENABLED         ((uint32_t)0x01000000U)         /* !< SYSOSC FCL is enabled */
+/* SYSCTL_CLKSTATUS[CURHSCLKSEL] Bits */
+#define SYSCTL_CLKSTATUS_CURHSCLKSEL_OFS         (16)                            /* !< CURHSCLKSEL Offset */
+#define SYSCTL_CLKSTATUS_CURHSCLKSEL_MASK        ((uint32_t)0x00010000U)         /* !< CURHSCLKSEL indicates the current
+                                                                                    clock source for HSCLK. */
+#define SYSCTL_CLKSTATUS_CURHSCLKSEL_SYSPLL      ((uint32_t)0x00000000U)         /* !< HSCLK is currently sourced from the
+                                                                                    SYSPLL */
+#define SYSCTL_CLKSTATUS_CURHSCLKSEL_HFCLK       ((uint32_t)0x00010000U)         /* !< HSCLK is currently sourced from the
+                                                                                    HFCLK */
+/* SYSCTL_CLKSTATUS[CURMCLKSEL] Bits */
+#define SYSCTL_CLKSTATUS_CURMCLKSEL_OFS          (17)                            /* !< CURMCLKSEL Offset */
+#define SYSCTL_CLKSTATUS_CURMCLKSEL_MASK         ((uint32_t)0x00020000U)         /* !< CURMCLKSEL indicates if MCLK is
+                                                                                    currently sourced from LFCLK. */
+#define SYSCTL_CLKSTATUS_CURMCLKSEL_NOTLFCLK     ((uint32_t)0x00000000U)         /* !< MCLK is not sourced from LFCLK */
+#define SYSCTL_CLKSTATUS_CURMCLKSEL_LFCLK        ((uint32_t)0x00020000U)         /* !< MCLK is sourced from LFCLK */
+/* SYSCTL_CLKSTATUS[FCCDONE] Bits */
+#define SYSCTL_CLKSTATUS_FCCDONE_OFS             (25)                            /* !< FCCDONE Offset */
+#define SYSCTL_CLKSTATUS_FCCDONE_MASK            ((uint32_t)0x02000000U)         /* !< FCCDONE indicates when a frequency
+                                                                                    clock counter capture is complete. */
+#define SYSCTL_CLKSTATUS_FCCDONE_NOTDONE         ((uint32_t)0x00000000U)         /* !< FCC capture is not done */
+#define SYSCTL_CLKSTATUS_FCCDONE_DONE            ((uint32_t)0x02000000U)         /* !< FCC capture is done */
+/* SYSCTL_CLKSTATUS[LFCLKFAIL] Bits */
+#define SYSCTL_CLKSTATUS_LFCLKFAIL_OFS           (23)                            /* !< LFCLKFAIL Offset */
+#define SYSCTL_CLKSTATUS_LFCLKFAIL_MASK          ((uint32_t)0x00800000U)         /* !< LFCLKFAIL indicates when the
+                                                                                    continous LFCLK monitor detects a
+                                                                                    LFXT or LFCLK_IN clock stuck failure. */
+#define SYSCTL_CLKSTATUS_LFCLKFAIL_FALSE         ((uint32_t)0x00000000U)         /* !< No LFCLK fault detected */
+#define SYSCTL_CLKSTATUS_LFCLKFAIL_TRUE          ((uint32_t)0x00800000U)         /* !< LFCLK stuck fault detected */
+
+/* SYSCTL_SYSSTATUS Bits */
+/* SYSCTL_SYSSTATUS[SHDNIOLOCK] Bits */
+#define SYSCTL_SYSSTATUS_SHDNIOLOCK_OFS          (14)                            /* !< SHDNIOLOCK Offset */
+#define SYSCTL_SYSSTATUS_SHDNIOLOCK_MASK         ((uint32_t)0x00004000U)         /* !< SHDNIOLOCK indicates when IO is
+                                                                                    locked due to SHUTDOWN */
+#define SYSCTL_SYSSTATUS_SHDNIOLOCK_FALSE        ((uint32_t)0x00000000U)         /* !< IO IS NOT Locked due to SHUTDOWN */
+#define SYSCTL_SYSSTATUS_SHDNIOLOCK_TRUE         ((uint32_t)0x00004000U)         /* !< IO IS Locked due to SHUTDOWN */
+/* SYSCTL_SYSSTATUS[EXTRSTPINDIS] Bits */
+#define SYSCTL_SYSSTATUS_EXTRSTPINDIS_OFS        (12)                            /* !< EXTRSTPINDIS Offset */
+#define SYSCTL_SYSSTATUS_EXTRSTPINDIS_MASK       ((uint32_t)0x00001000U)         /* !< EXTRSTPINDIS indicates when user
+                                                                                    has disabled the use of external
+                                                                                    reset pin */
+#define SYSCTL_SYSSTATUS_EXTRSTPINDIS_FALSE      ((uint32_t)0x00000000U)         /* !< External Reset Pin Enabled */
+#define SYSCTL_SYSSTATUS_EXTRSTPINDIS_TRUE       ((uint32_t)0x00001000U)         /* !< External Reset Pin Disabled */
+/* SYSCTL_SYSSTATUS[VBATGOOD] Bits */
+#define SYSCTL_SYSSTATUS_VBATGOOD_OFS            (7)                             /* !< VBATGOOD Offset */
+#define SYSCTL_SYSSTATUS_VBATGOOD_MASK           ((uint32_t)0x00000080U)         /* !< VBATGOOD is set by hardware when
+                                                                                    the VBAT Power Domain is valid. */
+#define SYSCTL_SYSSTATUS_VBATGOOD_FALSE          ((uint32_t)0x00000000U)         /* !< VBAT Power Domain is not valid */
+#define SYSCTL_SYSSTATUS_VBATGOOD_TRUE           ((uint32_t)0x00000080U)         /* !< VBAT Power Domain is valid */
+/* SYSCTL_SYSSTATUS[PMUIREFGOOD] Bits */
+#define SYSCTL_SYSSTATUS_PMUIREFGOOD_OFS         (6)                             /* !< PMUIREFGOOD Offset */
+#define SYSCTL_SYSSTATUS_PMUIREFGOOD_MASK        ((uint32_t)0x00000040U)         /* !< PMUIREFGOOD is set by hardware when
+                                                                                    the PMU current reference is ready. */
+#define SYSCTL_SYSSTATUS_PMUIREFGOOD_FALSE       ((uint32_t)0x00000000U)         /* !< IREF is not ready */
+#define SYSCTL_SYSSTATUS_PMUIREFGOOD_TRUE        ((uint32_t)0x00000040U)         /* !< IREF is ready */
+/* SYSCTL_SYSSTATUS[SWDCFGDIS] Bits */
+#define SYSCTL_SYSSTATUS_SWDCFGDIS_OFS           (13)                            /* !< SWDCFGDIS Offset */
+#define SYSCTL_SYSSTATUS_SWDCFGDIS_MASK          ((uint32_t)0x00002000U)         /* !< SWDCFGDIS indicates when user has
+                                                                                    disabled the use of SWD Port */
+#define SYSCTL_SYSSTATUS_SWDCFGDIS_FALSE         ((uint32_t)0x00000000U)         /* !< SWD Port Enabled */
+#define SYSCTL_SYSSTATUS_SWDCFGDIS_TRUE          ((uint32_t)0x00002000U)         /* !< SWD Port Disabled */
+/* SYSCTL_SYSSTATUS[ANACPUMPGOOD] Bits */
+#define SYSCTL_SYSSTATUS_ANACPUMPGOOD_OFS        (5)                             /* !< ANACPUMPGOOD Offset */
+#define SYSCTL_SYSSTATUS_ANACPUMPGOOD_MASK       ((uint32_t)0x00000020U)         /* !< ANACPUMPGOOD is set by hardware
+                                                                                    when the VBOOST analog mux charge
+                                                                                    pump is ready. */
+#define SYSCTL_SYSSTATUS_ANACPUMPGOOD_FALSE      ((uint32_t)0x00000000U)         /* !< VBOOST is not ready */
+#define SYSCTL_SYSSTATUS_ANACPUMPGOOD_TRUE       ((uint32_t)0x00000020U)         /* !< VBOOST is ready */
+/* SYSCTL_SYSSTATUS[REBOOTATTEMPTS] Bits */
+#define SYSCTL_SYSSTATUS_REBOOTATTEMPTS_OFS      (30)                            /* !< REBOOTATTEMPTS Offset */
+#define SYSCTL_SYSSTATUS_REBOOTATTEMPTS_MASK     ((uint32_t)0xC0000000U)         /* !< REBOOTATTEMPTS indicates the number
+                                                                                    of boot attempts taken before the
+                                                                                    user application starts. */
+/* SYSCTL_SYSSTATUS[BORLVL] Bits */
+#define SYSCTL_SYSSTATUS_BORLVL_OFS              (4)                             /* !< BORLVL Offset */
+#define SYSCTL_SYSSTATUS_BORLVL_MASK             ((uint32_t)0x00000010U)         /* !< BORLVL indicates if a BOR event
+                                                                                    occured and the BOR threshold was
+                                                                                    switched to BOR0 by hardware. */
+#define SYSCTL_SYSSTATUS_BORLVL_FALSE            ((uint32_t)0x00000000U)         /* !< No BOR violation occured */
+#define SYSCTL_SYSSTATUS_BORLVL_TRUE             ((uint32_t)0x00000010U)         /* !< A BOR violation occured and the BOR
+                                                                                    threshold was switched to BOR0 */
+/* SYSCTL_SYSSTATUS[FLASHDED] Bits */
+#define SYSCTL_SYSSTATUS_FLASHDED_OFS            (0)                             /* !< FLASHDED Offset */
+#define SYSCTL_SYSSTATUS_FLASHDED_MASK           ((uint32_t)0x00000001U)         /* !< FLASHDED indicates if a flash ECC
+                                                                                    double bit error was detected (DED). */
+#define SYSCTL_SYSSTATUS_FLASHDED_FALSE          ((uint32_t)0x00000000U)         /* !< No flash ECC double bit error
+                                                                                    detected */
+#define SYSCTL_SYSSTATUS_FLASHDED_TRUE           ((uint32_t)0x00000001U)         /* !< Flash ECC double bit error detected */
+/* SYSCTL_SYSSTATUS[FLASHSEC] Bits */
+#define SYSCTL_SYSSTATUS_FLASHSEC_OFS            (1)                             /* !< FLASHSEC Offset */
+#define SYSCTL_SYSSTATUS_FLASHSEC_MASK           ((uint32_t)0x00000002U)         /* !< FLASHSEC indicates if a flash ECC
+                                                                                    single bit error was detected and
+                                                                                    corrected (SEC). */
+#define SYSCTL_SYSSTATUS_FLASHSEC_FALSE          ((uint32_t)0x00000000U)         /* !< No flash ECC single bit error
+                                                                                    detected */
+#define SYSCTL_SYSSTATUS_FLASHSEC_TRUE           ((uint32_t)0x00000002U)         /* !< Flash ECC single bit error was
+                                                                                    detected and corrected */
+/* SYSCTL_SYSSTATUS[BORCURTHRESHOLD] Bits */
+#define SYSCTL_SYSSTATUS_BORCURTHRESHOLD_OFS     (2)                             /* !< BORCURTHRESHOLD Offset */
+#define SYSCTL_SYSSTATUS_BORCURTHRESHOLD_MASK    ((uint32_t)0x0000000CU)         /* !< BORCURTHRESHOLD indicates the
+                                                                                    active brown-out reset supply monitor
+                                                                                    configuration. */
+#define SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORMIN  ((uint32_t)0x00000000U)         /* !< Default minimum threshold; a BOR0-
+                                                                                    violation triggers a BOR */
+#define SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVEL1 ((uint32_t)0x00000004U)         /* !< A BOR1- violation generates a
+                                                                                    BORLVL interrupt */
+#define SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVEL2 ((uint32_t)0x00000008U)         /* !< A BOR2- violation generates a
+                                                                                    BORLVL interrupt */
+#define SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVEL3 ((uint32_t)0x0000000CU)         /* !< A BOR3- violation generates a
+                                                                                    BORLVL interrupt */
+
+/* SYSCTL_DEDERRADDR Bits */
+/* SYSCTL_DEDERRADDR[ADDR] Bits */
+#define SYSCTL_DEDERRADDR_ADDR_OFS               (0)                             /* !< ADDR Offset */
+#define SYSCTL_DEDERRADDR_ADDR_MASK              ((uint32_t)0xFFFFFFFFU)         /* !< Address of MEMORY DED Error. */
+
+/* SYSCTL_RSTCAUSE Bits */
+/* SYSCTL_RSTCAUSE[ID] Bits */
+#define SYSCTL_RSTCAUSE_ID_OFS                   (0)                             /* !< ID Offset */
+#define SYSCTL_RSTCAUSE_ID_MASK                  ((uint32_t)0x0000001FU)         /* !< ID is a read-to-clear field which
+                                                                                    indicates the lowest level reset
+                                                                                    cause since the last read. */
+#define SYSCTL_RSTCAUSE_ID_NORST                 ((uint32_t)0x00000000U)         /* !< No reset since last read */
+#define SYSCTL_RSTCAUSE_ID_PORHWFAIL             ((uint32_t)0x00000001U)         /* !< POR- violation, SHUTDNSTOREx or PMU
+                                                                                    trim parity fault */
+#define SYSCTL_RSTCAUSE_ID_POREXNRST             ((uint32_t)0x00000002U)         /* !< NRST triggered POR (&gt;1s hold) */
+#define SYSCTL_RSTCAUSE_ID_PORSW                 ((uint32_t)0x00000003U)         /* !< Software triggered POR */
+#define SYSCTL_RSTCAUSE_ID_BORSUPPLY             ((uint32_t)0x00000004U)         /* !< BOR0- violation */
+#define SYSCTL_RSTCAUSE_ID_BORWAKESHUTDN         ((uint32_t)0x00000005U)         /* !< SHUTDOWN mode exit */
+#define SYSCTL_RSTCAUSE_ID_BOOTNONPMUPARITY      ((uint32_t)0x00000008U)         /* !< Non-PMU trim parity fault */
+#define SYSCTL_RSTCAUSE_ID_BOOTCLKFAIL           ((uint32_t)0x00000009U)         /* !< Fatal clock failure */
+#define SYSCTL_RSTCAUSE_ID_BOOTEXNRST            ((uint32_t)0x0000000CU)         /* !< NRST triggered BOOTRST (&lt;1s
+                                                                                    hold) */
+#define SYSCTL_RSTCAUSE_ID_BOOTSW                ((uint32_t)0x0000000DU)         /* !< Software triggered BOOTRST */
+#define SYSCTL_RSTCAUSE_ID_SYSWWDT0              ((uint32_t)0x0000000EU)         /* !< WWDT0 violation */
+#define SYSCTL_RSTCAUSE_ID_SYSBSLEXIT            ((uint32_t)0x00000010U)         /* !< BSL exit */
+#define SYSCTL_RSTCAUSE_ID_SYSBSLENTRY           ((uint32_t)0x00000011U)         /* !< BSL entry */
+#define SYSCTL_RSTCAUSE_ID_SYSWWDT1              ((uint32_t)0x00000013U)         /* !< WWDT1 violation */
+#define SYSCTL_RSTCAUSE_ID_SYSFLASHECC           ((uint32_t)0x00000014U)         /* !< Flash uncorrectable ECC error */
+#define SYSCTL_RSTCAUSE_ID_SYSCPULOCK            ((uint32_t)0x00000015U)         /* !< CPULOCK violation */
+#define SYSCTL_RSTCAUSE_ID_SYSDBG                ((uint32_t)0x0000001AU)         /* !< Debug triggered SYSRST */
+#define SYSCTL_RSTCAUSE_ID_SYSSW                 ((uint32_t)0x0000001BU)         /* !< Software triggered SYSRST */
+#define SYSCTL_RSTCAUSE_ID_CPUDBG                ((uint32_t)0x0000001CU)         /* !< Debug triggered CPURST */
+#define SYSCTL_RSTCAUSE_ID_CPUSW                 ((uint32_t)0x0000001DU)         /* !< Software triggered CPURST */
+
+/* SYSCTL_RESETLEVEL Bits */
+/* SYSCTL_RESETLEVEL[LEVEL] Bits */
+#define SYSCTL_RESETLEVEL_LEVEL_OFS              (0)                             /* !< LEVEL Offset */
+#define SYSCTL_RESETLEVEL_LEVEL_MASK             ((uint32_t)0x00000007U)         /* !< LEVEL is used to specify the type
+                                                                                    of reset to be issued when RESETCMD
+                                                                                    is set to generate a software
+                                                                                    triggered reset. */
+#define SYSCTL_RESETLEVEL_LEVEL_CPU              ((uint32_t)0x00000000U)         /* !< Issue a SYSRST (CPU plus
+                                                                                    peripherals only) */
+#define SYSCTL_RESETLEVEL_LEVEL_BOOT             ((uint32_t)0x00000001U)         /* !< Issue a BOOTRST (CPU, peripherals,
+                                                                                    and boot configuration routine) */
+#define SYSCTL_RESETLEVEL_LEVEL_BOOTLOADERENTRY  ((uint32_t)0x00000002U)         /* !< Issue a SYSRST and enter the boot
+                                                                                    strap loader (BSL) */
+#define SYSCTL_RESETLEVEL_LEVEL_POR              ((uint32_t)0x00000003U)         /* !< Issue a power-on reset (POR) */
+#define SYSCTL_RESETLEVEL_LEVEL_BOOTLOADEREXIT   ((uint32_t)0x00000004U)         /* !< Issue a SYSRST and exit the boot
+                                                                                    strap loader (BSL) */
+
+/* SYSCTL_RESETCMD Bits */
+/* SYSCTL_RESETCMD[KEY] Bits */
+#define SYSCTL_RESETCMD_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define SYSCTL_RESETCMD_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< The key value of E4h (228) must be
+                                                                                    written to KEY together with GO to
+                                                                                    trigger the reset. */
+#define SYSCTL_RESETCMD_KEY_VALUE                ((uint32_t)0xE4000000U)         /* !< Issue reset */
+/* SYSCTL_RESETCMD[GO] Bits */
+#define SYSCTL_RESETCMD_GO_OFS                   (0)                             /* !< GO Offset */
+#define SYSCTL_RESETCMD_GO_MASK                  ((uint32_t)0x00000001U)         /* !< Execute the reset specified in
+                                                                                    RESETLEVEL.LEVEL.  Must be written
+                                                                                    together with the KEY. */
+#define SYSCTL_RESETCMD_GO_TRUE                  ((uint32_t)0x00000001U)         /* !< Issue reset */
+
+/* SYSCTL_BORTHRESHOLD Bits */
+/* SYSCTL_BORTHRESHOLD[LEVEL] Bits */
+#define SYSCTL_BORTHRESHOLD_LEVEL_OFS            (0)                             /* !< LEVEL Offset */
+#define SYSCTL_BORTHRESHOLD_LEVEL_MASK           ((uint32_t)0x00000003U)         /* !< LEVEL specifies the desired BOR
+                                                                                    threshold and BOR mode. */
+#define SYSCTL_BORTHRESHOLD_LEVEL_BORMIN         ((uint32_t)0x00000000U)         /* !< Default minimum threshold; a BOR0-
+                                                                                    violation triggers a BOR */
+#define SYSCTL_BORTHRESHOLD_LEVEL_BORLEVEL1      ((uint32_t)0x00000001U)         /* !< A BOR1- violation generates a
+                                                                                    BORLVL interrupt */
+#define SYSCTL_BORTHRESHOLD_LEVEL_BORLEVEL2      ((uint32_t)0x00000002U)         /* !< A BOR2- violation generates a
+                                                                                    BORLVL interrupt */
+#define SYSCTL_BORTHRESHOLD_LEVEL_BORLEVEL3      ((uint32_t)0x00000003U)         /* !< A BOR3- violation generates a
+                                                                                    BORLVL interrupt */
+
+/* SYSCTL_BORCLRCMD Bits */
+/* SYSCTL_BORCLRCMD[KEY] Bits */
+#define SYSCTL_BORCLRCMD_KEY_OFS                 (24)                            /* !< KEY Offset */
+#define SYSCTL_BORCLRCMD_KEY_MASK                ((uint32_t)0xFF000000U)         /* !< The key value of C7h (199) must be
+                                                                                    written to KEY together with GO to
+                                                                                    trigger the clear and BOR threshold
+                                                                                    change. */
+#define SYSCTL_BORCLRCMD_KEY_VALUE               ((uint32_t)0xC7000000U)         /* !< Issue clear */
+/* SYSCTL_BORCLRCMD[GO] Bits */
+#define SYSCTL_BORCLRCMD_GO_OFS                  (0)                             /* !< GO Offset */
+#define SYSCTL_BORCLRCMD_GO_MASK                 ((uint32_t)0x00000001U)         /* !< GO clears any prior BOR violation
+                                                                                    status indications and attempts to
+                                                                                    change the active BOR mode to that
+                                                                                    specified in the LEVEL field of the
+                                                                                    BORTHRESHOLD register. */
+#define SYSCTL_BORCLRCMD_GO_TRUE                 ((uint32_t)0x00000001U)         /* !< Issue clear */
+
+/* SYSCTL_SYSOSCFCLCTL Bits */
+/* SYSCTL_SYSOSCFCLCTL[KEY] Bits */
+#define SYSCTL_SYSOSCFCLCTL_KEY_OFS              (24)                            /* !< KEY Offset */
+#define SYSCTL_SYSOSCFCLCTL_KEY_MASK             ((uint32_t)0xFF000000U)         /* !< The key value of 2Ah (42) must be
+                                                                                    written to KEY together with
+                                                                                    SETUSEFCL to enable the FCL. */
+#define SYSCTL_SYSOSCFCLCTL_KEY_VALUE            ((uint32_t)0x2A000000U)         /* !< Issue Command */
+/* SYSCTL_SYSOSCFCLCTL[SETUSEFCL] Bits */
+#define SYSCTL_SYSOSCFCLCTL_SETUSEFCL_OFS        (0)                             /* !< SETUSEFCL Offset */
+#define SYSCTL_SYSOSCFCLCTL_SETUSEFCL_MASK       ((uint32_t)0x00000001U)         /* !< Set SETUSEFCL to enable the
+                                                                                    frequency correction loop in SYSOSC.
+                                                                                    Once enabled, this state is locked
+                                                                                    until the next BOOTRST. */
+#define SYSCTL_SYSOSCFCLCTL_SETUSEFCL_TRUE       ((uint32_t)0x00000001U)         /* !< Enable the SYSOSC FCL */
+/* SYSCTL_SYSOSCFCLCTL[SETUSEEXRES] Bits */
+#define SYSCTL_SYSOSCFCLCTL_SETUSEEXRES_OFS      (1)                             /* !< SETUSEEXRES Offset */
+#define SYSCTL_SYSOSCFCLCTL_SETUSEEXRES_MASK     ((uint32_t)0x00000002U)         /* !< Set SETUSEEXRES to specify that an
+                                                                                    external resistor will be used for
+                                                                                    the FCL.  An appropriate resistor
+                                                                                    must be populated on the ROSC pin.
+                                                                                    This state is locked until the next
+                                                                                    BOOTRST. */
+#define SYSCTL_SYSOSCFCLCTL_SETUSEEXRES_TRUE     ((uint32_t)0x00000002U)         /* !< Enable the SYSOSC external Resistor */
+
+/* SYSCTL_LFXTCTL Bits */
+/* SYSCTL_LFXTCTL[KEY] Bits */
+#define SYSCTL_LFXTCTL_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define SYSCTL_LFXTCTL_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< The key value of 91h (145) must be
+                                                                                    written to KEY together with either
+                                                                                    STARTLFXT or SETUSELFXT to set the
+                                                                                    corresponding bit. */
+#define SYSCTL_LFXTCTL_KEY_VALUE                 ((uint32_t)0x91000000U)         /* !< Issue command */
+/* SYSCTL_LFXTCTL[SETUSELFXT] Bits */
+#define SYSCTL_LFXTCTL_SETUSELFXT_OFS            (1)                             /* !< SETUSELFXT Offset */
+#define SYSCTL_LFXTCTL_SETUSELFXT_MASK           ((uint32_t)0x00000002U)         /* !< Set SETUSELFXT to switch LFCLK to
+                                                                                    LFXT.  Once set, SETUSELFXT remains
+                                                                                    set until the next BOOTRST. */
+#define SYSCTL_LFXTCTL_SETUSELFXT_FALSE          ((uint32_t)0x00000000U)
+#define SYSCTL_LFXTCTL_SETUSELFXT_TRUE           ((uint32_t)0x00000002U)         /* !< Use LFXT as the LFCLK source */
+/* SYSCTL_LFXTCTL[STARTLFXT] Bits */
+#define SYSCTL_LFXTCTL_STARTLFXT_OFS             (0)                             /* !< STARTLFXT Offset */
+#define SYSCTL_LFXTCTL_STARTLFXT_MASK            ((uint32_t)0x00000001U)         /* !< Set STARTLFXT to start the low
+                                                                                    frequency crystal oscillator (LFXT).
+                                                                                    Once set, STARTLFXT remains set until
+                                                                                    the next BOOTRST. */
+#define SYSCTL_LFXTCTL_STARTLFXT_FALSE           ((uint32_t)0x00000000U)         /* !< LFXT not started */
+#define SYSCTL_LFXTCTL_STARTLFXT_TRUE            ((uint32_t)0x00000001U)         /* !< Start LFXT */
+
+/* SYSCTL_EXLFCTL Bits */
+/* SYSCTL_EXLFCTL[KEY] Bits */
+#define SYSCTL_EXLFCTL_KEY_OFS                   (24)                            /* !< KEY Offset */
+#define SYSCTL_EXLFCTL_KEY_MASK                  ((uint32_t)0xFF000000U)         /* !< The key value of 36h (54) must be
+                                                                                    written to KEY together with
+                                                                                    SETUSEEXLF to set SETUSEEXLF. */
+#define SYSCTL_EXLFCTL_KEY_VALUE                 ((uint32_t)0x36000000U)         /* !< Issue command */
+/* SYSCTL_EXLFCTL[SETUSEEXLF] Bits */
+#define SYSCTL_EXLFCTL_SETUSEEXLF_OFS            (0)                             /* !< SETUSEEXLF Offset */
+#define SYSCTL_EXLFCTL_SETUSEEXLF_MASK           ((uint32_t)0x00000001U)         /* !< Set SETUSEEXLF to switch LFCLK to
+                                                                                    the LFCLK_IN digital clock input.
+                                                                                    Once set, SETUSEEXLF remains set
+                                                                                    until the next BOOTRST. */
+#define SYSCTL_EXLFCTL_SETUSEEXLF_TRUE           ((uint32_t)0x00000001U)         /* !< Use LFCLK_IN as the LFCLK source */
+
+/* SYSCTL_SHDNIOREL Bits */
+/* SYSCTL_SHDNIOREL[KEY] Bits */
+#define SYSCTL_SHDNIOREL_KEY_OFS                 (24)                            /* !< KEY Offset */
+#define SYSCTL_SHDNIOREL_KEY_MASK                ((uint32_t)0xFF000000U)         /* !< The key value 91h must be written
+                                                                                    to KEY together with RELEASE to set
+                                                                                    RELEASE. */
+#define SYSCTL_SHDNIOREL_KEY_VALUE               ((uint32_t)0x91000000U)         /* !< Issue command */
+/* SYSCTL_SHDNIOREL[RELEASE] Bits */
+#define SYSCTL_SHDNIOREL_RELEASE_OFS             (0)                             /* !< RELEASE Offset */
+#define SYSCTL_SHDNIOREL_RELEASE_MASK            ((uint32_t)0x00000001U)         /* !< Set RELEASE to release the IO after
+                                                                                    a SHUTDOWN mode exit. */
+#define SYSCTL_SHDNIOREL_RELEASE_TRUE            ((uint32_t)0x00000001U)         /* !< Release IO */
+
+/* SYSCTL_EXRSTPIN Bits */
+/* SYSCTL_EXRSTPIN[KEY] Bits */
+#define SYSCTL_EXRSTPIN_KEY_OFS                  (24)                            /* !< KEY Offset */
+#define SYSCTL_EXRSTPIN_KEY_MASK                 ((uint32_t)0xFF000000U)         /* !< The key value 1Eh must be written
+                                                                                    together with DISABLE to disable the
+                                                                                    reset function. */
+#define SYSCTL_EXRSTPIN_KEY_VALUE                ((uint32_t)0x1E000000U)         /* !< Issue command */
+/* SYSCTL_EXRSTPIN[DISABLE] Bits */
+#define SYSCTL_EXRSTPIN_DISABLE_OFS              (0)                             /* !< DISABLE Offset */
+#define SYSCTL_EXRSTPIN_DISABLE_MASK             ((uint32_t)0x00000001U)         /* !< Set DISABLE to disable the reset
+                                                                                    function of the NRST pin.  Once set,
+                                                                                    this configuration is locked until
+                                                                                    the next POR. */
+#define SYSCTL_EXRSTPIN_DISABLE_FALSE            ((uint32_t)0x00000000U)         /* !< Reset function of NRST pin is
+                                                                                    enabled */
+#define SYSCTL_EXRSTPIN_DISABLE_TRUE             ((uint32_t)0x00000001U)         /* !< Reset function of NRST pin is
+                                                                                    disabled */
+
+/* SYSCTL_SYSSTATUSCLR Bits */
+/* SYSCTL_SYSSTATUSCLR[KEY] Bits */
+#define SYSCTL_SYSSTATUSCLR_KEY_OFS              (24)                            /* !< KEY Offset */
+#define SYSCTL_SYSSTATUSCLR_KEY_MASK             ((uint32_t)0xFF000000U)         /* !< The key value CEh (206) must be
+                                                                                    written to KEY together with ALLECC
+                                                                                    to clear the ECC state. */
+#define SYSCTL_SYSSTATUSCLR_KEY_VALUE            ((uint32_t)0xCE000000U)         /* !< Issue command */
+/* SYSCTL_SYSSTATUSCLR[ALLECC] Bits */
+#define SYSCTL_SYSSTATUSCLR_ALLECC_OFS           (0)                             /* !< ALLECC Offset */
+#define SYSCTL_SYSSTATUSCLR_ALLECC_MASK          ((uint32_t)0x00000001U)         /* !< Set ALLECC to clear all ECC related
+                                                                                    SYSSTATUS indicators. */
+#define SYSCTL_SYSSTATUSCLR_ALLECC_CLEAR         ((uint32_t)0x00000001U)         /* !< Clear ECC error state */
+
+/* SYSCTL_SWDCFG Bits */
+/* SYSCTL_SWDCFG[KEY] Bits */
+#define SYSCTL_SWDCFG_KEY_OFS                    (24)                            /* !< KEY Offset */
+#define SYSCTL_SWDCFG_KEY_MASK                   ((uint32_t)0xFF000000U)         /* !< The key value 62h (98) must be
+                                                                                    written to KEY together with DISBALE
+                                                                                    to disable the SWD functions. */
+#define SYSCTL_SWDCFG_KEY_VALUE                  ((uint32_t)0x62000000U)         /* !< Issue command */
+/* SYSCTL_SWDCFG[DISABLE] Bits */
+#define SYSCTL_SWDCFG_DISABLE_OFS                (0)                             /* !< DISABLE Offset */
+#define SYSCTL_SWDCFG_DISABLE_MASK               ((uint32_t)0x00000001U)         /* !< Set DISABLE to disable the SWD
+                                                                                    function on SWD pins, allowing the
+                                                                                    SWD pins to be used as GPIO. */
+#define SYSCTL_SWDCFG_DISABLE_TRUE               ((uint32_t)0x00000001U)         /* !< Disable SWD function on SWD pins */
+
+/* SYSCTL_FCCCMD Bits */
+/* SYSCTL_FCCCMD[KEY] Bits */
+#define SYSCTL_FCCCMD_KEY_OFS                    (24)                            /* !< KEY Offset */
+#define SYSCTL_FCCCMD_KEY_MASK                   ((uint32_t)0xFF000000U)         /* !< The key value 0Eh (14) must be
+                                                                                    written with GO to start a capture. */
+#define SYSCTL_FCCCMD_KEY_VALUE                  ((uint32_t)0x0E000000U)         /* !< Issue command */
+/* SYSCTL_FCCCMD[GO] Bits */
+#define SYSCTL_FCCCMD_GO_OFS                     (0)                             /* !< GO Offset */
+#define SYSCTL_FCCCMD_GO_MASK                    ((uint32_t)0x00000001U)         /* !< Set GO to start a capture with the
+                                                                                    frequency clock counter (FCC). */
+#define SYSCTL_FCCCMD_GO_TRUE                    ((uint32_t)0x00000001U)
+
+/* SYSCTL_SHUTDNSTORE0 Bits */
+/* SYSCTL_SHUTDNSTORE0[DATA] Bits */
+#define SYSCTL_SHUTDNSTORE0_DATA_OFS             (0)                             /* !< DATA Offset */
+#define SYSCTL_SHUTDNSTORE0_DATA_MASK            ((uint32_t)0x000000FFU)         /* !< Shutdown storage byte 0 */
+
+/* SYSCTL_SHUTDNSTORE1 Bits */
+/* SYSCTL_SHUTDNSTORE1[DATA] Bits */
+#define SYSCTL_SHUTDNSTORE1_DATA_OFS             (0)                             /* !< DATA Offset */
+#define SYSCTL_SHUTDNSTORE1_DATA_MASK            ((uint32_t)0x000000FFU)         /* !< Shutdown storage byte 1 */
+
+/* SYSCTL_SHUTDNSTORE2 Bits */
+/* SYSCTL_SHUTDNSTORE2[DATA] Bits */
+#define SYSCTL_SHUTDNSTORE2_DATA_OFS             (0)                             /* !< DATA Offset */
+#define SYSCTL_SHUTDNSTORE2_DATA_MASK            ((uint32_t)0x000000FFU)         /* !< Shutdown storage byte 2 */
+
+/* SYSCTL_SHUTDNSTORE3 Bits */
+/* SYSCTL_SHUTDNSTORE3[DATA] Bits */
+#define SYSCTL_SHUTDNSTORE3_DATA_OFS             (0)                             /* !< DATA Offset */
+#define SYSCTL_SHUTDNSTORE3_DATA_MASK            ((uint32_t)0x000000FFU)         /* !< Shutdown storage byte 3 */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_devices_msp_peripherals_m0p_hw_sysctl_mspm0l122x_l222x__include */

--- a/mspm0/source/ti/driverlib/dl_adc12.c
+++ b/mspm0/source/ti/driverlib/dl_adc12.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_adc12.h>
+
+#ifdef __MSPM0_HAS_ADC12__
+
+void DL_ADC12_setClockConfig(ADC12_Regs *adc12, DL_ADC12_ClockConfig *config)
+{
+    DL_Common_updateReg(&adc12->ULLMEM.GPRCM.CLKCFG,
+        (ADC12_CLKCFG_KEY_UNLOCK_W | (uint32_t) config->clockSel),
+        (ADC12_CLKCFG_KEY_MASK | ADC12_CLKCFG_SAMPCLK_MASK));
+
+    DL_Common_updateReg(&adc12->ULLMEM.CTL0, (uint32_t) config->divideRatio,
+        ADC12_CTL0_SCLKDIV_MASK);
+
+    adc12->ULLMEM.CLKFREQ = (uint32_t) config->freqRange;
+}
+
+void DL_ADC12_getClockConfig(ADC12_Regs *adc12, DL_ADC12_ClockConfig *config)
+{
+    uint32_t clockConfig =
+        adc12->ULLMEM.GPRCM.CLKCFG & ADC12_CLKCFG_SAMPCLK_MASK;
+    uint32_t divideRatio = adc12->ULLMEM.CTL0 & ADC12_CTL0_SCLKDIV_MASK;
+    uint32_t freqRange   = adc12->ULLMEM.CLKFREQ & ADC12_CLKFREQ_FRANGE_MASK;
+
+    config->clockSel = (DL_ADC12_CLOCK)(clockConfig);
+
+    config->divideRatio = (DL_ADC12_CLOCK_DIVIDE)(divideRatio);
+
+    config->freqRange = (DL_ADC12_CLOCK_FREQ_RANGE)(freqRange);
+}
+
+#endif /* __MSPM0_HAS_ADC12__ */

--- a/mspm0/source/ti/driverlib/dl_adc12.h
+++ b/mspm0/source/ti/driverlib/dl_adc12.h
@@ -1,0 +1,2248 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_adc12.h
+ *  @brief      Analog to Digital Converter (ADC)
+ *  @defgroup   ADC12 Analog to Digital Converter (ADC12)
+ *
+ *  @anchor ti_dl_dl_adc12_Overview
+ *  # Overview
+ *
+ *  The Analog to Digital Converter Driver Library allows full configuration of
+ *  the MSPM0 ADC module.
+ *  The ADC is a high-performance successive-approximation-register (SAR)
+ *  analog-to-digital converter.
+ *
+ *  <hr>
+ ******************************************************************************/
+/** @addtogroup ADC12
+ * @{
+ */
+#ifndef ti_dl_dl_adc12__include
+#define ti_dl_dl_adc12__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_ADC12__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+#if (ADC_SYS_NUM_ANALOG_CHAN > 16)
+/*
+ * @brief Device has more than 16 ADC input channels
+ */
+#define DEVICE_HAS_GREATER_THAN_16_INPUT_CHAN
+#endif
+
+ /** @addtogroup DL_ADC12_SEQ_END_ADDR
+ * @{
+ */
+
+/*!
+ * @brief Sequence end address set to 00
+ */
+#define DL_ADC12_SEQ_END_ADDR_00                     (ADC12_CTL2_ENDADD_ADDR_00)
+
+/*!
+ * @brief Sequence end address set to 01
+ */
+#define DL_ADC12_SEQ_END_ADDR_01                     (ADC12_CTL2_ENDADD_ADDR_01)
+
+/*!
+ * @brief Sequence end address set to 02
+ */
+#define DL_ADC12_SEQ_END_ADDR_02                     (ADC12_CTL2_ENDADD_ADDR_02)
+
+/*!
+ * @brief Sequence end address set to 03
+ */
+#define DL_ADC12_SEQ_END_ADDR_03                     (ADC12_CTL2_ENDADD_ADDR_03)
+
+/*!
+ * @brief Sequence end address set to 04
+ */
+#define DL_ADC12_SEQ_END_ADDR_04                     (ADC12_CTL2_ENDADD_ADDR_04)
+
+/*!
+ * @brief Sequence end address set to 05
+ */
+#define DL_ADC12_SEQ_END_ADDR_05                     (ADC12_CTL2_ENDADD_ADDR_05)
+
+/*!
+ * @brief Sequence end address set to 06
+ */
+#define DL_ADC12_SEQ_END_ADDR_06                     (ADC12_CTL2_ENDADD_ADDR_06)
+
+/*!
+ * @brief Sequence end address set to 07
+ */
+#define DL_ADC12_SEQ_END_ADDR_07                     (ADC12_CTL2_ENDADD_ADDR_07)
+
+/*!
+ * @brief Sequence end address set to 08
+ */
+#define DL_ADC12_SEQ_END_ADDR_08                     (ADC12_CTL2_ENDADD_ADDR_08)
+
+/*!
+ * @brief Sequence end address set to 09
+ */
+#define DL_ADC12_SEQ_END_ADDR_09                     (ADC12_CTL2_ENDADD_ADDR_09)
+
+/*!
+ * @brief Sequence end address set to 10
+ */
+#define DL_ADC12_SEQ_END_ADDR_10                     (ADC12_CTL2_ENDADD_ADDR_10)
+
+/*!
+ * @brief Sequence end address set to 11
+ */
+#define DL_ADC12_SEQ_END_ADDR_11                     (ADC12_CTL2_ENDADD_ADDR_11)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_SEQ_START_ADDR
+ * @{
+ */
+
+/*!
+ * @brief Sequence start address set to 00
+ */
+#define DL_ADC12_SEQ_START_ADDR_00                 (ADC12_CTL2_STARTADD_ADDR_00)
+
+/*!
+ * @brief Sequence start address set to 01
+ */
+#define DL_ADC12_SEQ_START_ADDR_01                 (ADC12_CTL2_STARTADD_ADDR_01)
+
+/*!
+ * @brief Sequence start address set to 02
+ */
+#define DL_ADC12_SEQ_START_ADDR_02                 (ADC12_CTL2_STARTADD_ADDR_02)
+
+/*!
+ * @brief Sequence start address set to 03
+ */
+#define DL_ADC12_SEQ_START_ADDR_03                 (ADC12_CTL2_STARTADD_ADDR_03)
+
+/*!
+ * @brief Sequence start address set to 04
+ */
+#define DL_ADC12_SEQ_START_ADDR_04                 (ADC12_CTL2_STARTADD_ADDR_04)
+
+/*!
+ * @brief Sequence start address set to 05
+ */
+#define DL_ADC12_SEQ_START_ADDR_05                 (ADC12_CTL2_STARTADD_ADDR_05)
+
+/*!
+ * @brief Sequence start address set to 06
+ */
+#define DL_ADC12_SEQ_START_ADDR_06                 (ADC12_CTL2_STARTADD_ADDR_06)
+
+/*!
+ * @brief Sequence start address set to 07
+ */
+#define DL_ADC12_SEQ_START_ADDR_07                 (ADC12_CTL2_STARTADD_ADDR_07)
+
+/*!
+ * @brief Sequence start address set to 08
+ */
+#define DL_ADC12_SEQ_START_ADDR_08                 (ADC12_CTL2_STARTADD_ADDR_08)
+
+/*!
+ * @brief Sequence start address set to 09
+ */
+#define DL_ADC12_SEQ_START_ADDR_09                 (ADC12_CTL2_STARTADD_ADDR_09)
+
+/*!
+ * @brief Sequence start address set to 10
+ */
+#define DL_ADC12_SEQ_START_ADDR_10                 (ADC12_CTL2_STARTADD_ADDR_10)
+
+/*!
+ * @brief Sequence start address set to 11
+ */
+#define DL_ADC12_SEQ_START_ADDR_11                 (ADC12_CTL2_STARTADD_ADDR_11)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_SAMP_MODE
+ * @{
+ */
+
+/*!
+ * @brief Single sample mode selected
+ */
+#define DL_ADC12_SAMP_MODE_SINGLE                     (ADC12_CTL1_CONSEQ_SINGLE)
+
+/*!
+ * @brief Repeat single sample mode selected
+ */
+#define DL_ADC12_SAMP_MODE_SINGLE_REPEAT        (ADC12_CTL1_CONSEQ_REPEATSINGLE)
+
+/*!
+ * @brief Sequence sample mode selected
+ */
+#define DL_ADC12_SAMP_MODE_SEQUENCE                 (ADC12_CTL1_CONSEQ_SEQUENCE)
+
+/*!
+ * @brief Repeat sequence sample mode selected
+ */
+#define DL_ADC12_SAMP_MODE_SEQUENCE_REPEAT    (ADC12_CTL1_CONSEQ_REPEATSEQUENCE)
+
+/** @}*/
+
+
+/** @addtogroup DL_ADC12_HW_AVG_NUM
+ * @{
+ */
+
+/*!
+ * @brief Doesn't accumulate conversions.
+ */
+#define DL_ADC12_HW_AVG_NUM_ACC_DISABLED               (ADC12_CTL1_AVGN_DISABLE)
+
+/*!
+ * @brief Accumulates 2 conversions and then is get divided by the
+ *        denominator selected.
+ */
+#define DL_ADC12_HW_AVG_NUM_ACC_2                        (ADC12_CTL1_AVGN_AVG_2)
+
+/*!
+ * @brief Accumulates 4 conversions and then is get divided by the
+ *        denominator selected.
+ */
+#define DL_ADC12_HW_AVG_NUM_ACC_4                        (ADC12_CTL1_AVGN_AVG_4)
+
+/*!
+ * @brief Accumulates 8 conversions and then is get divided by the
+ *        denominator selected.
+ */
+#define DL_ADC12_HW_AVG_NUM_ACC_8                        (ADC12_CTL1_AVGN_AVG_8)
+
+/*!
+ * @brief Accumulates 16 conversions and then is get divided by the
+ *        denominator selected.
+ */
+#define DL_ADC12_HW_AVG_NUM_ACC_16                      (ADC12_CTL1_AVGN_AVG_16)
+
+/*!
+ * @brief Accumulates 32 conversions and then is get divided by the
+ *        denominator selected.
+ */
+#define DL_ADC12_HW_AVG_NUM_ACC_32                      (ADC12_CTL1_AVGN_AVG_32)
+
+/*!
+ * @brief Accumulates 64 conversions and then is get divided by the
+ *        denominator selected.
+ */
+#define DL_ADC12_HW_AVG_NUM_ACC_64                      (ADC12_CTL1_AVGN_AVG_64)
+
+/*!
+ * @brief Accumulates 128 conversions and then is get divided by the
+ *        denominator selected.
+ */
+#define DL_ADC12_HW_AVG_NUM_ACC_128                    (ADC12_CTL1_AVGN_AVG_128)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_HW_AVG_DEN
+ * @{
+ */
+
+/*!
+ * @brief Accumulated conversions are divided by 1.
+ */
+#define DL_ADC12_HW_AVG_DEN_DIV_BY_1                    (ADC12_CTL1_AVGD_SHIFT0)
+
+/*!
+ * @brief Accumulated conversions are divided by 2.
+ */
+#define DL_ADC12_HW_AVG_DEN_DIV_BY_2                    (ADC12_CTL1_AVGD_SHIFT1)
+
+/*!
+ * @brief Accumulated conversions are divided by 4.
+ */
+#define DL_ADC12_HW_AVG_DEN_DIV_BY_4                    (ADC12_CTL1_AVGD_SHIFT2)
+
+/*!
+ * @brief Accumulated conversions are divided by 8.
+ */
+#define DL_ADC12_HW_AVG_DEN_DIV_BY_8                    (ADC12_CTL1_AVGD_SHIFT3)
+
+/*!
+ * @brief Accumulated conversions are divided by 16.
+ */
+#define DL_ADC12_HW_AVG_DEN_DIV_BY_16                   (ADC12_CTL1_AVGD_SHIFT4)
+
+/*!
+ * @brief Accumulated conversions are divided by 32.
+ */
+#define DL_ADC12_HW_AVG_DEN_DIV_BY_32                   (ADC12_CTL1_AVGD_SHIFT5)
+
+/*!
+ * @brief Accumulated conversions are divided by 64.
+ */
+#define DL_ADC12_HW_AVG_DEN_DIV_BY_64                   (ADC12_CTL1_AVGD_SHIFT6)
+
+/*!
+ * @brief Accumulated conversions are divided by 128.
+ */
+#define DL_ADC12_HW_AVG_DEN_DIV_BY_128                  (ADC12_CTL1_AVGD_SHIFT7)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_POWER_DOWN_MODE
+ * @{
+ */
+
+/*!
+ * @brief ADC12 power down mode auto
+ */
+#define DL_ADC12_POWER_DOWN_MODE_AUTO                    (ADC12_CTL0_PWRDN_AUTO)
+
+/*!
+ * @brief ADC12 power down mode manual
+ */
+#define DL_ADC12_POWER_DOWN_MODE_MANUAL                (ADC12_CTL0_PWRDN_MANUAL)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_INPUT_CHAN
+ *  @{
+ */
+/*!
+ * @brief ADC12 input channel 0 selected
+ */
+#define DL_ADC12_INPUT_CHAN_0                      (ADC12_MEMCTL_CHANSEL_CHAN_0)
+
+/*!
+ * @brief ADC12 input channel 1 selected
+ */
+#define DL_ADC12_INPUT_CHAN_1                      (ADC12_MEMCTL_CHANSEL_CHAN_1)
+
+/*!
+ * @brief ADC12 input channel 2 selected
+ */
+#define DL_ADC12_INPUT_CHAN_2                      (ADC12_MEMCTL_CHANSEL_CHAN_2)
+
+/*!
+ * @brief ADC12 input channel 3 selected
+ */
+#define DL_ADC12_INPUT_CHAN_3                      (ADC12_MEMCTL_CHANSEL_CHAN_3)
+
+/*!
+ * @brief ADC12 input channel 4 selected
+ */
+#define DL_ADC12_INPUT_CHAN_4                      (ADC12_MEMCTL_CHANSEL_CHAN_4)
+
+/*!
+ * @brief ADC12 input channel 5 selected
+ */
+#define DL_ADC12_INPUT_CHAN_5                      (ADC12_MEMCTL_CHANSEL_CHAN_5)
+
+/*!
+ * @brief ADC12 input channel 6 selected
+ */
+#define DL_ADC12_INPUT_CHAN_6                      (ADC12_MEMCTL_CHANSEL_CHAN_6)
+
+/*!
+ * @brief ADC12 input channel 7 selected
+ */
+#define DL_ADC12_INPUT_CHAN_7                      (ADC12_MEMCTL_CHANSEL_CHAN_7)
+
+/*!
+ * @brief ADC12 input channel 8 selected
+ */
+#define DL_ADC12_INPUT_CHAN_8                      (ADC12_MEMCTL_CHANSEL_CHAN_8)
+
+/*!
+ * @brief ADC12 input channel 9 selected
+ */
+#define DL_ADC12_INPUT_CHAN_9                      (ADC12_MEMCTL_CHANSEL_CHAN_9)
+
+/*!
+ * @brief ADC12 input channel 10 selected
+ */
+#define DL_ADC12_INPUT_CHAN_10                    (ADC12_MEMCTL_CHANSEL_CHAN_10)
+
+/*!
+ * @brief ADC12 input channel 11 selected
+ */
+#define DL_ADC12_INPUT_CHAN_11                    (ADC12_MEMCTL_CHANSEL_CHAN_11)
+
+/*!
+ * @brief ADC12 input channel 12 selected
+ */
+#define DL_ADC12_INPUT_CHAN_12                    (ADC12_MEMCTL_CHANSEL_CHAN_12)
+
+/*!
+ * @brief ADC12 input channel 13 selected
+ */
+#define DL_ADC12_INPUT_CHAN_13                    (ADC12_MEMCTL_CHANSEL_CHAN_13)
+
+/*!
+ * @brief ADC12 input channel 14 selected
+ */
+#define DL_ADC12_INPUT_CHAN_14                    (ADC12_MEMCTL_CHANSEL_CHAN_14)
+
+/*!
+ * @brief ADC12 input channel 15 selected
+ */
+#define DL_ADC12_INPUT_CHAN_15                    (ADC12_MEMCTL_CHANSEL_CHAN_15)
+
+#ifdef DEVICE_HAS_GREATER_THAN_16_INPUT_CHAN
+/*!
+ * @brief ADC12 input channel 16 selected
+ */
+#define DL_ADC12_INPUT_CHAN_16                    (ADC12_MEMCTL_CHANSEL_CHAN_16)
+
+/*!
+ * @brief ADC12 input channel 17 selected
+ */
+#define DL_ADC12_INPUT_CHAN_17                    (ADC12_MEMCTL_CHANSEL_CHAN_17)
+
+/*!
+ * @brief ADC12 input channel 18 selected
+ */
+#define DL_ADC12_INPUT_CHAN_18                    (ADC12_MEMCTL_CHANSEL_CHAN_18)
+
+/*!
+ * @brief ADC12 input channel 19 selected
+ */
+#define DL_ADC12_INPUT_CHAN_19                    (ADC12_MEMCTL_CHANSEL_CHAN_19)
+
+/*!
+ * @brief ADC12 input channel 20 selected
+ */
+#define DL_ADC12_INPUT_CHAN_20                    (ADC12_MEMCTL_CHANSEL_CHAN_20)
+
+/*!
+ * @brief ADC12 input channel 21 selected
+ */
+#define DL_ADC12_INPUT_CHAN_21                    (ADC12_MEMCTL_CHANSEL_CHAN_21)
+
+/*!
+ * @brief ADC12 input channel 22 selected
+ */
+#define DL_ADC12_INPUT_CHAN_22                    (ADC12_MEMCTL_CHANSEL_CHAN_22)
+
+/*!
+ * @brief ADC12 input channel 23 selected
+ */
+#define DL_ADC12_INPUT_CHAN_23                    (ADC12_MEMCTL_CHANSEL_CHAN_23)
+
+/*!
+ * @brief ADC12 input channel 24 selected
+ */
+#define DL_ADC12_INPUT_CHAN_24                    (ADC12_MEMCTL_CHANSEL_CHAN_24)
+
+/*!
+ * @brief ADC12 input channel 25 selected
+ */
+#define DL_ADC12_INPUT_CHAN_25                    (ADC12_MEMCTL_CHANSEL_CHAN_25)
+
+/*!
+ * @brief ADC12 input channel 26 selected
+ */
+#define DL_ADC12_INPUT_CHAN_26                    (ADC12_MEMCTL_CHANSEL_CHAN_26)
+
+/*!
+ * @brief ADC12 input channel 27 selected
+ */
+#define DL_ADC12_INPUT_CHAN_27                    (ADC12_MEMCTL_CHANSEL_CHAN_27)
+
+/*!
+ * @brief ADC12 input channel 28 selected
+ */
+#define DL_ADC12_INPUT_CHAN_28                    (ADC12_MEMCTL_CHANSEL_CHAN_28)
+
+/*!
+ * @brief ADC12 input channel 29 selected
+ */
+#define DL_ADC12_INPUT_CHAN_29                    (ADC12_MEMCTL_CHANSEL_CHAN_29)
+
+/*!
+ * @brief ADC12 input channel 30 selected
+ */
+#define DL_ADC12_INPUT_CHAN_30                    (ADC12_MEMCTL_CHANSEL_CHAN_30)
+
+/*!
+ * @brief ADC12 input channel 31 selected
+ */
+#define DL_ADC12_INPUT_CHAN_31                    (ADC12_MEMCTL_CHANSEL_CHAN_31)
+
+#endif /* DEVICE_HAS_GREATER_THAN_16_INPUT_CHAN */
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_REFERENCE_VOLTAGE
+ *  @{
+ */
+
+/*!
+ * @brief ADC12 voltage reference VDDA
+ */
+#define DL_ADC12_REFERENCE_VOLTAGE_VDDA                (ADC12_MEMCTL_VRSEL_VDDA)
+
+/*!
+ * @brief ADC12 voltage reference external
+ */
+#define DL_ADC12_REFERENCE_VOLTAGE_EXTREF            (ADC12_MEMCTL_VRSEL_EXTREF)
+
+/*!
+ * @brief ADC12 voltage reference internal
+ */
+#define DL_ADC12_REFERENCE_VOLTAGE_INTREF            (ADC12_MEMCTL_VRSEL_INTREF)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_SAMPLE_TIMER_SOURCE
+ *  @{
+ */
+
+/*!
+ * @brief ADC12 sample adc12 source 0
+ */
+#define DL_ADC12_SAMPLE_TIMER_SOURCE_SCOMP0      (ADC12_MEMCTL_STIME_SEL_SCOMP0)
+
+/*!
+ * @brief ADC12 sample adc12 source 1
+ */
+#define DL_ADC12_SAMPLE_TIMER_SOURCE_SCOMP1      (ADC12_MEMCTL_STIME_SEL_SCOMP1)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_AVERAGING_MODE
+ *  @{
+ */
+
+/*!
+ * @brief ADC12 averaging mode enabled
+ */
+#define DL_ADC12_AVERAGING_MODE_ENABLED              (ADC12_MEMCTL_AVGEN_ENABLE)
+
+/*!
+ * @brief ADC12 averaging mode disabled
+ */
+#define DL_ADC12_AVERAGING_MODE_DISABLED            (ADC12_MEMCTL_AVGEN_DISABLE)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_BURN_OUT_SOURCE
+ *  @{
+ */
+
+/*!
+ * @brief ADC12 burn out current source enabled
+ */
+#define DL_ADC12_BURN_OUT_SOURCE_ENABLED             (ADC12_MEMCTL_BCSEN_ENABLE)
+
+/*!
+ * @brief ADC12 burn out current source enabled
+ */
+#define DL_ADC12_BURN_OUT_SOURCE_DISABLED           (ADC12_MEMCTL_BCSEN_DISABLE)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_TRIGGER_MODE
+ *  @{
+ */
+
+/*!
+ * @brief ADC12 trigger automaticaly step to next memory conversion register
+ */
+#define DL_ADC12_TRIGGER_MODE_AUTO_NEXT           (ADC12_MEMCTL_TRIG_AUTO_NEXT)
+
+/*!
+ * @brief ADC12 valid trigger will step to next memory conversion register
+ */
+#define DL_ADC12_TRIGGER_MODE_TRIGGER_NEXT      (ADC12_MEMCTL_TRIG_TRIGGER_NEXT)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_WINDOWS_COMP_MODE
+ *  @{
+ */
+
+/*!
+ * @brief ADC12 window comparator enabled
+ */
+#define DL_ADC12_WINDOWS_COMP_MODE_ENABLED         (ADC12_MEMCTL_WINCOMP_ENABLE)
+
+/*!
+ * @brief ADC12 window comparator disabled
+ */
+#define DL_ADC12_WINDOWS_COMP_MODE_DISABLED       (ADC12_MEMCTL_WINCOMP_DISABLE)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_STATUS_CONVERSION
+ *  @{
+ */
+
+/*!
+ * @brief Indicates sample or conversion is in progress
+ */
+#define DL_ADC12_STATUS_CONVERSION_ACTIVE             (ADC12_STATUS_BUSY_ACTIVE)
+
+/*!
+ * @brief Indicates sample or conversion is not in progress
+ */
+#define DL_ADC12_STATUS_CONVERSION_IDLE                 (ADC12_STATUS_BUSY_IDLE)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_STATUS_REFERENCE
+ *  @{
+ */
+
+/*!
+ * @brief Indicates reference buffer is powered up and ready
+ */
+#define DL_ADC12_STATUS_REFERENCE_READY           (ADC12_STATUS_REFBUFRDY_READY)
+
+/*!
+ * @brief Indicates reference buffer is not ready
+ */
+#define DL_ADC12_STATUS_REFERENCE_NOTREADY     (ADC12_STATUS_REFBUFRDY_NOTREADY)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_INTERRUPTS
+ *  @{
+ */
+
+/*!
+ * @brief ADC12 MEMRESX overflow
+ */
+#define DL_ADC12_INTERRUPT_OVERFLOW           (ADC12_CPU_INT_IMASK_OVIFG_SET)
+
+/*!
+ * @brief ADC12 sequence conversion trigger overflow
+ */
+#define DL_ADC12_INTERRUPT_TRIG_OVF      (ADC12_CPU_INT_IMASK_TOVIFG_SET)
+
+/*!
+ * @brief ADC12 MEMRESx result higher than window comparator high threshold
+ */
+#define DL_ADC12_INTERRUPT_WINDOW_COMP_HIGH (ADC12_CPU_INT_IMASK_HIGHIFG_SET)
+
+/*!
+ * @brief ADC12 MEMRESx result lower than window comparator low threshold
+ */
+#define DL_ADC12_INTERRUPT_WINDOW_COMP_LOW   (ADC12_CPU_INT_IMASK_LOWIFG_SET)
+
+/*!
+ * @brief ADC12 MEMRESx result is between low and high window comparator
+ *        threshold
+ */
+#define DL_ADC12_INTERRUPT_INIFG              (ADC12_CPU_INT_IMASK_INIFG_SET)
+
+/*!
+ * @brief ADC12 DMA done
+ */
+#define DL_ADC12_INTERRUPT_DMA_DONE         (ADC12_CPU_INT_IMASK_DMADONE_SET)
+
+/*!
+ * @brief ADC12 MEMRESX underflow
+ */
+#define DL_ADC12_INTERRUPT_UNDERFLOW          (ADC12_CPU_INT_IMASK_UVIFG_SET)
+
+/*!
+ * @brief ADC12 MEM0 result loaded interrupt
+ */
+#define DL_ADC12_INTERRUPT_MEM0_RESULT_LOADED \
+                                         (ADC12_CPU_INT_IMASK_MEMRESIFG0_SET)
+
+/*!
+ * @brief ADC12 MEM1 result loaded interrupt
+ */
+#define DL_ADC12_INTERRUPT_MEM1_RESULT_LOADED \
+                                         (ADC12_CPU_INT_IMASK_MEMRESIFG1_SET)
+
+/*!
+ * @brief ADC12 MEM2 result loaded interrupt
+ */
+#define DL_ADC12_INTERRUPT_MEM2_RESULT_LOADED \
+                                         (ADC12_CPU_INT_IMASK_MEMRESIFG2_SET)
+
+/*!
+ * @brief ADC12 MEM3 result loaded interrupt
+ */
+#define DL_ADC12_INTERRUPT_MEM3_RESULT_LOADED \
+                                         (ADC12_CPU_INT_IMASK_MEMRESIFG3_SET)
+
+/*!
+ * @brief ADC12 MEM4 result loaded interrupt
+ */
+#define DL_ADC12_INTERRUPT_MEM4_RESULT_LOADED \
+                                         (ADC12_CPU_INT_IMASK_MEMRESIFG4_SET)
+
+/*!
+ * @brief ADC12 MEM5 result loaded interrupt
+ */
+#define DL_ADC12_INTERRUPT_MEM5_RESULT_LOADED \
+                                         (ADC12_CPU_INT_IMASK_MEMRESIFG5_SET)
+
+/*!
+ * @brief ADC12 MEM6 result loaded interrupt
+ */
+#define DL_ADC12_INTERRUPT_MEM6_RESULT_LOADED \
+                                         (ADC12_CPU_INT_IMASK_MEMRESIFG6_SET)
+
+/*!
+ * @brief ADC12 MEM7 result loaded interrupt
+ */
+#define DL_ADC12_INTERRUPT_MEM7_RESULT_LOADED \
+                                         (ADC12_CPU_INT_IMASK_MEMRESIFG7_SET)
+
+/*!
+ * @brief ADC12 MEM8 result loaded interrupt
+ */
+#define DL_ADC12_INTERRUPT_MEM8_RESULT_LOADED \
+                                         (ADC12_CPU_INT_IMASK_MEMRESIFG8_SET)
+
+/*!
+ * @brief ADC12 MEM9 result loaded interrupt
+ */
+#define DL_ADC12_INTERRUPT_MEM9_RESULT_LOADED \
+                                         (ADC12_CPU_INT_IMASK_MEMRESIFG9_SET)
+
+/*!
+ * @brief ADC12 MEM10 result loaded interrupt
+ */
+#define DL_ADC12_INTERRUPT_MEM10_RESULT_LOADED \
+                                        (ADC12_CPU_INT_IMASK_MEMRESIFG10_SET)
+
+/*!
+ * @brief ADC12 MEM12 result loaded interrupt
+ */
+#define DL_ADC12_INTERRUPT_MEM11_RESULT_LOADED \
+                                        (ADC12_CPU_INT_IMASK_MEMRESIFG11_SET)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_EVENT
+ *  @{
+ */
+
+/*!
+ * @brief ADC12 MEMRESx result higher than window comparator high threshold
+ */
+#define DL_ADC12_EVENT_WINDOW_COMP_HIGH     (ADC12_GEN_EVENT_IMASK_HIGHIFG_SET)
+
+/*!
+ * @brief ADC12 MEMRESx result lower than window comparator low threshold
+ */
+#define DL_ADC12_EVENT_WINDOW_COMP_LOW       (ADC12_GEN_EVENT_IMASK_LOWIFG_SET)
+
+/*!
+ * @brief ADC12 MEMRESx result between high and low window comparator threshold
+ */
+#define DL_ADC12_EVENT_INIFG                  (ADC12_GEN_EVENT_IMASK_INIFG_SET)
+
+/*!
+ * @brief ADC12 MEM0 result loaded interrupt
+ */
+#define DL_ADC12_EVENT_MEM0_RESULT_LOADED \
+                                         (ADC12_GEN_EVENT_IMASK_MEMRESIFG0_SET)
+
+/** @}*/
+
+/** @addtogroup DL_ADC12_DMA
+ *  @{
+ */
+
+/*!
+ * @brief ADC12 MEM0 result loaded interrupt
+ */
+#define DL_ADC12_DMA_MEM0_RESULT_LOADED  (ADC12_DMA_TRIG_IMASK_MEMRESIFG0_SET)
+
+/*!
+ * @brief ADC12 MEM1 result loaded interrupt
+ */
+#define DL_ADC12_DMA_MEM1_RESULT_LOADED  (ADC12_DMA_TRIG_IMASK_MEMRESIFG1_SET)
+
+/*!
+ * @brief ADC12 MEM2 result loaded interrupt
+ */
+#define DL_ADC12_DMA_MEM2_RESULT_LOADED  (ADC12_DMA_TRIG_IMASK_MEMRESIFG2_SET)
+
+/*!
+ * @brief ADC12 MEM3 result loaded interrupt
+ */
+#define DL_ADC12_DMA_MEM3_RESULT_LOADED  (ADC12_DMA_TRIG_IMASK_MEMRESIFG3_SET)
+
+/*!
+ * @brief ADC12 MEM4 result loaded interrupt
+ */
+#define DL_ADC12_DMA_MEM4_RESULT_LOADED  (ADC12_DMA_TRIG_IMASK_MEMRESIFG4_SET)
+
+/*!
+ * @brief ADC12 MEM5 result loaded interrupt
+ */
+#define DL_ADC12_DMA_MEM5_RESULT_LOADED  (ADC12_DMA_TRIG_IMASK_MEMRESIFG5_SET)
+
+/*!
+ * @brief ADC12 MEM6 result loaded interrupt
+ */
+#define DL_ADC12_DMA_MEM6_RESULT_LOADED  (ADC12_DMA_TRIG_IMASK_MEMRESIFG6_SET)
+
+/*!
+ * @brief ADC12 MEM7 result loaded interrupt
+ */
+#define DL_ADC12_DMA_MEM7_RESULT_LOADED  (ADC12_DMA_TRIG_IMASK_MEMRESIFG7_SET)
+
+/*!
+ * @brief ADC12 MEM8 result loaded interrupt
+ */
+#define DL_ADC12_DMA_MEM8_RESULT_LOADED  (ADC12_DMA_TRIG_IMASK_MEMRESIFG8_SET)
+
+/*!
+ * @brief ADC12 MEM9 result loaded interrupt
+ */
+#define DL_ADC12_DMA_MEM9_RESULT_LOADED  (ADC12_DMA_TRIG_IMASK_MEMRESIFG9_SET)
+
+/*!
+ * @brief ADC12 MEM10 result loaded interrupt
+ */
+#define DL_ADC12_DMA_MEM10_RESULT_LOADED \
+                                        (ADC12_DMA_TRIG_IMASK_MEMRESIFG10_SET)
+
+/*!
+ * @brief ADC12 MEM11 result loaded interrupt
+ */
+#define DL_ADC12_DMA_MEM11_RESULT_LOADED \
+                                        (ADC12_DMA_TRIG_IMASK_MEMRESIFG11_SET)
+
+/** @}*/
+
+/*!
+ * @brief  This is an internal macro is used to resolve the offset to ADC12 SVT
+ *         aperture
+ */
+#define DL_ADC12_SVT_OFFSET                  ((uint32_t)0x555000 >> (uint32_t)2)
+
+/* clang-format on */
+
+/*! @enum DL_ADC12_MEM_IDX */
+typedef enum {
+
+    /*! ADC12 Memory conversion index 0 */
+    DL_ADC12_MEM_IDX_0 = 0,
+
+    /*! ADC12 Memory conversion index 1 */
+    DL_ADC12_MEM_IDX_1 = 1,
+
+    /*! ADC12 Memory conversion index 2 */
+    DL_ADC12_MEM_IDX_2 = 2,
+
+    /*! ADC12 Memory conversion index 3 */
+    DL_ADC12_MEM_IDX_3 = 3,
+
+    /*! ADC12 Memory conversion index 4 */
+    DL_ADC12_MEM_IDX_4 = 4,
+
+    /*! ADC12 Memory conversion index 5 */
+    DL_ADC12_MEM_IDX_5 = 5,
+
+    /*! ADC12 Memory conversion index 6 */
+    DL_ADC12_MEM_IDX_6 = 6,
+
+    /*! ADC12 Memory conversion index 7 */
+    DL_ADC12_MEM_IDX_7 = 7,
+
+    /*! ADC12 Memory conversion index 8 */
+    DL_ADC12_MEM_IDX_8 = 8,
+
+    /*! ADC12 Memory conversion index 9 */
+    DL_ADC12_MEM_IDX_9 = 9,
+
+    /*! ADC12 Memory conversion index 10 */
+    DL_ADC12_MEM_IDX_10 = 10,
+
+    /*! ADC12 Memory conversion index 11 */
+    DL_ADC12_MEM_IDX_11 = 11,
+
+} DL_ADC12_MEM_IDX;
+
+/*! @enum DL_ADC12_REPEAT_MODE */
+typedef enum {
+
+    /*! Sequence mode single repeat */
+    DL_ADC12_REPEAT_MODE_ENABLED = ADC12_CTL1_CONSEQ_REPEATSINGLE,
+
+    /*! Sequence mode single */
+    DL_ADC12_REPEAT_MODE_DISABLED = ADC12_CTL1_CONSEQ_SINGLE
+
+} DL_ADC12_REPEAT_MODE;
+
+/*! @enum DL_ADC12_SAMPLING_SOURCE */
+typedef enum {
+    /*! Timer high phase is used as source of the sample signal */
+    DL_ADC12_SAMPLING_SOURCE_AUTO = ADC12_CTL1_SAMPMODE_AUTO,
+
+    /*! External or software trigger is used as source of the sample signal */
+    DL_ADC12_SAMPLING_SOURCE_MANUAL = ADC12_CTL1_SAMPMODE_MANUAL
+} DL_ADC12_SAMPLING_SOURCE;
+
+/*! @enum DL_ADC12_TRIG_SRC */
+typedef enum {
+    /*! Conversion is triggered by software. */
+    DL_ADC12_TRIG_SRC_SOFTWARE = ADC12_CTL1_TRIGSRC_SOFTWARE,
+
+    /*! Conversion is triggered by hardware */
+    DL_ADC12_TRIG_SRC_EVENT = ADC12_CTL1_TRIGSRC_EVENT
+
+} DL_ADC12_TRIG_SRC;
+
+/*! @enum DL_ADC12_SAMP_CONV_RES */
+typedef enum {
+    /*! 12-bits resolution */
+    DL_ADC12_SAMP_CONV_RES_12_BIT = ADC12_CTL2_RES_BIT_12,
+    /*! 10-bits resolution */
+    DL_ADC12_SAMP_CONV_RES_10_BIT = ADC12_CTL2_RES_BIT_10,
+    /*! 8-bits resolution */
+    DL_ADC12_SAMP_CONV_RES_8_BIT = ADC12_CTL2_RES_BIT_8
+} DL_ADC12_SAMP_CONV_RES;
+
+/*! @enum DL_ADC12_SAMP_CONV_DATA_FORMAT */
+typedef enum {
+    /*! Results are read as binary unsigned, right aligned. */
+    DL_ADC12_SAMP_CONV_DATA_FORMAT_UNSIGNED = ADC12_CTL2_DF_UNSIGNED,
+
+    /*! Result are read as signed binary (2s complement), left aligned. */
+    DL_ADC12_SAMP_CONV_DATA_FORMAT_SIGNED = ADC12_CTL2_DF_SIGNED
+
+} DL_ADC12_SAMP_CONV_DATA_FORMAT;
+
+/*! @enum DL_ADC12_IIDX */
+typedef enum {
+    /*! ADC12 interrupt index for MEMRESX overflow */
+    DL_ADC12_IIDX_OVERFLOW = ADC12_CPU_INT_IIDX_STAT_OVIFG,
+
+    /*! ADC12 interrupt index for sequence conversion trigger overflow */
+    DL_ADC12_IIDX_TRIG_OVERFLOW = ADC12_CPU_INT_IIDX_STAT_TOVIFG,
+
+    /*! ADC12 interrupt index for MEMRESx result higher than window
+     * comparator high threshold */
+    DL_ADC12_IIDX_WINDOW_COMP_HIGH = ADC12_CPU_INT_IIDX_STAT_HIGHIFG,
+
+    /*! ADC12 interrupt index for MEMRESx result lower than window
+    *  comparator low threshold */
+    DL_ADC12_IIDX_WINDOW_COMP_LOW = ADC12_CPU_INT_IIDX_STAT_LOWIFG,
+
+    /*! ADC12 interrupt index for result in range */
+    DL_ADC12_IIDX_INIFG = ADC12_CPU_INT_IIDX_STAT_INIFG,
+
+    /*! ADC12 interrupt index for DMA done */
+    DL_ADC12_IIDX_DMA_DONE = ADC12_CPU_INT_IIDX_STAT_DMADONE,
+
+    /*! ADC12 interrupt index for MEMRESX underflow */
+    DL_ADC12_IIDX_UNDERFLOW = ADC12_CPU_INT_IIDX_STAT_UVIFG,
+
+    /*! ADC12 interrupt index for MEM0 result loaded interrupt */
+    DL_ADC12_IIDX_MEM0_RESULT_LOADED = ADC12_CPU_INT_IIDX_STAT_MEMRESIFG0,
+
+    /*! ADC12 interrupt index for MEM1 result loaded interrupt */
+    DL_ADC12_IIDX_MEM1_RESULT_LOADED = ADC12_CPU_INT_IIDX_STAT_MEMRESIFG1,
+
+    /*! ADC12 interrupt index for MEM2 result loaded interrupt */
+    DL_ADC12_IIDX_MEM2_RESULT_LOADED = ADC12_CPU_INT_IIDX_STAT_MEMRESIFG2,
+
+    /*! ADC12 interrupt index for MEM3 result loaded interrupt */
+    DL_ADC12_IIDX_MEM3_RESULT_LOADED = ADC12_CPU_INT_IIDX_STAT_MEMRESIFG3,
+
+    /*! ADC12 interrupt index for MEM4 result loaded interrupt */
+    DL_ADC12_IIDX_MEM4_RESULT_LOADED = ADC12_CPU_INT_IIDX_STAT_MEMRESIFG4,
+
+    /*! ADC12 interrupt index for MEM5 result loaded interrupt */
+    DL_ADC12_IIDX_MEM5_RESULT_LOADED = ADC12_CPU_INT_IIDX_STAT_MEMRESIFG5,
+
+    /*! ADC12 interrupt index for MEM6 result loaded interrupt */
+    DL_ADC12_IIDX_MEM6_RESULT_LOADED = ADC12_CPU_INT_IIDX_STAT_MEMRESIFG6,
+
+    /*! ADC12 interrupt index for MEM7 result loaded interrupt */
+    DL_ADC12_IIDX_MEM7_RESULT_LOADED = ADC12_CPU_INT_IIDX_STAT_MEMRESIFG7,
+
+    /*! ADC12 interrupt index for MEM8 result loaded interrupt */
+    DL_ADC12_IIDX_MEM8_RESULT_LOADED = ADC12_CPU_INT_IIDX_STAT_MEMRESIFG8,
+
+    /*! ADC12 interrupt index for MEM9 result loaded interrupt */
+    DL_ADC12_IIDX_MEM9_RESULT_LOADED = ADC12_CPU_INT_IIDX_STAT_MEMRESIFG9,
+
+    /*! ADC12 interrupt index for MEM10 result loaded interrupt */
+    DL_ADC12_IIDX_MEM10_RESULT_LOADED = ADC12_CPU_INT_IIDX_STAT_MEMRESIFG10,
+
+    /*! ADC12 interrupt index for MEM10 result loaded interrupt */
+    DL_ADC12_IIDX_MEM11_RESULT_LOADED = ADC12_CPU_INT_IIDX_STAT_MEMRESIFG11,
+} DL_ADC12_IIDX;
+
+/* clang-format on */
+/*! @enum DL_ADC12_CLOCK */
+typedef enum {
+    /*! SYSOSC is the source of ADC sample clock*/
+    DL_ADC12_CLOCK_SYSOSC = ADC12_CLKCFG_SAMPCLK_SYSOSC,
+    /*! ULPCLK is the source of ADC sample clock*/
+    DL_ADC12_CLOCK_ULPCLK = ADC12_CLKCFG_SAMPCLK_ULPCLK,
+    /*! HFCLK is the source of ADC sample clock*/
+    DL_ADC12_CLOCK_HFCLK = ADC12_CLKCFG_SAMPCLK_HFCLK,
+} DL_ADC12_CLOCK;
+
+/*! @enum DL_ADC12_CLOCK_DIVIDE */
+typedef enum {
+
+    /*! Divide sample clock source by 1 */
+    DL_ADC12_CLOCK_DIVIDE_1 = ADC12_CTL0_SCLKDIV_DIV_BY_1,
+
+    /*! Divide sample clock source by 2 */
+    DL_ADC12_CLOCK_DIVIDE_2 = ADC12_CTL0_SCLKDIV_DIV_BY_2,
+
+    /*! Divide sample clock source by 4 */
+    DL_ADC12_CLOCK_DIVIDE_4 = ADC12_CTL0_SCLKDIV_DIV_BY_4,
+
+    /*! Divide sample clock source by 8 */
+    DL_ADC12_CLOCK_DIVIDE_8 = ADC12_CTL0_SCLKDIV_DIV_BY_8,
+
+    /*! Divide sample clock source by 16 */
+    DL_ADC12_CLOCK_DIVIDE_16 = ADC12_CTL0_SCLKDIV_DIV_BY_16,
+
+    /*! Divide sample clock source by 24 */
+    DL_ADC12_CLOCK_DIVIDE_24 = ADC12_CTL0_SCLKDIV_DIV_BY_24,
+
+    /*! Divide sample clock source by 32 */
+    DL_ADC12_CLOCK_DIVIDE_32 = ADC12_CTL0_SCLKDIV_DIV_BY_32,
+
+    /*! Divide sample clock source by 48 */
+    DL_ADC12_CLOCK_DIVIDE_48 = ADC12_CTL0_SCLKDIV_DIV_BY_48,
+
+} DL_ADC12_CLOCK_DIVIDE;
+
+/*! @enum DL_ADC12_CLOCK_FREQ_RANGE */
+typedef enum {
+    /*! Specifies ADC clock (ADCCLK) frequency range is from 1 MHz to 4 MHz */
+    DL_ADC12_CLOCK_FREQ_RANGE_1_TO_4 = ADC12_CLKFREQ_FRANGE_RANGE1TO4,
+
+    /*! Specifies ADC clock (ADCCLK) frequency range is from 4 MHz to 8 MHz */
+    DL_ADC12_CLOCK_FREQ_RANGE_4_TO_8 = ADC12_CLKFREQ_FRANGE_RANGE4TO8,
+
+    /*! Specifies ADC clock (ADCCLK) frequency range is from 8 MHz to 16 MHz */
+    DL_ADC12_CLOCK_FREQ_RANGE_8_TO_16 = ADC12_CLKFREQ_FRANGE_RANGE8TO16,
+
+    /*! Specifies ADC clock (ADCCLK) frequency range is from 16 MHz to 20 MHz */
+    DL_ADC12_CLOCK_FREQ_RANGE_16_TO_20 = ADC12_CLKFREQ_FRANGE_RANGE16TO20,
+
+    /*! Specifies ADC clock (ADCCLK) frequency range is from 20 MHz to 24 MHz */
+    DL_ADC12_CLOCK_FREQ_RANGE_20_TO_24 = ADC12_CLKFREQ_FRANGE_RANGE20TO24,
+
+    /*! Specifies ADC clock (ADCCLK) frequency range is from 24 MHz to 32 MHz */
+    DL_ADC12_CLOCK_FREQ_RANGE_24_TO_32 = ADC12_CLKFREQ_FRANGE_RANGE24TO32,
+
+    /*! Specifies ADC clock (ADCCLK) frequency range is from 32 MHz to 40 MHz */
+    DL_ADC12_CLOCK_FREQ_RANGE_32_TO_40 = ADC12_CLKFREQ_FRANGE_RANGE32TO40,
+
+    /*! Specifies ADC clock (ADCCLK) frequency range is from 40 MHz to 48 MHz */
+    DL_ADC12_CLOCK_FREQ_RANGE_40_TO_48 = ADC12_CLKFREQ_FRANGE_RANGE40TO48,
+
+} DL_ADC12_CLOCK_FREQ_RANGE;
+
+/**
+ * @brief  Configuration struct for @ref DL_ADC12_setClockConfig.
+ */
+typedef struct {
+    /*! ADC12 clock source selection. This sources the ADCCLK. One of
+     * @ref DL_ADC12_CLOCK */
+    DL_ADC12_CLOCK clockSel;
+    /*! ADC12 clock source frequency range. One of
+     * @ref DL_ADC12_CLOCK_FREQ_RANGE */
+    DL_ADC12_CLOCK_FREQ_RANGE freqRange;
+    /*! ADC12 sample clock divider selection. This is used to generate the ADC12
+     * Sample Clock frequency. One of @ref DL_ADC12_CLOCK_DIVIDE */
+    DL_ADC12_CLOCK_DIVIDE divideRatio;
+} DL_ADC12_ClockConfig;
+
+/**
+ * @brief Enables power on adc12 module
+ *
+ * @param adc12        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_ADC12_enablePower(ADC12_Regs *adc12)
+{
+    adc12->ULLMEM.GPRCM.PWREN =
+        (ADC12_PWREN_KEY_UNLOCK_W | ADC12_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power on adc12 module
+ *
+ * @param adc12        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_ADC12_disablePower(ADC12_Regs *adc12)
+{
+    adc12->ULLMEM.GPRCM.PWREN =
+        (ADC12_PWREN_KEY_UNLOCK_W | ADC12_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief Returns if  power on adc12 module
+ *
+ * @param adc12        Pointer to the register overlay for the peripheral
+ *
+ * @return true if power is enabled
+ * @return false if power is disabled
+ */
+__STATIC_INLINE bool DL_ADC12_isPowerEnabled(ADC12_Regs *adc12)
+{
+    return ((adc12->ULLMEM.GPRCM.PWREN & ADC12_PWREN_ENABLE_MASK) ==
+            ADC12_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Resets adc12 peripheral
+ *
+ * @param adc12        Pointer to the register overlay for the ADC12 peripheral
+ */
+__STATIC_INLINE void DL_ADC12_reset(ADC12_Regs *adc12)
+{
+    adc12->ULLMEM.GPRCM.RSTCTL =
+        (ADC12_RSTCTL_KEY_UNLOCK_W | ADC12_RSTCTL_RESETSTKYCLR_CLR |
+            ADC12_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief Returns if adc12 peripheral was reset
+ *
+ * @param adc12        Pointer to the register overlay for the ADC12 peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_ADC12_isReset(ADC12_Regs *adc12)
+{
+    return ((adc12->ULLMEM.GPRCM.STAT & ADC12_STAT_RESETSTKY_MASK) ==
+            ADC12_STAT_RESETSTKY_RESET);
+}
+
+/**
+ * @brief Initializes ADC12 for single sampling mode operation. This
+ * initialization configures MEMCTL0 as the default memory control register for
+ * the conversion. If the conversion needs use a different memory control
+ * register the user can call @ref DL_ADC12_setStartAddress to specify a
+ * different control register.
+ *
+ * @param[in] adc12       Pointer to the register overlay for the peripheral
+ * @param[in] repeatMode  Specifies repeat configuration. One of
+ *                    @ref DL_ADC12_REPEAT_MODE
+ * @param[in] sampleMode  Specifies source of the sampling signal. One of
+ *                    @ref DL_ADC12_SAMPLING_SOURCE
+ * @param[in] trigSrc     Specifies sampling trigger source. One of
+ *                    @ref DL_ADC12_TRIG_SRC
+ * @param[in] resolution  Specifies sample conversion resolution. One of
+ *                    @ref DL_ADC12_SAMP_CONV_RES
+ * @param[in] dataFormat  Specifies sample conversion data format. One of
+ *                    @ref DL_ADC12_SAMP_CONV_DATA_FORMAT
+ *
+ */
+__STATIC_INLINE void DL_ADC12_initSingleSample(ADC12_Regs *adc12,
+    uint32_t repeatMode, uint32_t sampleMode, uint32_t trigSrc,
+    uint32_t resolution, uint32_t dataFormat)
+{
+    DL_Common_updateReg(&adc12->ULLMEM.CTL1,
+        (repeatMode | sampleMode | trigSrc),
+        (ADC12_CTL1_SAMPMODE_MASK | ADC12_CTL1_CONSEQ_MASK |
+            ADC12_CTL1_TRIGSRC_MASK));
+
+    DL_Common_updateReg(&adc12->ULLMEM.CTL2,
+        (ADC12_CTL2_STARTADD_ADDR_00 | ADC12_CTL2_ENDADD_ADDR_00 | resolution |
+            dataFormat),
+        (ADC12_CTL2_STARTADD_MASK | ADC12_CTL2_ENDADD_MASK |
+            ADC12_CTL2_RES_MASK | ADC12_CTL2_DF_MASK));
+}
+
+/**
+ *  @brief Sets the start address for ADC conversion.
+ *
+ *  @param[in] adc12       Pointer to the register overlay for the peripheral
+ *  @param[in] startAdd    If ADC has been initialized in Single Sample mode,
+ *                         startAdd specifies the memory control register to be
+ *                         used during conversion. If ADC is initialized in
+ *                         sequence sampling mode, it specifies the first memory
+ *                         control register in the sequence. One of
+ *                         @ref DL_ADC12_SEQ_START_ADDR
+ *
+ */
+__STATIC_INLINE void DL_ADC12_setStartAddress(
+    ADC12_Regs *adc12, uint32_t startAdd)
+{
+    DL_Common_updateReg(
+        &adc12->ULLMEM.CTL2, startAdd, ADC12_CTL2_STARTADD_MASK);
+}
+
+/**
+ *  @brief Gets start address for ADC conversion.
+ *
+ *  @param[in] adc12       Pointer to the register overlay for the peripheral
+ *
+ *  @return One of @ref DL_ADC12_SEQ_END_ADDR
+ *
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getStartAddress(ADC12_Regs *adc12)
+{
+    return (adc12->ULLMEM.CTL2 & ADC12_CTL2_STARTADD_MASK);
+}
+
+/**
+ *  @brief Sets the end address for ADC conversion.
+ *
+ *  @param[in] adc12       Pointer to the register overlay for the peripheral
+ *  @param[in] endAdd      When ADC is initialized in sequence sampling  mode it
+ *                         specifies the last memory control register in the
+ *                         sequence. One of @ref DL_ADC12_SEQ_END_ADDR
+ *
+ */
+__STATIC_INLINE void DL_ADC12_setEndAddress(ADC12_Regs *adc12, uint32_t endAdd)
+{
+    DL_Common_updateReg(&adc12->ULLMEM.CTL2, endAdd, ADC12_CTL2_ENDADD_MASK);
+}
+
+/**
+ *  @brief Gets end address for ADC conversion.
+ *
+ *  @param[in] adc12       Pointer to the register overlay for the peripheral
+ *
+ *  @return One of @ref DL_ADC12_SEQ_END_ADDR
+ *
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getEndAddress(ADC12_Regs *adc12)
+{
+    return (adc12->ULLMEM.CTL2 & ADC12_CTL2_ENDADD_MASK);
+}
+
+/**
+ * @brief Initializes ADC12 for sequence sampling mode operation
+ *
+ * @param[in] adc12       Pointer to the register overlay for the peripheral
+ * @param[in] repeatMode  Specifies repeat configuration. One of
+ *                        @ref DL_ADC12_REPEAT_MODE
+ * @param[in] sampleMode  Specifies source of the sampling signal. One of
+ *                        @ref DL_ADC12_SAMPLING_SOURCE
+ * @param[in] trigSrc     Specifies sampling trigger source. One of
+ *                        @ref DL_ADC12_TRIG_SRC
+ * @param[in] startAdd    Specifies the starting address to sequence conversion.
+ *                        One of @ref DL_ADC12_SEQ_START_ADDR
+ * @param[in] endAdd      Specifies the ending address to sequence conversion.
+ *                        One of @ref DL_ADC12_SEQ_END_ADDR
+ * @param[in] resolution  Specifies sample conversion resolution. One of
+ *                        @ref DL_ADC12_SAMP_CONV_RES
+ * @param[in] dataFormat  Specifies sample conversion data format. One of
+ *                        @ref DL_ADC12_SAMP_CONV_DATA_FORMAT
+ */
+__STATIC_INLINE void DL_ADC12_initSeqSample(ADC12_Regs *adc12,
+    uint32_t repeatMode, uint32_t sampleMode, uint32_t trigSrc,
+    uint32_t startAdd, uint32_t endAdd, uint32_t resolution,
+    uint32_t dataFormat)
+{
+    DL_Common_updateReg(&adc12->ULLMEM.CTL1,
+        (ADC12_CTL1_CONSEQ_SEQUENCE | repeatMode | sampleMode | trigSrc),
+        (ADC12_CTL1_SAMPMODE_MASK | ADC12_CTL1_CONSEQ_MASK |
+            ADC12_CTL1_TRIGSRC_MASK));
+
+    DL_Common_updateReg(&adc12->ULLMEM.CTL2,
+        (startAdd | endAdd | resolution | dataFormat),
+        (ADC12_CTL2_ENDADD_MASK | ADC12_CTL2_STARTADD_MASK |
+            ADC12_CTL2_RES_MASK | ADC12_CTL2_DF_MASK));
+}
+
+/**
+ * @brief Returns ADC12 resolution
+ *
+ * @param[in] adc12       Pointer to the register overlay for the peripheral
+ *
+ * @return One of @ref DL_ADC12_SAMP_CONV_RES
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getResolution(ADC12_Regs *adc12)
+{
+    return (adc12->ULLMEM.CTL2 & ADC12_CTL2_RES_MASK);
+}
+
+/**
+ * @brief Returns ADC12 data format
+ *
+ * @param[in] adc12       Pointer to the register overlay for the peripheral
+ *
+ * @return One of @ref DL_ADC12_SAMP_CONV_DATA_FORMAT
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getDataFormat(ADC12_Regs *adc12)
+{
+    return (adc12->ULLMEM.CTL2 & ADC12_CTL2_DF_MASK);
+}
+
+/**
+ * @brief  Returns ADC12 sampling source
+ *
+ * @param[in] adc12   Pointer to the register overlay for the peripheral
+ *
+ * @return  One of @ref DL_ADC12_SAMPLING_SOURCE
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getSamplingSource(ADC12_Regs *adc12)
+{
+    return (adc12->ULLMEM.CTL1 & ADC12_CTL1_SAMPMODE_MASK);
+}
+
+/**
+ * @brief Returns ADC12 sampling mode
+ *
+ * @param[in] adc12   Pointer to the register overlay for the peripheral
+ *
+ * @return One of @ref DL_ADC12_SAMP_MODE
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getSampleMode(ADC12_Regs *adc12)
+{
+    return (adc12->ULLMEM.CTL1 & ADC12_CTL1_CONSEQ_MASK);
+}
+
+/**
+ * @brief Returns ADC12 trigger mode
+ *
+ * @param[in] adc12   Pointer to the register overlay for the peripheral
+ *
+ * @return One of @ref DL_ADC12_TRIG_SRC
+ */
+__STATIC_INLINE DL_ADC12_TRIG_SRC DL_ADC12_getTriggerSource(ADC12_Regs *adc12)
+{
+    uint32_t trigSrc = adc12->ULLMEM.CTL1 & ADC12_CTL1_TRIGSRC_MASK;
+
+    return (DL_ADC12_TRIG_SRC)(trigSrc);
+}
+
+/**
+ * @brief Start ADC12 conversion
+ *
+ * @param[in] adc12  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_ADC12_startConversion(ADC12_Regs *adc12)
+{
+    adc12->ULLMEM.CTL1 |= (ADC12_CTL1_SC_START);
+}
+
+/**
+ * @brief Stop ADC12 conversion
+ *
+ * @param[in] adc12  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_ADC12_stopConversion(ADC12_Regs *adc12)
+{
+    adc12->ULLMEM.CTL1 &= ~(ADC12_CTL1_SC_START);
+}
+
+/**
+ * @brief Check if ADC12 conversion is started
+ *
+ * @param[in] adc12  Pointer to the register overlay for the peripheral
+ *
+ * @return If ADC12 conversion is started
+ *
+ * @retval  true  ADC12 conversion is started
+ * @retval  false ADC12 conversion is stopped
+ */
+__STATIC_INLINE bool DL_ADC12_isConversionStarted(ADC12_Regs *adc12)
+{
+    return ((adc12->ULLMEM.CTL1 & ADC12_CTL1_SC_MASK) == ADC12_CTL1_SC_START);
+}
+
+/**
+ * @brief Enables DMA for data transfer
+ *
+ * @param[in] adc12 Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_ADC12_enableDMA(ADC12_Regs *adc12)
+{
+    adc12->ULLMEM.CTL2 |= (ADC12_CTL2_DMAEN_ENABLE);
+}
+
+/**
+ * @brief Disables DMA for data transfer
+ *
+ * @param[in] adc12 Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_ADC12_disableDMA(ADC12_Regs *adc12)
+{
+    adc12->ULLMEM.CTL2 &= ~(ADC12_CTL2_DMAEN_ENABLE);
+}
+
+/**
+ * @brief Check if DMA is enabled
+ *
+ * @param[in] adc12  Pointer to the register overlay for the peripheral
+ *
+ * @return If DMA is enabled
+ *
+ * @retval  true  DMA is enabled
+ * @retval  false DMA is disabled
+ */
+__STATIC_INLINE bool DL_ADC12_isDMAEnabled(ADC12_Regs *adc12)
+{
+    return ((adc12->ULLMEM.CTL2 & ADC12_CTL2_DMAEN_ENABLE) ==
+            ADC12_CTL2_DMAEN_ENABLE);
+}
+
+/**
+ * @brief Set number of ADC results to be transfer on a DMA trigger
+ *
+ * @param[in] adc12    Pointer to the register overlay for the peripheral
+ * @param[in] sampCnt  Number of ADC results to be transfer on a DMA trigger.
+ *                     Valid range 0 - 24.
+ *
+ */
+__STATIC_INLINE void DL_ADC12_setDMASamplesCnt(
+    ADC12_Regs *adc12, uint8_t sampCnt)
+{
+    DL_Common_updateReg(&adc12->ULLMEM.CTL2, (((uint32_t) sampCnt) << 11),
+        ADC12_CTL2_SAMPCNT_MASK);
+}
+
+/**
+ * @brief Get number of ADC results to be transfer on a DMA trigger
+ *
+ * @param[in] adc12    Pointer to the register overlay for the peripheral
+ *
+ * @return Number of ADC results to be transfer on a DMA trigger
+ */
+__STATIC_INLINE uint8_t DL_ADC12_getDMASampleCnt(ADC12_Regs *adc12)
+{
+    return (uint8_t)((adc12->ULLMEM.CTL2 & ADC12_CTL2_SAMPCNT_MASK) >> 11);
+}
+
+/**
+ * @brief Enables FIFO mode
+ *
+ * @param[in] adc12    Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_ADC12_enableFIFO(ADC12_Regs *adc12)
+{
+    adc12->ULLMEM.CTL2 |= (ADC12_CTL2_FIFOEN_ENABLE);
+}
+
+/**
+ * @brief Disables FIFO mode
+ *
+ * @param[in] adc12    Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_ADC12_disableFIFO(ADC12_Regs *adc12)
+{
+    adc12->ULLMEM.CTL2 &= ~(ADC12_CTL2_FIFOEN_ENABLE);
+}
+
+/**
+ * @brief Checks if FIFO mode is enabled
+ *
+ * @param[in] adc12    Pointer to the register overlay for the peripheral
+ *
+ * @return If FIFO mode is enabled
+ *
+ * @retval  true  FIFO mode is enabled
+ * @retval  false FIFO mode is disabled
+ *
+ */
+__STATIC_INLINE bool DL_ADC12_isFIFOEnabled(ADC12_Regs *adc12)
+{
+    return ((adc12->ULLMEM.CTL2 & ADC12_CTL2_FIFOEN_MASK) ==
+            ADC12_CTL2_FIFOEN_ENABLE);
+}
+
+/**
+ * @brief Configures ADC12 sample clock divider and sample clock frequency range
+ *
+ * @param[in] adc12       Pointer to the register overlay for the peripheral
+ * @param[in] config      Pointer to the clock configuration struct
+ *                        @ref DL_ADC12_ClockConfig.
+ */
+void DL_ADC12_setClockConfig(ADC12_Regs *adc12, DL_ADC12_ClockConfig *config);
+
+/**
+ * @brief Returns ADC12 sample clock configuration
+ *
+ * @param[in] adc12       Pointer to the register overlay for the peripheral
+ * @param[in] config      Pointer to the clock configuration struct
+ *                        @ref DL_ADC12_ClockConfig.
+ */
+void DL_ADC12_getClockConfig(ADC12_Regs *adc12, DL_ADC12_ClockConfig *config);
+
+/**
+ * @brief Configures ADC12 power down mode
+ *
+ * @param[in] adc12         Pointer to the register overlay for the peripheral
+ * @param[in] powerDownMode Specifies the power down mode. One of
+ *                          @ref DL_ADC12_POWER_DOWN_MODE.
+ */
+__STATIC_INLINE void DL_ADC12_setPowerDownMode(
+    ADC12_Regs *adc12, uint32_t powerDownMode)
+{
+    DL_Common_updateReg(
+        &adc12->ULLMEM.CTL0, powerDownMode, ADC12_CTL0_PWRDN_MASK);
+}
+
+/**
+ * @brief Returns ADC power down mode
+ *
+ * @param[in] adc12         Pointer to the register overlay for the peripheral
+ *
+ * @return  The current ADC12 power down mode
+ *
+ * @retval  One of @ref DL_ADC12_POWER_DOWN_MODE
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getPowerDownMode(ADC12_Regs *adc12)
+{
+    return (adc12->ULLMEM.CTL0 & ADC12_CTL0_PWRDN_MASK);
+}
+
+/**
+ *  @brief      Enable ADC12 conversion
+ *
+ *  @param[in]  adc12  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_ADC12_enableConversions(ADC12_Regs *adc12)
+{
+    adc12->ULLMEM.CTL0 |= (ADC12_CTL0_ENC_ON);
+}
+
+/**
+ *  @brief      Disable ADC12 conversion
+ *
+ *  @param[in]  adc12  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_ADC12_disableConversions(ADC12_Regs *adc12)
+{
+    adc12->ULLMEM.CTL0 &= ~(ADC12_CTL0_ENC_ON);
+}
+
+/**
+ *  @brief      Check if ADC12 conversion is enabled
+ *
+ *  @param[in]  adc12  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If the ADC12 conversion is enabled
+ *
+ *  @retval     true  The ADC12 conversion is enabled
+ *  @retval     false The ADC12 conversion is disabled
+ *
+ */
+__STATIC_INLINE bool DL_ADC12_isConversionsEnabled(ADC12_Regs *adc12)
+{
+    return ((adc12->ULLMEM.CTL0 & ADC12_CTL0_ENC_MASK) == ADC12_CTL0_ENC_ON);
+}
+
+/**
+ * @brief Configure ADC12 hardware average
+ *
+ * @param[in] adc12       Pointer to the register overlay for the peripheral
+ * @param[in] numerator   Specifies the number of conversion to accumulate. One
+ *                        of @ref DL_ADC12_HW_AVG_NUM
+ * @param[in] denominator Specifies the number to divide the accumulated value
+ *                        by. One of @ref DL_ADC12_HW_AVG_DEN
+ */
+__STATIC_INLINE void DL_ADC12_configHwAverage(
+    ADC12_Regs *adc12, uint32_t numerator, uint32_t denominator)
+{
+    DL_Common_updateReg(&adc12->ULLMEM.CTL1, (numerator | denominator),
+        (ADC12_CTL1_AVGN_MASK | ADC12_CTL1_AVGD_MASK));
+}
+
+/**
+ * @brief Return the hardware average configuration
+ *
+ * @param[in] adc12       Pointer to the register overlay for the peripheral
+ *
+ * @return Bitwise OR of @ref DL_ADC12_HW_AVG_NUM and @ref DL_ADC12_HW_AVG_DEN
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getHwAverageConfig(ADC12_Regs *adc12)
+{
+    return (
+        adc12->ULLMEM.CTL1 & (ADC12_CTL1_AVGN_MASK | ADC12_CTL1_AVGD_MASK));
+}
+
+/**
+ *  @brief      Set sample time 0
+ *
+ *  @param[in]  adc12    Pointer to the register overlay for the peripheral
+ *  @param[in]  adcclks  Specifies the sample time in number of ADCCLK cycles.
+ *                       Actual sample time is (adcclks + 1)
+ *
+ */
+__STATIC_INLINE void DL_ADC12_setSampleTime0(
+    ADC12_Regs *adc12, uint16_t adcclks)
+{
+    adc12->ULLMEM.SCOMP0 = (adcclks);
+}
+
+/**
+ * @brief Get sample time 0
+ *
+ * @param[in]   adc12   Pointer to the register overlay for the peripheral
+ *
+ * @return Sample time 0 in ADCCLKS.
+ */
+__STATIC_INLINE uint16_t DL_ADC12_getSampleTime0(ADC12_Regs *adc12)
+{
+    return (uint16_t)(adc12->ULLMEM.SCOMP0 + (uint32_t) 1);
+}
+
+/**
+ *  @brief      Set sample time 1
+ *
+ *  @param[in]  adc12    Pointer to the register overlay for the peripheral
+ *  @param[in]  adcclks  Specifies the sample time in number of ADCCLK cycles.
+ *                       Actual sample time is (adcclks + 1)
+ *
+ */
+__STATIC_INLINE void DL_ADC12_setSampleTime1(
+    ADC12_Regs *adc12, uint16_t adcclks)
+{
+    adc12->ULLMEM.SCOMP1 = (adcclks);
+}
+
+/**
+ * @brief Get sample time 1
+ *
+ * @param[in]   adc12   Pointer to the register overlay for the peripheral
+ *
+ * @return Sample time 1 in ADCCLKS.
+ */
+__STATIC_INLINE uint16_t DL_ADC12_getSampleTime1(ADC12_Regs *adc12)
+{
+    return (uint16_t)(adc12->ULLMEM.SCOMP1 + (uint32_t) 1);
+}
+
+/**
+ * @brief Configures window comparator low threshold
+ *
+ * @param[in] adc12          Pointer to the register overlay for the peripheral
+ * @param[in] threshold      Window comparator low threshold value. Threshold
+ *                           value must take into account result data format and
+ *                           and resolution confugred via
+ *                           DL_ADC12_initSingleSample or DL_ADC12_initSeqSample
+ */
+__STATIC_INLINE void DL_ADC12_configWinCompLowThld(
+    ADC12_Regs *adc12, uint16_t threshold)
+{
+    adc12->ULLMEM.WCLOW = (threshold);
+}
+
+/**
+ * @brief Configures window comparator high threshold
+ *
+ * @param[in] adc12          Pointer to the register overlay for the peripheral
+ * @param[in] threshold      Window comparator high threshold value. Threshold
+ *                           value must take into account result data format and
+ *                           and resolution confugred via
+ *                           DL_ADC12_initSingleSample or DL_ADC12_initSeqSample
+ */
+__STATIC_INLINE void DL_ADC12_configWinCompHighThld(
+    ADC12_Regs *adc12, uint16_t threshold)
+{
+    adc12->ULLMEM.WCHIGH = (threshold);
+}
+
+/**
+ * @brief Returns the data from the top of FIFO
+ *
+ * @param[in] adc12         Pointer to the register overlay for the peripheral
+ *
+ * @return Data from the top of FIFO.
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getFIFOData(ADC12_Regs *adc12)
+{
+    volatile const uint32_t *pReg = &adc12->ULLMEM.FIFODATA;
+
+    return (uint32_t)(*(pReg + DL_ADC12_SVT_OFFSET));
+}
+
+/**
+ * @brief Returns the address of FIFO data register
+ *
+ * @param[in] adc12         Pointer to the register overlay for the peripheral
+ *
+ * @return Address of FIFO data register
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getFIFOAddress(ADC12_Regs *adc12)
+{
+    return ((uint32_t)(&adc12->ULLMEM.FIFODATA + DL_ADC12_SVT_OFFSET));
+}
+
+/**
+ * @brief Configures conversion memory
+ *
+ * @param[in] adc12    Pointer to the register overlay for the peripheral
+ * @param[in] idx      Memory conversion index. @ref DL_ADC12_MEM_IDX.
+ * @param[in] chansel  Selects input channel. One of @ref DL_ADC12_INPUT_CHAN
+ * @param[in] vref     Selects reference voltage. One of
+ *                 @ref DL_ADC12_REFERENCE_VOLTAGE
+ * @param[in] stime    Selects source of sample adc12 period. One of
+ *                 @ref DL_ADC12_SAMPLE_TIMER_SOURCE
+ * @param[in] avgen    Selects averaging mode. One of
+ *                 @ref DL_ADC12_AVERAGING_MODE
+ * @param[in] bcsen    Selects burn out current source selection. One of
+ *                 @ref DL_ADC12_BURN_OUT_SOURCE
+ * @param[in] trig     Selects trigger mode. One of
+ *                 @ref DL_ADC12_TRIGGER_MODE
+ * @param[in] wincomp  Selects window comparator mode. One of
+ *                 @ref DL_ADC12_WINDOWS_COMP_MODE
+ */
+__STATIC_INLINE void DL_ADC12_configConversionMem(ADC12_Regs *adc12,
+    DL_ADC12_MEM_IDX idx, uint32_t chansel, uint32_t vref, uint32_t stime,
+    uint32_t avgen, uint32_t bcsen, uint32_t trig, uint32_t wincomp)
+{
+    adc12->ULLMEM.MEMCTL[idx] =
+        (chansel | vref | stime | avgen | bcsen | trig | wincomp);
+}
+
+/**
+ * @brief Returns conversion memory configuration
+ *
+ * @param[in] adc12    Pointer to the register overlay for the peripheral
+ * @param[in] idx      Memory conversion index. @ref DL_ADC12_MEM_IDX.
+ * @return Bitwise OR of @ref DL_ADC12_INPUT_CHAN,
+ *         @ref DL_ADC12_REFERENCE_VOLTAGE, @ref DL_ADC12_SAMPLE_TIMER_SOURCE,
+ *         @ref DL_ADC12_AVERAGING_MODE, @ref DL_ADC12_BURN_OUT_SOURCE,
+ *         @ref DL_ADC12_TRIGGER_MODE, @ref DL_ADC12_WINDOWS_COMP_MODE
+ *
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getConversionMemConfig(
+    ADC12_Regs *adc12, DL_ADC12_MEM_IDX idx)
+{
+    return (adc12->ULLMEM.MEMCTL[idx]);
+}
+
+/**
+ * @brief Returns the conversion result for the selected memory index
+ *
+ * @param[in] adc12     Pointer to the register overlay for the peripheral
+ * @param[in] idx       Memory conversion index. @ref DL_ADC12_MEM_IDX.
+ *
+ * @return Conversion result
+ *
+ */
+__STATIC_INLINE uint16_t DL_ADC12_getMemResult(
+    ADC12_Regs *adc12, DL_ADC12_MEM_IDX idx)
+{
+    volatile const uint32_t *pReg = &adc12->ULLMEM.MEMRES[idx];
+
+    return (uint16_t)(*(pReg + DL_ADC12_SVT_OFFSET));
+}
+
+/**
+ * @brief Returns the conversion result memory address.
+ *
+ * @param[in] adc12     Pointer to the register overlay for the peripheral
+ * @param[in] idx       Memory conversion index. @ref DL_ADC12_MEM_IDX.
+ *
+ * @return Conversion result memory address
+ *
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getMemResultAddress(
+    ADC12_Regs *adc12, DL_ADC12_MEM_IDX idx)
+{
+    return ((uint32_t)(&adc12->ULLMEM.MEMRES[idx] + DL_ADC12_SVT_OFFSET));
+}
+
+/**
+ * @brief Returns ADC12 status
+ *
+ * @param[in] adc12    Pointer to the register overlay for the peripheral
+ *
+ * @return Bitwise OR of @ref DL_ADC12_STATUS_CONVERSION and
+ *         @ref DL_ADC12_STATUS_REFERENCE
+ *
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getStatus(ADC12_Regs *adc12)
+{
+    return (adc12->ULLMEM.STATUS);
+}
+
+/**
+ * @brief Allows SYSOSC to not run at base frequency when device is in RUN mode.
+ *
+ * @param[in] adc12    Pointer to the register overlay for the peripheral
+ *
+ *
+ */
+__STATIC_INLINE void DL_ADC12_disableForcingSYSOSCOnInRunMode(
+    ADC12_Regs *adc12)
+{
+    DL_Common_updateReg(&adc12->ULLMEM.GPRCM.CLKCFG,
+        (ADC12_CLKCFG_CCONRUN_DISABLE | ADC12_CLKCFG_KEY_UNLOCK_W),
+        (ADC12_CLKCFG_CCONRUN_MASK | ADC12_CLKCFG_KEY_MASK));
+}
+
+/**
+ * @brief Forces SYSOSC to run at base frequency when device is in RUN mode.
+ *
+ * @param[in] adc12    Pointer to the register overlay for the peripheral
+ *
+ *
+ */
+__STATIC_INLINE void DL_ADC12_forceSYSOSCOnInRunMode(ADC12_Regs *adc12)
+{
+    adc12->ULLMEM.GPRCM.CLKCFG |=
+        (ADC12_CLKCFG_KEY_UNLOCK_W | ADC12_CLKCFG_CCONRUN_ENABLE);
+}
+
+/**
+ * @brief Allows SYSOSC to not run at base frequency when device is in STOP mode.
+ *
+ * @param[in] adc12    Pointer to the register overlay for the peripheral
+ *
+ *
+ */
+__STATIC_INLINE void DL_ADC12_disableForcingSYSOSCOnInStopMode(
+    ADC12_Regs *adc12)
+{
+    DL_Common_updateReg(&adc12->ULLMEM.GPRCM.CLKCFG,
+        (ADC12_CLKCFG_CCONSTOP_DISABLE | ADC12_CLKCFG_KEY_UNLOCK_W),
+        (ADC12_CLKCFG_CCONSTOP_MASK | ADC12_CLKCFG_KEY_MASK));
+}
+
+/**
+ * @brief Forces SYSOSC to run at base frequency when device is in STOP mode.
+ *
+ * @param[in] adc12    Pointer to the register overlay for the peripheral
+ *
+ *
+ */
+__STATIC_INLINE void DL_ADC12_forceSYSOSCOnInStopMode(ADC12_Regs *adc12)
+{
+    adc12->ULLMEM.GPRCM.CLKCFG |=
+        (ADC12_CLKCFG_KEY_UNLOCK_W | ADC12_CLKCFG_CCONSTOP_ENABLE);
+}
+
+/**
+ *  @brief      Enable ADC12 interrupt
+ *
+ *  @param[in]  adc12  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_ADC12_INTERRUPTS.
+ */
+__STATIC_INLINE void DL_ADC12_enableInterrupt(
+    ADC12_Regs *adc12, uint32_t interruptMask)
+{
+    adc12->ULLMEM.CPU_INT.IMASK |= (interruptMask);
+}
+
+/**
+ *  @brief      Disable ADC12 interrupt
+ *
+ *  @param[in]  adc12  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_ADC12_INTERRUPTS.
+ *
+ */
+__STATIC_INLINE void DL_ADC12_disableInterrupt(
+    ADC12_Regs *adc12, uint32_t interruptMask)
+{
+    adc12->ULLMEM.CPU_INT.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief      Check which ADC12 interrupts are enabled
+ *
+ *  @param[in]  adc12          Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_ADC12_INTERRUPTS.
+ *
+ *  @return     Which of the requested ADC12 interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_ADC12_INTERRUPTS values
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getEnabledInterrupts(
+    ADC12_Regs *adc12, uint32_t interruptMask)
+{
+    return (adc12->ULLMEM.CPU_INT.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled ADC12 interrupt
+ *
+ *  Checks if the ADC12 interrupt that was previously enabled is pending.
+ *
+ *  @param[in]  adc12  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_ADC12_INTERRUPTS.
+ *
+ *  @return     If the enabled ADC12 interrupt is pending
+ *
+ *  @sa         DL_ADC12_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getEnabledInterruptStatus(
+    ADC12_Regs *adc12, uint32_t interruptMask)
+{
+    return (adc12->ULLMEM.CPU_INT.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any ADC12 interrupt
+ *
+ *  Checks if the ADC12 interrupt is pending. Interrupt does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  adc12  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_ADC12_INTERRUPTS.
+ *
+ *  @return     If the ADC12 interrupt is pending
+ *
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getRawInterruptStatus(
+    ADC12_Regs *adc12, uint32_t interruptMask)
+{
+    return (adc12->ULLMEM.CPU_INT.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending ADC12 interrupt
+ *
+ *  Checks if any of the ADC12 interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  adc12  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The highest priority pending ADC12 interrupt
+ *
+ *  @retval     One of @ref DL_ADC12_IIDX
+ */
+__STATIC_INLINE DL_ADC12_IIDX DL_ADC12_getPendingInterrupt(ADC12_Regs *adc12)
+{
+    return ((DL_ADC12_IIDX) adc12->ULLMEM.CPU_INT.IIDX);
+}
+
+/**
+ *  @brief      Clear pending ADC12 interrupt
+ *
+ *  @param[in]  adc12  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_ADC12_INTERRUPTS.
+ *
+ */
+__STATIC_INLINE void DL_ADC12_clearInterruptStatus(
+    ADC12_Regs *adc12, uint32_t interruptMask)
+{
+    adc12->ULLMEM.CPU_INT.ICLR |= (interruptMask);
+}
+
+/**
+ *  @brief Sets the event publisher channel id
+ *
+ *  @param[in]  adc12 Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  chanID  Channel ID number. Valid range 0-15. If ChanID == 0
+ *                      publisher is disconnected.
+ */
+__STATIC_INLINE void DL_ADC12_setPublisherChanID(
+    ADC12_Regs *adc12, uint8_t chanID)
+{
+    adc12->ULLMEM.FPUB_1 = (chanID & ADC12_FPUB_1_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event publisher channel id
+ *
+ *  @param[in]  adc12 Pointer to the register overlay for the
+ *                      peripheral
+ *
+ *  @return     Event publisher channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_ADC12_getPublisherChanID(ADC12_Regs *adc12)
+{
+    return (uint8_t)(adc12->ULLMEM.FPUB_1 & ADC12_FPUB_1_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Sets the event subscriber channel id
+ *
+ *  @param[in]  adc12 Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  chanID  Channel ID number. Valid range 0-15. If ChanID == 0
+ *                      subscriber is disconnected.
+ */
+__STATIC_INLINE void DL_ADC12_setSubscriberChanID(
+    ADC12_Regs *adc12, uint8_t chanID)
+{
+    adc12->ULLMEM.FSUB_0 = (chanID & ADC12_FSUB_0_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event subscriber channel id
+ *
+ *  @param[in]  adc12 Pointer to the register overlay for the
+ *                      peripheral
+ *
+ *  @return     Event subscriber channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_ADC12_getSubscriberChanID(ADC12_Regs *adc12)
+{
+    return (uint8_t)(adc12->ULLMEM.FSUB_0 & ADC12_FSUB_0_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief      Enable ADC12 event
+ *
+ *  @param[in]  adc12          Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of events to enable. Bitwise OR of
+ *                             @ref DL_ADC12_EVENT.
+ */
+__STATIC_INLINE void DL_ADC12_enableEvent(
+    ADC12_Regs *adc12, uint32_t eventMask)
+{
+    adc12->ULLMEM.GEN_EVENT.IMASK |= (eventMask);
+}
+
+/**
+ *  @brief      Disable ADC12 event
+ *
+ *  @param[in]  adc12          Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of events to enable. Bitwise OR of
+ *                             @ref DL_ADC12_EVENT.
+ */
+__STATIC_INLINE void DL_ADC12_disableEvent(
+    ADC12_Regs *adc12, uint32_t eventMask)
+{
+    adc12->ULLMEM.GEN_EVENT.IMASK &= ~(eventMask);
+}
+
+/**
+ *  @brief      Check which adc12 dma triggers are enabled
+ *
+ *  @param[in]  adc12          Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of events to check. Bitwise OR of
+ *                             @ref DL_ADC12_EVENT.
+ *
+ *  @return     Which of the requested adc12 events are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_ADC12_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getEnabledEvents(
+    ADC12_Regs *adc12, uint32_t eventMask)
+{
+    return (adc12->ULLMEM.GEN_EVENT.IMASK & eventMask);
+}
+
+/**
+ *  @brief      Check event flag of enabled adc12 event
+ *
+ *  Checks if any of the adc12 events that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  adc12        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of events to check. Bitwise OR of
+ *                             @ref DL_ADC12_EVENT.
+ *
+ *  @return     Which of the requested adc12 eventes are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_ADC12_EVENT values
+ *
+ *  @sa         DL_ADC12_enableEvent
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getEnabledEventStatus(
+    ADC12_Regs *adc12, uint32_t eventMask)
+{
+    return (adc12->ULLMEM.GEN_EVENT.MIS & ~(eventMask));
+}
+
+/**
+ *  @brief      Check event flag of any adc12 event
+ *
+ *  Checks if any events are pending. Events do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  adc12          Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of event to check. Bitwise OR of
+ *                             @ref DL_ADC12_EVENT.
+ *
+ *  @return     Which of the requested adc12 event are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_ADC12_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getRawEventsStatus(
+    ADC12_Regs *adc12, uint32_t eventMask)
+{
+    return (adc12->ULLMEM.GEN_EVENT.RIS & ~(eventMask));
+}
+
+/**
+ *  @brief      Clear pending adc12 events
+ *
+ *  @param[in]  adc12          Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of events to clear. Bitwise OR of
+ *                             @ref DL_ADC12_EVENT.
+ */
+__STATIC_INLINE void DL_ADC12_clearEventsStatus(
+    ADC12_Regs *adc12, uint32_t eventMask)
+{
+    adc12->ULLMEM.GEN_EVENT.ICLR |= (eventMask);
+}
+
+/**
+ *  @brief      Enable ADC12 DMA triggers
+ *
+ *  @param[in]  adc12          Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  dmaMask      Bit mask of DMA triggers to enable. Bitwise OR of
+ *                             @ref DL_ADC12_DMA.
+ */
+__STATIC_INLINE void DL_ADC12_enableDMATrigger(
+    ADC12_Regs *adc12, uint32_t dmaMask)
+{
+    adc12->ULLMEM.DMA_TRIG.IMASK |= (dmaMask);
+}
+
+/**
+ *  @brief      Disable ADC12 DMA triggers
+ *
+ *  @param[in]  adc12          Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  dmaMask        Bit mask of DMA triggers to enable. Bitwise OR of
+ *                             @ref DL_ADC12_DMA.
+ */
+__STATIC_INLINE void DL_ADC12_disableDMATrigger(
+    ADC12_Regs *adc12, uint32_t dmaMask)
+{
+    adc12->ULLMEM.DMA_TRIG.IMASK &= ~(dmaMask);
+}
+
+/**
+ *  @brief      Check which adc12 DMA triggers are enabled
+ *
+ *  @param[in]  adc12          Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  dmaMask        Bit mask of DMA triggers to check. Bitwise OR of
+ *                             @ref DL_ADC12_DMA.
+ *
+ *  @return     Which of the requested adc12 DMA triggers are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_ADC12_DMA values
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getEnabledDMATrigger(
+    ADC12_Regs *adc12, uint32_t dmaMask)
+{
+    return (adc12->ULLMEM.DMA_TRIG.IMASK & dmaMask);
+}
+
+/**
+ *  @brief      Check event flag of enabled adc12 DMA triggers
+ *
+ *  Checks if any of the adc12 DMA triggers that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  adc12          Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  dmaMask      Bit mask of DMA triggers to check. Bitwise OR of
+ *                             @ref DL_ADC12_DMA.
+ *
+ *  @return     Which of the requested adc12 eventes are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_ADC12_DMA values
+ *
+ *  @sa         DL_ADC12_enableDMATrigger
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getEnabledDMATriggerStatus(
+    ADC12_Regs *adc12, uint32_t dmaMask)
+{
+    return (adc12->ULLMEM.DMA_TRIG.MIS & ~(dmaMask));
+}
+
+/**
+ *  @brief      Check DMA triggers flag of any adc12 dma trigger
+ *
+ *  Checks if any dma trigger are pending. DMA triggers do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  adc12          Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  dmaMask        Bit mask of DMA triggers to check. Bitwise OR of
+ *                             @ref DL_ADC12_DMA.
+ *
+ *  @return     Which of the requested adc12 dma triggers are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_ADC12_DMA values
+ */
+__STATIC_INLINE uint32_t DL_ADC12_getRawDMATriggerStatus(
+    ADC12_Regs *adc12, uint32_t dmaMask)
+{
+    return (adc12->ULLMEM.DMA_TRIG.RIS & ~(dmaMask));
+}
+
+/**
+ *  @brief      Clear pending adc12 DMA triggers
+ *
+ *  @param[in]  adc12          Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  dmaMask        Bit mask of DMA triggers to clear. Bitwise OR of
+ *                             @ref DL_ADC12_DMA.
+ */
+__STATIC_INLINE void DL_ADC12_clearDMATriggerStatus(
+    ADC12_Regs *adc12, uint32_t dmaMask)
+{
+    adc12->ULLMEM.DMA_TRIG.ICLR |= (dmaMask);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_ADC12__ */
+
+#endif /* ti_dl_dl_adc12__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_aes.c
+++ b/mspm0/source/ti/driverlib/dl_aes.c
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_aes.h>
+
+#ifdef __MSPM0_HAS_AES__
+
+static void DL_AES_loadDataWord(
+    volatile uint32_t *pReg, const uint32_t *pData, uint8_t len);
+
+static const uint32_t *DL_AES_checkAlignmentAndReturnPointer(
+    const uint8_t *ptr);
+
+DL_AES_STATUS DL_AES_setKey(
+    AES_Regs *aes, const uint8_t *key, DL_AES_KEY_LENGTH keyLength)
+{
+    DL_AES_STATUS status = DL_AES_STATUS_SUCCESS;
+    const uint32_t *keyAligned;
+
+    keyAligned = DL_AES_checkAlignmentAndReturnPointer(key);
+    if (keyAligned != NULL) {
+        DL_AES_setKeyAligned(aes, keyAligned, keyLength);
+    } else {
+        status = DL_AES_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AES_setKeyAligned(
+    AES_Regs *aes, const uint32_t *keyAligned, DL_AES_KEY_LENGTH keyLength)
+{
+    uint8_t numWords;
+
+    switch (keyLength) {
+        case DL_AES_KEY_LENGTH_128:
+            numWords = 4U;
+            break;
+        case DL_AES_KEY_LENGTH_256:
+            numWords = 8U;
+            break;
+        default:
+            numWords = 0U;
+            break;
+    }
+
+    DL_AES_loadDataWord(&aes->AESAKEY, keyAligned, numWords);
+}
+
+DL_AES_STATUS DL_AES_loadDataIn(AES_Regs *aes, const uint8_t *data)
+{
+    DL_AES_STATUS status = DL_AES_STATUS_SUCCESS;
+    const uint32_t *dataAligned;
+
+    dataAligned = DL_AES_checkAlignmentAndReturnPointer(data);
+    if (dataAligned != NULL) {
+        DL_AES_loadDataInAligned(aes, dataAligned);
+    } else {
+        status = DL_AES_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AES_loadDataInAligned(AES_Regs *aes, const uint32_t *dataAligned)
+{
+    DL_AES_loadDataWord(&aes->AESADIN, dataAligned, 4);
+}
+
+DL_AES_STATUS DL_AES_getDataOut(AES_Regs *aes, uint8_t *data)
+{
+    DL_AES_STATUS status = DL_AES_STATUS_SUCCESS;
+    uint32_t *dataAligned;
+
+    uint32_t address = (uint32_t) data;
+    if ((address << 30) != 0x00000000u) {
+        /* Unaligned access */
+        status = DL_AES_STATUS_UNALIGNED_ACCESS;
+    } else {
+        /* Aligned Access */
+        dataAligned = (uint32_t *) address;
+        DL_AES_getDataOutAligned(aes, dataAligned);
+    }
+    return status;
+}
+
+void DL_AES_getDataOutAligned(AES_Regs *aes, uint32_t *dataAligned)
+{
+    uint8_t i;
+    uint32_t *pData;
+    volatile uint32_t const *aesPtr;
+
+    pData  = dataAligned;
+    aesPtr = (volatile uint32_t const *) &(aes->AESADOUT);
+
+    for (i = 0U; i < 4U; i++) {
+        *pData = *aesPtr;
+        pData++;
+    }
+}
+
+DL_AES_STATUS DL_AES_loadXORDataIn(AES_Regs *aes, const uint8_t *data)
+{
+    DL_AES_STATUS status = DL_AES_STATUS_SUCCESS;
+    const uint32_t *dataAligned;
+
+    dataAligned = DL_AES_checkAlignmentAndReturnPointer(data);
+    if (dataAligned != NULL) {
+        DL_AES_loadXORDataInAligned(aes, dataAligned);
+    } else {
+        status = DL_AES_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AES_loadXORDataInAligned(AES_Regs *aes, const uint32_t *dataAligned)
+{
+    DL_AES_loadDataWord(&aes->AESAXDIN, dataAligned, 4);
+}
+
+DL_AES_STATUS DL_AES_loadXORDataInWithoutTrigger(
+    AES_Regs *aes, const uint8_t *data)
+{
+    DL_AES_STATUS status = DL_AES_STATUS_SUCCESS;
+    const uint32_t *dataAligned;
+
+    dataAligned = DL_AES_checkAlignmentAndReturnPointer(data);
+    if (dataAligned != NULL) {
+        DL_AES_loadXORDataInWithoutTriggerAligned(aes, dataAligned);
+    } else {
+        status = DL_AES_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AES_loadXORDataInWithoutTriggerAligned(
+    AES_Regs *aes, const uint32_t *dataAligned)
+{
+    DL_AES_loadDataWord(&aes->AESAXIN, dataAligned, 4);
+}
+
+DL_AES_STATUS DL_AES_xorData(
+    uint8_t *data, uint8_t *xorData, uint8_t *xorOutputData)
+{
+    DL_AES_STATUS status = DL_AES_STATUS_SUCCESS;
+    uint32_t *dataAligned;
+    uint32_t *xorDataAligned;
+    uint32_t *xorOutputDataAligned;
+
+    uint32_t dataAddress          = (uint32_t) data;
+    uint32_t xorDataAddress       = (uint32_t) xorData;
+    uint32_t xorOutputDataAddress = (uint32_t) xorOutputData;
+
+    if (((dataAddress << 30) != 0x00000000u) ||
+        ((xorDataAddress << 30) != 0x00000000u) ||
+        ((xorOutputDataAddress << 30) != 0x00000000u)) {
+        /* Unaligned access */
+        status = DL_AES_STATUS_UNALIGNED_ACCESS;
+    } else {
+        /* Aligned Access */
+        dataAligned          = (uint32_t *) dataAddress;
+        xorDataAligned       = (uint32_t *) xorDataAddress;
+        xorOutputDataAligned = (uint32_t *) xorOutputDataAddress;
+        DL_AES_xorDataAligned(
+            dataAligned, xorDataAligned, xorOutputDataAligned);
+    }
+    return status;
+}
+
+void DL_AES_xorDataAligned(uint32_t *dataAligned, uint32_t *xorDataAligned,
+    uint32_t *xorOutputDataAligned)
+{
+    uint8_t i;
+
+    uint32_t *tempData          = dataAligned;
+    uint32_t *tempXorData       = xorDataAligned;
+    uint32_t *tempXorOutputData = xorOutputDataAligned;
+
+    for (i = 0U; i < 4U; i++) {
+        *tempXorOutputData = *tempData ^ *tempXorData;
+        tempXorOutputData++;
+        tempData++;
+        tempXorData++;
+    }
+}
+
+static void DL_AES_loadDataWord(
+    volatile uint32_t *pReg, const uint32_t *pData, uint8_t len)
+{
+    uint8_t i;
+    const uint32_t *pTemp;
+
+    pTemp = pData;
+
+    for (i = 0; i < len; i++) {
+        *pReg = *pTemp;
+        pTemp++;
+    }
+}
+
+static const uint32_t *DL_AES_checkAlignmentAndReturnPointer(
+    const uint8_t *ptr)
+{
+    uint32_t address = (uint32_t) ptr;
+    const uint32_t *alignedPtr;
+    if ((address << 30) != 0x00000000u) {
+        /* Unaligned access */
+        alignedPtr = NULL;
+    } else {
+        /* Aligned Access */
+        alignedPtr = (const uint32_t *) address;
+    }
+    return alignedPtr;
+}
+
+bool DL_AES_saveConfiguration(AES_Regs *aes, DL_AES_backupConfig *ptr)
+{
+    bool stateSaved = !ptr->backupRdy;
+    if (stateSaved) {
+        ptr->controlWord0   = aes->AESACTL0;
+        ptr->controlWord1   = aes->AESACTL1;
+        ptr->interruptMask0 = aes->CPU_INT.IMASK;
+        ptr->interruptMask1 = aes->DMA_TRIG0.IMASK;
+        ptr->interruptMask2 = aes->DMA_TRIG1.IMASK;
+        ptr->interruptMask3 = aes->DMA_TRIG2.IMASK;
+        ptr->backupRdy      = true;
+    }
+    return stateSaved;
+}
+
+bool DL_AES_restoreConfiguration(AES_Regs *aes, DL_AES_backupConfig *ptr)
+{
+    bool stateRestored = ptr->backupRdy;
+    if (stateRestored) {
+        aes->AESACTL0        = ptr->controlWord0;
+        aes->AESACTL1        = ptr->controlWord1;
+        aes->CPU_INT.IMASK   = ptr->interruptMask0;
+        aes->DMA_TRIG0.IMASK = ptr->interruptMask1;
+        aes->DMA_TRIG1.IMASK = ptr->interruptMask2;
+        aes->DMA_TRIG2.IMASK = ptr->interruptMask3;
+        ptr->backupRdy       = false;
+    }
+    return stateRestored;
+}
+
+#endif /* __MSPM0_HAS_AES__ */

--- a/mspm0/source/ti/driverlib/dl_aes.h
+++ b/mspm0/source/ti/driverlib/dl_aes.h
@@ -1,0 +1,1239 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_aes.h
+ *  @brief      Advanced Encryption Standard (AES) Driver Library
+ *  @defgroup   AES Advanced Encryption Standard (AES)
+ *
+ *  @anchor ti_dl_dl_aes_Overview
+ *  # Overview
+ *
+ *  The AES DriverLib allows full configuration of the MSPM0 AES module.
+ *  The AES accelerator module accelerates encryption and decryption operations in hardware based
+ *  on the FIPS PUB 197 advanced encryption standard (AES).
+ *
+ *  <hr>
+ ******************************************************************************/
+/** @addtogroup AES
+ * @{
+ */
+#ifndef ti_dl_dl_aes__include
+#define ti_dl_dl_aes__include
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_AES__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/*!
+ * @brief AES Ready interrupt
+ */
+#define DL_AES_INTERRUPT_AES_READY            (AES_CPU_INT_IMASK_AESRDY_MASK)
+
+/*!
+ * @brief DMA Trigger Event 0
+ */
+#define DL_AES_EVENT_AES_DMA_TRIGGER0           (AES_DMA_TRIG0_IMASK_DMA0_MASK)
+
+/*!
+ * @brief DMA Trigger Event 1
+ */
+#define DL_AES_EVENT_AES_DMA_TRIGGER1            (AES_DMA_TRIG1_IMASK_DMA1_SET)
+
+/*!
+ * @brief DMA Trigger Event 2
+ */
+#define DL_AES_EVENT_AES_DMA_TRIGGER2            (AES_DMA_TRIG2_IMASK_DMA2_SET)
+
+/* clang-format on */
+
+/*! @enum DL_AES_MODE */
+typedef enum {
+    /*! @brief Selects encryption using Electronic Code Book (ECB) mode. */
+    DL_AES_MODE_ENCRYPT_ECB_MODE =
+        (AES_AESACTL0_OPX_OP0 | AES_AESACTL0_CMX_ECB),
+
+    /*! @brief Selects encryption using Cipher Block Chaining (CBC) mode. */
+    DL_AES_MODE_ENCRYPT_CBC_MODE =
+        (AES_AESACTL0_OPX_OP0 | AES_AESACTL0_CMX_CBC),
+
+    /*! @brief Selects encryption using Output Feedback (OFB) mode. */
+    DL_AES_MODE_ENCRYPT_OFB_MODE =
+        (AES_AESACTL0_OPX_OP0 | AES_AESACTL0_CMX_OFB),
+
+    /*! @brief Selects encryption using Cipher Feedback (CFB) mode. */
+    DL_AES_MODE_ENCRYPT_CFB_MODE =
+        (AES_AESACTL0_OPX_OP0 | AES_AESACTL0_CMX_CFB),
+
+    /*! @brief Selects decryption using Electronic Code Book (ECB) mode. */
+    DL_AES_MODE_DECRYPT_SAME_KEY_ECB_MODE =
+        (AES_AESACTL0_OPX_OP1 | AES_AESACTL0_CMX_ECB),
+
+    /*! @brief Selects decryption using Cipher Block Chaining (CBC) mode. */
+    DL_AES_MODE_DECRYPT_SAME_KEY_CBC_MODE =
+        (AES_AESACTL0_OPX_OP1 | AES_AESACTL0_CMX_CBC),
+
+    /*! @brief Selects decryption using Output Feedback (OFB) mode. */
+    DL_AES_MODE_DECRYPT_SAME_KEY_OFB_MODE =
+        (AES_AESACTL0_OPX_OP1 | AES_AESACTL0_CMX_OFB),
+
+    /*! @brief Selects decryption using Cipher Feedback (CFB) mode. */
+    DL_AES_MODE_DECRYPT_SAME_KEY_CFB_MODE =
+        (AES_AESACTL0_OPX_OP1 | AES_AESACTL0_CMX_CFB),
+
+    /*! @brief Selects first round key for Electronic Code Book (ECB) mode. */
+    DL_AES_MODE_GEN_FIRST_ROUND_KEY_ECB_MODE =
+        (AES_AESACTL0_OPX_OP2 | AES_AESACTL0_CMX_ECB),
+
+    /*! @brief Selects first round key using Cipher Block Chaining (CBC) mode. */
+    DL_AES_MODE_GEN_FIRST_ROUND_KEY_CBC_MODE =
+        (AES_AESACTL0_OPX_OP2 | AES_AESACTL0_CMX_CBC),
+
+    /*! @brief Selects first round key using Output Feedback (OFB) mode. */
+    DL_AES_MODE_GEN_FIRST_ROUND_KEY_OFB_MODE =
+        (AES_AESACTL0_OPX_OP2 | AES_AESACTL0_CMX_OFB),
+
+    /*! @brief Selects first round key using Cipher Feedback (CFB) mode. */
+    DL_AES_MODE_GEN_FIRST_ROUND_KEY_CFB_MODE =
+        (AES_AESACTL0_OPX_OP2 | AES_AESACTL0_CMX_CFB),
+
+    /*! @brief Selects decryption with 1st round key using ECB mode. */
+    DL_AES_MODE_DECRYPT_KEY_IS_FIRST_ROUND_KEY_ECB_MODE =
+        (AES_AESACTL0_OPX_OP3 | AES_AESACTL0_CMX_ECB),
+
+    /*! @brief Selects decryption with 1st round key using CBC mode. */
+    DL_AES_MODE_DECRYPT_KEY_IS_FIRST_ROUND_KEY_CBC_MODE =
+        (AES_AESACTL0_OPX_OP3 | AES_AESACTL0_CMX_CBC),
+
+    /*! @brief Selects decryption with 1st round key using OFB mode. */
+    DL_AES_MODE_DECRYPT_KEY_IS_FIRST_ROUND_KEY_OFB_MODE =
+        (AES_AESACTL0_OPX_OP3 | AES_AESACTL0_CMX_OFB),
+
+    /*! @brief Selects decryption with 1st round key using CFB mode. */
+    DL_AES_MODE_DECRYPT_KEY_IS_FIRST_ROUND_KEY_CFB_MODE =
+        (AES_AESACTL0_OPX_OP3 | AES_AESACTL0_CMX_CFB),
+} DL_AES_MODE;
+
+/*! @enum DL_AES_IIDX */
+typedef enum {
+    /*! AES interrupt index for AES module ready */
+    DL_AES_IIDX_AES_READY = AES_CPU_INT_IIDX_STAT_AESRDY,
+    /*! AES interrupt index for enabling DMA trigger event 0 */
+    DL_AES_IIDX_AES_DMA_TRIGGER0 = AES_DMA_TRIG0_IIDX_STAT_DMA0,
+    /*! AES interrupt index for enabling DMA trigger event 1 */
+    DL_AES_IIDX_AES_DMA_TRIGGER1 = AES_DMA_TRIG1_IIDX_STAT_DMA1,
+    /*! AES interrupt index for enabling DMA trigger event 2 */
+    DL_AES_IIDX_AES_DMA_TRIGGER2 = AES_DMA_TRIG2_IIDX_STAT_DMA2
+} DL_AES_IIDX;
+
+/*! @enum DL_AES_OPERATION */
+typedef enum {
+    /*! Encryption mode selected  */
+    DL_AES_OPERATION_ENC = AES_AESACTL0_OPX_OP0,
+    /*! Decryption. The provided key is the same key used for encryption.  */
+    DL_AES_OPERATION_DEC_SAME_KEY = AES_AESACTL0_OPX_OP1,
+    /*! Generate first round key required for decryption.  */
+    DL_AES_OPERATION_GEN_FIRST_ROUND = AES_AESACTL0_OPX_OP2,
+    /*! Decryption. The provided key is the first round key required for
+     *  decryption  */
+    DL_AES_OPERATION_DEC_KEY_IS_FIRST_ROUND = AES_AESACTL0_OPX_OP3,
+} DL_AES_OPERATION;
+
+/*! @enum DL_AES_KEY_LENGTH */
+typedef enum {
+    /*! Key length set to 128 */
+    DL_AES_KEY_LENGTH_128 = AES_AESACTL0_KLX_AES128,
+    /*! Key length set to 256  */
+    DL_AES_KEY_LENGTH_256 = AES_AESACTL0_KLX_AES256,
+} DL_AES_KEY_LENGTH;
+
+/*! @enum DL_AES_STATUS */
+typedef enum {
+    /*! Operation was successful */
+    DL_AES_STATUS_SUCCESS,
+    /*! Operation was not performed because address was unaligned */
+    DL_AES_STATUS_UNALIGNED_ACCESS,
+} DL_AES_STATUS;
+
+/**
+ * @brief Configuration structure to backup AES peripheral state before going
+ *        to STOP/STANDBY mode. Used by @ref DL_AES_saveConfiguration
+ */
+typedef struct {
+    /*! Combination of AESACTL0 fields, compressed to a single word as they
+     *  are stored in the AES registers. See @ref DL_AES_init for
+     *  how the peripheral control word 0 is created */
+    uint32_t controlWord0;
+    /*! Combination of AESACTL1 fields, compressed to a single word as they
+     *  are stored in the AES registers. See @ref DL_AES_init for
+     *  how the peripheral control word 1 is created */
+    uint32_t controlWord1;
+    /*! AES interrupt mask 0. Value of @ref DL_AES_INTERRUPT_AES_READY stored
+     * from the current state of the AES Interrupt Event 0 register set */
+    uint32_t interruptMask0;
+    /*! AES interrupt mask 1. Value of @ref DL_AES_EVENT_AES_DMA_TRIGGER0 stored
+     *  from the current state of the AES Interrupt Event 1 register set */
+    uint32_t interruptMask1;
+    /*! AES interrupt mask 2. Value of @ref DL_AES_EVENT_AES_DMA_TRIGGER1 stored
+     * from the current state of the AES Interrupt Event 2 register set */
+    uint32_t interruptMask2;
+    /*! AES interrupt mask 3. Value of @ref DL_AES_EVENT_AES_DMA_TRIGGER2 stored
+     * from the current state of the AES Interrupt Event 3 register set */
+    uint32_t interruptMask3;
+    /*! Boolean flag indicating whether or not a valid configuration structure
+       exists. Should not be modified by the user. */
+    bool backupRdy;
+} DL_AES_backupConfig;
+
+/**
+ * @brief Enables power on AES module
+ *
+ * @param aes        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AES_enablePower(AES_Regs *aes)
+{
+    aes->GPRCM.PWREN = (AES_PWREN_KEY_UNLOCK_W | AES_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power on AES module
+ *
+ * @param aes        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AES_disablePower(AES_Regs *aes)
+{
+    aes->GPRCM.PWREN = (AES_PWREN_KEY_UNLOCK_W | AES_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief Returns if power enabled on AES module
+ *
+ * @param aes        Pointer to the register overlay for the peripheral
+ *
+ * @return true if power is enabled
+ * @return false if power is disabled
+ */
+__STATIC_INLINE bool DL_AES_isPowerEnabled(AES_Regs *aes)
+{
+    return (
+        (aes->GPRCM.PWREN & AES_PWREN_ENABLE_MASK) == AES_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Resets AES peripheral
+ *
+ * @param aes        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AES_reset(AES_Regs *aes)
+{
+    aes->GPRCM.RSTCTL =
+        (AES_RSTCTL_KEY_UNLOCK_W | AES_RSTCTL_RESETSTKYCLR_CLR |
+            AES_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief Returns if AES peripheral was reset
+ *
+ * @param aes        Pointer to the register overlay for the peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_AES_isReset(AES_Regs *aes)
+{
+    return ((aes->GPRCM.STAT & AES_STAT_RESETSTKY_MASK) ==
+            AES_STAT_RESETSTKY_RESET);
+}
+
+/**
+ *  @brief  Initializes AES peripheral
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *
+ *  @param[in] aesConfig     Configures AES cipher mode, key length and
+ *                           operation configuration. One of @ref DL_AES_MODE
+ *  @param[in] keyLength     Configures AES key length. One of
+ *                           @ref DL_AES_KEY_LENGTH
+ */
+
+__STATIC_INLINE void DL_AES_init(
+    AES_Regs *aes, DL_AES_MODE aesConfig, DL_AES_KEY_LENGTH keyLength)
+{
+    DL_Common_updateReg(&aes->AESACTL0,
+        ((uint32_t) aesConfig | (uint32_t) keyLength),
+        (uint32_t)(AES_AESACTL0_OPX_MASK | AES_AESACTL0_CMX_MASK |
+                   AES_AESACTL0_KLX_MASK));
+}
+
+/**
+ *  @brief Immediately resets the complete AES accelerator module even when
+ *         busy.
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *
+ */
+
+__STATIC_INLINE void DL_AES_softwareReset(AES_Regs *aes)
+{
+    aes->AESACTL0 |= (AES_AESACTL0_SWRST_RST);
+}
+
+/**
+ *  @brief Returns status of AES error flag
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *
+ *  @return Status of AES module fault flag
+ *
+ *  @retval true flag is set
+ *  @retval false flag is cleared
+ */
+__STATIC_INLINE bool DL_AES_isFaultFlagSet(AES_Regs *aes)
+{
+    return (
+        (aes->AESACTL0 & AES_AESACTL0_ERRFG_MASK) == AES_AESACTL0_ERRFG_ERR);
+}
+
+/**
+ *  @brief Clears AES error flag
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *
+ */
+__STATIC_INLINE void DL_AES_clearFaultFlag(AES_Regs *aes)
+{
+    aes->AESACTL0 &= ~(AES_AESACTL0_ERRFG_ERR);
+}
+
+/**
+ *  @brief Enables cipher mode
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *
+ */
+__STATIC_INLINE void DL_AES_enableCipherMode(AES_Regs *aes)
+{
+    aes->AESACTL0 |= (AES_AESACTL0_CMEN_ENABLE);
+}
+
+/**
+ *  @brief Disables cipher mode
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *
+ */
+__STATIC_INLINE void DL_AES_disablesCipherMode(AES_Regs *aes)
+{
+    aes->AESACTL0 &= ~(AES_AESACTL0_CMEN_ENABLE);
+}
+
+/**
+ * @brief Set cipher block counter value
+ *
+ * Sets the number of blocks to be encrypted or decrypted, the block counter
+ * decrements with each performed encryption or decryption.
+ * Block cipher mode must be enabled with @ref DL_AES_enableCipherMode. If block
+ * cipher mode is disabled, writes to this register are ignored.
+ * If this register has a value > 0 and block cipher mode has been enabled,
+ * further writes to this register are ignored until the value of this register
+ * is 0.
+ *
+ * @param       aes      Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  count    The value to set the cipher block counter to.
+ *                       Value between [0x0, 0xFF]
+ *
+ * @sa          DL_AES_enableCipherMode
+ */
+__STATIC_INLINE void DL_AES_setCipherBlockCounter(
+    AES_Regs *aes, uint32_t count)
+{
+    DL_Common_updateReg(&aes->AESACTL1, count, AES_AESACTL1_BLKCNTX_MASK);
+}
+
+/**
+ * @brief Get current cipher block counter value
+ *
+ * The block counter decrements with each performed encryption or decryption.
+ *
+ * @param aes        Pointer to the register overlay for the peripheral
+ *
+ * @return           The current cipher block counter value
+ *
+ * @retval           Value between [0x0, 0xFF]
+ */
+__STATIC_INLINE uint32_t DL_AES_getCipherBlockCounter(AES_Regs *aes)
+{
+    return (aes->AESACTL1 & AES_AESACTL1_BLKCNTX_MASK);
+}
+
+/**
+ *
+ * @brief Gets the AES module busy status.
+ *
+ * @param[in] aes           Pointer to the register overlay for the
+ *                          peripheral
+ * @return Status of AES module
+ *
+ * @retval true. Module is busy
+ * @retval false. Module is in idle state
+ *
+ */
+__STATIC_INLINE bool DL_AES_isBusy(AES_Regs *aes)
+{
+    return (
+        (aes->AESASTAT & AES_AESASTAT_BUSY_MASK) == AES_AESASTAT_BUSY_BUSY);
+}
+
+/**
+ *
+ * @brief Gets the DATAOUT read status
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ * @return Status of DATAOUT read status
+ *
+ * @retval true. All bytes read
+ * @retval false. Not all bytes read
+ *
+ */
+__STATIC_INLINE bool DL_AES_getDataOutReadStatus(AES_Regs *aes)
+{
+    return (
+        (aes->AESASTAT & AES_AESASTAT_DOUTRD_MASK) == AES_AESASTAT_DOUTRD_ALL);
+}
+
+/**
+ *
+ * @brief Gets Key byte count
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *
+ * @return Number of Key bytes loaded
+ *
+ */
+__STATIC_INLINE uint8_t DL_AES_getKeyBytesCount(AES_Regs *aes)
+{
+    return ((uint8_t)((aes->AESASTAT & AES_AESASTAT_KEYCNTX_MAXNUM) >> 4));
+}
+
+/**
+ *
+ * @brief Gets Data In byte count
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *
+ * @return Number of Data In bytes loaded
+ *
+ */
+__STATIC_INLINE uint8_t DL_AES_getDataInBytesCount(AES_Regs *aes)
+{
+    return ((uint8_t)((aes->AESASTAT & AES_AESASTAT_DINCNTX_MAXNUM) >> 8));
+}
+
+/**
+ *
+ * @brief Gets Data Out byte count
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *
+ * @return Number of Data Out bytes loaded
+ *
+ */
+__STATIC_INLINE uint8_t DL_AES_getDataOutBytesCount(AES_Regs *aes)
+{
+    return ((uint8_t)((aes->AESASTAT & AES_AESASTAT_DOUTCNTX_MAXNUM) >> 12));
+}
+
+/**
+ *
+ * @brief Set bit to write all STATE bytes to STATE registers
+ *        and triggers a new encryption
+ *
+ * @param[in] aes            Pointer to the register overlay for the
+ *                           peripheral
+ *
+ */
+__STATIC_INLINE void DL_AES_setAllDataWritten(AES_Regs *aes)
+{
+    aes->AESASTAT |= AES_AESASTAT_DINWR_ALL;
+}
+
+/**
+ *
+ * @brief Set bit to write all KEY bytes to KEY register,
+ *        which is used to encrypt and decrypt data
+ *
+ * @param[in] aes            Pointer to the register overlay for the
+ *                           peripheral
+ *
+ */
+__STATIC_INLINE void DL_AES_setAllKeyWritten(AES_Regs *aes)
+{
+    aes->AESASTAT |= AES_AESASTAT_KEYWR_ALL;
+}
+
+/**
+ *
+ * @brief Check if all bytes are to be written to
+ *        registers containing STATE info
+ *
+ * @param[in] aes            Pointer to the register overlay for the
+ *                           peripheral
+ *
+ * @retval true All bytes are written to these registers
+ * @retval false Not all bytes are written to these registers
+ *
+ */
+__STATIC_INLINE bool DL_AES_isAllDataWritten(AES_Regs *aes)
+{
+    return (aes->AESASTAT & AES_AESASTAT_DINWR_MASK) == AES_AESASTAT_DINWR_ALL;
+}
+
+/**
+ *
+ * @brief Check if all bytes are to be written to
+ *        registers containing KEY info
+ *
+ * @param[in] aes            Pointer to the register overlay for the
+ *                           peripheral
+ *
+ * @retval true All bytes are written to these registers
+ * @retval false Not all bytes are written to these registers
+ */
+__STATIC_INLINE bool DL_AES_isAllKeysWritten(AES_Regs *aes)
+{
+    return (aes->AESASTAT & AES_AESASTAT_KEYWR_MASK) == AES_AESASTAT_KEYWR_ALL;
+}
+
+/**
+ *
+ *  @brief Loads a 128 or 256 bit key to AES module.
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *
+ *  @param[in] key           Pointer to an aligned uint8_t array that contains
+ *                           the cipher key.
+ *
+ *  @param[in] keyLength     length of the key. One of @ref DL_AES_KEY_LENGTH
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AES_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AES_setKeyAligned
+ *
+ */
+DL_AES_STATUS DL_AES_setKey(
+    AES_Regs *aes, const uint8_t *key, DL_AES_KEY_LENGTH keyLength);
+
+/**
+ *
+ *  @brief Loads a 128 or 256 bit key to AES module.
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *
+ *  @param[in] keyAligned    Pointer to an uint32_t array that contains the
+ *                           cipher key.
+ *
+ *  @param[in] keyLength     length of the key. One of @ref DL_AES_KEY_LENGTH
+ *
+ *  @sa DL_AES_setKey
+ *
+ */
+void DL_AES_setKeyAligned(
+    AES_Regs *aes, const uint32_t *keyAligned, DL_AES_KEY_LENGTH keyLength);
+
+/**
+ *
+ *  @brief XORs an AES 128-bit block of data in software
+ *
+ *  @param[in] data           Pointer to initial data block for the operation
+ *  @param[in] xorData        Pointer to 128-bit data block to xor with data
+ *  @param[out] xorOutputData Pointer to output block of data ^ xorData
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AES_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AES_xorDataAligned
+ *
+ */
+DL_AES_STATUS DL_AES_xorData(
+    uint8_t *data, uint8_t *xorData, uint8_t *xorOutputData);
+
+/**
+ *
+ *  @brief XORs an aligned 128-bit data block in software
+ *
+ *  @param[in] dataAligned           Pointer to initial data block for the
+ *                                   operation
+ *  @param[in] xorDataAligned        Pointer to 128-bit data block to xor with
+ *                                   data
+ *  @param[out] xorOutputDataAligned Pointer to output block of data ^ xorData
+ *
+ *  @sa DL_AES_xorData
+ */
+void DL_AES_xorDataAligned(uint32_t *dataAligned, uint32_t *xorDataAligned,
+    uint32_t *xorOutputDataAligned);
+
+/**
+ *
+ *  @brief Encrypts a block of data using the AES module.
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in] data          Is a pointer to an aligned uint8_t array with a
+ *                           length of 16 that contains data to be encrypted.
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AES_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AES_loadDataInAligned
+ */
+DL_AES_STATUS DL_AES_loadDataIn(AES_Regs *aes, const uint8_t *data);
+
+/**
+ *
+ *  @brief Encrypts a block of data using the AES module.
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in] dataAligned   Is a pointer to an uint32_t array with a length of
+ *                           4 that contains data to be encrypted.
+ *
+ *  @sa DL_AES_loadDataIn
+ *
+ */
+void DL_AES_loadDataInAligned(AES_Regs *aes, const uint32_t *dataAligned);
+
+/**
+ *
+ *  @brief Gets output of encrypted data
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[out] data         Is a pointer to an uint8_t array with a length of
+ *                           16 where the output of the AES module will
+ *                           be placed.
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AES_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        writes, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AES_getDataOutAligned
+ */
+DL_AES_STATUS DL_AES_getDataOut(AES_Regs *aes, uint8_t *data);
+
+/**
+ *
+ *  @brief Gets output of encrypted data
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in] dataAligned   Is a pointer to an uint32_t array with a length of
+ *                           4 where the output of the AES module will
+ *                           be placed.
+ *  @sa DL_AES_getDataOut
+ *
+ */
+void DL_AES_getDataOutAligned(AES_Regs *aes, uint32_t *dataAligned);
+
+/**
+ *
+ *  @brief Data is XORed with the current word of the state and then block of
+ *         data is encrypted. Encryption or decryption is started immediately
+ *         after loading data.
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in] data          Is a pointer to an aligned uint8_t array with a
+ *                           length of 16 that contains data to be encrypted.
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AES_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AES_loadXORDataInAligned
+ *
+ */
+DL_AES_STATUS DL_AES_loadXORDataIn(AES_Regs *aes, const uint8_t *data);
+
+/**
+ *
+ *  @brief Data is XORed with the current word of the state and then block of
+ *         data is encrypted. Encryption or decryption is started immediately
+ *         after loading data.
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in] dataAligned   Is a pointer to an uint32_t array with a length of
+ *                           4 that contains data to be encrypted.
+ *
+ *  @sa DL_AES_loadXORDataIn
+ *
+ */
+void DL_AES_loadXORDataInAligned(AES_Regs *aes, const uint32_t *dataAligned);
+
+/**
+ *
+ *  @brief Data is XORed with the current word of the state and then block of
+ *         data is encrypted. Encryption or decryption is NOT started after
+ *         loading data.
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in] data          Is a pointer to an aligned uint8_t array with a
+ *                           length of 16 that contains data to be encrypted.
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AES_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AES_loadXORDataInWithoutTriggerAligned
+ *
+ */
+DL_AES_STATUS DL_AES_loadXORDataInWithoutTrigger(
+    AES_Regs *aes, const uint8_t *data);
+
+/**
+ *
+ *  @brief Data is XORed with the current word of the state and then block of
+ *         data is encrypted. Encryption or decryption is NOT started after
+ *         loading data.
+ *
+ *  @param[in] aes           Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in] dataAligned   Is a pointer to an uint32_t array with a length of
+ *                           4 that contains data to be encrypted.
+ *
+ *  @sa DL_AES_loadXORDataInWithoutTrigger
+ *
+ */
+void DL_AES_loadXORDataInWithoutTriggerAligned(
+    AES_Regs *aes, const uint32_t *dataAligned);
+
+/**
+ *  @brief      Enable AES Ready interrupt
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                            peripheral
+ */
+__STATIC_INLINE void DL_AES_enableInterrupt(AES_Regs *aes)
+{
+    aes->CPU_INT.IMASK |= DL_AES_INTERRUPT_AES_READY;
+}
+
+/**
+ *  @brief      Enables DMA trigger 0 to publish AES events to the DMA
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                            peripheral
+ */
+__STATIC_INLINE void DL_AES_enableDMATrigger0Interrupt(AES_Regs *aes)
+{
+    aes->DMA_TRIG0.IMASK |= DL_AES_EVENT_AES_DMA_TRIGGER0;
+}
+
+/**
+ *  @brief      Enables DMA trigger 1 to publish AES events to the DMA
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                            peripheral
+ */
+__STATIC_INLINE void DL_AES_enableDMATrigger1Interrupt(AES_Regs *aes)
+{
+    aes->DMA_TRIG1.IMASK |= DL_AES_EVENT_AES_DMA_TRIGGER1;
+}
+
+/**
+ *  @brief      Enables DMA trigger 2 to publish AES events to the DMA
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                            peripheral
+ */
+__STATIC_INLINE void DL_AES_enableDMATrigger2Interrupt(AES_Regs *aes)
+{
+    aes->DMA_TRIG2.IMASK |= DL_AES_EVENT_AES_DMA_TRIGGER2;
+}
+
+/**
+ *  @brief      Disable AES Ready interrupt
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ */
+__STATIC_INLINE void DL_AES_disableInterrupt(AES_Regs *aes)
+{
+    aes->CPU_INT.IMASK &= ~(AES_CPU_INT_IMASK_AESRDY_MASK);
+}
+
+/**
+ *  @brief      Disable DMA Trigger 0 Event
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ */
+__STATIC_INLINE void DL_AES_disableDMATrigger0Event(AES_Regs *aes)
+{
+    aes->DMA_TRIG0.IMASK &= ~(AES_DMA_TRIG0_IMASK_DMA0_MASK);
+}
+
+/**
+ *  @brief      Disable DMA Trigger 1 Event
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ */
+__STATIC_INLINE void DL_AES_disableDMATrigger1Event(AES_Regs *aes)
+{
+    aes->DMA_TRIG1.IMASK &= ~(AES_DMA_TRIG1_IMASK_DMA1_MASK);
+}
+
+/**
+ *  @brief      Disable DMA Trigger 2 Event
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ */
+__STATIC_INLINE void DL_AES_disableDMATrigger2Event(AES_Regs *aes)
+{
+    aes->DMA_TRIG2.IMASK &= ~(AES_DMA_TRIG2_IMASK_DMA2_MASK);
+}
+
+/**
+ *  @brief      Check if AES Ready interrupt is enabled
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                            peripheral
+ *
+ *  @return     If AES Ready interrupt is enabled
+ *
+ *  @retval      DL_AES_INTERRUPT_AES_READY if AES Ready interrupt is enabled
+ *  @retval      0 if AES Ready interrupt is not enabled
+ */
+__STATIC_INLINE uint32_t DL_AES_getEnabledInterrupts(AES_Regs *aes)
+{
+    return (aes->CPU_INT.IMASK & AES_CPU_INT_IMASK_AESRDY_MASK);
+}
+
+/**
+ *  @brief      Check if DMA Trigger 0 Event is enabled
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                            peripheral
+ *
+ *  @return     If DMA Trigger 0 Event is enabled
+ *
+ *  @retval      DL_AES_EVENT_AES_DMA_TRIGGER0 if DMA Trigger 0 Event is enabled
+ *  @retval      0 if DMA Trigger 0 Event is not enabled
+ */
+__STATIC_INLINE uint32_t DL_AES_getEnabledDMATrigger0Event(AES_Regs *aes)
+{
+    return (aes->DMA_TRIG0.IMASK & AES_DMA_TRIG0_IMASK_DMA0_MASK);
+}
+
+/**
+ *  @brief      Check if DMA Trigger 1 Event is enabled
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                            peripheral
+ *
+ *  @return     If DMA Trigger 1 Event is enabled
+ *
+ *  @retval      DL_AES_EVENT_AES_DMA_TRIGGER1 if DMA Trigger 1 Event is enabled
+ *  @retval      0 if DMA Trigger 1 Event is not enabled
+ */
+__STATIC_INLINE uint32_t DL_AES_getEnabledDMATrigger1Event(AES_Regs *aes)
+{
+    return (aes->DMA_TRIG1.IMASK & AES_DMA_TRIG1_IMASK_DMA1_MASK);
+}
+
+/**
+ *  @brief      Check if DMA Trigger 2 Event is enabled
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                            peripheral
+ *
+ *  @return     If DMA Trigger 2 Event is enabled
+ *
+ *  @retval      DL_AES_EVENT_AES_DMA_TRIGGER2 if DMA Trigger 2 Event is enabled
+ *  @retval      0 if DMA Trigger 2 Event is not enabled
+ */
+__STATIC_INLINE uint32_t DL_AES_getEnabledDMATrigger2Event(AES_Regs *aes)
+{
+    return (aes->DMA_TRIG2.IMASK & AES_DMA_TRIG2_IMASK_DMA2_MASK);
+}
+
+/**
+ *  @brief      Check interrupt flag of AES Ready interrupt
+ *
+ *  Checks if AES Ready interrupt that was previously enabled is pending.
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     If AES Ready interrupt is pending
+ *
+ *  @retval      DL_AES_INTERRUPT_AES_READY if AES Ready interrupt is pending
+ *  @retval      0 if AES Ready interrupt is not pending
+ *
+ *  @sa         DL_AES_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_AES_getEnabledInterruptStatus(AES_Regs *aes)
+{
+    return (aes->CPU_INT.MIS & AES_CPU_INT_IMASK_AESRDY_MASK);
+}
+
+/**
+ *  @brief      Check interrupt flag of DMA Trigger 0 Event
+ *
+ *  Checks if DMA Trigger 0 Event that was previously enabled is pending.
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     If DMA Trigger 0 Event is pending
+ *
+ *  @retval      DL_AES_EVENT_AES_DMA_TRIGGER0 if DMA Trigger 0 Event is pending
+ *  @retval      0 if DMA Trigger 0 Event is not pending
+ *
+ *  @sa         DL_AES_enableDMATrigger0Event
+ */
+__STATIC_INLINE uint32_t DL_AES_getEnabledDMATrigger0EventStatus(AES_Regs *aes)
+{
+    return (aes->DMA_TRIG0.MIS & AES_DMA_TRIG0_IMASK_DMA0_MASK);
+}
+
+/**
+ *  @brief      Check interrupt flag of DMA Trigger 1 Event
+ *
+ *  Checks if DMA Trigger 1 Event that was previously enabled is pending.
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     If DMA Trigger 1 Event is pending
+ *
+ *  @retval      DL_AES_EVENT_AES_DMA_TRIGGER1 if DMA Trigger 1 Event is pending
+ *  @retval      0 if DMA Trigger 1 Event is not pending
+ *
+ *  @sa         DL_AES_enableDMATrigger1Event
+ */
+__STATIC_INLINE uint32_t DL_AES_getEnabledDMATrigger1EventStatus(AES_Regs *aes)
+{
+    return (aes->DMA_TRIG1.MIS & AES_DMA_TRIG1_IMASK_DMA1_MASK);
+}
+
+/**
+ *  @brief      Check interrupt flag of DMA Trigger 2 Event
+ *
+ *  Checks if DMA Trigger 2 Event that was previously enabled is pending.
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     If DMA Trigger 2 Event is pending
+ *
+ *  @retval      DL_AES_EVENT_AES_DMA_TRIGGER2 if DMA Trigger 2 Event is pending
+ *  @retval      0 if DMA Trigger 2 Event is not pending
+ *
+ *  @sa         DL_AES_enableDMATrigger2Event
+ */
+__STATIC_INLINE uint32_t DL_AES_getEnabledDMATrigger2EventStatus(AES_Regs *aes)
+{
+    return (aes->DMA_TRIG2.MIS & AES_DMA_TRIG2_IMASK_DMA2_MASK);
+}
+
+/**
+ *  @brief      Check interrupt flag of AES Ready interrupt
+ *
+ *  Checks if AES Ready Interrupt is pending. Interrupt does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     If AES Ready interrupt is pending
+ *
+ *  @retval      DL_AES_EVENT_AES_DMA_TRIGGER0 if AES Ready interrupt is pending
+ *  @retval      0 if AES Ready interrupt is not pending
+ */
+__STATIC_INLINE uint32_t DL_AES_getRawInterruptStatus(AES_Regs *aes)
+{
+    return (aes->CPU_INT.RIS & AES_CPU_INT_IMASK_AESRDY_MASK);
+}
+
+/**
+ *  @brief      Check interrupt flag of DMA Trigger 0 Event
+ *
+ *  Checks if DMA Trigger 0 Event is pending. Event does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     If DMA Trigger 0 Event is pending
+ *
+ *  @retval      DL_AES_EVENT_AES_DMA_TRIGGER0 if DMA Trigger 0 Event is pending
+ *  @retval      0 if DMA Trigger 0 Event is not pending
+ */
+__STATIC_INLINE uint32_t DL_AES_getRawDMATrigger0EventStatus(AES_Regs *aes)
+{
+    return (aes->DMA_TRIG0.RIS & AES_DMA_TRIG0_IMASK_DMA0_MASK);
+}
+
+/**
+ *  @brief      Check interrupt flag of DMA Trigger 1 Event
+ *
+ *  Checks if DMA Trigger 1 Event is pending. Event does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     If DMA Trigger 1 Event is pending
+ *
+ *  @retval      DL_AES_EVENT_AES_DMA_TRIGGER0 if DMA Trigger 1 Event is pending
+ *  @retval      0 if DMA Trigger 1 Event is not pending
+ */
+__STATIC_INLINE uint32_t DL_AES_getRawDMATrigger1EventStatus(AES_Regs *aes)
+{
+    return (aes->DMA_TRIG1.RIS & AES_DMA_TRIG1_IMASK_DMA1_MASK);
+}
+
+/**
+ *  @brief      Check interrupt flag of DMA Trigger 2 Event
+ *
+ *  Checks if DMA Trigger 2 Event is pending. Event does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     If DMA Trigger 2 Event is pending
+ *
+ *  @retval      DL_AES_EVENT_AES_DMA_TRIGGER0 if DMA Trigger 2 Event is pending
+ *  @retval      0 if DMA Trigger 2 Event is not pending
+ */
+__STATIC_INLINE uint32_t DL_AES_getRawDMATrigger2EventStatus(AES_Regs *aes)
+{
+    return (aes->DMA_TRIG2.RIS & AES_DMA_TRIG2_IMASK_DMA2_MASK);
+}
+
+/**
+ *  @brief      Get highest priority pending AES interrupt
+ *
+ *  Checks if AES Ready Interrupt is pending. Interrupt does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     The highest priority pending AES interrupt
+ */
+__STATIC_INLINE DL_AES_IIDX DL_AES_getPendingInterrupt(AES_Regs *aes)
+{
+    uint32_t interruptIdx = (uint32_t) aes->CPU_INT.IIDX;
+
+    return (DL_AES_IIDX) interruptIdx;
+}
+
+/**
+ *  @brief      Get highest priority pending DMA Trigger 0 Event
+ *
+ *  Checks if DMA Trigger 0 Event os pending. Event does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     The highest priority pending DMA Trigger 0 Event
+ */
+__STATIC_INLINE DL_AES_IIDX DL_AES_getPendingDMATrigger0Event(AES_Regs *aes)
+{
+    uint32_t eventIdx = (uint32_t) aes->DMA_TRIG0.IIDX;
+
+    return (DL_AES_IIDX) eventIdx;
+}
+
+/**
+ *  @brief      Get highest priority pending DMA Trigger 1 Event
+ *
+ *  Checks if DMA Trigger 1 Event os pending. Event does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     The highest priority pending DMA Trigger 1 Event
+ */
+__STATIC_INLINE DL_AES_IIDX DL_AES_getPendingDMATrigger1Event(AES_Regs *aes)
+{
+    uint32_t eventIdx = (uint32_t) aes->DMA_TRIG1.IIDX;
+
+    return (DL_AES_IIDX) eventIdx;
+}
+
+/**
+ *  @brief      Get highest priority pending DMA Trigger 2 Event
+ *
+ *  Checks if DMA Trigger 2 Event os pending. Event does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     The highest priority pending DMA Trigger 2 Event
+ */
+__STATIC_INLINE DL_AES_IIDX DL_AES_getPendingDMATrigger2Event(AES_Regs *aes)
+{
+    uint32_t eventIdx = (uint32_t) aes->DMA_TRIG2.IIDX;
+
+    return (DL_AES_IIDX) eventIdx;
+}
+
+/**
+ *  @brief      Clear pending AES Ready Interrupt
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ */
+__STATIC_INLINE void DL_AES_clearInterruptStatus(AES_Regs *aes)
+{
+    aes->CPU_INT.ICLR |= AES_CPU_INT_IMASK_AESRDY_MASK;
+}
+
+/**
+ *  @brief      Clear pending DMA Trigger 0 Event
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ */
+__STATIC_INLINE void DL_AES_clearDMATrigger0EventStatus(AES_Regs *aes)
+{
+    aes->DMA_TRIG0.ICLR |= AES_DMA_TRIG0_IMASK_DMA0_MASK;
+}
+
+/**
+ *  @brief      Clear pending DMA Trigger 1 Event
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                             peripheral
+ */
+__STATIC_INLINE void DL_AES_clearDMATrigger1EventStatus(AES_Regs *aes)
+{
+    aes->DMA_TRIG1.ICLR |= AES_DMA_TRIG1_IMASK_DMA1_MASK;
+}
+
+/**
+ *  @brief      Clear pending DMA Trigger 2 Event
+ *
+ *  @param[in]  aes           Pointer to the register overlay for the
+ *                            peripheral
+ */
+__STATIC_INLINE void DL_AES_clearDMATrigger2EventStatus(AES_Regs *aes)
+{
+    aes->DMA_TRIG2.ICLR |= AES_DMA_TRIG2_IMASK_DMA2_MASK;
+}
+
+/**
+ *  @brief      Save AES configuration before entering a power loss state.
+ *              Note that operation-specific variables (intermediate data,
+ *              key, IV) will need to be re-loaded after picking up the
+ *              peripheral from a powerloss state.
+ *
+ *  @param[in]  aes  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr  Configuration backup setup structure. See
+ *              @ref DL_AES_backupConfig.
+ *
+ *  @retval     FALSE if a configuration already exists in ptr (will not be
+ *              overwritten). TRUE if a configuration was successfully saved
+ *
+ */
+bool DL_AES_saveConfiguration(AES_Regs *aes, DL_AES_backupConfig *ptr);
+
+/**
+ *  @brief      Restore AES configuration after leaving a power loss state.
+ *              Note that operation-specific variables (intermediate data,
+ *              key, IV) will need to be re-loaded after picking up the
+ *              peripheral from a powerloss state.
+ *
+ *  @param[in]  aes  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr  Configuration backup setup structure. See
+ *              @ref DL_AES_backupConfig.
+ *
+ *  @retval     FALSE if a configuration does not exist in ptr (will not be
+ *              loaded). TRUE if a configuration successfully loaded
+ *
+ */
+bool DL_AES_restoreConfiguration(AES_Regs *aes, DL_AES_backupConfig *ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_AES__ */
+
+#endif /* ti_dl_dl_aes__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_aesadv.c
+++ b/mspm0/source/ti/driverlib/dl_aesadv.c
@@ -1,0 +1,554 @@
+/*
+ * Copyright (c) 2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_aesadv.h>
+
+#ifdef __MSPM0_HAS_AESADV__
+
+static void DL_AESADV_loadData(
+    volatile uint32_t *destPtr, const uint32_t *srcPtr, uint8_t numWords);
+static void DL_AESADV_readData(
+    uint32_t *destPtr, volatile const uint32_t *srcPtr, uint8_t numWords);
+
+static const uint32_t *DL_AESADV_checkAlignmentAndReturnConstPtr(
+    const uint8_t *ptr);
+
+static uint32_t *DL_AESADV_checkAlignmentAndReturnPtr(uint8_t *ptr);
+
+DL_AESADV_STATUS DL_AESADV_setKey(
+    AESADV_Regs *aesadv, const uint8_t *key, DL_AESADV_KEY_SIZE keySize)
+{
+    DL_AESADV_STATUS status = DL_AESADV_STATUS_SUCCESS;
+    const uint32_t *keyAligned;
+
+    keyAligned = DL_AESADV_checkAlignmentAndReturnConstPtr(key);
+    if (keyAligned != NULL) {
+        DL_AESADV_setKeyAligned(aesadv, keyAligned, keySize);
+    } else {
+        status = DL_AESADV_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AESADV_setKeyAligned(AESADV_Regs *aesadv, const uint32_t *keyAligned,
+    DL_AESADV_KEY_SIZE keySize)
+{
+    uint8_t numWords;
+
+    switch (keySize) {
+        case DL_AESADV_KEY_SIZE_128_BIT:
+            numWords = 4U;
+            break;
+        case DL_AESADV_KEY_SIZE_256_BIT:
+            numWords = 8U;
+            break;
+        default:
+            /* invalid key size*/
+            numWords = 0U;
+            break;
+    }
+
+    DL_Common_updateReg(
+        &aesadv->CTRL, (uint32_t) keySize, AESADV_CTRL_KEYSIZE_MASK);
+
+    DL_AESADV_loadData(&aesadv->KEY0, keyAligned, numWords);
+
+    return;
+}
+
+DL_AESADV_STATUS DL_AESADV_setGCMHashKey(
+    AESADV_Regs *aesadv, const uint8_t *hashKey)
+{
+    DL_AESADV_STATUS status = DL_AESADV_STATUS_SUCCESS;
+    const uint32_t *hashKeyAligned;
+
+    hashKeyAligned = DL_AESADV_checkAlignmentAndReturnConstPtr(hashKey);
+    if (hashKeyAligned != NULL) {
+        DL_AESADV_setGCMHashKeyAligned(aesadv, hashKeyAligned);
+    } else {
+        status = DL_AESADV_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AESADV_setGCMHashKeyAligned(
+    AESADV_Regs *aesadv, const uint32_t *hashKeyAligned)
+{
+    uint8_t numWords = 4U;
+
+    DL_AESADV_loadData(&aesadv->GHASH_H0, hashKeyAligned, numWords);
+
+    return;
+}
+
+DL_AESADV_STATUS DL_AESADV_setSecondKey(
+    AESADV_Regs *aesadv, const uint8_t *secondKey)
+{
+    DL_AESADV_STATUS status = DL_AESADV_STATUS_SUCCESS;
+    const uint32_t *secondKeyAligned;
+
+    secondKeyAligned = DL_AESADV_checkAlignmentAndReturnConstPtr(secondKey);
+    if (secondKeyAligned != NULL) {
+        DL_AESADV_setSecondKeyAligned(aesadv, secondKeyAligned);
+    } else {
+        status = DL_AESADV_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AESADV_setSecondKeyAligned(
+    AESADV_Regs *aesadv, const uint32_t *secondKeyAligned)
+{
+    uint8_t numWords = 4U;
+
+    DL_AESADV_loadData(&aesadv->GHASH_H0, secondKeyAligned, numWords);
+
+    return;
+}
+
+DL_AESADV_STATUS DL_AESADV_setThirdKey(
+    AESADV_Regs *aesadv, const uint8_t *thirdKey)
+{
+    DL_AESADV_STATUS status = DL_AESADV_STATUS_SUCCESS;
+    const uint32_t *thirdKeyAligned;
+
+    thirdKeyAligned = DL_AESADV_checkAlignmentAndReturnConstPtr(thirdKey);
+    if (thirdKeyAligned != NULL) {
+        DL_AESADV_setThirdKeyAligned(aesadv, thirdKeyAligned);
+    } else {
+        status = DL_AESADV_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AESADV_setThirdKeyAligned(
+    AESADV_Regs *aesadv, const uint32_t *thirdKeyAligned)
+{
+    uint8_t numWords = 4U;
+
+    DL_AESADV_loadData(&aesadv->GCMCCM_TAG0, thirdKeyAligned, numWords);
+
+    return;
+}
+
+DL_AESADV_STATUS DL_AESADV_loadIntermediateTAG(
+    AESADV_Regs *aesadv, const uint8_t *tag)
+{
+    DL_AESADV_STATUS status = DL_AESADV_STATUS_SUCCESS;
+    const uint32_t *tagAligned;
+
+    tagAligned = DL_AESADV_checkAlignmentAndReturnConstPtr(tag);
+    if (tagAligned != NULL) {
+        DL_AESADV_loadIntermediateTAGAligned(aesadv, tagAligned);
+    } else {
+        status = DL_AESADV_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AESADV_loadIntermediateTAGAligned(
+    AESADV_Regs *aesadv, const uint32_t *tagAligned)
+{
+    uint8_t numWords = 4U;
+
+    DL_AESADV_loadData(&aesadv->GCMCCM_TAG0, tagAligned, numWords);
+
+    return;
+}
+
+DL_AESADV_STATUS DL_AESADV_loadInitializationVector(
+    AESADV_Regs *aesadv, uint8_t *iv)
+{
+    DL_AESADV_STATUS status = DL_AESADV_STATUS_SUCCESS;
+    uint32_t *ivAligned;
+
+    ivAligned = DL_AESADV_checkAlignmentAndReturnPtr(iv);
+    if (ivAligned != NULL) {
+        DL_AESADV_loadInitializationVectorAligned(aesadv, ivAligned);
+    } else {
+        status = DL_AESADV_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AESADV_loadInitializationVectorAligned(
+    AESADV_Regs *aesadv, uint32_t *ivAligned)
+{
+    uint8_t numWords = 4U;
+
+    DL_AESADV_loadData(&aesadv->IV0, ivAligned, numWords);
+
+    return;
+}
+
+DL_AESADV_STATUS DL_AESADV_readInitializationVector(
+    AESADV_Regs *aesadv, uint8_t *iv)
+{
+    DL_AESADV_STATUS status = DL_AESADV_STATUS_SUCCESS;
+    uint32_t *ivAligned;
+
+    ivAligned = DL_AESADV_checkAlignmentAndReturnPtr(iv);
+    if (ivAligned != NULL) {
+        DL_AESADV_readInitializationVectorAligned(aesadv, ivAligned);
+    } else {
+        status = DL_AESADV_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AESADV_readInitializationVectorAligned(
+    AESADV_Regs *aesadv, uint32_t *ivAligned)
+{
+    uint8_t numWords = 4U;
+    volatile uint32_t *sourcePtr;
+
+    sourcePtr = (volatile uint32_t *) &aesadv->IV0;
+
+    DL_AESADV_readData(ivAligned, sourcePtr, numWords);
+
+    return;
+}
+
+void DL_AESADV_loadCCMNonceAndCounter(
+    AESADV_Regs *aesadv, uint8_t *nonce, DL_AESADV_CCM_CTR_WIDTH ctrWidth)
+{
+    uint8_t *noncePtr = nonce;
+    uint8_t numWords  = 4U;
+    uint32_t ivArray[4];
+    uint8_t *ivPtr = (uint8_t *) &ivArray[0];
+    uint8_t i;
+
+    /* calculation of the nonce length. (Length described in table in header) */
+    uint8_t ccml = (uint8_t)((uint32_t) ctrWidth >> AESADV_CTRL_CCML_OFS);
+    uint8_t counterWidthInBytes = (ccml + 1U);
+
+    /* subtracting the counterWidth in bytes as well as the flag byte */
+    uint8_t nonceWidthInBytes = 14U - ccml;
+
+    *ivPtr++ = ccml;
+
+    /* addition of the Nonce */
+    for (i = 0; i < nonceWidthInBytes; i++) {
+        *ivPtr++ = *noncePtr++;
+    }
+
+    /* Counter is always initialized to zeros */
+    for (i = 0; i < counterWidthInBytes; i++) {
+        *ivPtr++ = 0x00;
+    }
+
+    DL_AESADV_loadData(&aesadv->IV0, ivArray, numWords);
+
+    return;
+}
+
+DL_AESADV_STATUS DL_AESADV_loadInputData(AESADV_Regs *aesadv, uint8_t *data)
+{
+    DL_AESADV_STATUS status = DL_AESADV_STATUS_SUCCESS;
+    uint32_t *dataAligned;
+
+    dataAligned = DL_AESADV_checkAlignmentAndReturnPtr(data);
+    if (dataAligned != NULL) {
+        DL_AESADV_loadInputDataAligned(aesadv, dataAligned);
+    } else {
+        status = DL_AESADV_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AESADV_loadInputDataAligned(AESADV_Regs *aesadv, uint32_t *dataAligned)
+{
+    uint8_t numWords = 4U;
+
+    DL_AESADV_loadData(&aesadv->DATA0, dataAligned, numWords);
+
+    return;
+}
+
+DL_AESADV_STATUS DL_AESADV_readOutputData(AESADV_Regs *aesadv, uint8_t *data)
+{
+    DL_AESADV_STATUS status = DL_AESADV_STATUS_SUCCESS;
+    uint32_t *dataAligned;
+
+    dataAligned = DL_AESADV_checkAlignmentAndReturnPtr(data);
+    if (dataAligned != NULL) {
+        DL_AESADV_readOutputDataAligned(aesadv, dataAligned);
+    } else {
+        status = DL_AESADV_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AESADV_readOutputDataAligned(
+    AESADV_Regs *aesadv, uint32_t *dataAligned)
+{
+    uint8_t numWords = 4U;
+
+    DL_AESADV_readData(dataAligned, &aesadv->DATA0, numWords);
+
+    return;
+}
+
+DL_AESADV_STATUS DL_AESADV_readTAG(AESADV_Regs *aesadv, uint8_t *tag)
+{
+    DL_AESADV_STATUS status = DL_AESADV_STATUS_SUCCESS;
+    uint32_t *tagAligned;
+
+    tagAligned = DL_AESADV_checkAlignmentAndReturnPtr(tag);
+    if (tagAligned != NULL) {
+        DL_AESADV_readTAGAligned(aesadv, tagAligned);
+    } else {
+        status = DL_AESADV_STATUS_UNALIGNED_ACCESS;
+    }
+    return status;
+}
+
+void DL_AESADV_readTAGAligned(AESADV_Regs *aesadv, uint32_t *tagAligned)
+{
+    uint8_t numWords = 4U;
+
+    DL_AESADV_readData(tagAligned, &aesadv->TAG0, numWords);
+
+    return;
+}
+
+void DL_AESADV_initECB(AESADV_Regs *aesadv, DL_AESADV_Config *config)
+{
+    DL_Common_updateReg(&aesadv->CTRL,
+        ((uint32_t) DL_AESADV_MODE_ECB | config->direction),
+        ((uint32_t) DL_AESADV_MODE_MASK | AESADV_CTRL_DIR_MASK |
+            AESADV_CTRL_SAVE_CNTXT_MASK));
+
+    DL_AESADV_setUpperCryptoLength(aesadv, config->upperCryptoLength);
+    DL_AESADV_setLowerCryptoLength(aesadv, config->lowerCryptoLength);
+}
+
+void DL_AESADV_initCBC(AESADV_Regs *aesadv, DL_AESADV_Config *config)
+{
+    DL_Common_updateReg(&aesadv->CTRL,
+        ((uint32_t) DL_AESADV_MODE_CBC | config->direction),
+        ((uint32_t) DL_AESADV_MODE_MASK | AESADV_CTRL_DIR_MASK |
+            AESADV_CTRL_SAVE_CNTXT_MASK));
+
+    DL_AESADV_loadInitializationVector(aesadv, config->iv);
+
+    DL_AESADV_setUpperCryptoLength(aesadv, config->upperCryptoLength);
+    DL_AESADV_setLowerCryptoLength(aesadv, config->lowerCryptoLength);
+}
+
+void DL_AESADV_initCFB(AESADV_Regs *aesadv, DL_AESADV_Config *config)
+{
+    DL_Common_updateReg(&aesadv->CTRL,
+        (((uint32_t) DL_AESADV_MODE_CFB) | ((uint32_t) config->direction) |
+            ((uint32_t) config->cfb_fbWidth)),
+        (DL_AESADV_MODE_MASK | AESADV_CTRL_DIR_MASK |
+            AESADV_CTRL_CTR_WIDTH_MASK | AESADV_CTRL_SAVE_CNTXT_MASK));
+
+    DL_AESADV_loadInitializationVector(aesadv, config->iv);
+
+    DL_AESADV_setUpperCryptoLength(aesadv, config->upperCryptoLength);
+    DL_AESADV_setLowerCryptoLength(aesadv, config->lowerCryptoLength);
+}
+
+void DL_AESADV_initOFB(AESADV_Regs *aesadv, DL_AESADV_Config *config)
+{
+    DL_Common_updateReg(&aesadv->CTRL,
+        (((uint32_t) DL_AESADV_MODE_OFB) | ((uint32_t) config->direction) |
+            ((uint32_t) config->cfb_fbWidth)),
+        (DL_AESADV_MODE_MASK | AESADV_CTRL_DIR_MASK |
+            AESADV_CTRL_CTR_WIDTH_MASK | AESADV_CTRL_SAVE_CNTXT_MASK));
+
+    DL_AESADV_loadInitializationVector(aesadv, config->iv);
+
+    DL_AESADV_setUpperCryptoLength(aesadv, config->upperCryptoLength);
+    DL_AESADV_setLowerCryptoLength(aesadv, config->lowerCryptoLength);
+}
+
+void DL_AESADV_initCTR(AESADV_Regs *aesadv, DL_AESADV_Config *config)
+{
+    DL_Common_updateReg(&aesadv->CTRL,
+        (((uint32_t) DL_AESADV_MODE_CTR) | ((uint32_t) config->direction) |
+            ((uint32_t) config->ctr_ctrWidth)),
+        (DL_AESADV_MODE_MASK | AESADV_CTRL_DIR_MASK |
+            AESADV_CTRL_CTR_WIDTH_MASK | AESADV_CTRL_SAVE_CNTXT_MASK));
+
+    DL_AESADV_loadInitializationVector(aesadv, config->iv);
+
+    DL_AESADV_setUpperCryptoLength(aesadv, config->upperCryptoLength);
+    DL_AESADV_setLowerCryptoLength(aesadv, config->lowerCryptoLength);
+}
+
+void DL_AESADV_initICM(AESADV_Regs *aesadv, DL_AESADV_Config *config)
+{
+    DL_Common_updateReg(&aesadv->CTRL,
+        ((uint32_t) DL_AESADV_MODE_ICM | ((uint32_t) config->direction)),
+        (DL_AESADV_MODE_MASK | AESADV_CTRL_DIR_MASK |
+            AESADV_CTRL_SAVE_CNTXT_MASK));
+
+    DL_AESADV_loadInitializationVector(aesadv, config->iv);
+
+    DL_AESADV_setUpperCryptoLength(aesadv, config->upperCryptoLength);
+    DL_AESADV_setLowerCryptoLength(aesadv, config->lowerCryptoLength);
+}
+
+void DL_AESADV_initCMAC(AESADV_Regs *aesadv, DL_AESADV_Config *config)
+{
+    uint32_t zeroArray[4] = {0x00000000, 0x00000000, 0x00000000, 0x00000000};
+
+    /* Set the second and third keys, and zero out the initialization vector */
+    DL_AESADV_setSecondKey(aesadv, config->k1);
+    DL_AESADV_setThirdKey(aesadv, config->k2);
+    DL_AESADV_loadInitializationVectorAligned(aesadv, &zeroArray[0]);
+
+    DL_Common_updateReg(&aesadv->CTRL,
+        ((uint32_t) DL_AESADV_MODE_CMAC | ((uint32_t) DL_AESADV_DIR_ENCRYPT) |
+            ((uint32_t) AESADV_CTRL_SAVE_CNTXT_ENABLE)),
+        (DL_AESADV_MODE_MASK | AESADV_CTRL_DIR_MASK |
+            AESADV_CTRL_SAVE_CNTXT_MASK));
+
+    DL_AESADV_setUpperCryptoLength(aesadv, config->upperCryptoLength);
+    DL_AESADV_setLowerCryptoLength(aesadv, config->lowerCryptoLength);
+}
+
+void DL_AESADV_initCBCMAC(AESADV_Regs *aesadv, DL_AESADV_Config *config)
+{
+    uint32_t zeroArray[4] = {0x00000000, 0x00000000, 0x00000000, 0x00000000};
+
+    /* Zero out the second and third keys and the IV for CBC-MAC as per spec */
+    DL_AESADV_setSecondKeyAligned(aesadv, &zeroArray[0]);
+    DL_AESADV_setThirdKeyAligned(aesadv, &zeroArray[0]);
+    DL_AESADV_loadInitializationVectorAligned(aesadv, &zeroArray[0]);
+
+    DL_Common_updateReg(&aesadv->CTRL,
+        ((uint32_t) DL_AESADV_MODE_CBCMAC |
+            ((uint32_t) DL_AESADV_DIR_ENCRYPT) |
+            ((uint32_t) AESADV_CTRL_SAVE_CNTXT_ENABLE)),
+        (DL_AESADV_MODE_MASK | AESADV_CTRL_DIR_MASK |
+            AESADV_CTRL_SAVE_CNTXT_MASK));
+
+    DL_AESADV_setUpperCryptoLength(aesadv, config->upperCryptoLength);
+    DL_AESADV_setLowerCryptoLength(aesadv, config->lowerCryptoLength);
+}
+
+void DL_AESADV_initGCM(AESADV_Regs *aesadv, DL_AESADV_Config *config)
+{
+    uint32_t zeroArray[4] = {0x00000000, 0x00000000, 0x00000000, 0x00000000};
+
+    /* Zero out the intermediate TAG for GCM as per spec */
+    DL_AESADV_loadIntermediateTAGAligned(aesadv, &zeroArray[0]);
+
+    DL_AESADV_loadInitializationVector(aesadv, config->iv);
+
+    DL_Common_updateReg(&aesadv->CTRL,
+        (((uint32_t) config->mode) | ((uint32_t) config->direction) |
+            ((uint32_t) DL_AESADV_CTR_WIDTH_32_BIT |
+                (uint32_t) AESADV_CTRL_SAVE_CNTXT_ENABLE)),
+        ((uint32_t) DL_AESADV_MODE_MASK | AESADV_CTRL_DIR_MASK |
+            AESADV_CTRL_CTR_WIDTH_MASK | AESADV_CTRL_SAVE_CNTXT_MASK));
+
+    DL_AESADV_setUpperCryptoLength(aesadv, config->upperCryptoLength);
+    DL_AESADV_setLowerCryptoLength(aesadv, config->lowerCryptoLength);
+
+    DL_AESADV_setAADLength(aesadv, config->aadLength);
+}
+
+void DL_AESADV_initCCM(AESADV_Regs *aesadv, DL_AESADV_Config *config)
+{
+    DL_AESADV_loadCCMNonceAndCounter(
+        aesadv, config->nonce, config->ccm_ctrWidth);
+
+    DL_Common_updateReg(&aesadv->CTRL,
+        (((uint32_t) DL_AESADV_MODE_CCM) | ((uint32_t) config->direction) |
+            ((uint32_t) config->ccm_ctrWidth) |
+            ((uint32_t) config->ccm_tagWidth) |
+            ((uint32_t) DL_AESADV_CTR_WIDTH_64_BIT) |
+            ((uint32_t) AESADV_CTRL_SAVE_CNTXT_ENABLE)),
+        (DL_AESADV_MODE_MASK | AESADV_CTRL_DIR_MASK | AESADV_CTRL_CCML_MASK |
+            AESADV_CTRL_CCMM_MASK | AESADV_CTRL_CTR_WIDTH_MASK |
+            AESADV_CTRL_SAVE_CNTXT_MASK));
+
+    DL_AESADV_setUpperCryptoLength(aesadv, config->upperCryptoLength);
+    DL_AESADV_setLowerCryptoLength(aesadv, config->lowerCryptoLength);
+
+    DL_AESADV_setAADLength(aesadv, config->aadLength);
+}
+
+static void DL_AESADV_loadData(
+    volatile uint32_t *destPtr, const uint32_t *srcPtr, uint8_t numWords)
+{
+    uint8_t i;
+    for (i = 0; i < numWords; i++) {
+        *destPtr++ = *srcPtr++;
+    }
+    return;
+}
+
+static void DL_AESADV_readData(
+    uint32_t *destPtr, volatile const uint32_t *srcPtr, uint8_t numWords)
+{
+    uint8_t i;
+    for (i = 0; i < numWords; i++) {
+        *destPtr++ = *srcPtr++;
+    }
+    return;
+}
+
+static const uint32_t *DL_AESADV_checkAlignmentAndReturnConstPtr(
+    const uint8_t *ptr)
+{
+    uint32_t address = (uint32_t) ptr;
+    const uint32_t *alignedPtr;
+    if ((address << 30) != 0x00000000u) {
+        /* Unaligned access */
+        alignedPtr = NULL;
+    } else {
+        /* Aligned Access */
+        alignedPtr = (const uint32_t *) address;
+    }
+    return alignedPtr;
+}
+
+static uint32_t *DL_AESADV_checkAlignmentAndReturnPtr(uint8_t *ptr)
+{
+    uint32_t address = (uint32_t) ptr;
+    uint32_t *alignedPtr;
+    if ((address << 30) != 0x00000000u) {
+        /* Unaligned access */
+        alignedPtr = NULL;
+    } else {
+        /* Aligned Access */
+        alignedPtr = (uint32_t *) address;
+    }
+    return alignedPtr;
+}
+
+#endif /* __MSPM0_HAS_AESADV__ */

--- a/mspm0/source/ti/driverlib/dl_aesadv.h
+++ b/mspm0/source/ti/driverlib/dl_aesadv.h
@@ -1,0 +1,2140 @@
+/*
+ * Copyright (c) 2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_aesadv.h
+ *  @brief      Advanced Encryption Standard Advanced (AESADV) Driver Library
+ *  @defgroup   AESADV Advanced Encryption Standard Advanced (AESADV)
+ *
+ *  @anchor ti_dl_dl_aesadv_Overview
+ *  # Overview
+ *
+ *  The AESADV DriverLib allows full configuration of the MSPM0 AESADV module.
+ *  The AESADV accelerator module accelerates encryption and decryption
+ *  operations in hardware based on the FIPS PUB 197 advanced encryption
+ *  standard (AES).
+ *
+ *  <hr>
+ ******************************************************************************/
+/** @addtogroup AESADV
+ * @{
+ */
+#ifndef ti_dl_dl_aesadv__include
+#define ti_dl_dl_aesadv__include
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_AESADV__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_AESADV_INTERRUPT
+ *  @{
+ */
+
+/*!
+ *  @brief AESADV Output Ready interrupt
+ *
+ *  @note Not compatible with the use of @ref DL_AESADV_enableDMAOperation
+ */
+#define DL_AESADV_INTERRUPT_OUTPUT_READY                                       \
+                                       (AESADV_CPU_INT_IMASK_OUTPUTRDY_SET)
+
+/*!
+ *  @brief AESADV Input Ready interrupt
+ *
+ *  @note Not compatible with the use of @ref DL_AESADV_enableDMAOperation
+ */
+#define DL_AESADV_INTERRUPT_INPUT_READY                                        \
+                                        (AESADV_CPU_INT_IMASK_INPUTRDY_SET)
+
+/*!
+ *  @brief AESADV Saved Context Ready interrupt. TAG and/or IV blocks are
+ *         available to be retrieved by the CPU.
+ */
+#define DL_AESADV_INTERRUPT_SAVED_OUTPUT_CONTEXT_READY                         \
+                                   (AESADV_CPU_INT_IMASK_SAVEDCNTXTRDY_SET)
+
+/*!
+ *  @brief AESADV Context Ready interrupt. Context bits can be overwritten.
+ */
+#define DL_AESADV_INTERRUPT_INPUT_CONTEXT_READY                                \
+                                        (AESADV_CPU_INT_IMASK_CNTXTRDY_SET)
+
+/** @}*/
+
+/** @addtogroup DL_AESADV_EVENT
+ *  @{
+ */
+
+/*!
+ *  @brief DMA Trigger Event used to request the DMA write to DATAIN
+ */
+#define DL_AESADV_EVENT_DMA_DATA_INPUT_TRIGGER                                 \
+                                           (AESADV_DMA_TRIG_DATAIN_IMASK_TRIG0_SET)
+
+/*!
+ *  @brief DMA Trigger Event used to request the DMA read from DATAOUT
+ */
+#define DL_AESADV_EVENT_DMA_DATA_OUTPUT_TRIGGER                                \
+                                           (AESADV_DMA_TRIG_DATAOUT_IMASK_TRIG1_SET)
+
+/** @}*/
+
+/*!
+ *  @brief AESADV Mode mask for all modes
+ */
+#define DL_AESADV_MODE_MASK                        ((AESADV_CTRL_CBC_MASK) | \
+                (AESADV_CTRL_CTR_MASK)     |      (AESADV_CTRL_ICM_MASK) | \
+                (AESADV_CTRL_CFB_MASK)     |   (AESADV_CTRL_CBCMAC_MASK) | \
+                (AESADV_CTRL_GCM_MASK)     |      (AESADV_CTRL_CCM_MASK) | \
+                (AESADV_CTRL_OFB_GCM_CCM_CONT_MASK) | 0x02000000)
+
+/* TODO: create define once XCBC-MAC MASK defined in IPXACT */
+
+/* clang-format on */
+
+/*! @enum DL_AESADV_IIDX */
+typedef enum {
+    /*! AESADV interrupt index for input context ready to be written */
+    DL_AESADV_IIDX_INPUT_CONTEXT_READY = AESADV_CPU_INT_IIDX_STAT_CNTXTRDY,
+    /*! AESADV interrupt index for saved output context (tag/IV) available */
+    DL_AESADV_IIDX_SAVED_OUTPUT_CONTEXT_READY =
+        AESADV_CPU_INT_IIDX_STAT_SAVEDCNTXTRDY,
+    /*! AESADV interrupt index indicating the engine can take more input.
+     *  Not compatible with @ref DL_AESADV_enableDMAOperation */
+    DL_AESADV_IIDX_INPUT_READY = AESADV_CPU_INT_IIDX_STAT_INPUTRDY,
+    /*! AESADV interrupt index indicating the engine has available output data.
+     *  Not compatible with @ref DL_AESADV_enableDMAOperation */
+    DL_AESADV_IIDX_OUTPUT_READY = AESADV_CPU_INT_IIDX_STAT_OUTPUTRDY,
+    /*! AES interrupt index for enabling DMA input request trigger event */
+    DL_AESADV_IIDX_DMA_INPUT_TRIGGER = AESADV_DMA_TRIG_DATAIN_IIDX_STAT_TRIG0,
+    /*! AES interrupt index for enabling DMA output request trigger event */
+    DL_AESADV_IIDX_DMA_OUTPUT_TRIGGER =
+        AESADV_DMA_TRIG_DATAOUT_IIDX_STAT_TRIG1,
+} DL_AESADV_IIDX;
+
+/*! @enum DL_AESADV_MODE */
+typedef enum {
+    /*! Electronic Codebook (ECB) mode */
+    DL_AESADV_MODE_ECB = 0x00,
+    /*! Cipher Block Chaining (CBC) mode */
+    DL_AESADV_MODE_CBC = (AESADV_CTRL_CBC_ENABLE),
+    /*! Counter (CTR) mode */
+    DL_AESADV_MODE_CTR = (AESADV_CTRL_CTR_ENABLE),
+    /*! Integer Counter Mode (ICM). ICM is a variant of CTR with a 16-bit wide
+     *  counter */
+    DL_AESADV_MODE_ICM = (AESADV_CTRL_ICM_ENABLE),
+    /*! Cipher Feedback (CFB) mode */
+    DL_AESADV_MODE_CFB = (AESADV_CTRL_CFB_ENABLE),
+    /*! Output Feedback (OFB) mode */
+    DL_AESADV_MODE_OFB = (AESADV_CTRL_OFB_GCM_CCM_CONT_OFB),
+    /*! Cipher-based message authentication code (CMAC). */
+    DL_AESADV_MODE_CMAC =
+        (0x02000000 |
+            AESADV_CTRL_CBC_ENABLE), /* TODO: add CMAC-define when given */
+    /*! Cipher block chaining message authentication code (CBC-MAC) mode */
+    DL_AESADV_MODE_CBCMAC = (AESADV_CTRL_CBCMAC_ENABLE),
+    /* TODO: Update GCM values once new defines in place */
+    /*! Galois/Counter Mode (GCM) with GHASH (GHASH_H loaded and Y0-encrypted
+     *  forced to 0) */
+    DL_AESADV_MODE_GCM_FORCE_ZERO =
+        (AESADV_CTRL_GCM_FORCE_ZERO) | (AESADV_CTRL_CTR_ENABLE),
+    /*! Galois/Counter Mode (GCM) with GHASH (H loaded Y0-encrypted
+     *  calculated internally) */
+    DL_AESADV_MODE_GCM_LOAD_HASH_KEY =
+        (AESADV_CTRL_GCM_LOAD_HASH_KEY) | (AESADV_CTRL_CTR_ENABLE),
+    /*! Galois/Counter Mode (GCM) with Autonomous GHASH (Both H and Y0-encrypted
+     *  calculated internally) */
+    DL_AESADV_MODE_GCM_AUTONOMOUS =
+        (AESADV_CTRL_GCM_AUTONOMOUS) | (AESADV_CTRL_CTR_ENABLE),
+    /*! Galois/Counter Mode GHASH only. Direction must be Decrypt */
+    DL_AESADV_MODE_GCM_GHASH_ONLY = (AESADV_CTRL_GCM_FORCE_ZERO),
+    /*! Cipher block chaining, message authentication code (CCM) mode */
+    DL_AESADV_MODE_CCM = (AESADV_CTRL_CCM_ENABLE) | (AESADV_CTRL_CTR_ENABLE),
+} DL_AESADV_MODE;
+
+/*! @enum DL_AESADV_KEY_SIZE */
+typedef enum {
+    /*! 128-bit Key Size */
+    DL_AESADV_KEY_SIZE_128_BIT = AESADV_CTRL_KEYSIZE_K128,
+    /*! 256-bit Key Size */
+    DL_AESADV_KEY_SIZE_256_BIT = AESADV_CTRL_KEYSIZE_K256,
+} DL_AESADV_KEY_SIZE;
+
+/*! @enum DL_AESADV_DIR */
+typedef enum {
+    /*! Encryption */
+    DL_AESADV_DIR_ENCRYPT = AESADV_CTRL_DIR_ENCRYPT,
+    /*! Decryption */
+    DL_AESADV_DIR_DECRYPT = AESADV_CTRL_DIR_DECRYPT,
+} DL_AESADV_DIR;
+
+/*! @enum DL_AESADV_CTR_WIDTH */
+typedef enum {
+    /*! Counter (CTR) mode 32-bit counter */
+    DL_AESADV_CTR_WIDTH_32_BIT = AESADV_CTRL_CTR_WIDTH_CTR32,
+    /*! Counter (CTR) mode 64-bit counter */
+    DL_AESADV_CTR_WIDTH_64_BIT = AESADV_CTRL_CTR_WIDTH_CTR64,
+    /*! Counter (CTR) mode 96-bit counter */
+    DL_AESADV_CTR_WIDTH_96_BIT = AESADV_CTRL_CTR_WIDTH_CTR96,
+    /*! Counter (CTR) mode 128-bit counter */
+    DL_AESADV_CTR_WIDTH_128_BIT = AESADV_CTRL_CTR_WIDTH_CTR128,
+} DL_AESADV_CTR_WIDTH;
+
+/*! @enum DL_AESADV_FB_WIDTH */
+typedef enum {
+    DL_AESADV_FB_WIDTH_128 = AESADV_CTRL_CTR_WIDTH_CFB128,
+} DL_AESADV_FB_WIDTH;
+
+/*! @enum DL_AESADV_CCM_CTR_WIDTH */
+typedef enum {
+    /*! Counter field width of 2 bytes (value of 1 stored in CCM-L) */
+    DL_AESADV_CCM_CTR_WIDTH_2_BYTES = ((uint32_t) 1U << AESADV_CTRL_CCML_OFS),
+    /*! Counter field width of 3 bytes (value of 2 stored in CCM-L) */
+    DL_AESADV_CCM_CTR_WIDTH_3_BYTES = ((uint32_t) 2 << AESADV_CTRL_CCML_OFS),
+    /*! Counter field width of 4 bytes (value of 3 stored in CCM-L) */
+    DL_AESADV_CCM_CTR_WIDTH_4_BYTES = ((uint32_t) 3 << AESADV_CTRL_CCML_OFS),
+    /*! Counter field width of 5 bytes (value of 4 stored in CCM-L) */
+    DL_AESADV_CCM_CTR_WIDTH_5_BYTES = ((uint32_t) 4 << AESADV_CTRL_CCML_OFS),
+    /*! Counter field width of 6 bytes (value of 5 stored in CCM-L) */
+    DL_AESADV_CCM_CTR_WIDTH_6_BYTES = ((uint32_t) 5 << AESADV_CTRL_CCML_OFS),
+    /*! Counter field width of 7 bytes (value of 6 stored in CCM-L) */
+    DL_AESADV_CCM_CTR_WIDTH_7_BYTES = ((uint32_t) 6 << AESADV_CTRL_CCML_OFS),
+    /*! Counter field width of 8 bytes (value of 7 stored in CCM-L) */
+    DL_AESADV_CCM_CTR_WIDTH_8_BYTES = ((uint32_t) 7 << AESADV_CTRL_CCML_OFS),
+} DL_AESADV_CCM_CTR_WIDTH;
+
+/*! @enum DL_AESADV_CCM_TAG_WIDTH */
+typedef enum {
+    /*! Authentication field width of 1 byte  (value of 0 stored in CCM-M) */
+    DL_AESADV_CCM_TAG_WIDTH_1_BYTE = ((uint32_t) 0 << AESADV_CTRL_CCMM_OFS),
+    /*! Authentication field width of 2 bytes (value of 1 stored in CCM-M) */
+    DL_AESADV_CCM_TAG_WIDTH_2_BYTES = ((uint32_t) 1 << AESADV_CTRL_CCMM_OFS),
+    /*! Authentication field width of 3 bytes (value of 2 stored in CCM-M) */
+    DL_AESADV_CCM_TAG_WIDTH_3_BYTES = ((uint32_t) 2 << AESADV_CTRL_CCMM_OFS),
+    /*! Authentication field width of 4 bytes (value of 3 stored in CCM-M) */
+    DL_AESADV_CCM_TAG_WIDTH_4_BYTES = ((uint32_t) 3 << AESADV_CTRL_CCMM_OFS),
+    /*! Authentication field width of 5 bytes (value of 4 stored in CCM-M) */
+    DL_AESADV_CCM_TAG_WIDTH_5_BYTES = ((uint32_t) 4 << AESADV_CTRL_CCMM_OFS),
+    /*! Authentication field width of 6 bytes (value of 5 stored in CCM-M) */
+    DL_AESADV_CCM_TAG_WIDTH_6_BYTES = ((uint32_t) 5 << AESADV_CTRL_CCMM_OFS),
+    /*! Authentication field width of 7 bytes (value of 6 stored in CCM-M) */
+    DL_AESADV_CCM_TAG_WIDTH_7_BYTES = ((uint32_t) 6 << AESADV_CTRL_CCMM_OFS),
+    /*! Authentication field width of 8 bytes (value of 7 stored in CCM-M) */
+    DL_AESADV_CCM_TAG_WIDTH_8_BYTES = ((uint32_t) 7 << AESADV_CTRL_CCMM_OFS),
+} DL_AESADV_CCM_TAG_WIDTH;
+
+/*! @enum DL_AESADV_STATUS */
+typedef enum {
+    /*! Operation was successful */
+    DL_AESADV_STATUS_SUCCESS,
+    /*! Operation was not performed because address was unaligned */
+    DL_AESADV_STATUS_UNALIGNED_ACCESS,
+} DL_AESADV_STATUS;
+
+/**
+ *  @brief Configuration structure for the AESADV module. It contains the
+ *         superset of configurable information for the control module.
+ */
+typedef struct {
+    /*! Mode field, one of @ref DL_AESADV_MODE */
+    DL_AESADV_MODE mode;
+    /*! Encrypt or decrypt, one of @ref DL_AESADV_DIR. Note that CBCMAC cannot
+     *  be configured with the decrypt direction */
+    DL_AESADV_DIR direction;
+    /*! Counter mode (CTR) counter width, one of @ref DL_AESADV_CTR_WIDTH. CTR
+     *  width is also used in combined operation modes CCM and GCM */
+    DL_AESADV_CTR_WIDTH ctr_ctrWidth;
+    /*! Cipher Feedback (CFB) feedback width, one of @ref DL_AESADV_FB_WIDTH */
+    DL_AESADV_FB_WIDTH cfb_fbWidth;
+    /*! CCM width of the counter length field for CCM operations, one of
+     *  @ref DL_AESADV_CCM_CTR_WIDTH. The ctr_width parameter must be equal to
+     *  or larger than this value */
+    DL_AESADV_CCM_CTR_WIDTH ccm_ctrWidth;
+    /*! CCM Width of the authentication field for CCM operations, one of
+     *  @ref DL_AESADV_CCM_TAG_WIDTH */
+    DL_AESADV_CCM_TAG_WIDTH ccm_tagWidth;
+    /*! Initialization Vector. Should be 32-bit aligned */
+    uint8_t *iv;
+    /*! Nonce in the case of CCM, this should point to the nonce. Refer to
+    *  @ref DL_AESADV_loadCCMNonceAndCounter in order to determine nonce length
+    *  used  */
+    uint8_t *nonce;
+    /*! Derived key K1, used in the authentication-only mode CMAC
+     *  Must be 32-bit aligned and equal to the block size (128-bits) */
+    uint8_t *k1;
+    /*! Derived key K2, used in the authentication-only mode CMAC
+     *  must be 32-bit aligned and equal to the block size (128-bits) */
+    uint8_t *k2;
+    /*! Crypto Data Length - 61-bit value expressed as an upper value and lower
+     *  value. This is the lower 32-bits */
+    uint32_t lowerCryptoLength;
+    /*! Crypto Data Length - 61-bit value expressed as an upper value and lower
+     *  value. This is the upper 29-bits */
+    uint32_t upperCryptoLength;
+    /*! Additional Authentication Data (AAD) Length. CCM/GCM specific */
+    uint32_t aadLength;
+} DL_AESADV_Config;
+
+/**
+ *  @brief Enables power on AESADV module
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_enablePower(AESADV_Regs *aesadv)
+{
+    aesadv->GPRCM.PWREN =
+        (AESADV_PWREN_KEY_UNLOCK_W | AESADV_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ *  @brief Disables power on AESADV module
+ *
+ *  @param[in] aesadv        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_disablePower(AESADV_Regs *aesadv)
+{
+    aesadv->GPRCM.PWREN =
+        (AESADV_PWREN_KEY_UNLOCK_W | AESADV_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ *  @brief Returns if power enabled on AESADV module
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @retval true   Power is enabled
+ *  @retval false  Power is disabled
+ */
+__STATIC_INLINE bool DL_AESADV_isPowerEnabled(AESADV_Regs *aesadv)
+{
+    return ((aesadv->GPRCM.PWREN & AESADV_PWREN_ENABLE_MASK) ==
+            AESADV_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ *  @brief Resets AESADV module
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_reset(AESADV_Regs *aesadv)
+{
+    aesadv->GPRCM.RSTCTL =
+        (AESADV_RSTCTL_KEY_UNLOCK_W | AESADV_RSTCTL_RESETSTKYCLR_CLR |
+            AESADV_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ *  @brief Returns if AESADV module was reset
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @retval true   Peripheral was reset
+ *  @retval false  Peripheral wasn't reset
+ */
+__STATIC_INLINE bool DL_AESADV_isReset(AESADV_Regs *aesadv)
+{
+    return ((aesadv->GPRCM.STAT & AESADV_STAT_RESETSTKY_MASK) ==
+            AESADV_STAT_RESETSTKY_RESET);
+}
+
+/**
+ *  @brief Returns if an AES output block is available to be read
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @retval true   AES output block is available
+ *  @retval false  No AES output block is available
+ */
+__STATIC_INLINE bool DL_AESADV_isOutputReady(AESADV_Regs *aesadv)
+{
+    return ((aesadv->CTRL & AESADV_CTRL_OUTPUT_RDY_MASK) ==
+            AESADV_CTRL_OUTPUT_RDY_READY);
+}
+
+/**
+ *  @brief Returns if the input buffer is empty, and more data can be written
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @retval true   Input buffer is empty
+ *  @retval false  Input buffer is not empty
+ */
+__STATIC_INLINE bool DL_AESADV_isInputReady(AESADV_Regs *aesadv)
+{
+    return ((aesadv->CTRL & AESADV_CTRL_INPUT_RDY_MASK) ==
+            AESADV_CTRL_INPUT_RDY_EMPTY);
+}
+
+/**
+ *  @brief Sets the direction of the engine (encrypt/decrypt)
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] direction    Direction. One of @ref DL_AESADV_DIR.
+ *
+ *  @note CBC-MAC must be configured as encrypt (@ref DL_AESADV_DIR_ENCRYPT).
+ */
+__STATIC_INLINE void DL_AESADV_setDirection(
+    AESADV_Regs *aesadv, DL_AESADV_DIR direction)
+{
+    DL_Common_updateReg(
+        &aesadv->CTRL, (uint32_t) direction, AESADV_CTRL_DIR_MASK);
+}
+
+/**
+ *  @brief Returns the direction of the AESADV peripheral (encrypt/decrypt)
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @return one of @ref DL_AESADV_DIR
+ */
+__STATIC_INLINE DL_AESADV_DIR DL_AESADV_getDirection(AESADV_Regs *aesadv)
+{
+    uint32_t direction = (aesadv->CTRL & AESADV_CTRL_DIR_MASK);
+
+    return (DL_AESADV_DIR)(direction);
+}
+
+/**
+ *  @brief Sets the key size of the AESADV peripheral
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] size         Key Size. One of @ref DL_AESADV_KEY_SIZE.
+ */
+__STATIC_INLINE void DL_AESADV_setKeySize(
+    AESADV_Regs *aesadv, DL_AESADV_KEY_SIZE size)
+{
+    DL_Common_updateReg(
+        &aesadv->CTRL, (uint32_t) size, AESADV_CTRL_KEYSIZE_MASK);
+}
+
+/**
+ *  @brief Returns the current key size of the AESADV peripheral
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @return one of @ref DL_AESADV_KEY_SIZE.
+ */
+__STATIC_INLINE DL_AESADV_KEY_SIZE DL_AESADV_getKeySize(AESADV_Regs *aesadv)
+{
+    uint32_t keySize = (aesadv->CTRL & AESADV_CTRL_KEYSIZE_MASK);
+
+    return (DL_AESADV_KEY_SIZE)(keySize);
+}
+
+/**
+ *  @brief Sets the AES algorithm mode
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] mode         Algorithm Mode. One of @ref DL_AESADV_MODE.
+ *
+ *  @note Selecting GCM as a mode requires an additional selection of the GHASH
+ *        parameters expected. Please refer to the TRM for more information.
+ *  @note Due to the dual use of the OFB/gcm_ccm_continue_aad bit field, if the
+ *        resumption of the AAD phase of a GCM/CCM operation is desired, it must
+ *        be set with the mode using @ref DL_AESADV_resumeAADPhase, for the bit
+ *        will be cleared in this function
+ *
+ *  @sa   DL_AESADV_resumeAADPhase
+ */
+__STATIC_INLINE void DL_AESADV_setMode(
+    AESADV_Regs *aesadv, DL_AESADV_MODE mode)
+{
+    DL_Common_updateReg(&aesadv->CTRL, (uint32_t) mode, DL_AESADV_MODE_MASK);
+}
+
+/**
+ *  @brief Returns the current selected mode
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @return one of @ref DL_AESADV_MODE.
+ *
+ *  @note upon resumption of a AAD phase of operation, the dual-purpose
+ *        bit of continue AAD/OFB will be read as one. In this case, the mode
+ *        must be set again for a valid value to be read.
+ *
+ *  @sa DL_AESADV_setMode
+ */
+__STATIC_INLINE DL_AESADV_MODE DL_AESADV_getMode(AESADV_Regs *aesadv)
+{
+    uint32_t mode = (aesadv->CTRL & DL_AESADV_MODE_MASK);
+    return (DL_AESADV_MODE)(mode);
+}
+
+/**
+ *  @brief Sets the feedback width of the AESADV peripheral
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] fbWidth      Feedback Width. One of @ref DL_AESADV_FB_WIDTH.
+ *
+ *  @note this is only applicable in cipher feeback mode (CFB). OFB always has
+ *        width 128.
+ */
+__STATIC_INLINE void DL_AESADV_setFeedbackWidth(
+    AESADV_Regs *aesadv, DL_AESADV_FB_WIDTH fbWidth)
+{
+    DL_Common_updateReg(
+        &aesadv->CTRL, (uint32_t) fbWidth, AESADV_CTRL_CTR_WIDTH_MASK);
+}
+
+/**
+ *  @brief Returns the current feedback width
+ *
+ *  @param[in] aesadv        Pointer to the register overlay for the peripheral
+ *
+ *  @return one of @ref DL_AESADV_FB_WIDTH.
+ *
+ *  @sa DL_AESADV_setFeedbackWidth
+ */
+__STATIC_INLINE DL_AESADV_FB_WIDTH DL_AESADV_getFeedbackWidth(
+    AESADV_Regs *aesadv)
+{
+    uint32_t fbWidth = (aesadv->CTRL & AESADV_CTRL_CTR_WIDTH_MASK);
+
+    return (DL_AESADV_FB_WIDTH)(fbWidth);
+}
+
+/**
+ *  @brief Sets the counter width of the AESADV peripheral
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] ctrWidth     Counter Width. One of @ref DL_AESADV_CTR_WIDTH.
+ *
+ *  @note this is only applicable in modes CTR, CCM
+ *  @note GCM restricts counter width to 32-bits, which is not required to be
+ *        set.
+ *  @note if using CCM, the counter width must be wide enough to accommodate the
+ *        chosen CCM length, one of @ref DL_AESADV_CCM_CTR_WIDTH (in bytes)
+ *
+ *  @sa DL_AESADV_setCCMCounterWidth
+ */
+__STATIC_INLINE void DL_AESADV_setCounterWidth(
+    AESADV_Regs *aesadv, DL_AESADV_CTR_WIDTH ctrWidth)
+{
+    DL_Common_updateReg(
+        &aesadv->CTRL, (uint32_t) ctrWidth, AESADV_CTRL_CTR_WIDTH_MASK);
+}
+
+/**
+ *  @brief Returns the current counter width
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @return one of @ref DL_AESADV_CTR_WIDTH.
+ *
+ *  @sa DL_AESADV_setCounterWidth
+ */
+__STATIC_INLINE DL_AESADV_CTR_WIDTH DL_AESADV_getCounterWidth(
+    AESADV_Regs *aesadv)
+{
+    uint32_t ctrWidth = (aesadv->CTRL & AESADV_CTRL_CTR_WIDTH_MASK);
+
+    return (DL_AESADV_CTR_WIDTH)(ctrWidth);
+}
+
+/**
+ *  @brief Sets the CCM counter width of the AESADV peripheral
+ *
+ *  Counter with CBC-MAC (CCM) Specific. Sets the width of the counter field
+ *  that is loaded into the initialization vector along with the nonce. This
+ *  signal is sometimes referred to as CCM-L. The nonce can be calculated via
+ *  the following table:
+ *
+ *  DL_AESADV_CCM_CTR_WIDTH (bytes) | Nonce Array Length Required (bytes)
+ *  --------------------------------|-------------------------------------
+ *              2                   |                13
+ *              3                   |                12
+ *              4                   |                11
+ *              5                   |                10
+ *              6                   |                 9
+ *              7                   |                 8
+ *              8                   |                 7
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] ccm_ctrWidth Counter Width. One of @ref DL_AESADV_CCM_CTR_WIDTH
+ *
+ *  @note this is only applicable in modes CCM
+ *  @note The general counter width must be wide enough to accommodate the
+ *        chosen CCM counter width, one of @ref DL_AESADV_CTR_WIDTH (in bits). A
+ *        counter width of 64-bits is sufficient to cover all cases.
+ *
+ *  @sa DL_AESADV_setCounterWidth
+ *  @sa DL_AESADV_loadCCMNonceAndCounter
+ */
+__STATIC_INLINE void DL_AESADV_setCCMCounterWidth(
+    AESADV_Regs *aesadv, DL_AESADV_CCM_CTR_WIDTH ccm_ctrWidth)
+{
+    DL_Common_updateReg(
+        &aesadv->CTRL, (uint32_t) ccm_ctrWidth, AESADV_CTRL_CCML_MASK);
+}
+
+/**
+ *  @brief Returns the current CCM-specific counter width
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @return one of @ref DL_AESADV_CCM_CTR_WIDTH.
+ *
+ *  @sa DL_AESADV_setCCMCounterWidth
+ */
+__STATIC_INLINE DL_AESADV_CCM_CTR_WIDTH DL_AESADV_getCCMCounterWidth(
+    AESADV_Regs *aesadv)
+{
+    uint32_t ccm_ctrWidth = (aesadv->CTRL & AESADV_CTRL_CCML_MASK);
+
+    return (DL_AESADV_CCM_CTR_WIDTH)(ccm_ctrWidth);
+}
+
+/**
+ *  @brief Sets the CCM authentication tag width of the AESADV peripheral
+ *
+ *  Counter with CBC-MAC (CCM) Specific. Sets the width of the authentication
+ *  field that is retrieved upon completion of the operation. The first bytes
+ *  of the calculated tag will be returned, and the rest of the tag ignored.
+ *  This signal is sometimes referred to as CCM-M.
+ *      The full-width tag will still be calculated, just the least-significant
+ *  bits will be used as according to this setting.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] ccm_tagWidth Tag Width. One of @ref DL_AESADV_CCM_TAG_WIDTH.
+ */
+__STATIC_INLINE void DL_AESADV_setCCMTagWidth(
+    AESADV_Regs *aesadv, DL_AESADV_CCM_TAG_WIDTH ccm_tagWidth)
+{
+    DL_Common_updateReg(
+        &aesadv->CTRL, (uint32_t) ccm_tagWidth, AESADV_CTRL_CCMM_MASK);
+}
+
+/**
+ *  @brief Returns the current CCM-specific authentication tag width
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @return one of @ref DL_AESADV_CCM_TAG_WIDTH.
+ *
+ *  @sa DL_AESADV_setCCMTagWidth
+ */
+__STATIC_INLINE DL_AESADV_CCM_TAG_WIDTH DL_AESADV_getCCMTagWidth(
+    AESADV_Regs *aesadv)
+{
+    uint32_t ccm_tagWidth = (aesadv->CTRL & AESADV_CTRL_CCMM_MASK);
+
+    return (DL_AESADV_CCM_TAG_WIDTH)(ccm_tagWidth);
+}
+
+/**
+ *  @brief  Halt operation and generate intermediate Digest for CCM/GCM
+ *
+ *  Specific to a multi-block CCM/GCM mode. This will interrupt processing at
+ *  the boundary of a full AES block (128-bits or 16 bytes) and prepare an
+ *  intermediate digest that can be used to resume operations.
+ *      If the user is still inputting additional authentication data (AAD), the
+ *  operation shall be resumed in the AAD phase. If the user is inputting
+ *  payload data (ciphertext/plaintext), the operation shall be resumed in the
+ *  data phase.
+ *      The user is responsible for reading and saving the intermediate digest
+ *  to preserve the state for a future resumption of the Operation.
+ *      The user must have at least 1 or more bytes of additional information
+ *  that needs to be inputted in order for a halt to occur.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_haltOperationAndGenerateDigest(
+    AESADV_Regs *aesadv)
+{
+    aesadv->CTRL |= AESADV_CTRL_GET_DIGEST_ENABLE;
+}
+
+/**
+ *  @brief Resume GCM or CCM operation in the AAD phase
+ *
+ *  Specific to a multi-block CCM/GCM mode that contains Additional
+ *  Authentication Data to be written after an operation has been halted. This
+ *  operation should be performed last, after the entire digest for the example
+ *  has been added. The mode is written in conjunction with the resumption
+ *  signal, so it must be provided.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] mode         A supported GCM or CCM mode from @ref DL_AESADV_MODE
+ *
+ *  @sa DL_AESADV_haltOperationAndReturnDigest
+ *  @sa DL_AESADV_resumeDataPhase
+ */
+__STATIC_INLINE void DL_AESADV_resumeAADPhase(
+    AESADV_Regs *aesadv, DL_AESADV_MODE mode)
+{
+    DL_Common_updateReg(&aesadv->CTRL,
+        (((uint32_t) mode) |
+            ((uint32_t) AESADV_CTRL_OFB_GCM_CCM_CONT_GCM_CCM_CONTINUE)),
+        (DL_AESADV_MODE_MASK | AESADV_CTRL_OFB_GCM_CCM_CONT_MASK));
+}
+
+/**
+ *  @brief Resume GCM or CCM operation in the Data phase
+ *
+ *  Specific to a multi-block CCM/GCM mode that contains additional Payload Data
+ *  (ciphertext/plaintext) to be written after an operation has been halted, and
+ *  any and all AAD has already been written before the time of halting. This
+ *  operation should be performed last, after the entire digest for the example
+ *  has been added. The mode is written in conjunction with the resumption
+ *  signal, so it must be provided.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] mode         A supported GCM or CCM mode from @ref DL_AESADV_MODE
+ *
+ *  @sa DL_AESADV_haltOperationAndReturnDigest
+ *  @sa DL_AESADV_resumeAADPhase
+ */
+__STATIC_INLINE void DL_AESADV_resumeDataPhase(
+    AESADV_Regs *aesadv, DL_AESADV_MODE mode)
+{
+    DL_Common_updateReg(&aesadv->CTRL,
+        ((uint32_t) mode | AESADV_CTRL_GCM_CONT_ENABLE),
+        ((uint32_t) DL_AESADV_MODE_MASK | AESADV_CTRL_GCM_CONT_MASK));
+}
+
+/**
+ *  @brief Enables the storage and return of a tag or result IV
+ *
+ *  Set if a given configuration must require an authentication TAG or result IV
+ *  to be stored as part of the result context. This will trigger the context
+ *  output DMA or interrupt assertion after operation completion. Additionally,
+ *  the saved context ready will now be set high. Th engine will retain the
+ *  registers until they have been read. Only after an associated TAG/IV has
+ *  been read will a new DMA request for an input context be sent.
+ *      Typically, this is set when methods return a TAG (GCM, CCM, CBCMAC) or
+ *  in case an IV is to be returned for a future continued operation (CBC, CTR,
+ *  etc.).
+ *      If not set, the engine will assert a DMA request with the current
+ *  context.
+ *
+ * @param[in] aesadv       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_enableSavedOutputContext(AESADV_Regs *aesadv)
+{
+    aesadv->CTRL |= AESADV_CTRL_SAVE_CNTXT_ENABLE;
+}
+
+/**
+ *  @brief Disables the storage and return of a tag or result IV
+ *
+ *  Set if a given configuration must require an authentication TAG or result IV
+ *  to be stored as part of the result context. This will trigger the context
+ *  output DMA or interrupt assertion after operation completion. Additionally,
+ *  the saved context ready will now be set high. Th engine will retain the
+ *  registers until they have been read.
+ *      Typically, this is set when methods return a TAG (GCM, CCM, CBCMAC) or
+ *  in case an IV is to be returned for a future continued operation (CBC, CTR,
+ *  etc.).
+ *      If not set, the engine will assert a DMA request with the current
+ *  context.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_disableSavedOutputContext(AESADV_Regs *aesadv)
+{
+    aesadv->CTRL &= ~(AESADV_CTRL_SAVE_CNTXT_ENABLE);
+}
+
+/**
+ *  @brief Returns whether the storage of additional context is enabled
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @retval true   Saved Output Context is enabled.
+ *  @retval false  Saved Output Context is disabled.
+ *
+ *  @sa DL_AESADV_enableSavedOutputContext
+ */
+__STATIC_INLINE bool DL_AESADV_isSavedOutputContextEnabled(AESADV_Regs *aesadv)
+{
+    return ((aesadv->CTRL & AESADV_CTRL_SAVE_CNTXT_MASK) ==
+            AESADV_CTRL_SAVE_CNTXT_ENABLE);
+}
+
+/**
+ *  @brief Returns whether additional output context is available to be read
+ *
+ *  At the end of an operation, if additional result information to the
+ *  ciphertext/plaintext is available such as TAG/IV(s), this will return true.
+ *  If this value is high, then the context cannot be written.
+ *
+ *  @param[in] aesadv        Pointer to the register overlay for the peripheral
+ *
+ *  @retval true   Saved Output Context is ready to be retrieved.
+ *  @retval false  Saved Output Context is unavailable.
+ *
+ *  @sa DL_AESADV_enableSavedOutputContext
+ */
+__STATIC_INLINE bool DL_AESADV_isSavedOutputContextReady(AESADV_Regs *aesadv)
+{
+    return ((aesadv->CTRL & AESADV_CTRL_SAVED_CNTXT_RDY_MASK) ==
+            AESADV_CTRL_SAVED_CNTXT_RDY_READY);
+}
+
+/**
+ *  @brief Returns whether the input context can be written by the application.
+ *
+ *  Determines if the context (mode, IV, key, etc.) can be modified from its
+ *  current state in the application by reading the CNTXT_RDY bit. This does not
+ *  mean that a previous operation has necessarily finished, just that a new
+ *  context may be written. Writing a new context before completion of the
+ *  current context will cancel the current operation.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @retval true   Context can be safely written to by the application
+ *  @retval false  Context cannot be written, AES Authentication TAGs or IV's
+ *                 are available and must be read before context can be
+ *                 interrupted
+ */
+__STATIC_INLINE bool DL_AESADV_isInputContextWriteable(AESADV_Regs *aesadv)
+{
+    return ((aesadv->CTRL & AESADV_CTRL_CNTXT_RDY_MASK) ==
+            AESADV_CTRL_CNTXT_RDY_READY);
+}
+
+/**
+ *  @brief Sets the lower 32 bits of the crypto input data length in bytes
+ *
+ *  The entire length of crypto input data that can be provided is 61-bits long,
+ *  and is thus set in two separate functions. The lower 32-bits will be set and
+ *  decremented as the operation continues.
+ *      Setting the crypto length to 0 for basic modes (CBC, CTR, ICM, CFB, OFB)
+ *  will configure the AESADV module to expect an infinite input stream for the
+ *  device.
+ *      For GCM and CCM, this mode does not include Additional Authentication
+ *  Data, this is set separately. If there is a positive AAD length, it is not
+ *  required for this register to have a nonzero value.
+ *      Reads from this register return all zeros, so reads are not necessary.
+ *      For modes that do not allow partial blocks such as CBC, this number must
+ *   be a multiple of 16.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] lowerLength  Lower 32-bits of crypto data length that will be
+ *                          inputted
+ *
+ *  @note This sets the context for the register, and thus should be called last
+ *        in the configuration for non-combined modes
+ *
+ *  @sa DL_AESADV_setUpperCryptoLength
+ *  @sa DL_AESADV_setAADLength
+ */
+__STATIC_INLINE void DL_AESADV_setLowerCryptoLength(
+    AESADV_Regs *aesadv, uint32_t lowerLength)
+{
+    aesadv->C_LENGTH_0 = lowerLength;
+}
+
+/**
+ *  @brief Sets the upper 29 bits of the crypto input data length in bytes
+ *
+ *  The entire length of crypto input data that can be provided is 61-bits long,
+ *  and is thus set in two separate functions. The upper 29-bits will be set in
+ *  this function should a length larger than or equal to 2^32 be necessary.
+ *  Bits 29-31 are to be zeroed out upon a write.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] upperLength  Upper 29 bits of the crypto data length in bytes
+ *                          that will be inputted
+ *
+ *  @note This sets the context for the register in combined modes (GCM/CCM),
+ *        and thus should be called last in the configuration
+ *
+ *  @sa DL_AESADV_setLowerCryptoLength
+ */
+__STATIC_INLINE void DL_AESADV_setUpperCryptoLength(
+    AESADV_Regs *aesadv, uint32_t upperLength)
+{
+    aesadv->C_LENGTH_1 = upperLength & 0x1FFFFFFFU;
+}
+
+/**
+ *  @brief Sets the length of additional authentication data (AAD)
+ *
+ *  Specific to CCM/GCM modes. Sets length of AAD for these modes and 0
+ *  otherwise. Can be zero if no AAD, or can be nonzero with a zero crypto
+ *  length for authentication-only operation. A write to this register triggers
+ *  the engine to start the context, and should be written after Crypto Length.
+ *      For GCM this can be any value < 2^32, for CCM this value must be less
+ *  than 2^16 - 2^8.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] aadLength    length of AAD in bytes.
+ *
+ *  @sa DL_AESADV_setLowerLength
+ */
+__STATIC_INLINE void DL_AESADV_setAADLength(
+    AESADV_Regs *aesadv, uint32_t aadLength)
+{
+    aesadv->AAD_LENGTH = aadLength;
+}
+
+/**
+ *  @brief Enables DMA Operation for the AESADV module
+ *
+ *  Sets the AESADV module to run with Data Inputs using the DMA to read/write
+ *  data rather than using register input/output
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @sa DL_AESADV_disableDMAOperation
+ */
+__STATIC_INLINE void DL_AESADV_enableDMAOperation(AESADV_Regs *aesadv)
+{
+    aesadv->DMA_HS = (AESADV_DMA_HS_DMA_DATA_ACK_DMA_ENABLE);
+}
+
+/**
+ *  @brief Disables DMA Operation for the AESADV module
+ *
+ *  Default behavior. Sets the AESADV module to run using register input output
+ *  with data provided by the CPU rather than using the DMA
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_disableDMAOperation(AESADV_Regs *aesadv)
+{
+    aesadv->DMA_HS = (AESADV_DMA_HS_DMA_DATA_ACK_DMA_DISABLE);
+}
+
+/**
+ *  @brief Returns if DMA Operation is enabled
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @retval true   Configured to read/write data using the DMA
+ *  @retval false  Configured to read/write data using the CPU (Default)
+ */
+__STATIC_INLINE bool DL_AESADV_isDMAOperationEnabled(AESADV_Regs *aesadv)
+{
+    return ((aesadv->DMA_HS & AESADV_DMA_HS_DMA_DATA_ACK_MASK) ==
+            AESADV_DMA_HS_DMA_DATA_ACK_DMA_ENABLE);
+}
+
+/**
+ *  @brief Returns if User Writes to the Key Registers on the AESADV are allowed
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @retval true   User Writes to the Key Registers are allowed
+ *  @retval false  The user cannot write to the Key Registers
+ *
+ *  @note If user key writes are disabled but desired, a module reset is
+ *        required
+ */
+__STATIC_INLINE bool DL_AESADV_isUserKeyWriteEnabled(AESADV_Regs *aesadv)
+{
+    return ((aesadv->STATUS & AESADV_STATUS_KEYWR_MASK) ==
+            AESADV_STATUS_KEYWR_ENABLED);
+}
+
+/**
+ *  @brief Loads a 128 or 256 bit regular key to the AESADV module
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] key          Pointer to an uint8_t array with a length that
+ *                          contains the cipher key
+ *  @param[in] keySize      Key Size. One of @ref DL_AESADV_KEY_SIZE
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AESADV_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AESADV_setKeyAligned
+ */
+DL_AESADV_STATUS DL_AESADV_setKey(
+    AESADV_Regs *aesadv, const uint8_t *key, DL_AESADV_KEY_SIZE keySize);
+
+/**
+ *  @brief Loads a 128 or 256 bit regular key to the AESADV module
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] keyAligned   Pointer to an uint32_t array with a length that
+ *                          contains the cipher key
+ *  @param[in] keySize      Key Size. One of @ref DL_AESADV_KEY_SIZE
+ *
+ *  @sa DL_AESADV_setKey
+ */
+void DL_AESADV_setKeyAligned(AESADV_Regs *aesadv, const uint32_t *keyAligned,
+    DL_AESADV_KEY_SIZE keySize);
+
+/**
+ *  @brief set the hash key
+ *
+ *  GCM-Specific. Sets the GHASH Hash key (sometimes referred to as H) if in
+ *  a GCM mode other than DL_AESADV_MODE_GCM_AUTONOMOUS.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] hashKey      Pointer to an uint8_t array of length 16 that
+ *                          contains the hash key
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AESADV_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AESADV_setGCMHashKeyAligned
+ */
+DL_AESADV_STATUS DL_AESADV_setGCMHashKey(
+    AESADV_Regs *aesadv, const uint8_t *hashKey);
+
+/**
+ *  @brief set the hash key
+ *
+ *  GCM-Specific. Sets the GHASH Hash key (sometimes referred to as H) if in
+ *  a GCM mode other than DL_AESADV_MODE_GCM_AUTONOMOUS.
+ *
+ *  @param[in] aesadv         Pointer to the register overlay for the peripheral
+ *  @param[in] hashKeyAligned Pointer to an uint32_t array of length 4 that
+ *                            contains the hash key
+ *
+ *  @sa DL_AESADV_setGCMHashKey
+ *
+ */
+void DL_AESADV_setGCMHashKeyAligned(
+    AESADV_Regs *aesadv, const uint32_t *hashKeyAligned);
+
+/**
+ *  @brief Loads the CBC-MAC second key
+ *
+ *  Specific to CBC-MAC operation.  Pre-calculated second key to perform a
+ *  final XOR operation on the last input data block.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] secondKey    Pointer to an uint8_t array of length 16 containing
+ *                          the second key
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AESADV_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AESADV_setSecondKeyAligned
+ */
+DL_AESADV_STATUS DL_AESADV_setSecondKey(
+    AESADV_Regs *aesadv, const uint8_t *secondKey);
+
+/**
+ *  @brief Loads the CBC-MAC second key
+ *
+ *  Specific to CBC-MAC operation.  Pre-calculated second key to perform a
+ *  final XOR operation on the last input data block.
+ *
+ *  @param[in] aesadv            Pointer to the register overlay for the
+ *                               peripheral
+ *  @param[in] secondKeyAligned  Pointer to an uint32_t array of length 4
+ *                               containing the second key
+ *
+ *  @sa DL_AESADV_setSecondKey
+ */
+void DL_AESADV_setSecondKeyAligned(
+    AESADV_Regs *aesadv, const uint32_t *secondKeyAligned);
+
+/**
+ *  @brief Loads the CBC-MAC third key
+ *
+ *  Specific to CBC-MAC operation. Pre-calculated third key to perform a
+ *  final XOR operation on the last input data block.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] thirdKey     Pointer to an uint8_t array of length 16 containing
+ *                          the third key
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AESADV_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AESADV_setThirdKeyAligned
+ */
+DL_AESADV_STATUS DL_AESADV_setThirdKey(
+    AESADV_Regs *aesadv, const uint8_t *thirdKey);
+
+/**
+ *  @brief Loads the CBC-MAC third key
+ *
+ *  Specific to CBC-MAC operation. Pre-calculated third key to perform a
+ *  final XOR operation on the last input data block.
+ *
+ *  @param[in] aesadv           Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in] thirdKeyAligned  Pointer to an uint32_t array of length 4
+ *                              containing the third key
+ *
+ *  @sa DL_AESADV_setThirdKey
+ */
+void DL_AESADV_setThirdKeyAligned(
+    AESADV_Regs *aesadv, const uint32_t *thirdKeyAligned);
+
+/**
+ *  @brief Loads either zero or an intermediate 128-bit TAG to resume GCM/CCM.
+ *
+ *  Specific to the GCM/CCM modes. During initialization and beginning of a new
+ *  combined operation mode (GCM or CCM only), this must be set to 0. However,
+ *  during continuation this tag is part of the saved intermediate digest that
+ *  must be restored.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] tag          Pointer to an uint8_t array of length 16 containing
+ *                          zeroes or the intermediate digest
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AESADV_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AESADV_loadIntermediateTAGAligned
+ */
+DL_AESADV_STATUS DL_AESADV_loadIntermediateTAG(
+    AESADV_Regs *aesadv, const uint8_t *tag);
+
+/**
+ *  @brief Loads either zero or an intermediate 128-bit TAG to resume GCM/CCM.
+ *
+ *  Specific to the GCM/CCM modes. During initialization and beginning of a new
+ *  combined operation mode (GCM or CCM only), this must be set to 0. However,
+ *  during continuation this tag is part of the saved intermediate digest that
+ *  must be restored.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] tagAligned   Pointer to an uint32_t array of length 4 containing
+ *                          zeroes or the intermediate digest
+ *
+ *  @sa DL_AESADV_loadIntermediateTAG
+ */
+void DL_AESADV_loadIntermediateTAGAligned(
+    AESADV_Regs *aesadv, const uint32_t *tagAligned);
+
+/**
+ *  @brief Loads the 128-bit initialization vector to the AESADV module.
+ *
+ *  When used with GCM, the upper word iv[127:96] needs to be written with
+ *  0x01000000 in order to appropriately mark the initial counter value of 1.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] iv           Pointer to an uint8_t array of length 16 containing
+ *                          the initialization vector
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AESADV_STATUS.
+ *
+ *  @note  For CCM, this iv must be written with the CCM-specific value A0. This
+ *         value consists of the concatenation of A0 flags, the nonce, and the
+ *         counter. There is a specialized function that can load this type of
+ *         IV found at @ref DL_AESADV_loadCCMNonceAndCounter.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AESADV_loadInitializationVectorAligned
+ *
+ *  @sa DL_AESADV_loadCCMNonceAndCounter
+ */
+DL_AESADV_STATUS DL_AESADV_loadInitializationVector(
+    AESADV_Regs *aesadv, uint8_t *iv);
+
+/**
+ *  @brief Loads the 128-bit initialization vector to the AESADV module.
+ *
+ *  When used with GCM, the upper word iv[127:96] needs to be written with
+ *  0x01000000 in order to appropriately mark the initial counter value of 1.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] ivAligned    Pointer to an uint32_t array of length 4 containing
+ *                          the initialization vector
+ *
+ *  @note  For CCM, this iv must be written with the CCM-specific value A0. This
+ *         value consists of the concatenation of A0 flags, the nonce, and the
+ *         counter. There is a specialized function that can load this type of
+ *         IV found at @ref DL_AESADV_loadCCMNonceAndCounter.
+ *
+ *  @sa DL_AESADV_loadCCMNonceAndCounter
+ *  @sa DL_AESADV_loadInitializationVector
+ */
+void DL_AESADV_loadInitializationVectorAligned(
+    AESADV_Regs *aesadv, uint32_t *ivAligned);
+
+/**
+ *  @brief Reads the 128-bit initialization vector from the AES Module
+ *
+ *  Contains the latest 128-bit initialization vector output from the engine.
+ *
+ *  @param[in] aesadv        Pointer to the register overlay for the
+ *                           peripheral
+ *
+ *  @param[out] iv           Pointer to an uint8_t array of length 16 where the
+ *                           iv will be written
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AESADV_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AESADV_readInitializationVectorAligned
+ */
+DL_AESADV_STATUS DL_AESADV_readInitializationVector(
+    AESADV_Regs *aesadv, uint8_t *iv);
+
+/**
+ *  @brief Reads the 128-bit initialization vector from the AES Module
+ *
+ *  Contains the latest 128-bit initialization vector output from the engine.
+ *
+ *  @param[in] aesadv        Pointer to the register overlay for the
+ *                           peripheral
+ *
+ *  @param[out] ivAligned    Pointer to an uint32_t array of length 4 where the
+ *                           iv will be written
+ *
+ *  @sa DL_AESADV_readInitializationVector
+ */
+void DL_AESADV_readInitializationVectorAligned(
+    AESADV_Regs *aesadv, uint32_t *ivAligned);
+
+/**
+ *  @brief Loads the CCM Nonce And Counter IV, also called A0
+ *
+ *  CCM-Specific use of the IV field called A0. The A0 field is formatted
+ *  as follows:
+ *
+ *  LSB                                                                   MSB
+ *  (5'b00000 concat 3'b counterWidth - 1) | Nonce | Counter IV (always 0's)
+ *
+ *  the counter width is set as one of DL_AESADV_CCM_CTR_WIDTH (equal to
+ *  counterWidth -1).
+ *      For example, a 5-byte width for the counter (and thus the data payload
+ *  width) will correspond to a Counter IV of 40-bits. The counter width taking
+ *  8 bits, and the Nonce taking the remaining 80-bits (10 bytes).
+ *      An 8-byte counter width would yield a counter IV width of 64-bits with a
+ *  Nonce taking the remaining 54-bits (7 bytes). The LSB of the IV will then
+ *  be 8'b00000111 or 0x07 (one less than the byte width)
+ *      Thus, the Nonce should be sufficiently wide to fit the bits that are
+ *  remaining for the nonce, and this will vary with the counter field width
+ *  provided. The LSB of the IV will be 0x04 (one less than the byte width)
+ *
+ *  The following table describes the Nonce array lengths that should be used:
+ *
+ *  DL_AESADV_CCM_CTR_WIDTH (bytes) | Nonce Array Length Required (bytes)
+ *  --------------------------------|-------------------------------------
+ *              2                   |                13
+ *              3                   |                12
+ *              4                   |                11
+ *              5                   |                10
+ *              6                   |                 9
+ *              7                   |                 8
+ *              8                   |                 7
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] nonce        Pointer to the uint8_t nonce Value for CCM, should
+ *                          be unique and length calculated as above.
+ *  @param[in] ctrWidth     Counter Width. One of @ref DL_AESADV_CCM_CTR_WIDTH.
+ *                          Should match width provided in control register.
+ *
+ *  @note During halting and resumption of CCM operations, it is required to use
+ *        the @ref DL_AESADV_loadInitializationVector and
+ *        @ref DL_AESADV_readInitializationVector functions as this preserves
+ *        the current counter state. This function is designed for
+ *        initialization of the operation only.
+ *
+ *  @sa DL_AESADV_loadInitializationVector
+ *  @sa DL_AESADV_readInitializationVector
+ */
+void DL_AESADV_loadCCMNonceAndCounter(
+    AESADV_Regs *aesadv, uint8_t *nonce, DL_AESADV_CCM_CTR_WIDTH ctrWidth);
+
+/**
+ *  @brief loads 128 bits (4 words) of input data
+ *
+ *  Loads the next 128 bits of input data. Either AAD (GCM/CCM) or Crypto Data.
+ *  If less than 128 bits are left (or if the width of data is less than 128
+ *  bits ex. CCM), it is still necessary to pad 0's to the remaining bits in
+ *  order for the engine to start the operation.
+ *      For GCM/CCM, the last AAD block can have less than 128 bits, and
+ *  should be padded with 0's rather than appended to the crypto data.
+ *      For authentication modes (GCM, CCM, CBC-MAC), refer to the TRM for
+ *  additional information about necessary padding.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] data         Pointer to uint8_t bit data array of length 16 to
+ *                          be inputted.
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AESADV_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AESADV_loadInputDataAligned
+ *
+ *  @sa DL_AESADV_readOutputData
+ */
+DL_AESADV_STATUS DL_AESADV_loadInputData(AESADV_Regs *aesadv, uint8_t *data);
+
+/**
+ *  @brief loads 128 bits (4 words) of input data
+ *
+ *  Loads the next 128 bits of input data. Either AAD (GCM/CCM) or Crypto Data.
+ *  If less than 128 bits are left (or if the width of data is less than 128
+ *  bits ex. CCM), it is still necessary to pad 0's to the remaining bits in
+ *  order for the engine to start the operation.
+ *      For GCM/CCM, the last AAD block can have less than 128 bits, and
+ *  should be padded with 0's rather than appended to the crypto data.
+ *      For authentication modes (GCM, CCM, CBC-MAC), refer to the TRM for
+ *  additional information about necessary padding.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] dataAligned  Pointer to uint32_t bit data array of length 4 to
+ *                          be inputted.
+ *
+ *  @sa DL_AESADV_loadInputData
+ *  @sa DL_AESADV_readOutputDataAligned
+ */
+void DL_AESADV_loadInputDataAligned(
+    AESADV_Regs *aesadv, uint32_t *dataAligned);
+
+/**
+ *  @brief reads 128-bits of output data that has been encrypted/decrypted.
+ *
+ *  Reads the ciphertext/plaintext outputted by the AESADV module. If less than
+ *  128 bits is expected, there still must be 128-bits read, which must mean
+ *  the data pointer has at least 128 bits to spare.
+ *
+ *  Inputting Additional Authentication Data (AAD) will not place any
+ *  information into the output buffer, thus a read is not required.
+ *
+ *  @param[in] aesadv        Pointer to the register overlay for the peripheral
+ *  @param[out] data         Pointer to the data that will be read, uint8_t
+ *                           requiring length of at least 16 to not overwrite
+ *                           other variables.
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AESADV_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AESADV_readOutputDataAligned
+ */
+DL_AESADV_STATUS DL_AESADV_readOutputData(AESADV_Regs *aesadv, uint8_t *data);
+
+/**
+ *  @brief reads 128-bits of output data that has been encrypted/decrypted.
+ *
+ *  Reads the ciphertext/plaintext outputted by the AESADV module. If less than
+ *  128 bits is expected, there still must be 128-bits read, which must mean
+ *  the data pointer has at least 128 bits to spare.
+ *
+ *  Inputting Additional Authentication Data (AAD) will not place any
+ *  information into the output buffer, thus a read is not required.
+ *
+ *  @param[in] aesadv        Pointer to the register overlay for the peripheral
+ *  @param[out] dataAligned  Pointer to the data that will be read, uint32_t
+ *                           requiring length of at least 4 to not overwrite
+ *                           other variables.
+ *
+ *  @sa DL_AESADV_readOutputData
+ */
+void DL_AESADV_readOutputDataAligned(
+    AESADV_Regs *aesadv, uint32_t *dataAligned);
+
+/**
+ *  @brief reads 128-bit output tag at the conclusion of operation/halt
+ *
+ *  Specific to authentication-enabled modes. Reads the tag. Only valid at the
+ *  conclusion of an operation, or because an operation has been halted and
+ *  requires a digest. In the case of a halted operation, the output will be
+ *  an intermediate tag for CCM or GCM.
+ *
+ *  @param[in] aesadv        Pointer to the register overlay for the peripheral
+ *  @param[out] tag          Pointer to the tag to be read, a uint8_t array of
+ *                           length 16
+ *
+ *  @return Status of operation. Operation will fail if not 32-bit aligned. One
+ *          of @ref DL_AESADV_STATUS.
+ *
+ *  @note This function adds additional cycles in order to verify no unaligned
+ *        access, if this is not necessary, consider using uint32_t pointers and
+ *        @ref DL_AESADV_readTAGAligned
+
+ *  @sa DL_AESADV_isSavedOutputContextReady
+ */
+DL_AESADV_STATUS DL_AESADV_readTAG(AESADV_Regs *aesadv, uint8_t *tag);
+
+/**
+ *  @brief reads 128-bit output tag at the conclusion of operation/halt
+ *
+ *  Specific to authentication-enabled modes. Reads the tag. Only valid at the
+ *  conclusion of an operation, or because an operation has been halted and
+ *  requires a digest. In the case of a halted operation, the output will be
+ *  an intermediate tag for CCM or GCM.
+ *
+ *  @param[in] aesadv        Pointer to the register overlay for the peripheral
+ *  @param[out] tagAligned   Pointer to the tag to be read, a uint32_t array of
+ *                           length 4
+ *
+ *  @sa DL_AESADV_isSavedOutputContextReady
+ */
+void DL_AESADV_readTAGAligned(AESADV_Regs *aesadv, uint32_t *tagAligned);
+
+/**
+ *  @brief Forces AESADV to begin processing input data.
+ *
+ *  This function will validate the input data buffer and force AESADV to begin
+ *  processing data. Any value can be used in order to force processing data.
+ *
+ *  @note To use, @ref DL_AESADV_enableDMAOperation must not be in use
+ *
+ *  @param[in] aesadv        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_forceInputDataAvailable(AESADV_Regs *aesadv)
+{
+    aesadv->FORCE_IN_AV = 0x0123CAFE;
+}
+
+/**
+ *  @brief Set the CCM AAD align data word.
+ *
+ *  Specific to CCM mode. Writes the alignment data word used to concatenate to
+ *  the next block of additional authentication data (AAD). Will need to be set
+ *  during initialization or during the resumption of a halted CCM operation.
+ *
+ *  @param[in] aesadv        Pointer to the register overlay for the peripheral
+ *  @param[in] alignWord     AAD alignment word of type uint32_t
+ */
+__STATIC_INLINE void DL_AESADV_setCCMAlignWord(
+    AESADV_Regs *aesadv, uint32_t alignWord)
+{
+    aesadv->CCM_ALN_WRD = alignWord;
+}
+
+/**
+ *  @brief Get the CCM AAD align data word.
+ *
+ *  Specific to CCM mode. Reads the alignment data word used to concatenate to
+ *  the next block of additional authentication data (AAD).
+ *
+ *  @param[in] aesadv        Pointer to the register overlay for the peripheral
+ *
+ *  @return Current AAD alignment word of type uint32_t
+ */
+__STATIC_INLINE uint32_t DL_AESADV_getCCMAlignWord(AESADV_Regs *aesadv)
+{
+    return (aesadv->CCM_ALN_WRD);
+}
+
+/**
+ *  @brief Sets the lower 32-bits of the data blocks remaining in an operation
+ *
+ *  Specific to GCM/CCM mode. The block count is 57-bits and represents the
+ *  number of remaining AES cryptographic payload blocks (non-AAD) in an
+ *  operation. During an interruption of a GCM/CCM operation, this number needs
+ *  to be saved and restored before resumption.
+ *
+ *  @param[in] aesadv           Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in] lowerBlockCount  Lower 32-bits of the overall data blocks
+ *                              remaining
+ *
+ *  @sa DL_AESADV_getLowerBlockCount
+ *  @sa DL_AESADV_setUpperBlockCount
+ */
+__STATIC_INLINE void DL_AESADV_setLowerBlockCount(
+    AESADV_Regs *aesadv, uint32_t lowerBlockCount)
+{
+    aesadv->BLK_CNT0 = lowerBlockCount;
+}
+
+/**
+ *  @brief Gets the lower 32-bits of the data blocks remaining in an operation
+ *
+ *  Specific to GCM/CCM mode. The block count is 57-bits and represents the
+ *  number of remaining AES cryptographic payload blocks (non-AAD) in an
+ *  operation. During an interruption of a GCM/CCM operation, this number needs
+ *  to be saved and restored before resumption.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @return Lower 32-bits of overall data blocks remaining
+ *
+ *  @sa DL_AESADV_setLowerBlockCount
+ */
+__STATIC_INLINE uint32_t DL_AESADV_getLowerBlockCount(AESADV_Regs *aesadv)
+{
+    return aesadv->BLK_CNT0;
+}
+
+/**
+ *  @brief Sets the upper 25-bits of the data blocks remaining in an operation
+ *
+ *  Specific to GCM/CCM mode. The block count is 57-bits and represents the
+ *  number of remaining AES cryptographic payload blocks (non-AAD) in an
+ *  operation. During an interruption of a GCM/CCM operation, this number needs
+ *  to be saved and restored before resumption.
+ *
+ *  @param[in] aesadv           Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in] upperBlockCount  Upper 25-bits of the overall data blocks
+ *                              remaining (bits [25:31] are ignored)
+ *
+ *  @sa DL_AESADV_getUpperBlockCount
+ *  @sa DL_AESADV_setLowerBlockCount
+ */
+__STATIC_INLINE void DL_AESADV_setUpperBlockCount(
+    AESADV_Regs *aesadv, uint32_t upperBlockCount)
+{
+    aesadv->BLK_CNT1 = (upperBlockCount & 0x01FFFFFFU);
+}
+
+/**
+ *  @brief Gets the upper 25-bits of the data blocks remaining in an operation
+ *
+ *  Specific to GCM/CCM mode. The block count is 57-bits and represents the
+ *  number of remaining AES cryptographic payload blocks (non-AAD) in an
+ *  operation. During an interruption of a GCM/CCM operation, this number needs
+ *  to be saved and restored before resumption.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @return Upper 25-bits of overall data blocks remaining (bits [25:31] are 0)
+ *
+ *  @sa DL_AESADV_setUpperBlockCount
+ */
+__STATIC_INLINE uint32_t DL_AESADV_getUpperBlockCount(AESADV_Regs *aesadv)
+{
+    return (aesadv->BLK_CNT1 & 0x01FFFFFFU);
+}
+
+/**
+ *  @brief      Enable AESADV interrupts
+ *
+ *  @param[in]  aesadv        Pointer to the register overlay for the peripheral
+ *  @param[in]  interruptMask Bit mask of interrupts to enable. Bitwise OR of
+ *                            @ref DL_AESADV_INTERRUPT
+ */
+__STATIC_INLINE void DL_AESADV_enableInterrupt(
+    AESADV_Regs *aesadv, uint32_t interruptMask)
+{
+    aesadv->CPU_INT.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disable AESADV interrupts
+ *
+ *  @param[in]  aesadv         Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_AESADV_INTERRUPT
+ */
+__STATIC_INLINE void DL_AESADV_disableInterrupt(
+    AESADV_Regs *aesadv, uint32_t interruptMask)
+{
+    aesadv->CPU_INT.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief      Check if AES Ready interrupt is enabled
+ *
+ *  @param[in]  aesadv         Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_AESADV_INTERRUPT
+ *
+ *  @return     Which of the requested AESADV interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_AESADV_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_AESADV_getEnabledInterrupts(
+    AESADV_Regs *aesadv, uint32_t interruptMask)
+{
+    return (aesadv->CPU_INT.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled AESADV interrupts
+ *
+ *  Checks if any of the AESADV interrupts that was previously enabled are
+ *  pending.
+ *
+ *  @param[in]  aesadv         Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_AESADV_INTERRUPT
+ *
+ *  @return     Which of the requested and enabled AESADV interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_AESADV_INTERRUPT
+ *
+ *  @sa         DL_AESADV_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_AESADV_getEnabledInterruptStatus(
+    AESADV_Regs *aesadv, uint32_t interruptMask)
+{
+    return (aesadv->CPU_INT.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any AESADV interrupts
+ *
+ *  Checks if any of the AESADV interrupts are pending. Interrupts do not have
+ *  to be previously enabled.
+ *
+ *  @param[in]  aesadv         Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_AESADV_INTERRUPT
+ *
+ *  @return     Which of the requested AESADV interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_AESADV_INTERRUPT
+ */
+__STATIC_INLINE uint32_t DL_AESADV_getRawInterruptStatus(
+    AESADV_Regs *aesadv, uint32_t interruptMask)
+{
+    return (aesadv->CPU_INT.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending AESADV interrupt
+ *
+ *  Checks if any AESADV interrupts are pending. Interrupt does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ *
+ *  @return     The highest priority pending AESADV interrupt
+ *
+ *  @retval     One of @ref DL_AESADV_IIDX
+ */
+__STATIC_INLINE DL_AESADV_IIDX DL_AESADV_getPendingInterrupt(
+    AESADV_Regs *aesadv)
+{
+    return ((DL_AESADV_IIDX) aesadv->CPU_INT.IIDX);
+}
+
+/**
+ *  @brief      Clear pending AESADV Interrupts
+ *
+ *  @param[in]  aesadv         Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_AESADV_INTERRUPT
+ */
+__STATIC_INLINE void DL_AESADV_clearInterruptStatus(
+    AESADV_Regs *aesadv, uint32_t interruptMask)
+{
+    aesadv->CPU_INT.ICLR = interruptMask;
+}
+
+/**
+ *  @brief      Enables DMA input trigger to publish AESADV write requests to
+ *              the DMA
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_enableDMAInputTriggerEvent(AESADV_Regs *aesadv)
+{
+    aesadv->DMA_TRIG_DATAIN.IMASK |= DL_AESADV_EVENT_DMA_DATA_INPUT_TRIGGER;
+}
+
+/**
+ *  @brief      Enables DMA output trigger to publish AESADV read requests to
+ *              the DMA
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_enableDMAOutputTriggerEvent(AESADV_Regs *aesadv)
+{
+    aesadv->DMA_TRIG_DATAOUT.IMASK |= DL_AESADV_EVENT_DMA_DATA_OUTPUT_TRIGGER;
+}
+
+/**
+ *  @brief      Disable DMA input trigger event
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_disableDMAInputTriggerEvent(AESADV_Regs *aesadv)
+{
+    aesadv->DMA_TRIG_DATAIN.IMASK &= ~(DL_AESADV_EVENT_DMA_DATA_INPUT_TRIGGER);
+}
+
+/**
+ *  @brief      Disable DMA output trigger event
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_disableDMAOutputTriggerEvent(
+    AESADV_Regs *aesadv)
+{
+    aesadv->DMA_TRIG_DATAOUT.IMASK &=
+        ~(DL_AESADV_EVENT_DMA_DATA_OUTPUT_TRIGGER);
+}
+
+/**
+ *  @brief      Check if the DMA input trigger event is enabled
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ *
+ *  @return     If DMA input trigger event is enabled
+ *
+ *  @retval     DL_AESADV_EVENT_DMA_DATA_INPUT_TRIGGER if DMA input trigger
+ *              event is enabled
+ *  @retval     0 if DMA input trigger event is not enabled
+ */
+__STATIC_INLINE uint32_t DL_AESADV_getEnabledDMAInputTriggerEvent(
+    AESADV_Regs *aesadv)
+{
+    return (aesadv->DMA_TRIG_DATAIN.IMASK &
+            DL_AESADV_EVENT_DMA_DATA_INPUT_TRIGGER);
+}
+
+/**
+ *  @brief      Check if the DMA output trigger event is enabled
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ *
+ *  @return     If DMA output trigger event is enabled
+ *
+ *  @retval     DL_AESADV_EVENT_DMA_DATA_OUTPUT_TRIGGER if DMA output trigger
+ *              event is enabled
+ *  @retval     0 if DMA output trigger event is not enabled
+ */
+__STATIC_INLINE uint32_t DL_AESADV_getEnabledDMAOutputTriggerEvent(
+    AESADV_Regs *aesadv)
+{
+    return (aesadv->DMA_TRIG_DATAOUT.IMASK &
+            DL_AESADV_EVENT_DMA_DATA_OUTPUT_TRIGGER);
+}
+
+/**
+ *  @brief      Check interrupt flag of DMA input trigger event
+ *
+ *  Checks if DMA input trigger event that was previously enabled is pending.
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ *
+ *  @return     If DMA input trigger event is pending
+ *
+ *  @retval     DL_AESADV_EVENT_DMA_DATA_INPUT_TRIGGER if DMA input trigger
+ *              event is pending
+ *  @retval     0 if DMA input trigger event is not pending
+ *
+ *  @sa         DL_AESADV_enableDMAInputTriggerEvent
+ */
+__STATIC_INLINE uint32_t DL_AESADV_getEnabledDMAInputTriggerEventStatus(
+    AESADV_Regs *aesadv)
+{
+    return (
+        aesadv->DMA_TRIG_DATAIN.MIS & DL_AESADV_EVENT_DMA_DATA_INPUT_TRIGGER);
+}
+
+/**
+ *  @brief      Check interrupt flag of DMA output trigger event
+ *
+ *  Checks if DMA output trigger event that was previously enabled is pending.
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ *
+ *  @return     If DMA output trigger event is pending
+ *
+ *  @retval     DL_AESADV_EVENT_DMA_DATA_OUTPUT_TRIGGER if DMA output trigger
+ *              event is pending
+ *  @retval     0 if DMA output trigger event is not pending
+ *
+ *  @sa         DL_AESADV_enableDMAOutputTriggerEvent
+ */
+__STATIC_INLINE uint32_t DL_AESADV_getEnabledDMAOutputTriggerEventStatus(
+    AESADV_Regs *aesadv)
+{
+    return (aesadv->DMA_TRIG_DATAOUT.MIS &
+            DL_AESADV_EVENT_DMA_DATA_OUTPUT_TRIGGER);
+}
+
+/**
+ *  @brief      Check interrupt flag of DMA input trigger event
+ *
+ *  Checks if DMA input trigger event is pending. Event does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ *
+ *  @return     If DMA input trigger event is pending
+ *
+ *  @retval     DL_AESADV_EVENT_DMA_DATA_INPUT_TRIGGER if DMA input trigger event is
+ *              pending
+ *  @retval     0 if DMA input trigger event is not pending
+ */
+__STATIC_INLINE uint32_t DL_AESADV_getRawDMAInputTriggerEventStatus(
+    AESADV_Regs *aesadv)
+{
+    return (
+        aesadv->DMA_TRIG_DATAIN.RIS & DL_AESADV_EVENT_DMA_DATA_INPUT_TRIGGER);
+}
+
+/**
+ *  @brief      Check interrupt flag of DMA output trigger event
+ *
+ *  Checks if DMA output trigger event is pending. Event does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ *
+ *  @return     If DMA output trigger event is pending
+ *
+ *  @retval     DL_AESADV_EVENT_DMA_DATA_INPUT_TRIGGER if DMA output trigger event is
+ *              pending
+ *  @retval     0 if DMA output trigger event is not pending
+ */
+__STATIC_INLINE uint32_t DL_AESADV_getRawDMAOutputTriggerEventStatus(
+    AESADV_Regs *aesadv)
+{
+    return (aesadv->DMA_TRIG_DATAOUT.RIS &
+            DL_AESADV_EVENT_DMA_DATA_OUTPUT_TRIGGER);
+}
+
+/**
+ *  @brief      Get highest priority pending DMA input trigger event
+ *
+ *  Checks if DMA input trigger event is pending. Event does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ *
+ *  @return     The highest priority pending DMA input trigger event
+ */
+__STATIC_INLINE DL_AESADV_IIDX DL_AESADV_getPendingDMAInputTriggerEvent(
+    AESADV_Regs *aesadv)
+{
+    uint32_t eventIIDX = aesadv->DMA_TRIG_DATAIN.IIDX;
+
+    return (DL_AESADV_IIDX) eventIIDX;
+}
+
+/**
+ *  @brief      Get highest priority pending DMA output trigger event
+ *
+ *  Checks if DMA output trigger event is pending. Event does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ *
+ *  @return     The highest priority pending DMA output trigger event
+ */
+__STATIC_INLINE DL_AESADV_IIDX DL_AESADV_getPendingDMAOutputTriggerEvent(
+    AESADV_Regs *aesadv)
+{
+    uint32_t eventIIDX = aesadv->DMA_TRIG_DATAOUT.IIDX;
+
+    return (DL_AESADV_IIDX)(eventIIDX);
+}
+
+/**
+ *  @brief      Clear pending DMA input trigger event
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_clearDMAInputTriggerEventStatus(
+    AESADV_Regs *aesadv)
+{
+    aesadv->DMA_TRIG_DATAIN.ICLR = DL_AESADV_EVENT_DMA_DATA_INPUT_TRIGGER;
+}
+
+/**
+ *  @brief      Clear pending DMA output trigger event
+ *
+ *  @param[in]  aesadv      Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_AESADV_clearDMAOutputTriggerEventStatus(
+    AESADV_Regs *aesadv)
+{
+    aesadv->DMA_TRIG_DATAOUT.ICLR = DL_AESADV_EVENT_DMA_DATA_OUTPUT_TRIGGER;
+}
+
+/**
+ *  @brief Returns the address of the AESADV input data register.
+ *
+ *  This API can be used with @ref DL_DMA_setDestAddr to set the destination
+ *  address when using DMA transfers. The Data should be written as 128-bit
+ *  block writes (4 32-bit words) to a region of memory starting at the provided
+ *  address.
+ *      Use with the @ref DL_AESADV_enableDMAOperation
+ *      The DMA output request use @ref DL_AESADV_EVENT_DMA_DATA_OUTPUT_TRIGGER
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @return Address of the AESADV input data register
+ *
+ *  @sa DL_AESADV_enableDMAOperation
+ */
+__STATIC_INLINE uintptr_t DL_AESADV_getDATAINAddr(AESADV_Regs *aesadv)
+{
+    return ((uintptr_t) &aesadv->DATA0);
+}
+
+/**
+ *  @brief Returns the address of the AESADV output data register.
+ *
+ *  This API can be used with @ref DL_DMA_setDestAddr to set the destination
+ *  address when using DMA transfers. The Data should be read as 128-bit
+ *  block read (4 32-bit words) to a region of memory starting at the provided
+ *  address.
+ *      Use with the @ref DL_AESADV_enableDMAOperation
+ *      The DMA output request use @ref DL_AESADV_EVENT_DMA_DATA_OUTPUT_TRIGGER
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *
+ *  @return Address of the AESADV output data register
+ *
+ *  @sa DL_AESADV_enableDMAOperation
+ */
+__STATIC_INLINE uintptr_t DL_AESADV_getDATAOUTAddr(AESADV_Regs *aesadv)
+{
+    return ((uintptr_t) &aesadv->DATA0);
+}
+
+/**
+ *  @brief Initializes the engine in the Electronic Codebook (ECB) mode
+ *
+ *  This function is designed to place the engine in Electronic Codebook (ECB)
+ *  mode with all necessary control context.
+ *      The primary key, however, must be set into the AES engine before this
+ *  function is called. This is because the key could come from either the
+ *  KEYSTORECTL or from plaintext depending on system setting.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] config       Pointer to configuration struct with valid values
+ *                          for: direction, lowerCryptoLength, upperCryptoLength
+ *
+ *  @sa DL_AESADV_setKey
+ */
+void DL_AESADV_initECB(AESADV_Regs *aesadv, DL_AESADV_Config *config);
+
+/**
+ *  @brief Initializes the engine in the Cipher-Block Chaining (CBC) mode
+ *
+ *  This function is designed to place the engine in Cipher Block Chaining (CBC)
+ *  mode with all necessary control context.
+ *      The primary key, however, must be set into the AES engine before this
+ *  function is called. This is because the key could come from either the
+ *  KEYSTORECTL or from plaintext depending on system setting.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] config       Pointer to configuration struct with valid values
+ *                          for: direction, iv, lowerCryptoLength,
+ *                               upperCryptoLength
+ *
+ *  @sa DL_AESADV_setKey
+ */
+void DL_AESADV_initCBC(AESADV_Regs *aesadv, DL_AESADV_Config *config);
+
+/**
+ *  @brief Initializes the engine in the Cipher Feedback (CFB) mode
+ *
+ *  This function is designed to place the engine in Cipher Feedback (CFB) mode
+ *  with all necessary control context.
+ *      The primary key, however, must be set into the AES engine before this
+ *  function is called. This is because the key could come from either the
+ *  KEYSTORECTL or from plaintext depending on system setting.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] config       Pointer to configuration struct with valid values
+ *                          for: direction, iv, lowerCryptoLength, upperCryptoLength,
+ *                               cfb_fbWidth
+ *
+ *  @sa DL_AESADV_setKey
+ */
+void DL_AESADV_initCFB(AESADV_Regs *aesadv, DL_AESADV_Config *config);
+
+/**
+ *  @brief Initializes the engine in the Output Feedback (OFB) mode
+ *
+ *  This function is designed to place the engine in Output Feedback (OFB) mode
+ *  with all necessary control context.
+ *      The primary key, however, must be set into the AES engine before this
+ *  function is called. This is because the key could come from either the
+ *  KEYSTORECTL or from plaintext depending on system setting.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] config       Pointer to configuration struct with valid values
+ *                          for: direction, iv, lowerCryptoLength,
+ *                               upperCryptoLength
+ *
+ *  @sa DL_AESADV_setKey
+ */
+void DL_AESADV_initOFB(AESADV_Regs *aesadv, DL_AESADV_Config *config);
+
+/**
+ *  @brief Initializes the engine in the Counter (CTR) mode
+ *
+ *  This function is designed to place the engine in Counter (CTR) mode with all
+ *  necessary control context.
+ *      The primary key, however, must be set into the AES engine before this
+ *  function is called. This is because the key could come from either the
+ *  KEYSTORECTL or from plaintext depending on system setting.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] config       Pointer to configuration struct with valid values
+ *                          for: direction iv, lowerCryptoLength,
+ *                               upperCryptoLength, ctr_ctrWidth. IV is
+ *                               typically 0x00000001
+ *
+ *  @sa DL_AESADV_setKey
+ */
+void DL_AESADV_initCTR(AESADV_Regs *aesadv, DL_AESADV_Config *config);
+
+/**
+ *  @brief Initializes the engine in the Integer Counter Mode (ICM)
+ *
+ *  This function is designed to place the engine in Integer Counter Mode (ICM)
+ *  with all necessary control context. ICM is a variant of CTR mode with a 16-
+ *  bit wide counter value.
+ *      The primary key, however, must be set into the AES engine before this
+ *  function is called. This is because the key could come from either the
+ *  KEYSTORECTL or from plaintext depending on system setting.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] config       Pointer to configuration struct with valid values
+ *                          for: direction iv, lowerCryptoLength,
+ *                               upperCryptoLength. IV is typically 0x00000001
+ *
+ *  @sa DL_AESADV_setKey
+ */
+void DL_AESADV_initICM(AESADV_Regs *aesadv, DL_AESADV_Config *config);
+
+/**
+ *  @brief Initializes the engine in the block cipher-based Message
+ *         Authentication Code (CMAC)
+ *
+ *  This function is designed to place the engine in block cipher-based Message
+ *  Authentication Code: CMAC. CMAC is strictly authentication and does not
+ *  generate any ciphertext or plaintext, but only a tag. CMAC is also
+ *  recommended by NIST in SP 800-38B for authentication. It consists of a
+ *  primary key as well as derived keys K1 and K2 which must be provided in
+ *  the configuration. The engine will not derive K1 and K2, and these must be
+ *  calculated beforehand and included in the config struct.
+ *      The primary key from which K1 and K2 are derived, however, must be set
+ *  in the AES engine before this function is called. This is because the key
+ *  could come from either the KEYSTORECTL or from plaintext depending on
+ *  system setting.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] config       Pointer to configuration struct with valid values
+ *                          for: K1, K2, lowerCryptoLength, upperCryptoLength.
+ *
+ *  @sa DL_AESADV_setKey
+ */
+void DL_AESADV_initCMAC(AESADV_Regs *aesadv, DL_AESADV_Config *config);
+
+/**
+ *  @brief Initializes the engine in the Cipher Block Chaining Message
+ *         Authenication Code (CBC-MAC)
+ *
+ *  This function is designed to place the engine in Cipher Block Chaining
+ *  Message Authenication Code (CBC-MAC). CBC-MAC is strictly authentication and
+ *  does not generate any ciphertext or plaintext, but only a tag.
+ *      The primary key, however, must be set into the AES engine before this
+ *  function is called. This is because the key could come from either the
+ *  KEYSTORECTL or from plaintext depending on system setting.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] config       Pointer to configuration struct with valid values
+ *                          for: lowerCryptoLength, upperCryptoLength.
+ *
+ *  @sa DL_AESADV_setKey
+ */
+void DL_AESADV_initCBCMAC(AESADV_Regs *aesadv, DL_AESADV_Config *config);
+
+/**
+ *  @brief Initializes the engine in the Galois/Counter Mode (GCM)
+ *
+ *  This function is designed to place the engine in Galois/Counter Mode (GCM).
+ *  GCM is both authentication and data encryption, and will generate both
+ *  ciphertext/plaintext and the corresponding tag.
+ *      The primary key and hash key (if expected from @ref DL_AESADV_MODE) must
+ *  be set into the AES engine before this function is called. This is because
+ *  the key could come from either the KEYSTORECTL or from plaintext depending
+ *  on system setting.
+ *      After this function has completed, the user is to first input all
+ *  additional authentication data (AAD) before entering the crypto payload.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] config       Pointer to configuration struct with valid values
+ *                          for: mode (one of the GCM operations), direction,
+ *                               iv, lowerCryptoLength, upperCryptoLength,
+ *                               aadLength. IV is
+ *                               typically 0x00000001. The maximum length in
+ *                               bytes is 2^36 - 32.
+ *
+ *  @sa DL_AESADV_setKey
+ *  @sa DL_AESADV_setHashKey
+ */
+void DL_AESADV_initGCM(AESADV_Regs *aesadv, DL_AESADV_Config *config);
+
+/**
+ *  @brief Initializes the engine in the Counter & CBC-MAC (CCM)mode
+ *
+ *  This function is designed to place the engine in Counter and Cipher-Block
+ *  Chaining Message Authentication Code (CCM) mode.
+ *  CCM is both authentication and data encryption, and will generate both
+ *  ciphertext/plaintext and the corresponding tag.
+ *      To calculate the length of the nonce and the counter width, please refer
+ *  to @ref DL_AESADV_loadCCMNonceAndCounter.
+ *      After this function has completed, the user is to first input all
+ *  additional authentication data (AAD) before entering the crypto payload.
+ *
+ *  @param[in] aesadv       Pointer to the register overlay for the peripheral
+ *  @param[in] config       Pointer to configuration struct with valid values
+ *                          for: direction, nonce, ccm_ctrWidth, ccm_tagWidth,
+ *                               lowerCryptoLength, upperCryptoLength, aadLength
+ *                               IV is typically 0x00000001. The maximum AAD
+ *                               Length is 2^16-2^8
+ *
+ *  @sa DL_AESADV_setKey
+ */
+void DL_AESADV_initCCM(AESADV_Regs *aesadv, DL_AESADV_Config *config);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_AESADV__ */
+
+#endif /* ti_dl_dl_aesadv__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_common.c
+++ b/mspm0/source/ti/driverlib/dl_common.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+
+#include <ti/driverlib/dl_common.h>
+
+void DL_Common_delayCycles(uint32_t cycles)
+{
+    /* this is a scratch register for the compiler to use */
+    uint32_t scratch;
+
+    /* There will be a 2 cycle delay here to fetch & decode instructions
+     * if branch and linking to this function */
+
+    /* Subtract 2 net cycles for constant offset: +2 cycles for entry jump,
+     * +2 cycles for exit, -1 cycle for a shorter loop cycle on the last loop,
+     * -1 for this instruction */
+
+    __asm volatile(
+#ifdef __GNUC__
+        ".syntax unified\n\t"
+#endif
+        "SUBS %0, %[numCycles], #2; \n"
+        "%=: \n\t"
+        "SUBS %0, %0, #4; \n\t"
+        "NOP; \n\t"
+        "BHS  %=b;" /* branches back to the label defined above if number > 0 */
+        /* Return: 2 cycles */
+        : "=&r"(scratch)
+        : [ numCycles ] "r"(cycles));
+}

--- a/mspm0/source/ti/driverlib/dl_common.h
+++ b/mspm0/source/ti/driverlib/dl_common.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_common.h
+ *  @brief      DriverLib Common APIs
+ *  @defgroup   DLCommon DriverLib Common APIs
+ *
+ *  @anchor ti_dl_dl_common_Overview
+ *  # Overview
+ *
+ *  APIs used across multiple DriverLib modules
+ *
+ *  <hr>
+ ******************************************************************************/
+/** @addtogroup DLCommon
+ * @{
+ */
+#ifndef ti_dl_dl_common__include
+#define ti_dl_dl_common__include
+
+#include <ti/devices/msp/msp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Writes value to specified register - retaining bits unaffected by mask.
+ *
+ * @param[in] reg     Pointer to the register overlay for the peripheral.
+ * @param[in] val     Value to be written to the register.
+ * @param[in] mask    Mask defines which bits will be altered.
+ */
+__STATIC_INLINE void DL_Common_updateReg(
+    volatile uint32_t *reg, uint32_t val, uint32_t mask)
+{
+    uint32_t tmp;
+
+    tmp  = *reg;
+    tmp  = tmp & ~mask;
+    *reg = tmp | (val & mask);
+}
+
+/**
+ * @brief   Consumes the number of CPU cycles specified.
+ *
+ * @param[in] cycles  Floor number of cycles to delay.
+ *                    Specifying zero will result in the maximum
+ *                    possible delay. Note that guarantees at least
+ *                    this number of cycles will be delayed,
+ *                    not that exactly this number of cycles will be
+ *                    delayed. If a more precise number of cycle delay value
+ *                    is needed, GPTimer is recommended.
+ *
+ *                    Typical variance from this function is 10 cycles or
+ *                    less assuming that the function is located in flash and
+ *                    that caching is enabled. Disabling caching may result in
+ *                    wait-states when fetching from flash.
+ *                    Other variance occurs due:
+ *                      - Amount of register stacking/unstacking around API entry/exit
+ *                      - Value of cycles relative to 4-cycle loop counter
+ *                      - Placement of code on a 2- or 4-byte aligned boundary
+ */
+void DL_Common_delayCycles(uint32_t cycles);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_dl_dl_common__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_comp.h
+++ b/mspm0/source/ti/driverlib/dl_comp.h
@@ -1,0 +1,1539 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_comp.h
+ *  @brief      Comparator (COMP)
+ *  @defgroup   COMP Comparator (COMP)
+ *
+ *  @anchor ti_dl_dl_comp_Overview
+ *  # Overview
+ *
+ *  The COMP DriverLib allows full configuration of the MSPM0 comparator module.
+ *  The comparator module (COMP) is an analog voltage comparator with general
+ *  comparator functionality.
+ *
+ *  <hr>
+ ******************************************************************************/
+/** @addtogroup COMP
+ * @{
+ */
+#ifndef ti_dl_m0p_dl_comp__include
+#define ti_dl_m0p_dl_comp__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_COMP__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_COMP_INTERRUPT
+ *  @{
+ */
+/*!
+ * @brief Comparator output ready interrupt
+ */
+#define DL_COMP_INTERRUPT_OUTPUT_READY               (COMP_CPU_INT_IMASK_OUTRDYIFG_SET)
+
+/*!
+ * @brief Rising or falling edge of comparator output (selected by IES bit)
+ *        interrupt
+ */
+#define DL_COMP_INTERRUPT_OUTPUT_EDGE                  (COMP_CPU_INT_IMASK_COMPIFG_SET)
+
+/*!
+ * @brief Rising or falling edge of comparator inverted output (selected by
+ *        IES bit) interrupt
+ */
+#define DL_COMP_INTERRUPT_OUTPUT_EDGE_INV           (COMP_CPU_INT_IMASK_COMPINVIFG_SET)
+
+/** @}*/
+
+/** @addtogroup DL_COMP_EVENT
+ *  @{
+ */
+/*!
+ * @brief Comparator output ready event
+ */
+#define DL_COMP_EVENT_OUTPUT_READY               (COMP_GEN_EVENT_IMASK_OUTRDYIFG_SET)
+
+/*!
+ * @brief Rising or falling edge of comparator output (selected by IES bit)
+ *        event
+ */
+#define DL_COMP_EVENT_OUTPUT_EDGE                  (COMP_GEN_EVENT_IMASK_COMPIFG_SET)
+
+/*!
+ * @brief Rising or falling edge of comparator inverted output (selected by
+ *        IES bit) event
+ */
+#define DL_COMP_EVENT_OUTPUT_EDGE_INV           (COMP_GEN_EVENT_IMASK_COMPINVIFG_SET)
+
+/** @}*/
+
+/* clang-format on */
+
+/*! @enum DL_COMP_IIDX */
+typedef enum {
+    /*! COMP interrupt index for no interrupt */
+    DL_COMP_IIDX_NO_INTERRUPT = COMP_CPU_INT_IIDX_STAT_NO_INTR,
+    /*! COMP interrupt index for comparator output ready interrupt */
+    DL_COMP_IIDX_OUTPUT_READY = COMP_CPU_INT_IIDX_STAT_OUTRDYIFG,
+    /*! COMP interrupt index for rising or falling edge of comparator output
+     * (selected by IES bit) interrupt */
+    DL_COMP_IIDX_OUTPUT_EDGE = COMP_CPU_INT_IIDX_STAT_COMPIFG,
+    /*! COMP interrupt index for rising or falling edge of comparator inverted
+     * output (selected by IES bit) interrupt */
+    DL_COMP_IIDX_OUTPUT_EDGE_INV = COMP_CPU_INT_IIDX_STAT_COMPINVIFG,
+} DL_COMP_IIDX;
+
+/*! @enum DL_COMP_MODE */
+typedef enum {
+    /*! Comparator is in fast mode */
+    DL_COMP_MODE_FAST = COMP_CTL1_MODE_FAST,
+    /*! Comparator is in ultra-low power (ULP) mode */
+    DL_COMP_MODE_ULP = COMP_CTL1_MODE_ULP,
+} DL_COMP_MODE;
+
+/*! @enum DL_COMP_OUTPUT_INT_EDGE */
+typedef enum {
+    /*! Rising edge sets COMPIFG and falling edge sets COMPINVIFG */
+    DL_COMP_OUTPUT_INT_EDGE_RISING = COMP_CTL1_IES_RISING,
+    /*! Falling edge sets COMPIFG and rising edge sets COMPINVIFG */
+    DL_COMP_OUTPUT_INT_EDGE_FALLING = COMP_CTL1_IES_FALLING,
+} DL_COMP_OUTPUT_INT_EDGE;
+
+/*! @enum DL_COMP_HYSTERESIS */
+typedef enum {
+    /*! No hysteresis */
+    DL_COMP_HYSTERESIS_NONE = COMP_CTL1_HYST_NO_HYS,
+    /*! Typical hysteresis voltage generated is 10mV */
+    DL_COMP_HYSTERESIS_10 = COMP_CTL1_HYST_LOW_HYS,
+    /*! Typical hysteresis voltage generated is 20mV */
+    DL_COMP_HYSTERESIS_20 = COMP_CTL1_HYST_MED_HYS,
+    /*! Typical hysteresis voltage generated is 30mV */
+    DL_COMP_HYSTERESIS_30 = COMP_CTL1_HYST_HIGH_HYS,
+} DL_COMP_HYSTERESIS;
+
+/*! @enum DL_COMP_POLARITY */
+typedef enum {
+    /*! Comparator output is non-inverted. When comparator is off, OUT is low */
+    DL_COMP_POLARITY_NON_INV = COMP_CTL1_OUTPOL_NON_INV,
+    /*! Comparator output is inverted. When comparator is off, OUT is high */
+    DL_COMP_POLARITY_INV = COMP_CTL1_OUTPOL_INV,
+} DL_COMP_POLARITY;
+
+/*! @enum DL_COMP_FILTER_DELAY */
+typedef enum {
+    /*! Typical filter delay of 70ns */
+    DL_COMP_FILTER_DELAY_70 = COMP_CTL1_FLTDLY_DLY_0,
+    /*! Typical filter delay of 500ns */
+    DL_COMP_FILTER_DELAY_500 = COMP_CTL1_FLTDLY_DLY_1,
+    /*! Typical filter delay of 1200ns */
+    DL_COMP_FILTER_DELAY_1200 = COMP_CTL1_FLTDLY_DLY_2,
+    /*! Typical filter delay of 2700ns */
+    DL_COMP_FILTER_DELAY_2700 = COMP_CTL1_FLTDLY_DLY_3,
+} DL_COMP_FILTER_DELAY;
+
+/*! @enum DL_COMP_IPSEL_CHANNEL */
+typedef enum {
+    /*! IPSEL is channel 0. See the device datasheet for more details. */
+    DL_COMP_IPSEL_CHANNEL_0 = COMP_CTL0_IPSEL_CH_0,
+    /*! IPSEL is channel 1. See the device datasheet for more details. */
+    DL_COMP_IPSEL_CHANNEL_1 = COMP_CTL0_IPSEL_CH_1,
+    /*! IPSEL is channel 2. See the device datasheet for more details. */
+    DL_COMP_IPSEL_CHANNEL_2 = COMP_CTL0_IPSEL_CH_2,
+    /*! IPSEL is channel 3. See the device datasheet for more details. */
+    DL_COMP_IPSEL_CHANNEL_3 = COMP_CTL0_IPSEL_CH_3,
+    /*! IPSEL is channel 4. See the device datasheet for more details. */
+    DL_COMP_IPSEL_CHANNEL_4 = COMP_CTL0_IPSEL_CH_4,
+    /*! IPSEL is channel 5. See the device datasheet for more details. */
+    DL_COMP_IPSEL_CHANNEL_5 = COMP_CTL0_IPSEL_CH_5,
+    /*! IPSEL is channel 6. See the device datasheet for more details. */
+    DL_COMP_IPSEL_CHANNEL_6 = COMP_CTL0_IPSEL_CH_6,
+    /*! IPSEL is channel 7. See the device datasheet for more details. */
+    DL_COMP_IPSEL_CHANNEL_7 = COMP_CTL0_IPSEL_CH_7,
+} DL_COMP_IPSEL_CHANNEL;
+
+/*! @enum DL_COMP_IMSEL_CHANNEL */
+typedef enum {
+    /*! IMSEL is channel 0. See the device datasheet for more details. */
+    DL_COMP_IMSEL_CHANNEL_0 = COMP_CTL0_IMSEL_CH_0,
+    /*! IMSEL is channel 1. See the device datasheet for more details. */
+    DL_COMP_IMSEL_CHANNEL_1 = COMP_CTL0_IMSEL_CH_1,
+    /*! IMSEL is channel 2. See the device datasheet for more details. */
+    DL_COMP_IMSEL_CHANNEL_2 = COMP_CTL0_IMSEL_CH_2,
+    /*! IMSEL is channel 3. See the device datasheet for more details. */
+    DL_COMP_IMSEL_CHANNEL_3 = COMP_CTL0_IMSEL_CH_3,
+    /*! IMSEL is channel 4. See the device datasheet for more details. */
+    DL_COMP_IMSEL_CHANNEL_4 = COMP_CTL0_IMSEL_CH_4,
+    /*! IMSEL is channel 5. See the device datasheet for more details. */
+    DL_COMP_IMSEL_CHANNEL_5 = COMP_CTL0_IMSEL_CH_5,
+    /*! IMSEL is channel 6. See the device datasheet for more details. */
+    DL_COMP_IMSEL_CHANNEL_6 = COMP_CTL0_IMSEL_CH_6,
+    /*! IMSEL is channel 7. See the device datasheet for more details. */
+    DL_COMP_IMSEL_CHANNEL_7 = COMP_CTL0_IMSEL_CH_7,
+} DL_COMP_IMSEL_CHANNEL;
+
+/*! @enum DL_COMP_ENABLE_CHANNEL */
+typedef enum {
+    /*! Channel input disabled for both the positive and negative terminals */
+    DL_COMP_ENABLE_CHANNEL_NONE =
+        (COMP_CTL0_IPEN_DISABLE | COMP_CTL0_IMEN_DISABLE),
+    /*! Channel input enabled for the positive terminal */
+    DL_COMP_ENABLE_CHANNEL_POS = COMP_CTL0_IPEN_ENABLE,
+    /*! Channel input enabled for the positive terminal */
+    DL_COMP_ENABLE_CHANNEL_NEG = COMP_CTL0_IMEN_ENABLE,
+    /*! Channel input enabled for both the positive and negative terminals */
+    DL_COMP_ENABLE_CHANNEL_POS_NEG =
+        (COMP_CTL0_IPEN_ENABLE | COMP_CTL0_IMEN_ENABLE),
+} DL_COMP_ENABLE_CHANNEL;
+
+/*! @enum DL_COMP_REF_MODE */
+typedef enum {
+    /*! ULP_REF bandgap, local reference buffer, and 8-bit COMP inside
+     * comparator operate in static mode */
+    DL_COMP_REF_MODE_STATIC = COMP_CTL2_REFMODE_STATIC,
+    /*! ULP_REF bandgap, local reference buffer, and 8-bit COMP inside
+     * comparator operate in sampled mode */
+    DL_COMP_REF_MODE_SAMPLED = COMP_CTL2_REFMODE_SAMPLED,
+} DL_COMP_REF_MODE;
+
+/*! @enum DL_COMP_REF_SOURCE */
+typedef enum {
+    /*! Reference voltage generator is disabled (local reference buffer as
+     * well as DAC) */
+    DL_COMP_REF_SOURCE_NONE = COMP_CTL2_REFSRC_OFF,
+    /*! VDDA selected as the reference source to DAC and DAC output applied
+     * as reference to comparator */
+    DL_COMP_REF_SOURCE_VDDA_DAC = COMP_CTL2_REFSRC_VDDA_DAC,
+    /*! VREF selected as the reference source to DAC and DAC output applied
+     * as reference to comparator */
+    DL_COMP_REF_SOURCE_VREF_DAC = COMP_CTL2_REFSRC_VREF_DAC,
+    /*! VREF applied as reference to comparator. For some devices, DAC is
+     * switched off. Refer to the device datasheet for more information. */
+    DL_COMP_REF_SOURCE_VREF = COMP_CTL2_REFSRC_VREF,
+    /*! VDDA is used as comparator reference. For some devices, DAC is
+     * switched off. Refer to the device datasheet for more information. */
+    DL_COMP_REF_SOURCE_VDDA = COMP_CTL2_REFSRC_VDDA,
+    /*! Internal reference selected as the reference source to the DAC and DAC
+     * output applied as reference to comparator */
+    DL_COMP_REF_SOURCE_INT_VREF_DAC = COMP_CTL2_REFSRC_INTVREF_DAC,
+#if (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPM0L122X_L222X)
+    /*! Internal VREF used as reference source of comparator */
+    DL_COMP_REF_SOURCE_INT_VREF = COMP_CTL2_REFSRC_INTVREF,
+#endif
+} DL_COMP_REF_SOURCE;
+
+/*! @enum DL_COMP_REF_TERMINAL_SELECT */
+typedef enum {
+    /*! Reference applied to positive terminal. If EXCH bit is 1, reference
+     * applied to negative terminal. */
+    DL_COMP_REF_TERMINAL_SELECT_POS = COMP_CTL2_REFSEL_POSITIVE,
+    /*! Reference applied to negative terminal. If EXCH bit is 0, reference
+     * applied to positive terminal. */
+    DL_COMP_REF_TERMINAL_SELECT_NEG = COMP_CTL2_REFSEL_NEGATIVE,
+} DL_COMP_REF_TERMINAL_SELECT;
+
+/*! @enum DL_COMP_BLANKING_SOURCE */
+typedef enum {
+    /*! Disable use of blanking source */
+    DL_COMP_BLANKING_SOURCE_DISABLE = COMP_CTL2_BLANKSRC_DISABLE,
+    /*! Blanking source 1 */
+    DL_COMP_BLANKING_SOURCE_1 = COMP_CTL2_BLANKSRC_BLANKSRC1,
+    /*! Blanking source 2 */
+    DL_COMP_BLANKING_SOURCE_2 = COMP_CTL2_BLANKSRC_BLANKSRC2,
+    /*! Blanking source 3 */
+    DL_COMP_BLANKING_SOURCE_3 = COMP_CTL2_BLANKSRC_BLANKSRC3,
+    /*! Blanking source 4 */
+    DL_COMP_BLANKING_SOURCE_4 = COMP_CTL2_BLANKSRC_BLANKSRC4,
+    /*! Blanking source 5 */
+    DL_COMP_BLANKING_SOURCE_5 = COMP_CTL2_BLANKSRC_BLANKSRC5,
+    /*! Blanking source 6 */
+    DL_COMP_BLANKING_SOURCE_6 = COMP_CTL2_BLANKSRC_BLANKSRC6,
+} DL_COMP_BLANKING_SOURCE;
+
+/*! @enum DL_COMP_DAC_CONTROL */
+typedef enum {
+    /*! Comparator output controls selection betwen DACCODE0 and DACCODE1 */
+    DL_COMP_DAC_CONTROL_COMP_OUT = COMP_CTL2_DACCTL_COMPOUT_SEL,
+    /*! DACSW bit controls selection betwen DACCODE0 and DACCODE1 */
+    DL_COMP_DAC_CONTROL_SW = COMP_CTL2_DACCTL_DACSW_SEL,
+} DL_COMP_DAC_CONTROL;
+
+/*! @enum DL_COMP_DAC_INPUT */
+typedef enum {
+    /*! DACCODE0 selected as input for 8-bit COMP when DACCTL bit is 1 */
+    DL_COMP_DAC_INPUT_DACCODE0 = COMP_CTL2_DACSW_DACCODE0_SEL,
+    /*! DACCODE1 selected as input for 8-bit COMP when DACCTL bit is 1 */
+    DL_COMP_DAC_INPUT_DACCODE1 = COMP_CTL2_DACSW_DACCODE1_SEL,
+} DL_COMP_DAC_INPUT;
+
+/*! @enum DL_COMP_OUTPUT */
+typedef enum {
+    /*! Comparator output is high */
+    DL_COMP_OUTPUT_HIGH = COMP_STAT_OUT_LOW,
+    /*! Comparator output is low */
+    DL_COMP_OUTPUT_LOW = COMP_STAT_OUT_HIGH,
+} DL_COMP_OUTPUT;
+
+/*! @enum DL_COMP_SUBSCRIBER_INDEX */
+typedef enum {
+    /*! COMP Subscriber index 0 */
+    DL_COMP_SUBSCRIBER_INDEX_0 = 0,
+    /*! COMP Subscriber index 1 */
+    DL_COMP_SUBSCRIBER_INDEX_1 = 1
+} DL_COMP_SUBSCRIBER_INDEX;
+
+/*!
+ *  @brief  Configuration struct for @ref DL_COMP_init
+ */
+typedef struct {
+    /*! The operating mode of the comparator */
+    DL_COMP_MODE mode;
+    /*! The channel inputs to the comparator terminals to enable */
+    DL_COMP_ENABLE_CHANNEL channelEnable;
+    /*! The channel input for the positive terminal of the comparator */
+    DL_COMP_IPSEL_CHANNEL posChannel;
+    /*! The channel input for the negative terminal of the comparator */
+    DL_COMP_IMSEL_CHANNEL negChannel;
+    /*! The polarity of the comparator output */
+    DL_COMP_POLARITY polarity;
+    /*! The hysteresis of the comparator */
+    DL_COMP_HYSTERESIS hysteresis;
+} DL_COMP_Config;
+
+/*!
+ *  @brief  Configuration struct for @ref DL_COMP_refVoltageInit
+ */
+typedef struct {
+    /*! The operating mode of the reference voltage generator */
+    DL_COMP_REF_MODE mode;
+    /*! The reference source of the comparator */
+    DL_COMP_REF_SOURCE source;
+    /*! The terminals the reference voltage is applied to */
+    DL_COMP_REF_TERMINAL_SELECT terminalSelect;
+    /*! Determines what controls the selection between DACCODE0 and DACCODE1 */
+    DL_COMP_DAC_CONTROL controlSelect;
+    /*! If DL_COMP_DAC_CONTROL_SW is enabled, selects between DACCODE0
+     * and DACCODE1 */
+    DL_COMP_DAC_INPUT inputSelect;
+} DL_COMP_RefVoltageConfig;
+
+/**
+ * @brief      Enables power on the comparator module
+ *
+ * @param[in]  comp  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_enablePower(COMP_Regs *comp)
+{
+    comp->GPRCM.PWREN = (COMP_PWREN_KEY_UNLOCK_W | COMP_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief      Disables power on the comparator module
+ *
+ * @param[in]  comp  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_disablePower(COMP_Regs *comp)
+{
+    comp->GPRCM.PWREN = (COMP_PWREN_KEY_UNLOCK_W | COMP_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief      Returns if power is on for the comparator module
+ *
+ * @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return    The status of the peripheral power
+ *
+ * @retval     true  If power is enabled
+ * @retval     false If power is disabled
+ */
+__STATIC_INLINE bool DL_COMP_isPowerEnabled(COMP_Regs *comp)
+{
+    return ((comp->GPRCM.PWREN & COMP_PWREN_ENABLE_MASK) ==
+            COMP_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief      Resets comparator peripheral
+ *
+ * @param[in]  comp  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_reset(COMP_Regs *comp)
+{
+    comp->GPRCM.RSTCTL =
+        (COMP_RSTCTL_KEY_UNLOCK_W | COMP_RSTCTL_RESETSTKYCLR_CLR |
+            COMP_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief      Returns if comparator was reset
+ *
+ * @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ * @return true  If peripheral was reset
+ * @return false If peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_COMP_isReset(COMP_Regs *comp)
+{
+    return ((comp->GPRCM.STAT & COMP_GPRCM_STAT_RESETSTKY_MASK) ==
+            COMP_GPRCM_STAT_RESETSTKY_RESET);
+}
+
+/**
+ *  @brief      Initialize the COMP peripheral
+ *
+ *  Initializes all the common configurable options for the COMP peripheral. Any
+ *  other custom configuration can be done after calling this API. The COMP is
+ *  not enabled in this API.
+ *
+ *  @param[in]  comp    Pointer to the register overlay for the peripheral
+ *  @param[in]  config  Configuration for COMP peripheral
+ */
+__STATIC_INLINE void DL_COMP_init(COMP_Regs *comp, DL_COMP_Config *config)
+{
+    DL_Common_updateReg(&comp->CTL0,
+        (uint32_t) config->posChannel | (uint32_t) config->negChannel |
+            (uint32_t) config->channelEnable,
+        COMP_CTL0_IMSEL_MASK | COMP_CTL0_IPSEL_MASK | COMP_CTL0_IPEN_MASK |
+            COMP_CTL0_IMEN_MASK);
+
+    DL_Common_updateReg(&comp->CTL1,
+        (uint32_t) config->mode | (uint32_t) config->polarity |
+            (uint32_t) config->hysteresis,
+        COMP_CTL1_MODE_MASK | COMP_CTL1_HYST_MASK | COMP_CTL1_OUTPOL_MASK);
+}
+
+/**
+ *  @brief      Initialize the comparator reference voltage generator
+ *
+ * Initializes all the common configurable options for the comparator
+ * reference voltage generator. Any other custom configuration can be done
+ * after calling this API.
+ *
+ *  @param[in]  comp    Pointer to the register overlay for the peripheral
+ *  @param[in]  config  Configuration for the reference voltage generator
+ */
+__STATIC_INLINE void DL_COMP_refVoltageInit(
+    COMP_Regs *comp, DL_COMP_RefVoltageConfig *config)
+{
+    DL_Common_updateReg(&comp->CTL2,
+        (uint32_t) config->mode | (uint32_t) config->source |
+            (uint32_t) config->terminalSelect |
+            (uint32_t) config->controlSelect | (uint32_t) config->inputSelect,
+        COMP_CTL2_REFMODE_MASK | COMP_CTL2_REFSRC_MASK |
+            COMP_CTL2_REFSEL_MASK | COMP_CTL2_DACCTL_MASK |
+            COMP_CTL2_DACSW_MASK);
+}
+
+/**
+ *  @brief      Enable the comparator peripheral
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_enable(COMP_Regs *comp)
+{
+    comp->CTL1 |= COMP_CTL1_ENABLE_ON;
+}
+
+/**
+ *  @brief      Checks if the comparator peripheral is enabled
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the enabled status of the comparator
+ *
+ *  @retval     true  The comparator peripheral is enabled
+ *  @retval     false The comparator peripheral is disabled
+
+ */
+__STATIC_INLINE bool DL_COMP_isEnabled(COMP_Regs *comp)
+{
+    return ((comp->CTL1 & COMP_CTL1_ENABLE_MASK) == COMP_CTL1_ENABLE_ON);
+}
+
+/**
+ *  @brief      Disable the comparator peripheral
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_disable(COMP_Regs *comp)
+{
+    comp->CTL1 &= ~(COMP_CTL1_ENABLE_MASK);
+}
+
+/**
+ *  @brief      Set the comparator operating mode
+ *
+ * The clock control for comparator is managed by SYSCTL, SYSCTL knows if
+ * comparator module is enabled and at also knows if it is in ultra-low power
+ * mode or fast mode. User needs to ensure the proper bus clock is selected
+ * for different comparator operation mode.
+ *   - In @ref DL_COMP_MODE_ULP, bus clock can be LFCLK or any of the high
+ *     speed clocks.
+ *   - In @ref DL_COMP_MODE_FAST, bus clock cannot be LFCLK.
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *  @param[in]  mode  Mode to set the comparator to.
+ *                    One of @ref DL_COMP_MODE.
+ */
+__STATIC_INLINE void DL_COMP_setCompMode(COMP_Regs *comp, DL_COMP_MODE mode)
+{
+    DL_Common_updateReg(&comp->CTL1, (uint32_t) mode, COMP_CTL1_MODE_MASK);
+}
+
+/**
+ *  @brief      Get the mode the comparator is set to
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The mode the comparator is set to
+ *
+ *  @retval     One of @ref DL_COMP_MODE
+ */
+__STATIC_INLINE DL_COMP_MODE DL_COMP_getCompMode(COMP_Regs *comp)
+{
+    uint32_t mode = (comp->CTL1 & COMP_CTL1_MODE_MASK);
+
+    return (DL_COMP_MODE)(mode);
+}
+
+/**
+ *  @brief      Enable exchange of the comparator inputs, and invert output
+ *
+ * When enabled, the input signals of comparator positive and negative
+ * terminals are exchanged. Additionally, the output signal from the comparator
+ * is inverted too. This allows the user to determine or compensate for the
+ * comparator input offset voltage.
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_enableExchangeInputs(COMP_Regs *comp)
+{
+    comp->CTL1 |= COMP_CTL1_EXCH_EXC;
+}
+
+/**
+ *  @brief      Checks if the inputs are exchanged and if output is inverted
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns if the inputs are exchanged and if output is inverted
+ *
+ *  @retval     true  The inputs are exchanged and output is inverted
+ *  @retval     false The inputs are not exchanged and output is not inverted
+
+ */
+__STATIC_INLINE bool DL_COMP_isExchangeInputsEnabled(COMP_Regs *comp)
+{
+    return ((comp->CTL1 & COMP_CTL1_EXCH_MASK) == COMP_CTL1_EXCH_EXC);
+}
+
+/**
+ *  @brief      Disable input exchange and invert output
+ *
+ * The input signals of the comparator positive and negative terminals are not
+ * exchanged, and the output signal from the comparator is not inverted.
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_disableExchangeInputs(COMP_Regs *comp)
+{
+    comp->CTL1 &= ~(COMP_CTL1_EXCH_MASK);
+}
+
+/**
+ *  @brief      Enable shorting of the comparator inputs
+ *
+ * When enabled, shorts the positive and negative input terminals of the
+ * comparator.
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_enableShortInputTerminals(COMP_Regs *comp)
+{
+    comp->CTL1 |= COMP_CTL1_SHORT_SHT;
+}
+
+/**
+ *  @brief      Checks if the comparator inputs are shorted
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns if the comparator inputs are shorted
+ *
+ *  @retval     true  The comparator inputs are shorted
+ *  @retval     false The comparator inputs are not shorted
+
+ */
+__STATIC_INLINE bool DL_COMP_isInputTerminalsShorted(COMP_Regs *comp)
+{
+    return ((comp->CTL1 & COMP_CTL1_SHORT_MASK) == COMP_CTL1_SHORT_SHT);
+}
+
+/**
+ *  @brief      Disable shorting the comparator inputs
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_disableShortInputTerminals(COMP_Regs *comp)
+{
+    comp->CTL1 &= ~(COMP_CTL1_SHORT_MASK);
+}
+
+/**
+ *  @brief      Set the interrupt edge for the comparator output
+ *
+ * The interrupt flags COMPIFG and COMPINVIFG are set either on the rising or
+ * falling edge of the comparator output.
+ *   - In @ref DL_COMP_OUTPUT_INT_EDGE_RISING, rising edge of the comparator
+ *     output sets the COMPIFG and falling edge sets the COMPINVIFG.
+ *   - In @ref DL_COMP_OUTPUT_INT_EDGE_FALLING, falling edge of the comparator
+ *     output sets the COMPIFG and rising edge sets the COMPINVIFG.
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *  @param[in]  edge  Interrupt edge for the comparator output.
+ *                    One of @ref DL_COMP_OUTPUT_INT_EDGE.
+ */
+__STATIC_INLINE void DL_COMP_setOutputInterruptEdge(
+    COMP_Regs *comp, DL_COMP_OUTPUT_INT_EDGE edge)
+{
+    DL_Common_updateReg(&comp->CTL1, (uint32_t) edge, COMP_CTL1_IES_MASK);
+}
+
+/**
+ *  @brief      Get the interrupt edge for the comparator output
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The interrupt edge for the comparator output
+ *
+ *  @retval     One of @ref DL_COMP_OUTPUT_INT_EDGE
+ */
+__STATIC_INLINE DL_COMP_OUTPUT_INT_EDGE DL_COMP_getOutputInterruptEdge(
+    COMP_Regs *comp)
+{
+    uint32_t interruptEdge = (comp->CTL1 & COMP_CTL1_IES_MASK);
+
+    return (DL_COMP_OUTPUT_INT_EDGE)(interruptEdge);
+}
+
+/**
+ *  @brief      Set the hysteresis voltage
+ *
+ *  @param[in]  comp     Pointer to the register overlay for the peripheral
+ *  @param[in]  voltage  Voltage value to set the hysteresis to
+ */
+__STATIC_INLINE void DL_COMP_setHysteresis(
+    COMP_Regs *comp, DL_COMP_HYSTERESIS voltage)
+{
+    DL_Common_updateReg(&comp->CTL1, (uint32_t) voltage, COMP_CTL1_HYST_MASK);
+}
+
+/**
+ *  @brief      Get the hysteresis voltage
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The hysteresis voltage
+ *
+ *  @retval     One of @ref DL_COMP_HYSTERESIS
+ */
+__STATIC_INLINE DL_COMP_HYSTERESIS DL_COMP_getHysteresis(COMP_Regs *comp)
+{
+    uint32_t hysteresis = (comp->CTL1 & COMP_CTL1_HYST_MASK);
+
+    return (DL_COMP_HYSTERESIS)(hysteresis);
+}
+
+/**
+ *  @brief      Set the output polarity
+ *
+ *  @param[in]  comp      Pointer to the register overlay for the peripheral
+ *  @param[in]  polarity  The polarity of the comparator output
+ */
+__STATIC_INLINE void DL_COMP_setOutputPolarity(
+    COMP_Regs *comp, DL_COMP_POLARITY polarity)
+{
+    DL_Common_updateReg(
+        &comp->CTL1, (uint32_t) polarity, COMP_CTL1_OUTPOL_MASK);
+}
+
+/**
+ *  @brief      Get the output polarity
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The output polarity
+ *
+ *  @retval     One of @ref DL_COMP_POLARITY
+ */
+__STATIC_INLINE DL_COMP_POLARITY DL_COMP_getOutputPolarity(COMP_Regs *comp)
+{
+    uint32_t polarity = (comp->CTL1 & COMP_CTL1_OUTPOL_MASK);
+
+    return (DL_COMP_POLARITY)(polarity);
+}
+
+/**
+ *  @brief      Enable output filter
+ *
+ * The output is filtered with an on-chip analog filter. The delay of the
+ * filter can be adjusted in four different steps. Refer to the device
+ * specific datasheet for the comparator propagation delay with different
+ * filter delay settings.
+ *
+ *  @param[in]  comp   Pointer to the register overlay for the peripheral
+ *  @param[in]  delay  Delay of the filter. One of @ref DL_COMP_FILTER_DELAY.
+ */
+__STATIC_INLINE void DL_COMP_enableOutputFilter(
+    COMP_Regs *comp, DL_COMP_FILTER_DELAY delay)
+{
+    comp->CTL1 |= (COMP_CTL1_FLTEN_ENABLE | (uint32_t) delay);
+}
+
+/**
+ *  @brief      Checks if output filter is enabled
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns if the output is filtered
+ *
+ *  @retval     true  The output is filtered
+ *  @retval     false The output is not filtered
+ */
+__STATIC_INLINE bool DL_COMP_isOutputFilterEnabled(COMP_Regs *comp)
+{
+    return ((comp->CTL1 & COMP_CTL1_FLTEN_MASK) == COMP_CTL1_FLTEN_ENABLE);
+}
+
+/**
+ *  @brief      Disable output filter using on-chip analog filter
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_disableOutputFilter(COMP_Regs *comp)
+{
+    comp->CTL1 &= ~(COMP_CTL1_FLTEN_MASK);
+}
+
+/**
+ *  @brief      Get the output filter delay
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The output filter delay
+ *
+ *  @retval     One of @ref DL_COMP_FILTER_DELAY
+ */
+__STATIC_INLINE DL_COMP_FILTER_DELAY DL_COMP_getOutputFilterDelay(
+    COMP_Regs *comp)
+{
+    uint32_t delay = (comp->CTL1 & COMP_CTL1_FLTDLY_MASK);
+
+    return (DL_COMP_FILTER_DELAY)(delay);
+}
+
+/**
+ *  @brief      Enable the window comparator
+ *
+ *  @param[in]  comp   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_enableWindowComparator(COMP_Regs *comp)
+{
+    comp->CTL1 |= COMP_CTL1_WINCOMPEN_ON;
+}
+
+/**
+ *  @brief      Checks if the window comparator is enabled
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns if the window comparator is enabled
+ *
+ *  @retval     true  The window comparator is enabled
+ *  @retval     false The window comparator is not enabled
+ */
+__STATIC_INLINE bool DL_COMP_isWindowComparatorEnabled(COMP_Regs *comp)
+{
+    return ((comp->CTL1 & COMP_CTL1_WINCOMPEN_MASK) == COMP_CTL1_WINCOMPEN_ON);
+}
+
+/**
+ *  @brief      Disable the window comparator
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_disableWindowComparator(COMP_Regs *comp)
+{
+    comp->CTL1 &= ~(COMP_CTL1_WINCOMPEN_MASK);
+}
+
+/**
+ *  @brief      Set the enabled channels for the comparator terminals
+ *
+ * Enables the selected analog input channels for the positive and
+ * negative comparator terminals.
+ *
+ *  @param[in]  comp      Pointer to the register overlay for the peripheral
+ *  @param[in]  channels  Input channels to enable
+ */
+__STATIC_INLINE void DL_COMP_setEnabledInputChannels(
+    COMP_Regs *comp, DL_COMP_ENABLE_CHANNEL channels)
+{
+    DL_Common_updateReg(&comp->CTL0, (uint32_t) channels,
+        (COMP_CTL0_IMEN_MASK | COMP_CTL0_IPEN_MASK));
+}
+
+/**
+ *  @brief      Get the enabled input channels
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The enabled input channels
+ *
+ *  @retval     One of @ref DL_COMP_ENABLE_CHANNEL
+ */
+__STATIC_INLINE DL_COMP_ENABLE_CHANNEL DL_COMP_getEnabledInputChannels(
+    COMP_Regs *comp)
+{
+    uint32_t channel =
+        (comp->CTL0 & (COMP_CTL0_IMEN_MASK | COMP_CTL0_IPEN_MASK));
+
+    return (DL_COMP_ENABLE_CHANNEL)(channel);
+}
+
+/**
+ *  @brief      Set the channel input for the positive terminal
+ *
+ * This API sets the IPSEL control bit to select the channel input for the
+ * positive terminal. Please see the device datasheet for more details on each
+ * channel input for each comparator instance.
+ *
+ * Note this API does not enable the positive terminal. Call
+ * @ref DL_COMP_setEnabledInputChannels to enable the terminals.
+ *
+ *  @param[in]  comp   Pointer to the register overlay for the peripheral
+ *  @param[in]  input  Channel input for the positive terminal
+ */
+__STATIC_INLINE void DL_COMP_setPositiveChannelInput(
+    COMP_Regs *comp, DL_COMP_IPSEL_CHANNEL input)
+{
+    DL_Common_updateReg(&comp->CTL0, (uint32_t) input, COMP_CTL0_IPSEL_MASK);
+}
+
+/**
+ *  @brief      Get the channel input for the positive terminal
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The channel input for the positive terminal
+ *
+ *  @retval     One of @ref DL_COMP_IPSEL_CHANNEL
+ */
+__STATIC_INLINE DL_COMP_IPSEL_CHANNEL DL_COMP_getPositiveChannelInput(
+    COMP_Regs *comp)
+{
+    uint32_t channel = (comp->CTL0 & COMP_CTL0_IPSEL_MASK);
+
+    return (DL_COMP_IPSEL_CHANNEL)(channel);
+}
+
+/**
+ *  @brief      Set the channel input for the negative terminal
+ *
+ * This API sets the IMSEL control bit to select the channel input for the
+ * negative terminal. Please see the device TRM for more details on each
+ * channel input for each comparator instance.
+ *
+ * Note this API does not enable the negative terminal. Call
+ * @ref DL_COMP_setEnabledInputChannels to enable the terminals.
+ *
+ *  @param[in]  comp   Pointer to the register overlay for the peripheral
+ *  @param[in]  input  Channel input for the negative terminal
+ */
+__STATIC_INLINE void DL_COMP_setNegativeChannelInput(
+    COMP_Regs *comp, DL_COMP_IMSEL_CHANNEL input)
+{
+    DL_Common_updateReg(&comp->CTL0, (uint32_t) input, COMP_CTL0_IMSEL_MASK);
+}
+
+/**
+ *  @brief      Get the channel input for the negative terminal
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The channel input for the negative terminal
+ *
+ *  @retval     One of @ref DL_COMP_IMSEL_CHANNEL
+ */
+__STATIC_INLINE DL_COMP_IMSEL_CHANNEL DL_COMP_getNegativeChannelInput(
+    COMP_Regs *comp)
+{
+    uint32_t channel = (comp->CTL0 & COMP_CTL0_IMSEL_MASK);
+
+    return (DL_COMP_IMSEL_CHANNEL)(channel);
+}
+
+/**
+ *  @brief      Set the mode for the reference voltage
+ *
+ * This bit requests ULP_REF bandgap operation in static mode or sampled mode.
+ * The local reference buffer and 8-bit COMP inside comparator module are also
+ * configured accordingly.
+ *     - In @ref DL_COMP_REF_MODE_STATIC, operation offers higher accuracy but
+ *       consumes higher current.
+ *     - In @ref DL_COMP_REF_MODE_SAMPLED, operation consumes lower current but
+ *       with relaxed reference voltage accuracy.
+ * Comparator requests for reference voltage from ULP_REF only when REFLVL > 0.
+ *
+ *  @param[in]  comp   Pointer to the register overlay for the peripheral
+ *  @param[in]  mode   Mode to set the reference voltage to
+ */
+__STATIC_INLINE void DL_COMP_setReferenceMode(
+    COMP_Regs *comp, DL_COMP_REF_MODE mode)
+{
+    DL_Common_updateReg(&comp->CTL2, (uint32_t) mode, COMP_CTL2_REFMODE_MASK);
+}
+
+/**
+ *  @brief      Get the mode for the reference voltage
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The mode of the reference voltage
+ *
+ *  @retval     One of @ref DL_COMP_REF_MODE
+ */
+__STATIC_INLINE DL_COMP_REF_MODE DL_COMP_getReferenceMode(COMP_Regs *comp)
+{
+    uint32_t mode = (comp->CTL2 & COMP_CTL2_REFMODE_MASK);
+
+    return (DL_COMP_REF_MODE)(mode);
+}
+
+/**
+ *  @brief      Set the reference source for the comparator
+ *
+ *  @param[in]  comp     Pointer to the register overlay for the peripheral
+ *  @param[in]  source   Reference source for the comparator
+ */
+__STATIC_INLINE void DL_COMP_setReferenceSource(
+    COMP_Regs *comp, DL_COMP_REF_SOURCE source)
+{
+    DL_Common_updateReg(&comp->CTL2, (uint32_t) source, COMP_CTL2_REFSRC_MASK);
+}
+
+/**
+ *  @brief      Get the reference source for the comparator
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The reference source
+ *
+ *  @retval     One of @ref DL_COMP_REF_SOURCE
+ */
+__STATIC_INLINE DL_COMP_REF_SOURCE DL_COMP_getReferenceSource(COMP_Regs *comp)
+{
+    uint32_t source = (comp->CTL2 & COMP_CTL2_REFSRC_MASK);
+
+    return (DL_COMP_REF_SOURCE)(source);
+}
+
+/**
+ *  @brief      Set the comparator terminal the reference voltage is applied to
+ *
+ * The reference voltage generator output can be applied to either the positive
+ * terminal or negative terminal of the comparator. When the reference voltage
+ * generator output is applied on a comparator terminal using REFSEL bit and
+ * the comparator channel (from device pins or from internal analog modules) is
+ * also selected on the same terminal using IPSEL/IPEN or IMSEL/IMEN bits, then
+ * the comparator channel selection takes precedence.
+ *
+ *  @param[in]  comp      Pointer to the register overlay for the peripheral
+ *  @param[in]  terminal  Terminal the reference voltage is applied to
+ */
+__STATIC_INLINE void DL_COMP_setReferenceCompTerminal(
+    COMP_Regs *comp, DL_COMP_REF_TERMINAL_SELECT terminal)
+{
+    DL_Common_updateReg(
+        &comp->CTL2, (uint32_t) terminal, COMP_CTL2_REFSEL_MASK);
+}
+
+/**
+ *  @brief      Get the comparator terminal the reference voltage is applied to
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The terminal the reference voltage is applied to
+ *
+ *  @retval     One of @ref DL_COMP_REF_TERMINAL_SELECT
+ */
+__STATIC_INLINE DL_COMP_REF_TERMINAL_SELECT DL_COMP_getReferenceCompTerminal(
+    COMP_Regs *comp)
+{
+    uint32_t terminal = (comp->CTL2 & COMP_CTL2_REFSEL_MASK);
+
+    return (DL_COMP_REF_TERMINAL_SELECT)(terminal);
+}
+
+/**
+ *  @brief      Set the blanking source for the comparator
+ *
+ *  @param[in]  comp     Pointer to the register overlay for the peripheral
+ *  @param[in]  source   Blanking source for the comparator
+ */
+__STATIC_INLINE void DL_COMP_setBlankingSource(
+    COMP_Regs *comp, DL_COMP_BLANKING_SOURCE source)
+{
+    DL_Common_updateReg(
+        &comp->CTL2, (uint32_t) source, COMP_CTL2_BLANKSRC_MASK);
+}
+
+/**
+ *  @brief      Get the blanking source for the comparator
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The blanking source
+ *
+ *  @retval     One of @ref DL_COMP_BLANKING_SOURCE
+ */
+__STATIC_INLINE DL_COMP_BLANKING_SOURCE DL_COMP_getBlankingSource(
+    COMP_Regs *comp)
+{
+    uint32_t source = (comp->CTL2 & COMP_CTL2_BLANKSRC_MASK);
+
+    return (DL_COMP_BLANKING_SOURCE)(source);
+}
+
+/**
+ *  @brief      Select the source for COMP control
+ *
+ * The DACCTL bit determines if the comparator output or a software control
+ * bit, DACSW, selects between DACCODE0 and DACCODE1 bits as the input to
+ * the COMP.
+ *
+ *  @param[in]  comp     Pointer to the register overlay for the peripheral
+ *  @param[in]  control  What controls the inputs to the COMP.
+ *                       One of @ref DL_COMP_DAC_CONTROL
+ */
+__STATIC_INLINE void DL_COMP_setDACControl(
+    COMP_Regs *comp, DL_COMP_DAC_CONTROL control)
+{
+    DL_Common_updateReg(
+        &comp->CTL2, (uint32_t) control, COMP_CTL2_DACCTL_MASK);
+}
+
+/**
+ *  @brief      Get what controls the input to the COMP
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The control input
+ *
+ *  @retval     One of @ref DL_COMP_DAC_CONTROL
+ */
+__STATIC_INLINE DL_COMP_DAC_CONTROL DL_COMP_getDACControl(COMP_Regs *comp)
+{
+    uint32_t control = (comp->CTL2 & COMP_CTL2_DACCTL_MASK);
+
+    return (DL_COMP_DAC_CONTROL)(control);
+}
+
+/**
+ *  @brief      Set whether DACCODE0 or DACCODE1 is the input to the COMP
+ *
+ * @pre The DACCTL bit must be set to 1 in order to program the DACSW bit to
+ * select between DACCODE0 or DACCODE1.
+ *
+ * @sa          DL_COMP_setDACControl
+ *
+ *  @param[in]  comp   Pointer to the register overlay for the peripheral
+ *  @param[in]  input  The input to the COMP. One of @ref DL_COMP_DAC_INPUT
+ */
+__STATIC_INLINE void DL_COMP_setDACInput(
+    COMP_Regs *comp, DL_COMP_DAC_INPUT input)
+{
+    DL_Common_updateReg(&comp->CTL2, (uint32_t) input, COMP_CTL2_DACSW_MASK);
+}
+
+/**
+ *  @brief      Get whether DACCODE0 or DACCODE1 is the input to the COMP
+ *
+ * @pre The DACCTL bit must be set to 1 in order to program the DACSW bit to
+ * select between DACCODE0 or DACCODE1.
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The input to the COMP
+ *
+ *  @retval     One of @ref DL_COMP_DAC_INPUT
+ */
+__STATIC_INLINE DL_COMP_DAC_INPUT DL_COMP_getDACInput(COMP_Regs *comp)
+{
+    uint32_t input = (comp->CTL2 & COMP_CTL2_DACSW_MASK);
+
+    return (DL_COMP_DAC_INPUT)(input);
+}
+
+/**
+ *  @brief      Set the 8-bit COMP input code through DACCODE0
+ *
+ * Sets the first 8-bit COMP code through DACCODE0.  When the COMP code is 0x0
+ * the COMP output will be 0 V. When the COMP code is 0xFF the COMP output will
+ * be selected reference voltage x 255/256.
+ *
+ * @pre The DACCTL bit determines what controls the selection between
+ * DACCODE0 and DACCODE1.
+ * @pre If DACCTL is 1, then the DACSW bit is used to select between DACCODE0
+ * or DACCODE1.
+ *
+ * @sa          DL_COMP_setDACControl
+ * @sa          DL_COMP_setDACInput
+ *
+ *  @param[in]  comp   Pointer to the register overlay for the peripheral
+ *  @param[in]  value  Code to set for codeDACCODE0.
+ *                     Value between 0x0 - 0xFF.
+ */
+__STATIC_INLINE void DL_COMP_setDACCode0(COMP_Regs *comp, uint32_t value)
+{
+    DL_Common_updateReg(&comp->CTL3, value, COMP_CTL3_DACCODE0_MASK);
+}
+
+/**
+ *  @brief      Get the code value of DACCODE0
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The code value that DACCODE0 is set to
+ *
+ *  @retval     Value between 0x0 - 0xFF
+ */
+__STATIC_INLINE uint32_t DL_COMP_getDACCode0(COMP_Regs *comp)
+{
+    return (comp->CTL3 & COMP_CTL3_DACCODE0_MASK);
+}
+
+/**
+ *  @brief      Set the 8-bit COMP input code through DACCODE1
+ *
+ * Sets the second 8-bit COMP code through DACCODE1.  When the COMP code is 0x0
+ * the COMP output will be 0 V. When the COMP code is 0xFF the COMP output will
+ * be selected reference voltage x 255/256.
+ *
+ * @pre The DACCTL bit determines what controls the selection between
+ * DACCODE0 and DACCODE1.
+ * @pre If DACCTL is 1, then the DACSW bit is used to select between DACCODE0
+ * or DACCODE1.
+ *
+ * @sa          DL_COMP_setDACControl
+ * @sa          DL_COMP_setDACInput
+ *
+ *  @param[in]  comp   Pointer to the register overlay for the peripheral
+ *  @param[in]  value  Code to set for codeDACCODE1.
+ *                     Value between 0x0 - 0xFF.
+ */
+__STATIC_INLINE void DL_COMP_setDACCode1(COMP_Regs *comp, uint32_t value)
+{
+    DL_Common_updateReg(&comp->CTL3, (value << COMP_CTL3_DACCODE1_OFS),
+        COMP_CTL3_DACCODE1_MASK);
+}
+
+/**
+ *  @brief      Get the code value of DACCODE1
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The code value that DACCODE1 is set to
+ *
+ *  @retval     Value between 0x0 - 0xFF
+ */
+__STATIC_INLINE uint32_t DL_COMP_getDACCode1(COMP_Regs *comp)
+{
+    return ((comp->CTL3 & COMP_CTL3_DACCODE1_MASK) >> COMP_CTL3_DACCODE1_OFS);
+}
+
+/**
+ *  @brief      Gets the comparator output
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the output status of the comparator. One of @ref DL_COMP_OUTPUT
+ */
+__STATIC_INLINE DL_COMP_OUTPUT DL_COMP_getComparatorOutput(COMP_Regs *comp)
+{
+    uint32_t output = (comp->STAT & COMP_STAT_OUT_MASK);
+
+    return (DL_COMP_OUTPUT)(output);
+}
+
+/**
+ *  @brief      Enable sampled mode of the comparator
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_enableSampledMode(COMP_Regs *comp)
+{
+    comp->CTL2 |= COMP_CTL2_SAMPMODE_ENABLE;
+}
+
+/**
+ *  @brief      Checks if sampled mode is enabled
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns if sampled mode is enabled
+ *
+ *  @retval     true  Sampled mode is enabled
+ *  @retval     false Sampled mode is disabled
+
+ */
+__STATIC_INLINE bool DL_COMP_isSampledModeEnabled(COMP_Regs *comp)
+{
+    return (
+        (comp->CTL2 & COMP_CTL2_SAMPMODE_MASK) == COMP_CTL2_SAMPMODE_ENABLE);
+}
+
+/**
+ *  @brief      Disable sampled mode
+ *
+ *  @param[in]  comp  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_COMP_disableSampledMode(COMP_Regs *comp)
+{
+    comp->CTL2 &= ~(COMP_CTL2_SAMPMODE_MASK);
+}
+
+/**
+ *  @brief Sets the event subscriber channel id
+ *
+ *  @param[in]  comp Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  index   Specifies the register event index to be configured
+ *  @param[in]  chanID  Channel ID number. Valid range 0-15. If ChanID == 0
+ *                      subscriber is disconnected.
+ */
+__STATIC_INLINE void DL_COMP_setSubscriberChanID(
+    COMP_Regs *comp, DL_COMP_SUBSCRIBER_INDEX index, uint8_t chanID)
+{
+    volatile uint32_t *pReg = &comp->FSUB_0;
+
+    *(pReg + (uint32_t) index) = (chanID & COMP_FSUB_0_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event subscriber channel id
+ *
+ *  @param[in]  comp Pointer to the register overlay for the peripheral
+ *  @param[in]  index  Specifies the register event index to be configured
+ *
+ *  @return     Event subscriber channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_COMP_getSubscriberChanID(
+    COMP_Regs *comp, DL_COMP_SUBSCRIBER_INDEX index)
+{
+    volatile uint32_t *pReg = &comp->FSUB_0;
+
+    return ((uint8_t)(*(pReg + (uint32_t) index) & COMP_FSUB_0_CHANID_MASK));
+}
+
+/**
+ *  @brief      Enable COMP interrupts
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_COMP_INTERRUPT.
+ */
+__STATIC_INLINE void DL_COMP_enableInterrupt(
+    COMP_Regs *comp, uint32_t interruptMask)
+{
+    comp->CPU_INT.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disable COMP interrupts
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to disable. Bitwise OR of
+ *                             @ref DL_COMP_INTERRUPT.
+ */
+__STATIC_INLINE void DL_COMP_disableInterrupt(
+    COMP_Regs *comp, uint32_t interruptMask)
+{
+    comp->CPU_INT.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief      Check which COMP interrupts are enabled
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_COMP_INTERRUPT.
+ *
+ *  @return     Which of the requested COMP interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_COMP_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_COMP_getEnabledInterrupts(
+    COMP_Regs *comp, uint32_t interruptMask)
+{
+    return (comp->CPU_INT.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled COMP interrupts
+ *
+ *  Checks if any of the COMP interrupts that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_COMP_INTERRUPT.
+ *
+ *  @return     Which of the requested COMP interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_COMP_INTERRUPT values
+ *
+ *  @sa         DL_COMP_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_COMP_getEnabledInterruptStatus(
+    COMP_Regs *comp, uint32_t interruptMask)
+{
+    return (comp->CPU_INT.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any COMP interrupt
+ *
+ *  Checks if any of the COMP interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_COMP_INTERRUPT.
+ *
+ *  @return     Which of the requested COMP interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_COMP_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_COMP_getRawInterruptStatus(
+    COMP_Regs *comp, uint32_t interruptMask)
+{
+    return (comp->CPU_INT.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending COMP interrupt
+ *
+ *  Checks if any of the COMP interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @return     The highest priority pending COMP interrupt. One of @ref
+ *               DL_COMP_IIDX
+ */
+__STATIC_INLINE DL_COMP_IIDX DL_COMP_getPendingInterrupt(COMP_Regs *comp)
+{
+    return (DL_COMP_IIDX)(comp->CPU_INT.IIDX);
+}
+
+/**
+ *  @brief      Clear pending COMP interrupts
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_COMP_INTERRUPT.
+ */
+__STATIC_INLINE void DL_COMP_clearInterruptStatus(
+    COMP_Regs *comp, uint32_t interruptMask)
+{
+    comp->CPU_INT.ICLR = interruptMask;
+}
+
+/**
+ *  @brief Sets the COMP event publisher channel ID
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  chanID         Channel ID number. Valid range 0-15.
+ *                             If ChanID == 0, publisher is disconnected.
+ */
+__STATIC_INLINE void DL_COMP_setPublisherChanID(
+    COMP_Regs *comp, uint8_t chanID)
+{
+    comp->FPUB_1 = (chanID & COMP_FPUB_1_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event publisher channel ID
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @return     Event publisher channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_COMP_getPublisherChanID(COMP_Regs *comp)
+{
+    return ((uint8_t)((comp->FPUB_1) & COMP_FPUB_1_CHANID_MAXIMUM));
+}
+
+/**
+ *  @brief      Enable COMP event
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_COMP_EVENT.
+ */
+__STATIC_INLINE void DL_COMP_enableEvent(COMP_Regs *comp, uint32_t eventMask)
+{
+    comp->GEN_EVENT.IMASK |= (eventMask);
+}
+
+/**
+ *  @brief      Disable COMP event
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_COMP_EVENT.
+ */
+__STATIC_INLINE void DL_COMP_disableEvent(COMP_Regs *comp, uint32_t eventMask)
+{
+    comp->GEN_EVENT.IMASK &= ~(eventMask);
+}
+
+/**
+ *  @brief      Check which COMP events are enabled
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_COMP_EVENT.
+ *
+ *  @return     Which of the requested COMP interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_COMP_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_COMP_getEnabledEvents(
+    COMP_Regs *comp, uint32_t eventMask)
+{
+    return ((comp->GEN_EVENT.IMASK) & (eventMask));
+}
+
+/**
+ *  @brief      Check event flag of enabled COMP event
+ *
+ *  Checks if any of the COMP events that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_COMP_EVENT.
+ *
+ *  @return     Which of the requested COMP interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_COMP_EVENT values
+ *
+ *  @sa         DL_COMP_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_COMP_getEnabledEventStatus(
+    COMP_Regs *comp, uint32_t eventMask)
+{
+    return ((comp->GEN_EVENT.MIS) & eventMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any COMP event
+ *
+ *  Checks if any events are pending. Events do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_COMP_EVENT.
+ *
+ *  @return     Which of the requested COMP interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_COMP_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_COMP_getRawEventsStatus(
+    COMP_Regs *comp, uint32_t eventMask)
+{
+    return ((comp->GEN_EVENT.RIS) & eventMask);
+}
+
+/**
+ *  @brief      Clear pending COMP events
+ *
+ *  @param[in]  comp           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_COMP_EVENT.
+ */
+__STATIC_INLINE void DL_COMP_clearEventsStatus(
+    COMP_Regs *comp, uint32_t eventMask)
+{
+    comp->GEN_EVENT.ICLR |= (eventMask);
+}
+
+/* clang-format on */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_COMP__ */
+
+#endif /* ti_dl_m0p_dl_comp__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_crc.c
+++ b/mspm0/source/ti/driverlib/dl_crc.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_crc.h>
+
+#ifdef __MSPM0_HAS_CRC__
+
+uint32_t DL_CRC_calculateBlock32(
+    CRC_Regs* crc, uint32_t seed, uint32_t* ptr, uint32_t size)
+{
+    uint32_t i;
+
+    DL_CRC_setSeed32(crc, seed);
+
+    for (i = 0; i < size; i++) {
+        DL_CRC_feedData32(crc, ptr[i]);
+    }
+
+    return (DL_CRC_getResult32(crc));
+}
+
+uint32_t DL_CRC_calculateMemoryRange32(
+    CRC_Regs* crc, uint32_t seed, uint32_t* ptrStart, uint32_t* ptrEnd)
+{
+    DL_CRC_setSeed32(crc, seed);
+
+    uint32_t* ptr = ptrStart;
+
+    while (ptr <= ptrEnd) {
+        DL_CRC_feedData32(crc, (uint32_t) *ptr);
+        ptr = ptr + 1;
+    }
+
+    return (DL_CRC_getResult32(crc));
+}
+
+uint16_t DL_CRC_calculateBlock16(
+    CRC_Regs* crc, uint16_t seed, uint16_t* ptr, uint16_t size)
+{
+    uint32_t i;
+
+    DL_CRC_setSeed16(crc, seed);
+
+    for (i = 0; i < size; i++) {
+        DL_CRC_feedData16(crc, ptr[i]);
+    }
+
+    return ((uint16_t) DL_CRC_getResult16(crc));
+}
+
+uint16_t DL_CRC_calculateMemoryRange16(
+    CRC_Regs* crc, uint16_t seed, uint16_t* ptrStart, uint16_t* ptrEnd)
+{
+    DL_CRC_setSeed16(crc, seed);
+
+    uint16_t* ptr = ptrStart;
+
+    while (ptr <= ptrEnd) {
+        DL_CRC_feedData16(crc, (uint16_t) *ptr);
+        ptr = ptr + 1;
+    }
+
+    return ((uint16_t) DL_CRC_getResult16(crc));
+}
+
+#endif /* __MSPM0_HAS_CRC__ */

--- a/mspm0/source/ti/driverlib/dl_crc.h
+++ b/mspm0/source/ti/driverlib/dl_crc.h
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_crc.h
+ *  @brief      Cyclic Redundancy Check (CRC) Driver Library
+ *  @defgroup   CRC Cyclic Redundancy Check (CRC)
+ *
+ *  @anchor ti_dl_dl_crc_Overview
+ *  # Overview
+ *
+ *  The CRC DriverLib allows full configuration of the MSPM0 CRC module.
+ *  The cyclic redundancy check (CRC) accelerator generates signatures for a
+ *  given data sequence based on the CRC16-CCITT polynomial or the
+ *  CRC32-ISO3309 polynomial.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup CRC
+ * @{
+ */
+#ifndef ti_dl_dl_crc__include
+#define ti_dl_dl_crc__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_CRC__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if (CRC_SYS_CRC32_ENABLE == 1)
+/*!
+ * @brief Device has support for CRC 32-bit polynomials
+ */
+#define DEVICE_HAS_CRC_32_BIT_POLYNOMIAL
+#endif
+
+/*! @enum DL_CRC_POLYNOMIAL */
+typedef enum {
+    /*! Use 16-bit polynomial for calculation. Follows CRC-16-CCITT standard
+     * with a polynomial value of 0x1021. */
+    DL_CRC_16_POLYNOMIAL = CRC_CRCCTRL_POLYSIZE_CRC16,
+#ifdef DEVICE_HAS_CRC_32_BIT_POLYNOMIAL
+    /*! Use 32-bit polynomial for calculation. Follows CRC32-ISO3309 standard
+     * with a polynomial value of 0x04C11DB7.*/
+    DL_CRC_32_POLYNOMIAL = CRC_CRCCTRL_POLYSIZE_CRC32
+#endif /* DEVICE_HAS_CRC_32_BIT_POLYNOMIAL */
+} DL_CRC_POLYNOMIAL;
+
+/*! @enum DL_CRC_BIT */
+typedef enum {
+    /*! CRC Bit Input and output are reversed */
+    DL_CRC_BIT_REVERSED = CRC_CRCCTRL_BITREVERSE_REVERSED,
+    /*! CRC Bit Input and output are not reversed */
+    DL_CRC_BIT_NOT_REVERSED = CRC_CRCCTRL_BITREVERSE_NOT_REVERSED
+} DL_CRC_BIT;
+
+/*! @enum DL_CRC_INPUT_ENDIANESS */
+typedef enum {
+    /*! CRC Input is proccessed in little endian.
+     *  LSB is lowest memory address and first to be processed. */
+    DL_CRC_INPUT_ENDIANESS_LITTLE_ENDIAN =
+        CRC_CRCCTRL_INPUT_ENDIANNESS_LITTLE_ENDIAN,
+    /*! CRC Input is proccessed in big endian.
+     *  LSB is highest memory address and last to be processed. */
+    DL_CRC_INPUT_ENDIANESS_BIG_ENDIAN = CRC_CRCCTRL_INPUT_ENDIANNESS_BIG_ENDIAN
+} DL_CRC_INPUT_ENDIANESS;
+
+/*! @enum DL_CRC_OUTPUT_BYTESWAP */
+typedef enum {
+    /*! CRC output byteswap is enabled */
+    DL_CRC_OUTPUT_BYTESWAP_ENABLED = CRC_CRCCTRL_OUTPUT_BYTESWAP_ENABLE,
+    /*! CRC output byteswap is disabled */
+    DL_CRC_OUTPUT_BYTESWAP_DISABLED = CRC_CRCCTRL_OUTPUT_BYTESWAP_DISABLE
+} DL_CRC_OUTPUT_BYTESWAP;
+
+/**
+ * @brief Enables power on crc module
+ *
+ * @param crc        Pointer to the register overlay for the CRC peripheral
+ */
+__STATIC_INLINE void DL_CRC_enablePower(CRC_Regs *crc)
+{
+    crc->GPRCM.PWREN = (CRC_PWREN_KEY_UNLOCK_W | CRC_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power on crc module
+ *
+ * @param crc        Pointer to the register overlay for the CRC peripheral
+ */
+__STATIC_INLINE void DL_CRC_disablePower(CRC_Regs *crc)
+{
+    crc->GPRCM.PWREN = (CRC_PWREN_KEY_UNLOCK_W | CRC_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief Returns if power on crc module is enabled
+ *
+ * @param crc        Pointer to the register overlay for the CRC peripheral
+ *
+ * @return true if power is enabled
+ * @return false if power is disabled
+ *
+ */
+__STATIC_INLINE bool DL_CRC_isPowerEnabled(CRC_Regs *crc)
+{
+    return (
+        (crc->GPRCM.PWREN & CRC_PWREN_ENABLE_MASK) == CRC_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Resets crc peripheral
+ *
+ * @param crc        Pointer to the register overlay for the CRC peripheral
+ */
+__STATIC_INLINE void DL_CRC_reset(CRC_Regs *crc)
+{
+    crc->GPRCM.RSTCTL =
+        (CRC_RSTCTL_KEY_UNLOCK_W | CRC_RSTCTL_RESETSTKYCLR_CLR |
+            CRC_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief Returns if crc module has been reset
+ *
+ * @param crc        Pointer to the register overlay for the CRC peripheral\
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_CRC_isReset(CRC_Regs *crc)
+{
+    return ((crc->GPRCM.STAT & CRC_STAT_RESETSTKY_MASK) ==
+            CRC_STAT_RESETSTKY_RESET);
+}
+
+/**
+ * @brief Initializes CRC
+ *
+ * @param crc          Pointer to the register overlay for the CRC peripheral
+ * @param poly         Selects CRC polynomial. One of @ref DL_CRC_POLYNOMIAL.
+ * @param bitOrd       Selects CRC bit order. One of @ref DL_CRC_BIT.
+ * @param inEndianness Selects CRC input endianess. One of
+ *                     @ref DL_CRC_INPUT_ENDIANESS.
+ * @param outByteSwap  Selects CRC output byte swap mode. One of
+ *                     @ref DL_CRC_OUTPUT_BYTESWAP.
+ *
+ */
+__STATIC_INLINE void DL_CRC_init(CRC_Regs *crc, DL_CRC_POLYNOMIAL poly,
+    DL_CRC_BIT bitOrd, DL_CRC_INPUT_ENDIANESS inEndianness,
+    DL_CRC_OUTPUT_BYTESWAP outByteSwap)
+{
+    crc->CRCCTRL = ((uint32_t) poly | (uint32_t) bitOrd |
+                    (uint32_t) inEndianness | (uint32_t) outByteSwap);
+}
+
+/*!
+ *  @brief      Initializes the seed for a 16-bit polynomial CRC calculation
+ *  @note       CRC seed is swapped when CRC module is configured in big-endian
+ *              mode. For example when calling DL_CRC_setSeed32(CRC, 0xaabb).
+ *              The CRC module will be initialized with 0xbbaa. Therefore, the
+ *              seed value should be appropriately specified taking endianness
+ *              into account. Please refer to the device TRM for additional
+ *              detail.
+ *
+ *  @param[in]  crc    Pointer to the register overlay for the CRC peripheral
+ *  @param[in]  seed   The seed for the CRC to start generating a signature from
+ */
+__STATIC_INLINE void DL_CRC_setSeed16(CRC_Regs *crc, uint16_t seed)
+{
+    volatile uintptr_t addr;
+    volatile uint16_t *pRef;
+
+    addr = (uintptr_t)((volatile uintptr_t *) &crc->CRCSEED);
+    pRef = (volatile uint16_t *) addr;
+
+    *pRef = seed;
+}
+
+/*!
+ *  @brief    Initializes the seed for a 32-bit polynomial CRC calculation
+ *  @note     CRC seed is swapped when CRC module is configured in big-endian
+ *            mode. For example when calling DL_CRC_setSeed32(CRC, 0xaabbccdd).
+ *            The CRC module will be initialized with 0xddccbbaa. Therefore, the
+ *            seed value should be appropriately specified taking endianness
+ *            into account. Please refer to the device TRM for additional
+ *            detail.
+ *
+ *  @param[in]  crc    Pointer to the register overlay for the CRC peripheral
+ *  @param[in]  seed   The seed for the CRC to start generating a signature from
+ */
+__STATIC_INLINE void DL_CRC_setSeed32(CRC_Regs *crc, uint32_t seed)
+{
+    crc->CRCSEED = seed;
+}
+
+/*!
+ *  @brief      Feeds 8-bit data into the CRC calculation
+ *
+ *  @param[in]  crc         Pointer to the register overlay for the CRC
+ *                          peripheral
+ *  @param[in]  dataIn      8-bit data value to add to the signature
+ *
+ */
+__STATIC_INLINE void DL_CRC_feedData8(CRC_Regs *crc, uint8_t dataIn)
+{
+    volatile uint8_t *pRef = (volatile uint8_t *) &crc->CRCIN;
+    *pRef                  = dataIn;
+}
+
+/*!
+ *  @brief      Feeds 16-bit data into the CRC calculation
+ *
+ *  @param[in]  crc         Pointer to the register overlay for the CRC
+ *                          peripheral
+ *  @param[in]  dataIn      16-bit data value to add to the signature
+ *
+ */
+__STATIC_INLINE void DL_CRC_feedData16(CRC_Regs *crc, uint16_t dataIn)
+{
+    volatile uintptr_t addr;
+    volatile uint16_t *pRef;
+
+    addr = (uintptr_t)((volatile uintptr_t *) &crc->CRCIN);
+    pRef = (volatile uint16_t *) addr;
+
+    *pRef = dataIn;
+}
+
+/*!
+ *  @brief      Feeds 32-bit data into the CRC calculation
+ *
+ *  Feeds a 32-bit value into the CRC calculation. 32-bit data can only be used
+ *  with the 32-bit polynomial.
+ *
+ *  @param[in]  crc         Pointer to the register overlay for the CRC
+ *                          peripheral
+ *  @param[in]  dataIn      32 bit data value to add to the signature
+ *
+ */
+__STATIC_INLINE void DL_CRC_feedData32(CRC_Regs *crc, uint32_t dataIn)
+{
+    crc->CRCIN = dataIn;
+}
+
+/*!
+ *  @brief      Returns the result from the 16-bit polynomial calculation
+ *
+ *  @param[in]  crc  Pointer to the register overlay for the CRC peripheral
+ *
+ *  @return     The calculation result for the 16-bit polynomial
+ */
+__STATIC_INLINE uint16_t DL_CRC_getResult16(CRC_Regs *crc)
+{
+    return ((uint16_t) crc->CRCOUT);
+}
+
+/*!
+ *  @brief      Returns the result from the 32-bit polynomial calculation
+ *
+ *  @param[in]  crc  Pointer to the register overlay for the CRC peripheral
+ *
+ *  @return     The calculation result for the 32-bit polynomial
+ */
+__STATIC_INLINE uint32_t DL_CRC_getResult32(CRC_Regs *crc)
+{
+    return (crc->CRCOUT);
+}
+
+/*!
+ *  @brief      Calculates the CRC over a range of 32-bit values
+ *
+ *  Uses the 32-bit polynomial to calculate the checksum over a block of
+ *  values.
+ *
+ *  @param[in]  crc   Pointer to the register overlay for the CRC peripheral
+ *  @param[in]  seed  The seed for the CRC to start generating a signature from
+ *  @param[in]  ptr   A pointer to the block of code to calculate the CRC over
+ *  @param[in]  size  The size of the block of uint32_t data
+ *
+ *  @return     The calculated CRC signature value
+ */
+extern uint32_t DL_CRC_calculateBlock32(
+    CRC_Regs *crc, uint32_t seed, uint32_t *ptr, uint32_t size);
+
+/*!
+ *  @brief      Calculates the CRC over a memory range
+ *
+ *  Calculates the checksum using the 32-bit polynomial over any memory range.
+ *
+ *  @param[in]  crc       Pointer to the register overlay for the CRC
+ *                        peripheral
+ *  @param[in]  seed      The seed used to start generating a signature from
+ *  @param[in]  ptrStart  A uint32_t pointer to the start of a block of code to
+ *                        calculate the CRC over
+ *  @param[in]  ptrEnd    A uint32_t pointer to the end of a block of code to
+ *                        calculate the CRC over
+ *
+ *  @return     The calculated CRC signature value
+ */
+extern uint32_t DL_CRC_calculateMemoryRange32(
+    CRC_Regs *crc, uint32_t seed, uint32_t *ptrStart, uint32_t *ptrEnd);
+
+/*!
+ *  @brief      Calculates the CRC over a range of 16-bit values
+ *
+ *  Uses the 16-bit polynomial to calculate the checksum over a block of
+ *  values.
+ *
+ *  @param[in]  crc   Pointer to the register overlay for the CRC peripheral
+ *  @param[in]  seed  The seed for the CRC to start generating a signature from
+ *  @param[in]  ptr   A pointer to the block of code to calculate the CRC over
+ *  @param[in]  size  The size of the block of 16-bit data
+ *
+ *  @return     The calculated CRC signature value
+ */
+extern uint16_t DL_CRC_calculateBlock16(
+    CRC_Regs *crc, uint16_t seed, uint16_t *ptr, uint16_t size);
+
+/*!
+ *  @brief      Calculates the CRC over a memory range
+ *
+ *  Calculates the checksum using the 16-bit polynomial over any memory range.
+ *
+ *  @param[in]  crc       Pointer to the register overlay for the CRC
+ *                        peripheral
+ *  @param[in]  seed      The seed used to start generating a signature from
+ *  @param[in]  ptrStart  A uint16_t pointer to the start of a block of code to
+ *                        calculate the CRC over
+ *  @param[in]  ptrEnd    A uint16_t pointer to the end of a block of code to
+ *                        calculate the CRC over
+ *
+ *  @return     The calculated CRC signature value
+ */
+extern uint16_t DL_CRC_calculateMemoryRange16(
+    CRC_Regs *crc, uint16_t seed, uint16_t *ptrStart, uint16_t *ptrEnd);
+
+/**
+ *  @brief Returns the address of the CRC input data register.
+ *
+ *  This API can be used with @ref DL_DMA_setDestAddr to set the destination
+ *  address when using DMA transfers
+ *
+ *  @param[in]  crc       Pointer to the register overlay for the CRC
+ *                        peripheral
+ *  @return Address of the CRC input data register
+ */
+__STATIC_INLINE uintptr_t DL_CRC_getCRCINAddr(CRC_Regs *crc)
+{
+    return ((uintptr_t) &crc->CRCIN);
+}
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_CRC__ */
+
+#endif /* ti_dl_dl_crc__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_crcp.c
+++ b/mspm0/source/ti/driverlib/dl_crcp.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_crcp.h>
+
+#ifdef __MSPM0_HAS_CRCP__
+
+uint32_t DL_CRCP_calculateBlock32(
+    CRCP_Regs* crcp, uint32_t seed, uint32_t* ptr, uint32_t size)
+{
+    uint32_t i;
+
+    DL_CRCP_setSeed32(crcp, seed);
+
+    for (i = 0; i < size; i++) {
+        DL_CRCP_feedData32(crcp, ptr[i]);
+    }
+
+    return (DL_CRCP_getResult32(crcp));
+}
+
+uint32_t DL_CRCP_calculateMemoryRange32(
+    CRCP_Regs* crcp, uint32_t seed, uint32_t* ptrStart, uint32_t* ptrEnd)
+{
+    DL_CRCP_setSeed32(crcp, seed);
+
+    uint32_t* ptr = ptrStart;
+
+    while (ptr <= ptrEnd) {
+        DL_CRCP_feedData32(crcp, (uint32_t) *ptr);
+        ptr = ptr + 1;
+    }
+
+    return (DL_CRCP_getResult32(crcp));
+}
+
+uint16_t DL_CRCP_calculateBlock16(
+    CRCP_Regs* crcp, uint16_t seed, uint16_t* ptr, uint16_t size)
+{
+    uint32_t i;
+
+    DL_CRCP_setSeed16(crcp, seed);
+
+    for (i = 0; i < size; i++) {
+        DL_CRCP_feedData16(crcp, ptr[i]);
+    }
+
+    return ((uint16_t) DL_CRCP_getResult16(crcp));
+}
+
+uint16_t DL_CRCP_calculateMemoryRange16(
+    CRCP_Regs* crcp, uint16_t seed, uint16_t* ptrStart, uint16_t* ptrEnd)
+{
+    DL_CRCP_setSeed16(crcp, seed);
+
+    uint16_t* ptr = ptrStart;
+
+    while (ptr <= ptrEnd) {
+        DL_CRCP_feedData16(crcp, (uint16_t) *ptr);
+        ptr = ptr + 1;
+    }
+
+    return ((uint16_t) DL_CRCP_getResult16(crcp));
+}
+
+#endif /* __MSPM0_HAS_CRCP__ */

--- a/mspm0/source/ti/driverlib/dl_crcp.h
+++ b/mspm0/source/ti/driverlib/dl_crcp.h
@@ -1,0 +1,541 @@
+/*
+ * Copyright (c) 2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_crcp.h
+ *  @brief      Cyclic Redundancy Check with Configurable Polynomial (CRCP) Driver Library
+ *  @defgroup   CRCP Cyclic Redundancy Check with Configurable Polynomial (CRCP)
+ *
+ *  @anchor ti_dl_dl_crcp_Overview
+ *  # Overview
+ *
+ *  The CRCP DriverLib allows full configuration of the MSPM0 CRCP module.
+ *  The cyclic redundancy check (CRC) accelerator generates signatures for a
+ *  given data sequence based on a user-configured polynomial, allowing for
+ *  support of any 16-bit or 32-bit polynomial including but not limited to:
+ *      * CRC32-IS03309
+ *      * CRC16-ITT
+ *      * CRC-32C
+ *      * CRC-32K
+ *      * CRC-16-Profibus
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup CRCP
+ * @{
+ */
+#ifndef ti_dl_dl_crcp__include
+#define ti_dl_dl_crcp__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_CRCP__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*! @enum DL_CRCP_POLYNOMIAL_SIZE */
+typedef enum {
+    /*! Use lower 16-bit value of CRCPOLY as polynomial for calculation.
+     * Upon reset, user will need to update polynomial value for 16-bits,
+     * such as the CRC-16-CCITT standard of 0x1021. */
+    DL_CRCP_POLYNOMIAL_SIZE_16 = CRCP_CRCCTRL_POLYSIZE_CRC16,
+    /*! Use 32-bit polynomial value of CRCPOLY as polynomial for calculation.
+     * Defaults to the CRC32-ISO3309 standard value of 0x04C11DB7. */
+    DL_CRCP_POLYNOMIAL_SIZE_32 = CRCP_CRCCTRL_POLYSIZE_CRC32
+} DL_CRCP_POLYNOMIAL_SIZE;
+
+/*! @enum DL_CRCP_BIT */
+typedef enum {
+    /*! CRCP Bit Input and output bit orders are reversed */
+    DL_CRCP_BIT_REVERSED = CRCP_CRCCTRL_BITREVERSE_REVERSED,
+    /*! CRCP Bit Input and output are not reversed */
+    DL_CRCP_BIT_NOT_REVERSED = CRCP_CRCCTRL_BITREVERSE_NOT_REVERSED
+} DL_CRCP_BIT;
+
+/*! @enum DL_CRCP_INPUT_ENDIANESS */
+typedef enum {
+    /*! CRCP Input is proccessed in little endian.
+     *  LSB is lowest memory address and first to be processed. */
+    DL_CRCP_INPUT_ENDIANESS_LITTLE_ENDIAN =
+        CRCP_CRCCTRL_INPUT_ENDIANNESS_LITTLE_ENDIAN,
+    /*! CRCP Input is proccessed in big endian.
+     *  LSB is highest memory address and last to be processed. */
+    DL_CRCP_INPUT_ENDIANESS_BIG_ENDIAN =
+        CRCP_CRCCTRL_INPUT_ENDIANNESS_BIG_ENDIAN
+} DL_CRCP_INPUT_ENDIANESS;
+
+/*! @enum DL_CRCP_OUTPUT_BYTESWAP */
+typedef enum {
+    /*! CRCP output byteswap is enabled */
+    DL_CRCP_OUTPUT_BYTESWAP_ENABLED = CRCP_CRCCTRL_OUTPUT_BYTESWAP_ENABLE,
+    /*! CRCP output byteswap is disabled */
+    DL_CRCP_OUTPUT_BYTESWAP_DISABLED = CRCP_CRCCTRL_OUTPUT_BYTESWAP_DISABLE
+} DL_CRCP_OUTPUT_BYTESWAP;
+
+/*! @enum DL_CRCP_CRCPOLY_POLYNOMIAL
+ *
+ *  @brief commonly used pre-defined polynomials to be used by CRCP
+ *         as mentioned by the website
+ *         http://www.sunshine2k.de/coding/javascript/crc/crc_js.html.
+ *         Custom polynomials can also be used in lieu of the follwoing.
+ */
+typedef enum {
+
+    /*! CRCP commonly used polynomial CRC32_MPEG2. To match online output,
+     *  seed value must be set to 0xFFFFFFFF */
+    DL_CRCP_CRCPOLY_POLYNOMIAL_32_MPEG2 = 0x04C11DB7,
+    /*! CRCP commonly used polynomial CRC32_Q. To match online output,
+     *  seed value must be set to 0x00000000 */
+    DL_CRCP_CRCPOLY_POLYNOMIAL_32_Q = 0x814141AB,
+    /*! CRCP commonly used polynomial CRC32_JAMCRC. To match online output,
+     *  seed value must be set to 0xFFFFFFFF and bit order reversed */
+    DL_CRCP_CRCPOLY_POLYNOMIAL_32_JAMCRC = 0x04C11DB7,
+    /*! CRCP commonly used polynomial CRC32_XFER. To match online output,
+     *  seed value must be set to 0x00000000 */
+    DL_CRCP_CRCPOLY_POLYNOMIAL_32_XFER = 0x000000AF,
+    /*! CRCP commonly used polynomial CRC16_CCIT_ZERO. To match online
+     *  output, seed value must be set to 0x0000 */
+    DL_CRCP_CRCPOLY_POLYNOMIAL_16_CCIT_ZERO = 0x00001021,
+    /*! CRCP commonly used polynomial CRC16_ARC. To match online output,
+     *  seed value must be set to 0x0000 and bit order reversed */
+    DL_CRCP_CRCPOLY_POLYNOMIAL_16_ARC = 0x00001DCF,
+    /*! CRCP commonly used polynomial CRC16_AUG_CCIT. To match online output,
+     *  seed value must be set to 0x1D0F */
+    DL_CRCP_CRCPOLY_POLYNOMIAL_16_AUG_CCIT = 0x00001021,
+    /*! CRCP commonly used polynomial CRC16_BUYPASS. To match online output,
+     *  seed value must be set to 0x0000 */
+    DL_CRCP_CRCPOLY_POLYNOMIAL_16_BUYPASS = 0x00008005,
+    /*! CRCP commonly used polynomial CRC16_CCIT_FALSE. To match online output,
+     *  seed value must be set to 0xFFFF */
+    DL_CRCP_CRCPOLY_POLYNOMIAL_16_CCIT_FALSE = 0x00001021,
+    /*! CRCP commonly used polynomial CRC16_CDMA2000. To match online output,
+     *  seed value must be set to 0xFFFF */
+    DL_CRCP_CRCPOLY_POLYNOMIAL_16_CDMA2000 = 0x0000C867,
+    /*! CRCP commonly used polynomial CRC16_MODBUS. To match online output,
+     *  seed value must be set to 0xFFFF and bit order reversed */
+    DL_CRCP_CRCPOLY_POLYNOMIAL_16_MODBUS = 0x00001DCF,
+
+} DL_CRCP_CRCPOLY_POLYNOMIAL;
+
+/*! @enum DL_CRCP_CRCSEED_SEED
+ *
+ *  @brief seeds for commonly used pre-defined polynomials to be used
+ *         by CRCP as mentioned by the website
+ *         http://www.sunshine2k.de/coding/javascript/crc/crc_js.html.
+ *         Custom polynomials can also be used in lieu of the follwoing.
+ */
+typedef enum {
+
+    /*! CRCP commonly used polynomial CRC32_MPEG2. To match online output,
+     *  polynomial must be set to 0x04C11DB7 */
+    DL_CRCP_CRCSEED_SEED_32_MPEG2 = 0xFFFFFFFF,
+    /*! CRCP commonly used polynomial CRC32_Q. To match online output,
+     *  polynomial must be set to 0x814141AB */
+    DL_CRCP_CRCSEED_SEED_32_Q = 0x00000000,
+    /*! CRCP commonly used polynomial CRC32_JAMCRC. To match online output,
+     *  polynomial must be set to 0x04C11DB7 and bit order reversed */
+    DL_CRCP_CRCSEED_SEED_32_JAMCRC = 0xFFFFFFFF,
+    /*! CRCP commonly used polynomial CRC32_XFER. To match online output,
+     *  polynomial must be set to 0x000000AF */
+    DL_CRCP_CRCSEED_SEED_32_XFER = 0x00000000,
+    /*! CRCP commonly used polynomial CRC16_CCIT_ZERO. To match online
+     *  output, polynomial must be set to 0x00001021 */
+    DL_CRCP_CRCSEED_SEED_16_CCIT_ZERO = 0x0000,
+    /*! CRCP commonly used polynomial CRC16_ARC. To match online output,
+     *  polynomial must be set to 0x00001DCF and bit order reversed */
+    DL_CRCP_CRCSEED_SEED_16_ARC = 0x0000,
+    /*! CRCP commonly used polynomial CRC16_AUG_CCIT. To match online output,
+     *  polynomial must be set to 0x00001021 */
+    DL_CRCP_CRCSEED_SEED_16_AUG_CCIT = 0x1D0F,
+    /*! CRCP commonly used polynomial CRC16_BUYPASS. To match online output,
+     *  polynomial must be set to 0x00008005 */
+    DL_CRCP_CRCSEED_SEED_16_BUYPASS = 0x0000,
+    /*! CRCP commonly used polynomial CRC16_CCIT_FALSE. To match online output,
+     *  polynomial must be set to 0x00001021 */
+    DL_CRCP_CRCSEED_SEED_16_CCIT_FALSE = 0xFFFF,
+    /*! CRCP commonly used polynomial CRC16_CDMA2000. To match online output,
+     *  polynomial must be set to 0x0000C867 */
+    DL_CRCP_CRCSEED_SEED_16_CDMA2000 = 0xFFFF,
+    /*! CRCP commonly used polynomial CRC16_MODBUS. To match online output,
+     *  polynomial must be set to 0x00001DCF and bit order reversed */
+    DL_CRCP_CRCSEED_SEED_16_MODBUS = 0xFFFF,
+
+} DL_CRCP_CRCSEED_SEED;
+
+/**
+ * @brief Enables power on CRCP module
+ *
+ * @param crcp         Pointer to the register overlay for the CRCP peripheral
+ */
+__STATIC_INLINE void DL_CRCP_enablePower(CRCP_Regs *crcp)
+{
+    crcp->GPRCM.PWREN = (CRCP_PWREN_KEY_UNLOCK_W | CRCP_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power on CRCP module
+ *
+ * @param crcp         Pointer to the register overlay for the CRCP peripheral
+ */
+__STATIC_INLINE void DL_CRCP_disablePower(CRCP_Regs *crcp)
+{
+    crcp->GPRCM.PWREN = (CRCP_PWREN_KEY_UNLOCK_W | CRCP_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief Returns if power on CRCP module is enabled
+ *
+ * @param crcp         Pointer to the register overlay for the CRCP peripheral
+ *
+ * @return true if power is enabled
+ * @return false if power is disabled
+ *
+ */
+__STATIC_INLINE bool DL_CRCP_isPowerEnabled(CRCP_Regs *crcp)
+{
+    return ((crcp->GPRCM.PWREN & CRCP_PWREN_ENABLE_MASK) ==
+            CRCP_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Resets CRCP peripheral
+ *
+ * @param crcp         Pointer to the register overlay for the CRCP peripheral
+ */
+__STATIC_INLINE void DL_CRCP_reset(CRCP_Regs *crcp)
+{
+    crcp->GPRCM.RSTCTL =
+        (CRCP_RSTCTL_KEY_UNLOCK_W | CRCP_RSTCTL_RESETSTKYCLR_CLR |
+            CRCP_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief Returns if CRCP module has been reset
+ *
+ * @param crcp         Pointer to the register overlay for the CRCP peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_CRCP_isReset(CRCP_Regs *crcp)
+{
+    return ((crcp->GPRCM.STAT & CRCP_STAT_RESETSTKY_MASK) ==
+            CRCP_STAT_RESETSTKY_RESET);
+}
+
+/**
+ * @brief Initializes the CRCP peripheral
+ *
+ * @param crcp         Pointer to the register overlay for the CRCP peripheral.
+ * @param polySize     Selects CRC polynomial size. One of
+ *                     @ref DL_CRCP_POLYNOMIAL_SIZE.
+ * @param bitOrd       Selects CRC bit order. One of @ref DL_CRCP_BIT.
+ * @param inEndianness Selects CRC input endianess. One of
+ *                     @ref DL_CRCP_INPUT_ENDIANESS.
+ * @param outByteSwap  Selects CRC output byte swap mode. One of
+ *                     @ref DL_CRCP_OUTPUT_BYTESWAP.
+ *
+ */
+__STATIC_INLINE void DL_CRCP_init(CRCP_Regs *crcp,
+    DL_CRCP_POLYNOMIAL_SIZE polySize, DL_CRCP_BIT bitOrd,
+    DL_CRCP_INPUT_ENDIANESS inEndianness, DL_CRCP_OUTPUT_BYTESWAP outByteSwap)
+{
+    crcp->CRCCTRL = ((uint32_t) polySize | (uint32_t) bitOrd |
+                     (uint32_t) inEndianness | (uint32_t) outByteSwap);
+}
+
+/*!
+ *  @brief      Initializes the seed for a 16-bit polynomial CRC calculation
+ *  @note       CRC seed is swapped when CRCP module is configured in big-endian
+ *              mode. For example when calling DL_CRCP_setSeed32(CRC, 0xaabb).
+ *              The CRCP module will be initialized with 0xbbaa. Therefore, the
+ *              seed value should be appropriately specified taking endianness
+ *              into account. Please refer to the device TRM for additional
+ *              detail.
+ *
+ *  Sets the inital seed for a 16-bit CRC calculation. can be any value,
+ *  or cast one of the common seeds in @ref DL_CRCP_CRCSEED_SEED.
+ *
+ *  @param[in]  crcp   Pointer to the register overlay for the CRCP peripheral
+ *  @param[in]  seed   The seed from which to start generating a signature
+ */
+__STATIC_INLINE void DL_CRCP_setSeed16(CRCP_Regs *crcp, uint16_t seed)
+{
+    volatile uintptr_t addr;
+    volatile uint16_t *pRef;
+
+    addr = (uintptr_t)((volatile uintptr_t *) &crcp->CRCSEED);
+    pRef = (volatile uint16_t *) addr;
+
+    *pRef = seed;
+}
+
+/*!
+ *  @brief    Initializes the seed for a 32-bit polynomial CRC calculation
+ *  @note     CRC seed is swapped when CRCP module is configured in big-endian
+ *            mode. For example when calling DL_CRCP_setSeed32(CRC, 0xaabbccdd).
+ *            The CRCP module will be initialized with 0xddccbbaa. Therefore,
+ *            the seed value should be appropriately specified taking endianness
+ *            into account. Please refer to the device TRM for additional
+ *            detail.
+ *
+ *  Sets the inital seed for a 32-bit CRC calculation. can be any value,
+ *  or cast one of the common seeds in @ref DL_CRCP_CRCSEED_SEED.
+ *
+ *  @param[in]  crcp   Pointer to the register overlay for the CRCP peripheral
+ *  @param[in]  seed   The seed from which to start generating a signature
+ */
+__STATIC_INLINE void DL_CRCP_setSeed32(CRCP_Regs *crcp, uint32_t seed)
+{
+    crcp->CRCSEED = seed;
+}
+
+/*!
+ *  @brief      Feeds 8-bit data into the CRC calculation
+ *
+ *  @param[in]  crcp        Pointer to the register overlay for the CRCP
+ *                          peripheral
+ *  @param[in]  dataIn      8-bit data value to add to the signature
+ *
+ */
+__STATIC_INLINE void DL_CRCP_feedData8(CRCP_Regs *crcp, uint8_t dataIn)
+{
+    volatile uint8_t *pRef = (volatile uint8_t *) &crcp->CRCIN;
+    *pRef                  = dataIn;
+}
+
+/*!
+ *  @brief      Feeds 16-bit data into the CRC calculation
+ *
+ *  @param[in]  crcp        Pointer to the register overlay for the CRCP
+ *                          peripheral
+ *  @param[in]  dataIn      16-bit data value to add to the signature
+ *
+ */
+__STATIC_INLINE void DL_CRCP_feedData16(CRCP_Regs *crcp, uint16_t dataIn)
+{
+    volatile uintptr_t addr;
+    volatile uint16_t *pRef;
+
+    addr = (uintptr_t)((volatile uintptr_t *) &crcp->CRCIN);
+    pRef = (volatile uint16_t *) addr;
+
+    *pRef = dataIn;
+}
+
+/*!
+ *  @brief      Feeds 32-bit data into the CRC calculation
+ *
+ *  Feeds a 32-bit value into the CRC calculation. 32-bit data can only be used
+ *  with the 32-bit polynomial.
+ *
+ *  @param[in]  crcp        Pointer to the register overlay for the CRCP
+ *                          peripheral
+ *  @param[in]  dataIn      32 bit data value to add to the signature
+ *
+ */
+__STATIC_INLINE void DL_CRCP_feedData32(CRCP_Regs *crcp, uint32_t dataIn)
+{
+    crcp->CRCIN = dataIn;
+}
+
+/*!
+ *  @brief      Returns the result from the 16-bit polynomial calculation
+ *
+ *  @note       CRC Output will be swapped if the CRCP module is configured
+ *              in byte-swap mode. For example, if enabled and CRCOUT register
+ *              has the value 0xaabbccdd, DL_CRCP_getResult16 would return
+ *              0xddcc. Please refer to the TRM for more information.
+ *
+ *  @param[in]  crcp Pointer to the register overlay for the CRCP peripheral
+ *
+ *  @return     The calculation result for the 16-bit polynomial
+ */
+__STATIC_INLINE uint16_t DL_CRCP_getResult16(CRCP_Regs *crcp)
+{
+    return ((uint16_t) crcp->CRCOUT);
+}
+
+/*!
+ *  @brief      Returns the result from the 32-bit polynomial calculation
+ *
+ *  @note       CRC Output will be swapped if the CRCP module is configured
+ *              in byte-swap mode. For example, if enabled and CRCOUT register
+ *              has value 0xaabbccdd, DL_CRCP_getResult32 would return
+ *              0xddccbbaa in the 32-bit case, and 0x0000ddcc. In the 16-bit
+ *              case. Additionally, if byte-swap is disabled, the 16-bit size
+ *              would return 0x0000ccdd. Please refer to the TRM for more
+ *              information.
+ *
+ *  @param[in]  crcp  Pointer to the register overlay for the CRCP peripheral
+ *
+ *  @return     The calculation result for the 32-bit polynomial
+ */
+__STATIC_INLINE uint32_t DL_CRCP_getResult32(CRCP_Regs *crcp)
+{
+    return (crcp->CRCOUT);
+}
+
+/*!
+ *  @brief      Sets the active polynomial terms for the CRC calculation
+ *
+ *  The polynomial can be any value represented with MSB first. Thus, in a
+ *  16-bit polynomial (where the 16th power is always present), the nth bit
+ *  corresponds to the inclusion of the nth term of the polynomial. For example,
+ *  The 16-bit polynomial CCIT x^16 + x^12 + x^5 + 1 is represented as 0x1021.
+ *  One can craft a custom polynomial, use an existing polynomial,
+ *  or cast one of the common polynomials in @ref DL_CRCP_CRCPOLY_POLYNOMIAL. If
+ *  the polynomial size is configured as 16-bit, the upper 16-bits are ignored.
+ *
+ *  @param[in]  crcp  Pointer to the register overlay for the CRCP peripheral
+ *  @param[in]  poly  Polynomial to implement (normal representation)
+ */
+__STATIC_INLINE void DL_CRCP_setPolynomial(CRCP_Regs *crcp, uint32_t poly)
+{
+    crcp->CRCPOLY = poly;
+}
+
+/*!
+ *  @brief      Gets the active polynomial terms for the CRC calculation
+ *
+ *  The polynomial can be any value represented as with MSB first. Thus, in a
+ *  16-bit polynomial (where the 16th power is always present), the nth bit
+ *  corresponds to the inclusion of the nth term of the polynomial. For example,
+ *  The 16-bit polynomial CCIT x^16 + x^12 + x^5 + 1 is represented as 0x1021.
+ *  If the polynomial size is configured as 16-bit, the upper 16-bits are ignored.
+ *
+ *  @param[in]  crcp  Pointer to the register overlay for the CRCP peripheral
+ *
+ *  @returns    Active polynomial (normal representation)
+ */
+__STATIC_INLINE uint32_t DL_CRCP_getPolynomial(CRCP_Regs *crcp)
+{
+    return (crcp->CRCPOLY);
+}
+
+/*!
+ *  @brief      Calculates the CRC over a range of 32-bit values
+ *
+ *  Uses the 32-bit polynomial to calculate the checksum over a block of
+ *  values.
+ *
+ *  @param[in]  crcp  Pointer to the register overlay for the CRCP peripheral
+ *  @param[in]  seed  The seed for the CRC to start generating a signature from
+ *  @param[in]  ptr   A pointer to the block of code to calculate the CRC over
+ *  @param[in]  size  The size of the block of uint32_t data
+ *
+ *  @return     The calculated CRC signature value
+ */
+extern uint32_t DL_CRCP_calculateBlock32(
+    CRCP_Regs *crcp, uint32_t seed, uint32_t *ptr, uint32_t size);
+
+/*!
+ *  @brief      Calculates the CRC over a memory range
+ *
+ *  Calculates the checksum using the 32-bit polynomial over any memory range.
+ *
+ *  @param[in]  crcp      Pointer to the register overlay for the CRC
+ *                        peripheral
+ *  @param[in]  seed      The seed used to start generating a signature from
+ *  @param[in]  ptrStart  A uint32_t pointer to the start of a block of code to
+ *                        calculate the CRC over
+ *  @param[in]  ptrEnd    A uint32_t pointer to the end of a block of code to
+ *                        calculate the CRC over
+ *
+ *  @return     The calculated CRC signature value
+ */
+extern uint32_t DL_CRCP_calculateMemoryRange32(
+    CRCP_Regs *crcp, uint32_t seed, uint32_t *ptrStart, uint32_t *ptrEnd);
+
+/*!
+ *  @brief      Calculates the CRC over a range of 16-bit values
+ *
+ *  Uses the 16-bit polynomial to calculate the checksum over a block of
+ *  values.
+ *
+ *  @param[in]  crcp  Pointer to the register overlay for the CRCP peripheral
+ *  @param[in]  seed  The seed for the CRCP to start generating a signature from
+ *  @param[in]  ptr   A pointer to the block of code to calculate the CRC over
+ *  @param[in]  size  The size of the block of 16-bit data
+ *
+ *  @return     The calculated CRC signature value
+ */
+extern uint16_t DL_CRCP_calculateBlock16(
+    CRCP_Regs *crcp, uint16_t seed, uint16_t *ptr, uint16_t size);
+
+/*!
+ *  @brief      Calculates the CRC over a memory range
+ *
+ *  Calculates the checksum using the 16-bit polynomial over any memory range.
+ *
+ *  @param[in]  crcp      Pointer to the register overlay for the CRC
+ *                        peripheral
+ *  @param[in]  seed      The seed used to start generating a signature from
+ *  @param[in]  ptrStart  A uint16_t pointer to the start of a block of code to
+ *                        calculate the CRC over
+ *  @param[in]  ptrEnd    A uint16_t pointer to the end of a block of code to
+ *                        calculate the CRC over
+ *
+ *  @return     The calculated CRC signature value
+ */
+extern uint16_t DL_CRCP_calculateMemoryRange16(
+    CRCP_Regs *crcp, uint16_t seed, uint16_t *ptrStart, uint16_t *ptrEnd);
+
+/**
+ *  @brief Returns the address of the CRC input data register.
+ *
+ *  This API can be used with @ref DL_DMA_setDestAddr to set the destination
+ *  address when using DMA transfers
+ *
+ *  @param[in]  crcp      Pointer to the register overlay for the CRC
+ *                        peripheral
+ *  @return Address of the CRC input data register
+ */
+__STATIC_INLINE uintptr_t DL_CRCP_getCRCINAddr(CRCP_Regs *crcp)
+{
+    return ((uintptr_t) &crcp->CRCIN);
+}
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_CRCP__ */
+
+#endif /* ti_dl_DL_CRCP__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_dac12.c
+++ b/mspm0/source/ti/driverlib/dl_dac12.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_dac12.h>
+
+#ifdef __MSPM0_HAS_DAC12__
+
+void DL_DAC12_init(DAC12_Regs *dac12, DL_DAC12_Config *config)
+{
+    /* CTL 0 - Input Data Formatting */
+    DL_DAC12_configDataFormat(
+        dac12, config->representation, config->resolution);
+
+    /* CTL 1 - DAC Module */
+    DL_Common_updateReg(&dac12->CTL1,
+        (uint32_t) config->outputEnable |
+            (uint32_t) config->voltageReferenceSource |
+            (uint32_t) config->amplifierSetting,
+        DAC12_CTL1_OPS_MASK | DAC12_CTL1_REFSP_MASK | DAC12_CTL1_REFSN_MASK |
+            DAC12_CTL1_AMPEN_MASK | DAC12_CTL1_AMPHIZ_MASK);
+
+    /* CTL 2 - FIFO */
+    DL_Common_updateReg(&dac12->CTL2,
+        ((uint32_t) config->fifoEnable | (uint32_t) config->fifoTriggerSource |
+            (uint32_t) config->dmaTriggerEnable |
+            (uint32_t) config->dmaTriggerThreshold),
+        DAC12_CTL2_DMATRIGEN_MASK | DAC12_CTL2_FIFOTH_MASK |
+            DAC12_CTL2_FIFOEN_MASK | DAC12_CTL2_FIFOTRIGSEL_MASK);
+
+    /* CTL3 Register - Sample Time Generator */
+    DL_Common_updateReg(&dac12->CTL3,
+        ((uint32_t) config->sampleTimeGeneratorEnable |
+            (uint32_t) config->sampleRate),
+        DAC12_CTL3_STIMCONFIG_MASK | DAC12_CTL3_STIMEN_MASK);
+}
+
+void DL_DAC12_outputBlocking8(DAC12_Regs *dac12, uint8_t data)
+{
+    while (DL_DAC12_isFIFOFull(dac12)) {
+        ;
+    }
+
+    DL_DAC12_output8(dac12, data);
+}
+
+void DL_DAC12_outputBlocking12(DAC12_Regs *dac12, uint16_t data)
+{
+    while (DL_DAC12_isFIFOFull(dac12)) {
+        ;
+    }
+
+    DL_DAC12_output12(dac12, data);
+}
+
+uint32_t DL_DAC12_fillFIFO8(DAC12_Regs *dac12, uint8_t *buffer, uint32_t count)
+{
+    uint32_t i;
+    for (i = 0; i < count; i++) {
+        if (!DL_DAC12_isFIFOFull(dac12)) {
+            DL_DAC12_output8(dac12, buffer[i]);
+        } else {
+            break;
+        }
+    }
+
+    return i;
+}
+
+uint32_t DL_DAC12_fillFIFO12(
+    DAC12_Regs *dac12, uint16_t *buffer, uint32_t count)
+{
+    uint32_t i;
+    for (i = 0; i < count; i++) {
+        if (!DL_DAC12_isFIFOFull(dac12)) {
+            DL_DAC12_output12(dac12, buffer[i]);
+        } else {
+            break;
+        }
+    }
+
+    return i;
+}
+
+void DL_DAC12_performSelfCalibrationBlocking(DAC12_Regs *dac12)
+{
+    DL_DAC12_startCalibration(dac12);
+    /*
+     * Tri-stated during calibration, and CALON will continue to be set
+     * Prevents the function from exiting until the calibration is finished.
+     */
+    while (DL_DAC12_isCalibrationRunning(dac12)) {
+        ;
+    }
+}
+
+#endif /* __MSPM0_HAS_DAC12__ */

--- a/mspm0/source/ti/driverlib/dl_dac12.h
+++ b/mspm0/source/ti/driverlib/dl_dac12.h
@@ -1,0 +1,1306 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file dl_dac12.h
+ *  @brief 12-bit DAC Driver Library
+ *  @defgroup   DAC12 Digital to Analog Converter (DAC12)
+ *
+ *  @anchor ti_dl_dl_dac12_Overview
+ *  # Overview
+ *
+ *  The Digital to Analog Converter Driver Library allows full configuration of
+ *  the MSPM0 DAC12 module. The DAC module is a 12-bit voltage-output
+ *  digital-to-analog converter (DAC).
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup DAC12
+ * @{
+ */
+#ifndef ti_dl_dl_dac12__include
+#define ti_dl_dl_dac12__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_DAC12__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @enum DL_DAC12_OUTPUT */
+typedef enum {
+    /*!  DAC output is disconnected from output pin */
+    DL_DAC12_OUTPUT_DISABLED = DAC12_CTL1_OPS_NOC0,
+    /*!  DAC output is available on output pin */
+    DL_DAC12_OUTPUT_ENABLED = DAC12_CTL1_OPS_OUT0,
+} DL_DAC12_OUTPUT;
+
+/** @enum DL_DAC12_REPRESENTATION */
+typedef enum {
+    /*!  Binary representation */
+    DL_DAC12_REPRESENTATION_BINARY = DAC12_CTL0_DFM_BINARY,
+    /*!  Two's complement representation */
+    DL_DAC12_REPRESENTATION_TWOS_COMPLEMENT = DAC12_CTL0_DFM_TWOS_COMP,
+} DL_DAC12_REPRESENTATION;
+
+/** @enum DL_DAC12_RESOLUTION */
+typedef enum {
+    /*!  12-bit input resolution */
+    DL_DAC12_RESOLUTION_12BIT = DAC12_CTL0_RES__12BITS,
+    /*!  8-bit input resolution */
+    DL_DAC12_RESOLUTION_8BIT = DAC12_CTL0_RES__8BITS,
+} DL_DAC12_RESOLUTION;
+
+/** @enum DL_DAC12_AMP */
+typedef enum {
+    /*!  Output amplifier off with high impedance tristate output */
+    DL_DAC12_AMP_OFF_TRISTATE = DAC12_CTL1_AMPHIZ_HIZ,
+    /*!  Output amplifier off with output pulled to ground */
+    DL_DAC12_AMP_OFF_0V = DAC12_CTL1_AMPHIZ_PULLDOWN,
+    /*!  Output amplifier enabled */
+    DL_DAC12_AMP_ON = DAC12_CTL1_AMPEN_ENABLE,
+} DL_DAC12_AMP;
+
+/** @enum DL_DAC12_VREF_SOURCE */
+typedef enum {
+    /*! Positive reference is VDDA, negative reference is VeREF- */
+    DL_DAC12_VREF_SOURCE_VDDA_VEREFN = (DAC12_CTL1_REFSP_VDDA |
+                                        DAC12_CTL1_REFSN_VEREFN) ,
+    /*! Positive reference is VeREF+, negative reference is VeREF- */
+    DL_DAC12_VREF_SOURCE_VEREFP_VEREFN = (DAC12_CTL1_REFSP_VEREFP |
+                                          DAC12_CTL1_REFSN_VEREFN),
+    /*! Positive reference is VDDA, negative reference is VSSA */
+    DL_DAC12_VREF_SOURCE_VDDA_VSSA = (DAC12_CTL1_REFSP_VDDA |
+                                      DAC12_CTL1_REFSN_VSSA),
+    /*! Positive reference is VeREF+, negative reference is VSSA */
+    DL_DAC12_VREF_SOURCE_VEREFP_VSSA = (DAC12_CTL1_REFSP_VEREFP |
+                                        DAC12_CTL1_REFSN_VSSA),
+} DL_DAC12_VREF_SOURCE;
+
+/** @enum DL_DAC12_SAMPLETIMER */
+typedef enum {
+    /*!  DAC sample timer generator is disabled */
+    DL_DAC12_SAMPLETIMER_DISABLE = DAC12_CTL3_STIMEN_CLR,
+    /*!  DAC sample timer generator is enabled */
+    DL_DAC12_SAMPLETIMER_ENABLE = DAC12_CTL3_STIMEN_SET,
+} DL_DAC12_SAMPLETIMER;
+
+
+/** @enum DL_DAC12_SAMPLES_PER_SECOND */
+typedef enum {
+    /*!  Sample Time Trigger rate of 500 Samples Per Second */
+    DL_DAC12_SAMPLES_PER_SECOND_500 = DAC12_CTL3_STIMCONFIG__500SPS,
+    /*!  Sample Time Trigger rate of 1,000 Samples Per Second */
+    DL_DAC12_SAMPLES_PER_SECOND_1K = DAC12_CTL3_STIMCONFIG__1KSPS,
+    /*!  Sample Time Trigger rate of 2,000 Samples Per Second */
+    DL_DAC12_SAMPLES_PER_SECOND_2K = DAC12_CTL3_STIMCONFIG__2KSPS,
+    /*!  Sample Time Trigger rate of 4,000 Samples Per Second */
+    DL_DAC12_SAMPLES_PER_SECOND_4K = DAC12_CTL3_STIMCONFIG__4KSPS,
+    /*!  Sample Time Trigger rate of 8,000 Samples Per Second */
+    DL_DAC12_SAMPLES_PER_SECOND_8K = DAC12_CTL3_STIMCONFIG__8KSPS,
+    /*!  Sample Time Trigger rate of 16,000 Samples Per Second */
+    DL_DAC12_SAMPLES_PER_SECOND_16K = DAC12_CTL3_STIMCONFIG__16KSPS,
+    /*!  Sample Time Trigger rate of 100,000 Samples Per Second */
+    DL_DAC12_SAMPLES_PER_SECOND_100K = DAC12_CTL3_STIMCONFIG__100KSPS,
+    /*!  Sample Time Trigger rate of 200,000 Samples Per Second */
+    DL_DAC12_SAMPLES_PER_SECOND_200K = DAC12_CTL3_STIMCONFIG__200KSPS,
+    /*!  Sample Time Trigger rate of 500,000 Samples Per Second */
+    DL_DAC12_SAMPLES_PER_SECOND_500K = DAC12_CTL3_STIMCONFIG__500KSPS,
+    /*!  Sample Time Trigger rate of 1,000,000 Samples Per Second */
+    DL_DAC12_SAMPLES_PER_SECOND_1M = DAC12_CTL3_STIMCONFIG__1MSPS,
+} DL_DAC12_SAMPLES_PER_SECOND;
+
+/** @enum DL_DAC12_FIFO */
+typedef enum {
+    /*!  DAC FIFO is disabled */
+    DL_DAC12_FIFO_DISABLED = DAC12_CTL2_FIFOEN_CLR,
+    /*!  DAC FIFO is enabled */
+    DL_DAC12_FIFO_ENABLED = DAC12_CTL2_FIFOEN_SET,
+} DL_DAC12_FIFO;
+
+
+/** @enum DL_DAC12_FIFO_THRESHOLD */
+typedef enum {
+    /*!  DAC FIFO threshold for DMA Trigger Generation where 1/4th of location are empty */
+    DL_DAC12_FIFO_THRESHOLD_ONE_QTR_EMPTY = DAC12_CTL2_FIFOTH_LOW,
+    /*!  DAC FIFO threshold for DMA Trigger Generation where 2/4th of locations are empty */
+    DL_DAC12_FIFO_THRESHOLD_TWO_QTRS_EMPTY = DAC12_CTL2_FIFOTH_MED,
+    /*!  DAC FIFO threshold for DMA Trigger Generation where 3/4th of locations are empty */
+    DL_DAC12_FIFO_THRESHOLD_THREE_QTRS_EMPTY = DAC12_CTL2_FIFOTH_HIGH,
+} DL_DAC12_FIFO_THRESHOLD;
+
+/** @enum DL_DAC12_FIFO_TRIGGER */
+typedef enum {
+    /*!  DAC FIFO read trigger sourced from the sample time generator */
+    DL_DAC12_FIFO_TRIGGER_SAMPLETIMER = DAC12_CTL2_FIFOTRIGSEL_STIM,
+    /*!  DAC FIFO read trigger sourced from the hardware trigger 0 event fabric */
+    DL_DAC12_FIFO_TRIGGER_HWTRIG0 = DAC12_CTL2_FIFOTRIGSEL_TRIG0,
+} DL_DAC12_FIFO_TRIGGER;
+
+/** @enum DL_DAC12_DMA_TRIGGER */
+typedef enum {
+    /*!  DMA trigger mechanism for DAC is disabled */
+    DL_DAC12_DMA_TRIGGER_DISABLED = DAC12_CTL2_DMATRIGEN_CLR,
+    /*!  DMA trigger mechanism for DAC is enabled */
+    DL_DAC12_DMA_TRIGGER_ENABLED = DAC12_CTL2_DMATRIGEN_SET,
+} DL_DAC12_DMA_TRIGGER;
+
+/** @enum DL_DAC12_CALIBRATION */
+typedef enum {
+
+    /*! Factory Trim */
+    DL_DAC12_CALIBRATION_FACTORY = DAC12_CALCTL_CALSEL_FACTORYTRIM,
+    /*! Self Trim (last calibration result) */
+    DL_DAC12_CALIBRATION_SELF = DAC12_CALCTL_CALSEL_SELFCALIBRATIONTRIM,
+
+} DL_DAC12_CALIBRATION;
+
+/** @addtogroup DL_DAC12_INTERRUPT
+ *  @{
+ */
+
+/*!
+ *  @brief Interrupt raised when the module ready event has occurred
+ */
+#define DL_DAC12_INTERRUPT_MODULE_READY             (DAC12_GEN_EVENT_IMASK_MODRDYIFG_SET)
+
+/*!
+ *  @brief Interrupt raised when the FIFO is empty
+ */
+#define DL_DAC12_INTERRUPT_FIFO_EMPTY            (DAC12_GEN_EVENT_IMASK_FIFOEMPTYIFG_SET)
+
+/*!
+ *  @brief Interrupt raised when the FIFO is 3/4th empty
+ */
+#define DL_DAC12_INTERRUPT_FIFO_THREE_QTRS_EMPTY   (DAC12_GEN_EVENT_IMASK_FIFO3B4IFG_SET)
+
+/*!
+ *  @brief Interrupt raised when the FIFO is 2/4ths empty
+ */
+#define DL_DAC12_INTERRUPT_FIFO_TWO_QTRS_EMPTY     (DAC12_GEN_EVENT_IMASK_FIFO1B2IFG_SET)
+
+/*!
+ *  @brief Interrupt raised when the FIFO is 1/4th empty
+ */
+#define DL_DAC12_INTERRUPT_FIFO_ONE_QTR_EMPTY      (DAC12_GEN_EVENT_IMASK_FIFO1B4IFG_SET)
+
+/*!
+ *  @brief Interrupt raised when the FIFO is full
+ */
+#define DL_DAC12_INTERRUPT_FIFO_FULL              (DAC12_GEN_EVENT_IMASK_FIFOFULLIFG_SET)
+
+/*!
+ *  @brief Interrupt raised when the FIFO is underrun
+ *         (tried to read from an empty FIFO)
+ */
+#define DL_DAC12_INTERRUPT_FIFO_UNDERRUN          (DAC12_GEN_EVENT_IMASK_FIFOURUNIFG_SET)
+
+/*!
+ *  @brief Interrupt raised as an Acknowledgement to the DMA completing a
+ *         transfer
+ *
+ *  During DMA operation only, once the DMA has performed its desired number
+ *  of transfers to the FIFO, the DMA will assert a DMA done event. The DMA will
+ *  also send a status, which is 0 if there is more data to send. If there is a
+ *  nonzero status, and the DMA is done sending information, the DMATrigger will
+ *  be disabled and this interrupt will be asserted.
+ */
+#define DL_DAC12_INTERRUPT_DMA_DONE                (DAC12_GEN_EVENT_IMASK_DMADONEIFG_SET)
+
+/** @}*/
+
+/** @addtogroup DL_DAC12_EVENT
+ *  @{
+ */
+
+/*!
+ *  @brief Event raised when the module ready event has occurred
+ */
+#define DL_DAC12_EVENT_MODULE_READY             (DAC12_GEN_EVENT_IMASK_MODRDYIFG_SET)
+
+/*!
+ *  @brief Event raised when the FIFO is empty
+ */
+#define DL_DAC12_EVENT_FIFO_EMPTY            (DAC12_GEN_EVENT_IMASK_FIFOEMPTYIFG_SET)
+
+/*!
+ *  @brief Event raised when the FIFO is 3/4th empty
+ */
+#define DL_DAC12_EVENT_FIFO_THREE_QTRS_EMPTY   (DAC12_GEN_EVENT_IMASK_FIFO3B4IFG_SET)
+
+/*!
+ *  @brief Event raised when the FIFO is 2/4ths empty
+ */
+#define DL_DAC12_EVENT_FIFO_TWO_QTRS_EMPTY     (DAC12_GEN_EVENT_IMASK_FIFO1B2IFG_SET)
+
+/*!
+ *  @brief Event raised when the FIFO is 1/4th empty
+ */
+#define DL_DAC12_EVENT_FIFO_ONE_QTR_EMPTY      (DAC12_GEN_EVENT_IMASK_FIFO1B4IFG_SET)
+
+/*!
+ *  @brief Event raised when the FIFO is full
+ */
+#define DL_DAC12_EVENT_FIFO_FULL              (DAC12_GEN_EVENT_IMASK_FIFOFULLIFG_SET)
+
+/*!
+ *  @brief Event raised when the FIFO is underrun
+ *         (tried to read from an empty FIFO)
+ */
+#define DL_DAC12_EVENT_FIFO_UNDERRUN          (DAC12_GEN_EVENT_IMASK_FIFOURUNIFG_SET)
+
+/*!
+ *  @brief Event raised as an Acknowledgement to the DMA completing a
+ *         transfer
+ *
+ *  During DMA operation only, once the DMA has performed its desired number
+ *  of transfers to the FIFO, the DMA will assert a DMA done event. The DMA will
+ *  also send a status, which is 0 if there is more data to send. If there is a
+ *  nonzero status, and the DMA is done sending information, the DMATrigger will
+ *  be disabled and this interrupt will be asserted.
+ */
+#define DL_DAC12_EVENT_DMA_DONE                (DAC12_GEN_EVENT_IMASK_DMADONEIFG_SET)
+
+/** @}*/
+
+/* clang-format on */
+
+/*! @enum DL_DAC12_IIDX */
+typedef enum {
+    /*! DAC interrupt index for no interrupt pending */
+    DL_DAC12_IIDX_NO_INT = DAC12_CPU_INT_IIDX_STAT_NO_INTR,
+    /*! DAC interrupt index when module is ready */
+    DL_DAC12_IIDX_MODULE_READY = DAC12_CPU_INT_IIDX_STAT_MODRDYIFG,
+    /*! DAC interrupt index when FIFO is full */
+    DL_DAC12_IIDX_FIFO_FULL = DAC12_CPU_INT_IIDX_STAT_FIFOFULLIFG,
+    /*! DAC interrupt index when FIFO is 1/4 empty */
+    DL_DAC12_IIDX_FIFO_1_4_EMPTY = DAC12_CPU_INT_IIDX_STAT_FIFO1B4IFG,
+    /*! DAC interrupt index when FIFO is 1/2 empty */
+    DL_DAC12_IIDX_FIFO_1_2_EMPTY = DAC12_CPU_INT_IIDX_STAT_FIFO1B2IFG,
+    /*! DAC interrupt index when FIFO is 3/4 empty */
+    DL_DAC12_IIDX_FIFO_3_4_EMPTY = DAC12_CPU_INT_IIDX_STAT_FIFO3B4IFG,
+    /*! DAC interrupt index when FIFO is empty */
+    DL_DAC12_IIDX_FIFO_EMPTY = DAC12_CPU_INT_IIDX_STAT_FIFOEMPTYIFG,
+    /*! DAC interrupt index if there is FIFO underrun */
+    DL_DAC12_IIDX_FIFO_UNDERRUN = DAC12_CPU_INT_IIDX_STAT_FIFOURUNIFG,
+    /*! DAC interrupt index for DMA transfer done */
+    DL_DAC12_IIDX_DMA_DONE = DAC12_CPU_INT_IIDX_STAT_DMADONEIFG
+} DL_DAC12_IIDX;
+
+/*! @enum DL_DAC12_SUBSCRIBER_INDEX */
+typedef enum {
+    /*! DAC12 Subscriber index 0 */
+    DL_DAC12_SUBSCRIBER_INDEX_0 = 0,
+} DL_DAC12_SUBSCRIBER_INDEX;
+
+/*! @enum DL_DAC12_EVENT_ROUTE */
+typedef enum {
+    /*! DAC12 event route 1 */
+    DL_DAC12_EVENT_ROUTE_1 = 0,
+} DL_DAC12_EVENT_ROUTE;
+
+/**
+ *  @brief  Configuration struct for @ref DL_DAC12_init
+ */
+typedef struct {
+    /*! Enables the DAC output on the device OUT pin. One of @ref DL_DAC12_OUTPUT */
+    DL_DAC12_OUTPUT outputEnable;
+
+    /*! The bit resolution. One of @ref DL_DAC12_RESOLUTION */
+    DL_DAC12_RESOLUTION resolution;
+
+    /*! The input data representation. One of @ref DL_DAC12_REPRESENTATION */
+    DL_DAC12_REPRESENTATION representation;
+
+    /*! The voltage reference. One of @ref DL_DAC12_VREF_SOURCE */
+    DL_DAC12_VREF_SOURCE voltageReferenceSource;
+
+    /*! Output amplifier setting. One of @ref DL_DAC12_AMP */
+    DL_DAC12_AMP amplifierSetting;
+
+    /*! The FIFO enable. One of @ref DL_DAC12_FIFO */
+    DL_DAC12_FIFO fifoEnable;
+
+    /*! The Read Fifo Trigger source. One of @ref DL_DAC12_FIFO_TRIGGER */
+    DL_DAC12_FIFO_TRIGGER fifoTriggerSource;
+
+    /*! The bit to enable a DMA trigger source to use the DMA instead of
+     *  the CPU to input data.
+     *  One of @ref DL_DAC12_DMA_TRIGGER
+     */
+    DL_DAC12_DMA_TRIGGER dmaTriggerEnable;
+
+    /*! The FIFO Threshold at which the DMA Trigger is asserted.
+     *  One of @ref DL_DAC12_FIFO_THRESHOLD
+     */
+    DL_DAC12_FIFO_THRESHOLD dmaTriggerThreshold;
+
+    /*! Enables the sample time generator as the FIFO trigger.
+     *  One of @ref DL_DAC12_SAMPLETIMER
+     */
+    DL_DAC12_SAMPLETIMER sampleTimeGeneratorEnable;
+
+    /*! Rate of the sample time generator. One of @ref
+     *  DL_DAC12_SAMPLES_PER_SECOND
+     */
+    DL_DAC12_SAMPLES_PER_SECOND sampleRate;
+} DL_DAC12_Config;
+
+/**
+ *  @brief      Initialize the DAC module
+ *
+ *  Initializes all the common configurable options for the DAC module. Any
+ *  other custom configuration can be done after this initialization.
+ *  @post DAC is not enabled
+ *
+ *  @param[in]  dac12   Pointer to the register overlay for the peripheral
+ *  @param[in]  config  Configuration for DAC12 peripheral
+ */
+void DL_DAC12_init(DAC12_Regs *dac12, DL_DAC12_Config *config);
+
+/**
+ * @brief Enables power on DAC12 module
+ *
+ * @param dac12        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_DAC12_enablePower(DAC12_Regs *dac12)
+{
+    dac12->GPRCM.PWREN =
+        (DAC12_PWREN_KEY_UNLOCK_W | DAC12_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power on dac12 module
+ *
+ * @param dac12        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_DAC12_disablePower(DAC12_Regs *dac12)
+{
+    dac12->GPRCM.PWREN =
+        (DAC12_PWREN_KEY_UNLOCK_W | DAC12_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief Returns if  power on dac12 module
+ *
+ * @param dac12        Pointer to the register overlay for the peripheral
+ *
+ * @return true if power is enabled
+ * @return false if power is disabled
+ */
+__STATIC_INLINE bool DL_DAC12_isPowerEnabled(DAC12_Regs *dac12)
+{
+    return ((dac12->GPRCM.PWREN & DAC12_PWREN_ENABLE_MASK) ==
+            DAC12_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Resets dac12 peripheral
+ *
+ * @param dac12        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_DAC12_reset(DAC12_Regs *dac12)
+{
+    dac12->GPRCM.RSTCTL =
+        (DAC12_RSTCTL_KEY_UNLOCK_W | DAC12_RSTCTL_RESETSTKYCLR_CLR |
+            DAC12_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief Returns if dac12 peripheral was reset
+ *
+ * @param dac12        Pointer to the register overlay for the peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_DAC12_isReset(DAC12_Regs *dac12)
+{
+    return ((dac12->GPRCM.STAT & DAC12_STAT_RESETSTKY_MASK) ==
+            DAC12_STAT_RESETSTKY_RESET);
+}
+
+/**
+ *  @brief      Enables the DAC module
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ */
+__STATIC_INLINE void DL_DAC12_enable(DAC12_Regs *dac12)
+{
+    dac12->CTL0 |= DAC12_CTL0_ENABLE_SET;
+}
+
+/**
+ *  @brief      Disables the DAC Module
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ */
+__STATIC_INLINE void DL_DAC12_disable(DAC12_Regs *dac12)
+{
+    dac12->CTL0 &= ~DAC12_CTL0_ENABLE_MASK;
+}
+
+/**
+ *  @brief      Checks the enable bit of the DAC
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @return     Whether the DAC module is enabled
+ *
+ *  @retval     true    Module enabled
+ *  @retval     false   Module disabled
+ */
+__STATIC_INLINE bool DL_DAC12_isEnabled(DAC12_Regs *dac12)
+{
+    uint32_t t = (dac12->CTL0 & DAC12_CTL0_ENABLE_MASK);
+    return (t == DAC12_CTL0_ENABLE_SET);
+}
+
+/**
+ *  @brief      Sets all elements of the input data format at once
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *  @param[in]  rep      Data Representation. One of
+ *                       @ref DL_DAC12_REPRESENTATION
+ *  @param[in]  res      Data Resolution. One of @ref DL_DAC12_RESOLUTION
+ */
+__STATIC_INLINE void DL_DAC12_configDataFormat(
+    DAC12_Regs *dac12, DL_DAC12_REPRESENTATION rep, DL_DAC12_RESOLUTION res)
+{
+    DL_Common_updateReg(&dac12->CTL0, ((uint32_t) rep | (uint32_t) res),
+        DAC12_CTL0_RES_MASK | DAC12_CTL0_DFM_MASK);
+}
+
+/**
+ *  @brief      Gets the currently configured amplifier setting
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @return     Currently configured amplifier setting
+ *
+ *  @retval     One of @ref DL_DAC12_AMP
+ */
+__STATIC_INLINE DL_DAC12_AMP DL_DAC12_getAmplifier(DAC12_Regs *dac12)
+{
+    uint32_t ampVal =
+        (dac12->CTL1 & (DAC12_CTL1_AMPEN_MASK | DAC12_CTL1_AMPHIZ_MASK));
+
+    return (DL_DAC12_AMP)(ampVal);
+}
+
+/**
+ *  @brief      Sets the DAC and output amplifer setting
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *  @param[in]  ampVal   amplifier configuration value. One of @ref DL_DAC12_AMP
+ */
+__STATIC_INLINE void DL_DAC12_setAmplifier(
+    DAC12_Regs *dac12, DL_DAC12_AMP ampVal)
+{
+    DL_Common_updateReg(&dac12->CTL1, (uint32_t) ampVal,
+        (DAC12_CTL1_AMPEN_MASK | DAC12_CTL1_AMPHIZ_MASK));
+}
+
+/**
+ *  @brief      Gets the currently configured reference voltage source
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @return     Currently configured reference voltage
+ *
+ *  @retval     Bitwise OR of @ref DL_DAC12_VREF_SOURCE
+ */
+__STATIC_INLINE DL_DAC12_VREF_SOURCE DL_DAC12_getReferenceVoltageSource(
+    DAC12_Regs *dac12)
+{
+    uint32_t refsVal =
+        (dac12->CTL1 & (DAC12_CTL1_REFSP_MASK | DAC12_CTL1_REFSN_MASK));
+
+    return (DL_DAC12_VREF_SOURCE)(refsVal);
+}
+
+/**
+ *  @brief      Set the reference voltage source of the DAC
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *  @param[in]  refsVal  reference voltage source. Bitwise OR of
+ *                       @ref DL_DAC12_VREF_SOURCE
+ */
+__STATIC_INLINE void DL_DAC12_setReferenceVoltageSource(
+    DAC12_Regs *dac12, DL_DAC12_VREF_SOURCE refsVal)
+{
+    DL_Common_updateReg(&dac12->CTL1, (uint32_t) refsVal,
+        (DAC12_CTL1_REFSP_MASK | DAC12_CTL1_REFSN_MASK));
+}
+
+/**
+ *  @brief      Enables the DAC output by connecting it to the OUT0 pin
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ */
+__STATIC_INLINE void DL_DAC12_enableOutputPin(DAC12_Regs *dac12)
+{
+    dac12->CTL1 |= DAC12_CTL1_OPS_OUT0;
+}
+
+/**
+ *  @brief      Disable the DAC output by disconnecting it from the OUT0 pin
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ */
+__STATIC_INLINE void DL_DAC12_disableOutputPin(DAC12_Regs *dac12)
+{
+    dac12->CTL1 &= ~DAC12_CTL1_OPS_MASK;
+}
+
+/**
+ *  @brief      Checks to see whether the output is connected
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @return     Status of output connection
+ *
+ *  @retval     true  Output is connected
+ *  @retval     false Output is not connected
+ */
+__STATIC_INLINE bool DL_DAC12_isOutputPinEnabled(DAC12_Regs *dac12)
+{
+    return ((dac12->CTL1 & DAC12_CTL1_OPS_MASK) == DAC12_CTL1_OPS_OUT0);
+}
+
+/**
+ *  @brief      Enables the FIFO module
+ *
+ *  Enables the FIFO and the FIFO hardware control state machine
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ */
+__STATIC_INLINE void DL_DAC12_enableFIFO(DAC12_Regs *dac12)
+{
+    /* Insert value */
+    dac12->CTL2 |= DAC12_CTL2_FIFOEN_SET;
+}
+
+/**
+ *  @brief      Disables the FIFO
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @sa         DL_DAC12_enableFIFO
+ */
+__STATIC_INLINE void DL_DAC12_disableFIFO(DAC12_Regs *dac12)
+{
+    /* Clear out the bit */
+    dac12->CTL2 &= ~DAC12_CTL2_FIFOEN_MASK;
+}
+
+/**
+ *  @brief      Checks whether the FIFO is enabled
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @return     Current status of the FIFO
+ *
+ *  @retval     true    FIFO is enabled
+ *  @retval     false   FIFO is not enabled
+ */
+__STATIC_INLINE bool DL_DAC12_isFIFOEnabled(DAC12_Regs *dac12)
+{
+    uint32_t t = (dac12->CTL2 & DAC12_CTL2_FIFOEN_MASK);
+    return (t == DAC12_CTL2_FIFOEN_SET);
+}
+
+/**
+ *  @brief      Gets the FIFO threshold
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @return     Currently configured FIFO Threshold
+ *
+ *  @retval     One of @ref DL_DAC12_FIFO_THRESHOLD
+ *
+ *  @sa         DL_DAC12_setFIFOThreshold
+ */
+__STATIC_INLINE DL_DAC12_FIFO_THRESHOLD DL_DAC12_getFIFOThreshold(
+    DAC12_Regs *dac12)
+{
+    uint32_t fifoThreshold = (dac12->CTL2 & DAC12_CTL2_FIFOTH_MASK);
+
+    return (DL_DAC12_FIFO_THRESHOLD)(fifoThreshold);
+}
+
+/**
+ *  @brief      Sets the FIFO threshold
+ *
+ *  Determines the FIFO threshold In case of DMA based operation,
+ *  DAC generates new DMA trigger when the number of empty locations in FIFO
+ *  match the selected FIFO threshold level.
+ *  In the case of CPU based operation, the FIFO threshold bits are don't care
+ *  and FIFO level is directly indicated through the respective bits in the
+ *  RIS register
+ *
+ *  @param[in]  dac12       pointer to the register overlay of the peripheral
+ *  @param[in]  fifoThreshold  Threshold value. One of @ref DL_DAC12_FIFO_THRESHOLD
+ */
+__STATIC_INLINE void DL_DAC12_setFIFOThreshold(
+    DAC12_Regs *dac12, DL_DAC12_FIFO_THRESHOLD fifoThreshold)
+{
+    DL_Common_updateReg(
+        &dac12->CTL2, (uint32_t) fifoThreshold, DAC12_CTL2_FIFOTH_MASK);
+}
+
+/**
+ *  @brief      Gets the FIFO read trigger source
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @return     Currently configured trigger source
+ *
+ *  @retval     One of @ref DL_DAC12_FIFO_TRIGGER
+ *
+ *  @sa         DL_DAC12_setFIFOTriggerSource
+ */
+__STATIC_INLINE DL_DAC12_FIFO_TRIGGER DL_DAC12_getFIFOTriggerSource(
+    DAC12_Regs *dac12)
+{
+    uint32_t fifoTrig = (dac12->CTL2 & DAC12_CTL2_FIFOTRIGSEL_MASK);
+
+    return (DL_DAC12_FIFO_TRIGGER)(fifoTrig);
+}
+
+/**
+ *  @brief      Sets the FIFO read trigger source
+ *
+ *  Selects the source for FIFO read trigger by the DAC. When the selected FIFO
+ *  read trigger is asserted, the data from FIFO (as indicated by read pointer)
+ *  is moved into internal DAC data register
+ *
+ *  @param[in]  dac12       pointer to the register overlay of the peripheral
+ *  @param[in]  fifoTrig    Read Trigger Source. One of
+ *                          @ref DL_DAC12_FIFO_TRIGGER
+ */
+__STATIC_INLINE void DL_DAC12_setFIFOTriggerSource(
+    DAC12_Regs *dac12, DL_DAC12_FIFO_TRIGGER fifoTrig)
+{
+    DL_Common_updateReg(
+        &dac12->CTL2, (uint32_t) fifoTrig, DAC12_CTL2_FIFOTRIGSEL_MASK);
+}
+
+/**
+ *  @brief      Enables the DMA trigger generator
+ *
+ *  When this is and the FIFO are enabled, the DMA trigger is generated based
+ *  on the empty FIFO locations qualified by the selected FIFO Threshold
+ *  settings. This bit is automatically cleared by hardware when the DMA done
+ *  event is asserted with DMA status signal value being nonzero
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @sa         DL_DAC12_enableFIFO
+ *  @sa         DL_DAC12_setFIFOThreshold
+ */
+__STATIC_INLINE void DL_DAC12_enableDMATrigger(DAC12_Regs *dac12)
+{
+    /* Insert value */
+    dac12->CTL2 |= DAC12_CTL2_DMATRIGEN_SET;
+}
+
+/**
+ *  @brief      Disables the DMA trigger generator
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @sa         DL_DAC12_enableDMATriggerGenerator
+ */
+__STATIC_INLINE void DL_DAC12_disableDMATrigger(DAC12_Regs *dac12)
+{
+    /* Clear out the bit */
+    dac12->CTL2 &= ~DAC12_CTL2_DMATRIGEN_MASK;
+}
+
+/**
+ *  @brief      Checks whether the DMA trigger generator is enabled
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @return     Current status of the DMA trigger generator
+ *
+ *  @retval     true   DMA Trigger enabled
+ *  @retval     false  DMA Trigger not enabled
+ */
+__STATIC_INLINE bool DL_DAC12_isDMATriggerEnabled(DAC12_Regs *dac12)
+{
+    uint32_t t = (dac12->CTL2 & DAC12_CTL2_DMATRIGEN_MASK);
+    return (t == DAC12_CTL2_DMATRIGEN_SET);
+}
+
+/**
+ *  @brief      Enables the sample time generator
+ *
+ *  The sample time generator can be selected as the FIFO Trigger @ref
+ *  DL_DAC12_setFIFOTriggerSource and control the rate at which the DAC will
+ *  consume inputs from the FIFO
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ */
+__STATIC_INLINE void DL_DAC12_enableSampleTimeGenerator(DAC12_Regs *dac12)
+{
+    /* Insert value */
+    dac12->CTL3 |= DAC12_CTL3_STIMEN_SET;
+}
+
+/**
+ *  @brief      Disables the sample time generator
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @sa         DL_DAC12_enableSampleTimeGenerator
+ */
+__STATIC_INLINE void DL_DAC12_disableSampleTimeGenerator(DAC12_Regs *dac12)
+{
+    /* Clear out the bit */
+    dac12->CTL3 &= ~DAC12_CTL3_STIMEN_MASK;
+}
+
+/**
+ *  @brief      Checks whether the sample time trigger generator is enabled
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @return     Current status of the sample time generator
+ *
+ *  @retval     true  Sample time generator is enabled
+ *  @retval     false Sample time generator is not enabled
+ */
+__STATIC_INLINE bool DL_DAC12_isSampleTimeGeneratorEnabled(DAC12_Regs *dac12)
+{
+    uint32_t t = (dac12->CTL3 & DAC12_CTL3_STIMEN_MASK);
+    return (t == DAC12_CTL3_STIMEN_SET);
+}
+
+/**
+ *  @brief      Gets the sample trigger rate of the sample time generator
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @return     Currently configured sample rate
+ *
+ *  @retval     One of @ref DL_DAC12_SAMPLES_PER_SECOND
+ */
+__STATIC_INLINE DL_DAC12_SAMPLES_PER_SECOND DL_DAC12_getSampleRate(
+    DAC12_Regs *dac12)
+{
+    uint32_t sampleRate = (dac12->CTL3 & DAC12_CTL3_STIMCONFIG_MASK);
+
+    return (DL_DAC12_SAMPLES_PER_SECOND)(sampleRate);
+}
+
+/**
+ *  @brief      Sets the sample triggering rate of the sample time generator
+ *
+ *  Sets the sample trigger rate of the sample time generator.
+ *  The sample time generator can be selected as the FIFO Trigger @ref
+ *  DL_DAC12_setFIFOTriggerSource and control the rate at which the DAC will
+ *  consume inputs from the FIFO
+ *
+ *  @param[in]  dac12       pointer to the register overlay of the peripheral
+ *  @param[in]  sampleRate  Desired sample rate. One of
+ *                          @ref DL_DAC12_SAMPLES_PER_SECOND
+ */
+__STATIC_INLINE void DL_DAC12_setSampleRate(
+    DAC12_Regs *dac12, DL_DAC12_SAMPLES_PER_SECOND sampleRate)
+{
+    DL_Common_updateReg(
+        &dac12->CTL3, (uint32_t) sampleRate, DAC12_CTL3_STIMCONFIG_MASK);
+}
+
+/**
+ *  @brief      Checks whether a calibration sequence is currently running
+ *
+ *  @param[in]  dac12    pointer to the register overlay of the peripheral
+ *
+ *  @return     Current status of an active calibration sequence
+ *
+ *  @retval     true  Calibration Sequence is currently running
+ *  @retval     false Calibration Sequence is not running
+ *
+ *  @sa         DL_DAC12_startCalibration
+ */
+__STATIC_INLINE bool DL_DAC12_isCalibrationRunning(DAC12_Regs *dac12)
+{
+    uint32_t t = (dac12->CALCTL & DAC12_CALCTL_CALON_MASK);
+    return (t == DAC12_CALCTL_CALON_ACTIVE);
+}
+
+/**
+ *  @brief      Initiates the DAC offset error calibration sequence
+ *
+ *  Initiates the DAC offset error calibration sequence and
+ *  the CALON_ACTIVE bit is automatically reset when the offset error
+ *  calibration completes. Upon completion, the correct calibration will be put
+ *  into the CALDATA register. This sequence can be started either on the fly
+ *  (once the module is ready) or during setup (where this is called directy
+ *  after enabling the DAC).
+ *
+ *  In order for the calibration to be successful, the AMP must already be
+ *  configured and the LOCK bit must be cleared for the value to be written
+ *  successfully. The output is also tri-stated during calibration.
+ *
+ *  A negative offset will mean that low input values will have a output of 0.
+ *  A positive offset will mean that an input of 0 will result in a non-zero
+ *  output.
+ *
+ *  @param[in]  dac12   pointer to the register overlay of the peripheral
+ */
+__STATIC_INLINE void DL_DAC12_startCalibration(DAC12_Regs *dac12)
+{
+    dac12->CALCTL =
+        (DAC12_CALCTL_CALON_ACTIVE | DAC12_CALCTL_CALSEL_SELFCALIBRATIONTRIM);
+}
+
+/**
+ *  @brief      Gets the DAC Calibration offset
+ *
+ *  Reads of the CALDATA register should only be performed after the
+ *  calibration sequence has completed. During calibration, this register is
+ *  continuously written to, and inaccurate values could be obtained.
+ *
+ *  @param[in]  dac12 pointer to the register overlay of the peripheral
+ *
+ *  @return     Current error calibration offset
+ *
+ *  @retval     -64 to +63 in two's complement
+ */
+__STATIC_INLINE uint32_t DL_DAC12_getCalibrationData(DAC12_Regs *dac12)
+{
+    return (dac12->CALDATA & DAC12_CALDATA_DATA_MASK);
+}
+
+/**
+ *  @brief      Perform calibration sequence
+ *
+ *  Enables writes, and then starts the calibration sequence. Should only be
+ *  called after the DAC module is enabled. This will only return when the
+ *  calibration sequence has completed.
+ *
+ *  @pre Amplifier settings should be configured. @ref DL_DAC12_setAmplifier
+ *  @post Calibration is complete, and CALDATA is locked to prevent writes.
+ *
+ *  @param[in]  dac12   pointer to the register overlay of the peripheral
+ */
+void DL_DAC12_performSelfCalibrationBlocking(DAC12_Regs *dac12);
+
+/**
+ *  @brief      Outputs an 8-bit data value
+ *
+ *  Using the CPU to control the DAC, this register can be written to if a
+ *  fixed output voltage is desired (ex. DC Generation) with the FIFO disabled,
+ *  or it can write with variable output (ex. AC Generation) by enabling the
+ *  FIFO and writing to this register. The value will then be written to the
+ *  FIFO internally. With FIFO enabled with @ref DL_DAC12_enableFIFO, the
+ *  FIFO-specific interrupts will be generated inside the DAC.
+ *
+ *  The DMA trigger generation mechanism must be kept disabled when CPU is used
+ *  to load data into DAC
+ *
+ *  @param[in]  dac12       pointer to the register overlay of the peripheral
+ *  @param[in]  dataValue   value to be written to the bit-field from 0x0 to
+ *                          0xFF. It can be either binary or two's complement
+ */
+__STATIC_INLINE void DL_DAC12_output8(DAC12_Regs *dac12, uint8_t dataValue)
+{
+    dac12->DATA0 = dataValue;
+}
+
+/**
+ *  @brief      Outputs a 12-bit Data Value
+ *
+ *  Using the CPU to control the DAC, this register can be written to if a
+ *  fixed output voltage is desired (ex. DC Generation) with the FIFO disabled,
+ *  or it can write with variable output (ex. AC Generation) by enabling the
+ *  FIFO and writing to this register. The value will then be written to the
+ *  FIFO internally. With FIFO enabled with @ref DL_DAC12_enableFIFO, the
+ *  FIFO-specific interrupts will be generated inside the DAC.
+ *
+ *  The DMA trigger generation mechanism must be kept disabled when CPU is used
+ *  to load data into DAC
+ *
+ *  @param[in]  dac12       pointer to the register overlay of the peripheral
+ *  @param[in]  dataValue   value to be written to the bit-field from 0x0 to
+ *                          0xFFF. It can be either binary or two's complement
+ */
+__STATIC_INLINE void DL_DAC12_output12(DAC12_Regs *dac12, uint32_t dataValue)
+{
+    dac12->DATA0 = (dataValue & DAC12_DATA0_DATA_VALUE_MASK);
+}
+
+/**
+ *  @brief      Fills the DAC fifo with 8-bit data values from the buffer
+ *
+ *  Writes as many values from the data buffer to the FIFO as possible,
+ *  and then exits when either the count is matched or the FIFO is full.
+ *
+ *  @param[in]  dac12       pointer to the register overlay of the peripheral
+ *  @param[in]  buffer      array containing the data values (0x00 - 0xFF) to
+ *                          be written
+ *  @param[in]  count       length of the buffer, or maximum desired transfer
+ *
+ *  @return     Count successfully transferred to the FIFO
+ *
+ *  @retval     0 - max(number of empty fifo slots, count)
+ */
+uint32_t DL_DAC12_fillFIFO8(
+    DAC12_Regs *dac12, uint8_t *buffer, uint32_t count);
+
+/**
+ *  @brief      Fills the DAC fifo with 12-bit data values from the buffer
+ *
+ *  Writes as many values from the data buffer to the FIFO as possible,
+ *  and then exits when either the count is matched or the FIFO is full.
+ *
+ *  @param[in]  dac12       pointer to the register overlay of the peripheral
+ *  @param[in]  buffer      array containing the data values (0x00 - 0xFFF) to
+ *                          be written
+ *  @param[in]  count       length of the buffer, or maximum desired transfer
+ *
+ *  @return     Count successfully transfered to the FIFO
+ *
+ *  @retval     0 - max(number of empty fifo slots, count)
+ */
+uint32_t DL_DAC12_fillFIFO12(
+    DAC12_Regs *dac12, uint16_t *buffer, uint32_t count);
+
+/**
+ *  @brief      Blocking 8-bit output to the DAC FIFO
+ *
+ *  Waits until the FIFO is not full, then writes a single value
+ *
+ *  @param[in]  dac12        pointer to the register overlay of the peripheral
+ *  @param[in]  data         data value (0x00 - 0xFF) to be written
+ */
+void DL_DAC12_outputBlocking8(DAC12_Regs *dac12, uint8_t data);
+
+/**
+ *  @brief      Blocking 12-bit output to the DAC FIFO
+ *
+ *  Waits until the FIFO is not full, then writes a single value
+ *
+ *  @param[in]  dac12        pointer to the register overlay of the peripheral
+ *  @param[in]  data         data value (0x000 - 0xFFF) to be written
+ */
+void DL_DAC12_outputBlocking12(DAC12_Regs *dac12, uint16_t data);
+
+/**
+ *  @brief      Checks the raw interrupt status of one or more interrupts
+ *
+ *  The raw interrupt status is independent of whether a specific interrupt is
+ *  enabled.
+ *
+ *  @param[in]  dac12         pointer to the register overlay of the peripheral
+ *  @param[in]  interruptMask the desired interrupt(s). One or more of
+ *                            @ref DL_DAC12_INTERRUPT
+ *
+ *  @return     currently asserted interrupts (whether enabled or not) bit-wise
+ *              AND with the inputted interrupts
+ *
+ *  @retval     0       no interrupts that were inputted are currently asserted
+ *  @retval     not 0   a bit-wise OR of the inputted @ref DL_DAC12_INTERRUPT
+ *                      registers that are currently asserted.
+ */
+__STATIC_INLINE uint32_t DL_DAC12_getInterruptStatus(
+    DAC12_Regs *dac12, uint32_t interruptMask)
+{
+    return (dac12->CPU_INT.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Clears the interrupt status of one or more interrupts
+ *
+ *  Accesses the write only interrupt clear (ICLR) register and writes a 1 to
+ *  the bits specified. Any bit that has 1 written to it will clear that pending
+ *  interrupt if it is currently pending.
+ *
+ *  @param[in]  dac12         pointer to the register overlay of the peripheral
+ *  @param[in]  interruptMask the desired interrupt(s). One or more of
+ *                            @ref DL_DAC12_INTERRUPT
+ */
+__STATIC_INLINE void DL_DAC12_clearInterruptStatus(
+    DAC12_Regs *dac12, uint32_t interruptMask)
+{
+    dac12->CPU_INT.ICLR = interruptMask;
+}
+
+/**
+ *  @brief      Enables one or more interrupts
+ *
+ *  Access and write to the IMASK register to enable the interrupts specified.
+ *
+ *  @param[in]  dac12         pointer to the register overlay of the peripheral
+ *  @param[in]  interruptMask the desired interrupt(s). One or more of
+ *                            @ref DL_DAC12_INTERRUPT
+ */
+__STATIC_INLINE void DL_DAC12_enableInterrupt(
+    DAC12_Regs *dac12, uint32_t interruptMask)
+{
+    dac12->CPU_INT.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disables one or more interrupts
+ *
+ *  Access and write to the IMASK register to disable the interrupts specified.
+ *
+ *  @param[in]  dac12         pointer to the register overlay of the peripheral
+ *  @param[in]  interruptMask the desired interrupt(s). One or more of
+ *                            @ref DL_DAC12_INTERRUPT
+ */
+__STATIC_INLINE void DL_DAC12_disableInterrupt(
+    DAC12_Regs *dac12, uint32_t interruptMask)
+{
+    dac12->CPU_INT.IMASK &= ~interruptMask;
+}
+
+/**
+ *  @brief      Gets the highest priority pending interrupt
+ *
+ *  Accesses and reads the IIDX register to obtain the highest currently
+ *  pending interrupt. Interrupts with lower offsets (and smaller values) are
+ *  higher priority than interrupts with higher offsets (and larger values).
+ *  In order for the interrupt to be pending, it must have been enabled and
+ *  asserted. Clearing the interrupt should will un-pend the interrupt.
+ *
+ *  @param[in]  dac12        pointer to the register overlay of the peripheral
+ *
+ *  @return     highest priority pending interrupt
+ *
+ *  @retval     One of @ref DL_DAC12_IIDX
+ */
+__STATIC_INLINE DL_DAC12_IIDX DL_DAC12_getPendingInterrupt(DAC12_Regs *dac12)
+{
+    return ((DL_DAC12_IIDX) dac12->CPU_INT.IIDX);
+}
+
+/**
+ *  @brief      Checks if the DAC FIFO is currently full
+ *
+ *  Accesses the raw interrupt status (RIS) register in order to get the
+ *  current state of the FIFOFull Interrupt flag.
+ *
+ *  @param[in]  dac12        pointer to the register overlay of the peripheral
+ *
+ *  @return     status of FIFO full interrupt flag
+ *
+ *  @retval     true   FIFO is currently full
+ *  @retval     false  FIFO is not full
+ */
+__STATIC_INLINE bool DL_DAC12_isFIFOFull(DAC12_Regs *dac12)
+{
+    uint32_t t =
+        DL_DAC12_getInterruptStatus(dac12, DL_DAC12_INTERRUPT_FIFO_FULL);
+    return (t == DL_DAC12_INTERRUPT_FIFO_FULL);
+}
+
+/**
+ *  @brief Sets the event publisher channel id
+ *
+ *  @param[in]  dac12 Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  chanID  Channel ID number. Valid range 0-15. If ChanID == 0
+ *                      publisher is disconnected.
+ */
+__STATIC_INLINE void DL_DAC12_setPublisherChanID(
+    DAC12_Regs *dac12, uint8_t chanID)
+{
+    dac12->FPUB_1 = (chanID & DAC12_FPUB_1_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event publisher channel id
+ *
+ *  @param[in]  dac12 Pointer to the register overlay for the
+ *                      peripheral
+ *  @return     Event publisher channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_DAC12_getPublisherChanID(DAC12_Regs *dac12)
+{
+    return ((uint8_t)((dac12->FPUB_1) & DAC12_FPUB_1_CHANID_MASK));
+}
+
+/**
+ *  @brief Sets the event subscriber channel id
+ *
+ *  @param[in]  dac12 Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  index   Specifies the register event index to be configured
+ *  @param[in]  chanID  Channel ID number. Valid range 0-15. If ChanID == 0
+ *                      subscriber is disconnected.
+ */
+__STATIC_INLINE void DL_DAC12_setSubscriberChanID(
+    DAC12_Regs *dac12, DL_DAC12_SUBSCRIBER_INDEX index, uint8_t chanID)
+{
+    volatile uint32_t *pReg = &dac12->FSUB_0;
+
+    *(pReg + (uint32_t) index) = (chanID & DAC12_FSUB_0_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event subscriber channel id
+ *
+ *  @param[in]  dac12 Pointer to the register overlay for the peripheral
+ *  @param[in]  index  Specifies the register event index to be configured
+ *
+ *  @return     Event subscriber channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_DAC12_getSubscriberChanID(
+    DAC12_Regs *dac12, DL_DAC12_SUBSCRIBER_INDEX index)
+{
+    volatile uint32_t *pReg = &dac12->FSUB_0;
+
+    return ((uint8_t)(*(pReg + (uint32_t) index) & DAC12_FSUB_0_CHANID_MASK));
+}
+
+/**
+ *  @brief      Enable DAC event
+ *
+ *  @param[in]  dac12        Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask      Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_DAC12_EVENT.
+ */
+__STATIC_INLINE void DL_DAC12_enableEvent(
+    DAC12_Regs *dac12, uint32_t eventMask)
+{
+    dac12->GEN_EVENT.IMASK |= (eventMask);
+}
+
+/**
+ *  @brief      Disable DAC event
+ *
+ *  @param[in]  dac12        Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask      Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_DAC12_EVENT.
+ */
+__STATIC_INLINE void DL_DAC12_disableEvent(
+    DAC12_Regs *dac12, uint32_t eventMask)
+{
+    dac12->GEN_EVENT.IMASK &= ~(eventMask);
+}
+
+/**
+ *  @brief      Check which DAC events are enabled
+ *
+ *  @param[in]  dac12        Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask      Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_DAC12_EVENT.
+ *
+ *  @return     Which of the requested DAC interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_DAC12_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_DAC12_getEnabledEvents(
+    DAC12_Regs *dac12, uint32_t eventMask)
+{
+    return ((dac12->GEN_EVENT.IMASK) & (eventMask));
+}
+
+/**
+ *  @brief      Check event flag of enabled DAC event
+ *
+ *  Checks if any of the DAC events that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  dac12        Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask      Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_DAC12_EVENT.
+ *
+ *  @return     Which of the requested DAC interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_DAC12_EVENT values
+ *
+ *  @sa         DL_DAC12_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_DAC12_getEnabledEventStatus(
+    DAC12_Regs *dac12, uint32_t eventMask)
+{
+    return ((dac12->GEN_EVENT.MIS) & eventMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any DAC event
+ *
+ *  Checks if any events are pending. Events do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  dac12        Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask      Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_DAC12_EVENT.
+ *
+ *  @return     Which of the requested DAC interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_DAC12_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_DAC12_getRawEventsStatus(
+    DAC12_Regs *dac12, uint32_t eventMask)
+{
+    return ((dac12->GEN_EVENT.RIS) & eventMask);
+}
+
+/**
+ *  @brief      Clear pending DAC events
+ *
+ *  @param[in]  dac12        Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_DAC12_EVENT.
+ */
+__STATIC_INLINE void DL_DAC12_clearEventsStatus(
+    DAC12_Regs *dac12, uint32_t eventMask)
+{
+    dac12->GEN_EVENT.ICLR |= (eventMask);
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __MSPM0_HAS_DAC12__ */
+
+#endif /* ti_dl_dl_dac12__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_dma.c
+++ b/mspm0/source/ti/driverlib/dl_dma.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_dma.h>
+
+void DL_DMA_initChannel(
+    DMA_Regs *dma, uint8_t channelNum, DL_DMA_Config *config)
+{
+    DL_DMA_configTransfer(dma, channelNum, config->transferMode,
+        config->extendedMode, config->srcWidth, config->destWidth,
+        config->srcIncrement, config->destIncrement);
+
+    DL_DMA_setTrigger(dma, channelNum, config->trigger, config->triggerType);
+}

--- a/mspm0/source/ti/driverlib/dl_dma.h
+++ b/mspm0/source/ti/driverlib/dl_dma.h
@@ -1,0 +1,1564 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_dma.h
+ *  @brief      Direct Memory Access (DMA) Driver Library
+ *  @defgroup   DMA Direct Memory Access (DMA)
+ *
+ *  @anchor ti_dl_dl_m0p_dma_Overview
+ *  # Overview
+ *
+ *  The Direct Memory Access (DMA) Library allows full configuration of
+ *  the MSPM0 DMA module.
+ *  The DMA controller transfers data from one address to another, without CPU
+ *  intervention, across the entire address range.
+ *  DMA controllers have multiple channels that can be configured independently
+ *
+ ******************************************************************************
+ */
+/** @addtogroup DMA
+ * @{
+ */
+#ifndef ti_dl_dl_m0p_dma__include
+#define ti_dl_dl_m0p_dma__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if (DMA_SYS_N_DMA_FULL_CHANNEL > 0)
+/*!
+ * @brief Device has support for DMA FULL channels
+ */
+#define DEVICE_HAS_DMA_FULL_CHANNEL
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_DMA_INTERRUPT
+ *  @{
+ */
+/*!
+ * @brief DMA channel 0 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL0                        (DMA_CPU_INT_IMASK_DMACH0_SET)
+
+/*!
+ * @brief DMA channel 1 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL1                        (DMA_CPU_INT_IMASK_DMACH1_SET)
+
+/*!
+ * @brief DMA channel 2 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL2                        (DMA_CPU_INT_IMASK_DMACH2_SET)
+
+/*!
+ * @brief DMA channel 3 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL3                        (DMA_CPU_INT_IMASK_DMACH3_SET)
+
+/*!
+ * @brief DMA channel 4 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL4                        (DMA_CPU_INT_IMASK_DMACH4_SET)
+
+/*!
+ * @brief DMA channel 5 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL5                        (DMA_CPU_INT_IMASK_DMACH5_SET)
+
+/*!
+ * @brief DMA channel 6 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL6                        (DMA_CPU_INT_IMASK_DMACH6_SET)
+
+/*!
+ * @brief DMA channel 7 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL7                        (DMA_CPU_INT_IMASK_DMACH7_SET)
+
+/*!
+ * @brief DMA channel 8 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL8                        (DMA_CPU_INT_IMASK_DMACH8_SET)
+
+/*!
+ * @brief DMA channel 9 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL9                        (DMA_CPU_INT_IMASK_DMACH9_SET)
+
+/*!
+ * @brief DMA channel 10 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL10                      (DMA_CPU_INT_IMASK_DMACH10_SET)
+
+/*!
+ * @brief DMA channel 12 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL12                      (DMA_CPU_INT_IMASK_DMACH12_SET)
+
+/*!
+ * @brief DMA channel 13 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL13                      (DMA_CPU_INT_IMASK_DMACH13_SET)
+
+/*!
+ * @brief DMA channel 14 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL14                      (DMA_CPU_INT_IMASK_DMACH14_SET)
+
+/*!
+ * @brief DMA channel 15 interrupt
+ */
+#define DL_DMA_INTERRUPT_CHANNEL15                      (DMA_CPU_INT_IMASK_DMACH15_SET)
+
+#ifdef DEVICE_HAS_DMA_FULL_CHANNEL
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 0 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_INTERRUPT_EARLY_CHANNEL0        (DMA_CPU_INT_IMASK_PREIRQCH0_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 1 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_INTERRUPT_EARLY_CHANNEL1        (DMA_CPU_INT_IMASK_PREIRQCH1_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 2 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_INTERRUPT_EARLY_CHANNEL2        (DMA_CPU_INT_IMASK_PREIRQCH2_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 3 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_INTERRUPT_EARLY_CHANNEL3        (DMA_CPU_INT_IMASK_PREIRQCH3_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 4 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_INTERRUPT_EARLY_CHANNEL4        (DMA_CPU_INT_IMASK_PREIRQCH4_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 5 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_INTERRUPT_EARLY_CHANNEL5        (DMA_CPU_INT_IMASK_PREIRQCH5_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 6 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_INTERRUPT_EARLY_CHANNEL6        (DMA_CPU_INT_IMASK_PREIRQCH6_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 7 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_INTERRUPT_EARLY_CHANNEL7        (DMA_CPU_INT_IMASK_PREIRQCH7_SET)
+#endif /* DEVICE_HAS_DMA_FULL_CHANNEL */
+
+/*!
+ * @brief DMA address error, source address not reachable
+ */
+#define DL_DMA_INTERRUPT_ADDR_ERROR                      (DMA_CPU_INT_IMASK_ADDRERR_SET)
+/*!
+ * @brief DMA data error, source data might be corrupted (PAR or ECC error)
+ */
+#define DL_DMA_INTERRUPT_DATA_ERROR                      (DMA_CPU_INT_IMASK_DATAERR_SET)
+
+/** @}*/
+
+/** @addtogroup DL_DMA_EVENT
+ *  @{
+ */
+/*!
+ * @brief DMA channel 0 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL0                             (DMA_GEN_EVENT_IMASK_DMACH0_SET)
+
+/*!
+ * @brief DMA channel 1 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL1                             (DMA_GEN_EVENT_IMASK_DMACH1_SET)
+
+/*!
+ * @brief DMA channel 2 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL2                             (DMA_GEN_EVENT_IMASK_DMACH2_SET)
+
+/*!
+ * @brief DMA channel 3 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL3                             (DMA_GEN_EVENT_IMASK_DMACH3_SET)
+
+/*!
+ * @brief DMA channel 4 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL4                             (DMA_GEN_EVENT_IMASK_DMACH4_SET)
+
+/*!
+ * @brief DMA channel 5 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL5                             (DMA_GEN_EVENT_IMASK_DMACH5_SET)
+
+/*!
+ * @brief DMA channel 6 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL6                             (DMA_GEN_EVENT_IMASK_DMACH6_SET)
+
+/*!
+ * @brief DMA channel 7 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL7                             (DMA_GEN_EVENT_IMASK_DMACH7_SET)
+
+/*!
+ * @brief DMA channel 8 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL8                             (DMA_GEN_EVENT_IMASK_DMACH8_SET)
+
+/*!
+ * @brief DMA channel 9 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL9                             (DMA_GEN_EVENT_IMASK_DMACH9_SET)
+
+/*!
+ * @brief DMA channel 10 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL10                           (DMA_GEN_EVENT_IMASK_DMACH10_SET)
+
+/*!
+ * @brief DMA channel 12 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL12                           (DMA_GEN_EVENT_IMASK_DMACH12_SET)
+
+/*!
+ * @brief DMA channel 13 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL13                           (DMA_GEN_EVENT_IMASK_DMACH13_SET)
+
+/*!
+ * @brief DMA channel 14 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL14                           (DMA_GEN_EVENT_IMASK_DMACH14_SET)
+
+/*!
+ * @brief DMA channel 15 interrupt
+ */
+#define DL_DMA_EVENT_CHANNEL15                           (DMA_GEN_EVENT_IMASK_DMACH15_SET)
+
+#ifdef DEVICE_HAS_DMA_FULL_CHANNEL
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 0 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_EVENT_EARLY_CHANNEL0            (DMA_GEN_EVENT_IMASK_PREIRQCH0_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 1 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_EVENT_EARLY_CHANNEL1            (DMA_GEN_EVENT_IMASK_PREIRQCH1_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 2 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_EVENT_EARLY_CHANNEL2            (DMA_GEN_EVENT_IMASK_PREIRQCH2_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 3 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_EVENT_EARLY_CHANNEL3            (DMA_GEN_EVENT_IMASK_PREIRQCH3_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 4 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_EVENT_EARLY_CHANNEL4            (DMA_GEN_EVENT_IMASK_PREIRQCH4_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 5 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_EVENT_EARLY_CHANNEL5            (DMA_GEN_EVENT_IMASK_PREIRQCH5_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 6 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_EVENT_EARLY_CHANNEL6            (DMA_GEN_EVENT_IMASK_PREIRQCH6_SET)
+
+/*!
+ * @brief Available for FULL-channel configuration only. Early IRQ for DMA
+ * channel 7 interrupt. Size counter has reached early IRQ threshold.
+ */
+#define DL_DMA_FULL_CH_EVENT_EARLY_CHANNEL7            (DMA_GEN_EVENT_IMASK_PREIRQCH7_SET)
+#endif /* DEVICE_HAS_DMA_FULL_CHANNEL */
+
+/*!
+ * @brief DMA address error, source address not reachable
+ */
+#define DL_DMA_EVENT_ADDR_ERROR                     (DMA_GEN_EVENT_IMASK_ADDRERR_SET)
+/*!
+ * @brief DMA data error, source data might be corrupted (PAR or ECC error)
+ */
+#define DL_DMA_EVENT_DATA_ERROR                     (DMA_GEN_EVENT_IMASK_DATAERR_SET)
+
+/** @}*/
+
+/*! @enum DL_DMA_TRANSFER_MODE */
+typedef enum {
+    /*! Each DMA trigger results in a single data transfer, once */
+    DL_DMA_SINGLE_TRANSFER_MODE = DMA_DMACTL_DMATM_SINGLE,
+    /*! Each DMA trigger results in a transfer of a block of data, once */
+    DL_DMA_SINGLE_BLOCK_TRANSFER_MODE = DMA_DMACTL_DMATM_BLOCK,
+#ifdef DEVICE_HAS_DMA_FULL_CHANNEL
+    /*! Available for FULL-channel configuration only. Each DMA trigger results
+     *  in a single data transfer, repeating */
+    DL_DMA_FULL_CH_REPEAT_SINGLE_TRANSFER_MODE = DMA_DMACTL_DMATM_RPTSNGL,
+    /*! Available for FULL-channel configuration only. Each DMA trigger results
+     *  in a transfer of a block of data, repeating */
+    DL_DMA_FULL_CH_REPEAT_BLOCK_TRANSFER_MODE = DMA_DMACTL_DMATM_RPTBLCK,
+#endif /* DEVICE_HAS_DMA_FULL_CHANNEL */
+} DL_DMA_TRANSFER_MODE;
+
+/*! @enum DL_DMA_EXTENDED_MODE */
+typedef enum {
+    /*! Normal operation */
+    DL_DMA_NORMAL_MODE = DMA_DMACTL_DMAEM_NORMAL,
+#ifdef DEVICE_HAS_DMA_FULL_CHANNEL
+    /*! Available for FULL-channel configuration only. Fills the destination
+     *  with a specific value */
+    DL_DMA_FULL_CH_FILL_MODE = DMA_DMACTL_DMAEM_FILLMODE,
+    /*! Available for FULL-channel configuration only. The source data contains
+     *  addresses and data */
+    DL_DMA_FULL_CH_TABLE_MODE = DMA_DMACTL_DMAEM_TABLEMODE,
+#endif /* DEVICE_HAS_DMA_FULL_CHANNEL */
+} DL_DMA_EXTENDED_MODE;
+
+/*! @enum DL_DMA_INCREMENT */
+typedef enum {
+    /*! Do not change address after each transfer */
+    DL_DMA_ADDR_UNCHANGED = DMA_DMACTL_DMASRCINCR_UNCHANGED,
+    /*! Decrement address by 1 * DL_DMA_WIDTH after each transfer */
+    DL_DMA_ADDR_DECREMENT = DMA_DMACTL_DMASRCINCR_DECREMENT,
+    /*! Increment address by 1 * DL_DMA_WIDTH after each transfer */
+    DL_DMA_ADDR_INCREMENT = DMA_DMACTL_DMASRCINCR_INCREMENT,
+    /*! Stride mode 2, increment address by 2 * DL_DMA_WIDTH (skip over every
+     * other element) */
+    DL_DMA_ADDR_STRIDE_2 = DMA_DMACTL_DMASRCINCR_STRIDE_2,
+    /*! Stride mode 3, increment address by 3 * DL_DMA_WIDTH (skip over two
+     * elements */
+    DL_DMA_ADDR_STRIDE_3 = DMA_DMACTL_DMASRCINCR_STRIDE_3,
+    /*! Stride mode 4, increment address by 4 * DL_DMA_WIDTH (skip over three
+     * elements */
+    DL_DMA_ADDR_STRIDE_4 = DMA_DMACTL_DMASRCINCR_STRIDE_4,
+    /*! Stride mode 5, increment address by 5 * DL_DMA_WIDTH (skip over four
+     * elements */
+    DL_DMA_ADDR_STRIDE_5 = DMA_DMACTL_DMASRCINCR_STRIDE_5,
+    /*! Stride mode 6, increment address by 6 * DL_DMA_WIDTH (skip over five
+     * elements */
+    DL_DMA_ADDR_STRIDE_6 = DMA_DMACTL_DMASRCINCR_STRIDE_6,
+    /*! Stride mode 7, increment address by 7 * DL_DMA_WIDTH (skip over six
+     * elements */
+    DL_DMA_ADDR_STRIDE_7 = DMA_DMACTL_DMASRCINCR_STRIDE_7,
+    /*! Stride mode 8, increment address by 8 * DL_DMA_WIDTH (skip over seven
+     * elements */
+    DL_DMA_ADDR_STRIDE_8 = DMA_DMACTL_DMASRCINCR_STRIDE_8,
+    /*! Stride mode 9, increment address by 9 * DL_DMA_WIDTH (skip over eight
+     * elements */
+    DL_DMA_ADDR_STRIDE_9 = DMA_DMACTL_DMASRCINCR_STRIDE_9,
+} DL_DMA_INCREMENT;
+
+/*! @enum DL_DMA_EARLY_INTERRUPT_THRESHOLD */
+typedef enum {
+    /*! Disable early interrupt events */
+    DL_DMA_EARLY_INTERRUPT_THRESHOLD_DISABLED = DMA_DMACTL_DMAPREIRQ_PREIRQ_DISABLE,
+    /*! Generate Early-IRQ event with one transfer pending (DMASZ=1) */
+    DL_DMA_EARLY_INTERRUPT_THRESHOLD_1 = DMA_DMACTL_DMAPREIRQ_PREIRQ_1,
+    /*! Generate Early-IRQ event with two transfers pending (DMASZ=2) */
+    DL_DMA_EARLY_INTERRUPT_THRESHOLD_2 = DMA_DMACTL_DMAPREIRQ_PREIRQ_2,
+    /*! Generate Early-IRQ event with three transfers pending (DMASZ=4) */
+    DL_DMA_EARLY_INTERRUPT_THRESHOLD_4 = DMA_DMACTL_DMAPREIRQ_PREIRQ_4,
+    /*! Generate Early-IRQ event with eight transfers pending (DMASZ=8) */
+    DL_DMA_EARLY_INTERRUPT_THRESHOLD_8 = DMA_DMACTL_DMAPREIRQ_PREIRQ_8,
+    /*! Generate Early-IRQ event with 32 transfers pending (DMASZ=32) */
+    DL_DMA_EARLY_INTERRUPT_THRESHOLD_32 = DMA_DMACTL_DMAPREIRQ_PREIRQ_32,
+    /*! Generate Early-IRQ event with 64 transfers pending (DMASZ=64) */
+    DL_DMA_EARLY_INTERRUPT_THRESHOLD_64 = DMA_DMACTL_DMAPREIRQ_PREIRQ_64,
+    /*! Generate Early-IRQ event when DMASZ reaches the half size point of the
+     * original transfer size */
+    DL_DMA_EARLY_INTERRUPT_THRESHOLD_HALF = DMA_DMACTL_DMAPREIRQ_PREIRQ_HALF,
+} DL_DMA_EARLY_INTERRUPT_THRESHOLD;
+
+/*! @enum DL_DMA_BURST_SIZE */
+typedef enum {
+    /*! No burst interruption. The block transfer always transfers all elements
+     * defined in the DMASZ register before priority is newly evaluated */
+    DL_DMA_BURST_SIZE_INFINITY = DMA_DMAPRIO_BURSTSZ_INFINITI,
+    /*! Burst size of a block transfer is 8 */
+    DL_DMA_BURST_SIZE_8 = DMA_DMAPRIO_BURSTSZ_BURST_8,
+    /*! Burst size of a block transfer is 16 */
+    DL_DMA_BURST_SIZE_16 = DMA_DMAPRIO_BURSTSZ_BUSRT_16,
+    /*! Burst size of a block transfer is 32 */
+    DL_DMA_BURST_SIZE_32 = DMA_DMAPRIO_BURSTSZ_BURST_32,
+} DL_DMA_BURST_SIZE;
+
+/*! @enum DL_DMA_TRIGGER_TYPE */
+typedef enum {
+    /*! Internal DMA channel is selected as the DMA trigger */
+    DL_DMA_TRIGGER_TYPE_INTERNAL = DMA_DMATCTL_DMATINT_INTERNAL,
+    /*! External DMA channel is selected as the DMA trigger */
+    DL_DMA_TRIGGER_TYPE_EXTERNAL = DMA_DMATCTL_DMATINT_EXTERNAL,
+} DL_DMA_TRIGGER_TYPE;
+
+/*! @enum DL_DMA_WIDTH */
+typedef enum {
+    /*! Byte Acccess (8-bit) */
+    DL_DMA_WIDTH_BYTE = DMA_DMACTL_DMASRCWDTH_BYTE,
+    /*! Half Word Acccess (16-bit) */
+    DL_DMA_WIDTH_HALF_WORD = DMA_DMACTL_DMASRCWDTH_HALF,
+    /*! Word Acccess (32-bit) */
+    DL_DMA_WIDTH_WORD = DMA_DMACTL_DMASRCWDTH_WORD,
+    /*! Long Acccess (64-bit) */
+    DL_DMA_WIDTH_LONG = DMA_DMACTL_DMASRCWDTH_LONG,
+} DL_DMA_WIDTH;
+
+/*! @enum DL_DMA_EVENT_IIDX */
+typedef enum {
+    /*! Enum to indicate that no DMA event has taken place */
+    DL_DMA_EVENT_IIDX_NO_INTR = DMA_GEN_EVENT_IIDX_STAT_NO_INTR,
+    /*! Enum to indicate that the channel 0 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH0 = DMA_GEN_EVENT_IIDX_STAT_DMACH0,
+    /*! Enum to indicate that the channel 1 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH1 = DMA_GEN_EVENT_IIDX_STAT_DMACH1,
+    /*! Enum to indicate that the channel 2 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH2 = DMA_GEN_EVENT_IIDX_STAT_DMACH2,
+    /*! Enum to indicate that the channel 3 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH3 = DMA_GEN_EVENT_IIDX_STAT_DMACH3,
+    /*! Enum to indicate that the channel 4 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH4 = DMA_GEN_EVENT_IIDX_STAT_DMACH4,
+    /*! Enum to indicate that the channel 5 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH5 = DMA_GEN_EVENT_IIDX_STAT_DMACH5,
+    /*! Enum to indicate that the channel 6 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH6 = DMA_GEN_EVENT_IIDX_STAT_DMACH6,
+    /*! Enum to indicate that the channel 7 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH7 = DMA_GEN_EVENT_IIDX_STAT_DMACH7,
+    /*! Enum to indicate that the channel 8 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH8 = DMA_GEN_EVENT_IIDX_STAT_DMACH8,
+    /*! Enum to indicate that the channel 9 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH9 = DMA_GEN_EVENT_IIDX_STAT_DMACH9,
+    /*! Enum to indicate that the channel 10 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH10 = DMA_GEN_EVENT_IIDX_STAT_DMACH10,
+    /*! Enum to indicate that the channel 11 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH11 = DMA_GEN_EVENT_IIDX_STAT_DMACH11,
+    /*! Enum to indicate that the channel 12 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH12 = DMA_GEN_EVENT_IIDX_STAT_DMACH12,
+    /*! Enum to indicate that the channel 13 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH13 = DMA_GEN_EVENT_IIDX_STAT_DMACH13,
+    /*! Enum to indicate that the channel 14 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH14 = DMA_GEN_EVENT_IIDX_STAT_DMACH14,
+    /*! Enum to indicate that the channel 15 interrupt has fired */
+    DL_DMA_EVENT_IIDX_DMACH15 = DMA_GEN_EVENT_IIDX_STAT_DMACH15,
+#ifdef DEVICE_HAS_DMA_FULL_CHANNEL
+    /*! Available for FULL-channel configuration only. Enum to indicate that the
+     *  early interrupt event for channel 0 interrupt has fired */
+    DL_DMA_FULL_CH_EVENT_IIDX_EARLY_IRQ_DMACH0 = DMA_GEN_EVENT_IIDX_STAT_PREIRQCH0,
+    /*! Available for FULL-channel configuration only. Enum to indicate that the
+     *  early interrupt event for channel 1 interrupt has fired */
+    DL_DMA_FULL_CH_EVENT_IIDX_EARLY_IRQ_DMACH1 = DMA_GEN_EVENT_IIDX_STAT_PREIRQCH1,
+    /*! Available for FULL-channel configuration only. Enum to indicate that the
+     *  early interrupt event for channel 2 interrupt has fired */
+    DL_DMA_FULL_CH_EVENT_IIDX_EARLY_IRQ_DMACH2 = DMA_GEN_EVENT_IIDX_STAT_PREIRQCH2,
+    /*! Available for FULL-channel configuration only. Enum to indicate that the
+     *  early interrupt event for channel 3 interrupt has fired */
+    DL_DMA_FULL_CH_EVENT_IIDX_EARLY_IRQ_DMACH3 = DMA_GEN_EVENT_IIDX_STAT_PREIRQCH3,
+    /*! Available for FULL-channel configuration only. Enum to indicate that the
+     *  early interrupt event for channel 4 interrupt has fired */
+    DL_DMA_FULL_CH_EVENT_IIDX_EARLY_IRQ_DMACH4 = DMA_GEN_EVENT_IIDX_STAT_PREIRQCH4,
+    /*! Available for FULL-channel configuration only. Enum to indicate that the
+     *  early interrupt event for channel 5 interrupt has fired */
+    DL_DMA_FULL_CH_EVENT_IIDX_EARLY_IRQ_DMACH5 = DMA_GEN_EVENT_IIDX_STAT_PREIRQCH5,
+    /*! Available for FULL-channel configuration only. Enum to indicate that the
+     *  early interrupt event for channel 6 interrupt has fired */
+    DL_DMA_FULL_CH_EVENT_IIDX_EARLY_IRQ_DMACH6 = DMA_GEN_EVENT_IIDX_STAT_PREIRQCH6,
+    /*! Available for FULL-channel configuration only. Enum to indicate that the
+     *  early interrupt event for channel 7 interrupt has fired */
+    DL_DMA_FULL_CH_EVENT_IIDX_EARLY_IRQ_DMACH7 = DMA_GEN_EVENT_IIDX_STAT_PREIRQCH7,
+#endif /* DEVICE_HAS_DMA_FULL_CHANNEL */
+    /*! Enum to indicate that a DMA address error has occurred */
+    DL_DMA_EVENT_IIDX_ADDR_ERROR = DMA_GEN_EVENT_IIDX_STAT_ADDRERR,
+
+    /*! Enum to indicate that a DMA data error has occurred */
+    DL_DMA_EVENT_IIDX_DATA_ERROR = DMA_GEN_EVENT_IIDX_STAT_DATAERR
+} DL_DMA_EVENT_IIDX;
+
+/*! @enum DL_DMA_PUBLISHER_INDEX */
+typedef enum {
+    /*! DMA Publisher index 0 */
+    DL_DMA_PUBLISHER_INDEX_0 = 0,
+} DL_DMA_PUBLISHER_INDEX;
+
+/*! @enum DL_DMA_SUBSCRIBER_INDEX */
+typedef enum {
+    /*! DMA Subscriber index 0 */
+    DL_DMA_SUBSCRIBER_INDEX_0 = 0,
+    /*! DMA Subscriber index 1 */
+    DL_DMA_SUBSCRIBER_INDEX_1 = 1
+} DL_DMA_SUBSCRIBER_INDEX;
+
+/* clang-format on */
+
+/*!
+ *  @brief Configuration struct for @ref DL_DMA_initChannel.
+ */
+typedef struct {
+    /*!
+     *  The event that should trigger a DMA transfer. Refer to the datasheet of
+     *  the device for which DMA trigger values map to which events.
+     */
+    uint8_t trigger;
+
+    /*!
+     *  Configure whether the DMA selects an internal or external channel as
+     *  the DMA trigger
+     */
+    DL_DMA_TRIGGER_TYPE triggerType;
+
+    /*!
+     * The transfer mode to use. Refer to the device datasheet to determine
+     * which modes are supported in the selected channel.
+     * One of @ref DL_DMA_TRANSFER_MODE.
+     */
+    DL_DMA_TRANSFER_MODE transferMode;
+
+    /*! The extended mode to use. One of @ref DL_DMA_EXTENDED_MODE. */
+    DL_DMA_EXTENDED_MODE extendedMode;
+
+    /*! The width of the DMA source. One of @ref DL_DMA_WIDTH. */
+    DL_DMA_WIDTH srcWidth;
+
+    /*! The width of the DMA destination. One of @ref DL_DMA_WIDTH. */
+    DL_DMA_WIDTH destWidth;
+
+    /*!
+     *  Amount to increment/decrement the DMA source address by. One of
+     *  @ref DL_DMA_INCREMENT.
+     */
+    DL_DMA_INCREMENT srcIncrement;
+
+    /*!
+     *  Amount to increment/decrement the DMA destination address by. One of
+     *  @ref DL_DMA_INCREMENT.
+     */
+    DL_DMA_INCREMENT destIncrement;
+} DL_DMA_Config;
+
+/**
+ *  @brief      Initialize a DMA channel
+ *
+ *  Initializes all the configurable options for a DMA channel. The DMA channel
+ *  is not enabled in this API.
+ *
+ *  @param[in]  dma           Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum    DMA channel to operate on
+ *  @param[in]  config        Pointer to DMA channel configuration settings
+ */
+void DL_DMA_initChannel(
+    DMA_Regs *dma, uint8_t channelNum, DL_DMA_Config *config);
+
+/**
+ *  @brief      Configure a DMA channel for a transfer
+ *
+ *  Configures the transfer settings for a DMA channel. The DMA channel is
+ *  not enabled in this API.
+ *
+ *  @param[in]  dma           Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum    DMA channel to operate on
+ *  @param[in]  transferMode  The transfer mode to use. Refer to the device
+ *                            datasheet to determine which modes are supported
+ *                            in the selected channel. One of
+ *                            @ref DL_DMA_TRANSFER_MODE.
+ *  @param[in]  extendedMode  The extended mode to use. One of
+ *                            @ref DL_DMA_EXTENDED_MODE.
+ *  @param[in]  srcWidth      The width of the DMA source. One of
+ *                            @ref DL_DMA_WIDTH.
+ *  @param[in]  destWidth     The width of the DMA destination. One of
+ *                            @ref DL_DMA_WIDTH.
+ *  @param[in]  srcIncrement  Amount to increment/decrement the DMA source
+ *                            address by. One of @ref DL_DMA_INCREMENT.
+ *  @param[in]  destIncrement Amount to increment/decrement the DMA destination
+ *                            address by. One of @ref DL_DMA_INCREMENT.
+ */
+__STATIC_INLINE void DL_DMA_configTransfer(DMA_Regs *dma, uint8_t channelNum,
+    DL_DMA_TRANSFER_MODE transferMode, DL_DMA_EXTENDED_MODE extendedMode,
+    DL_DMA_WIDTH srcWidth, DL_DMA_WIDTH destWidth,
+    DL_DMA_INCREMENT srcIncrement, DL_DMA_INCREMENT destIncrement)
+{
+    dma->DMACHAN[channelNum].DMACTL =
+        ((uint32_t) transferMode | (uint32_t) extendedMode |
+            (((uint32_t) destIncrement) << 4) | (uint32_t) srcIncrement |
+            ((uint32_t) destWidth << 4) | (uint32_t) srcWidth);
+}
+
+/**
+ *  @brief      Configure the DMA for round-robin priority
+ *
+ *  When round-robin priority is enabled, the channel that completes a transfer
+ *  becomes the lowest priority. If multiple triggers happen simultaneously or
+ *  are pending, the channel that transferred least recently will transfer
+ *  first. Once it's complete the next highest priority channel will transfer.
+ *
+ *  @param[in]  dma  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_DMA_enableRoundRobinPriority(DMA_Regs *dma)
+{
+    dma->DMAPRIO |= DMA_DMAPRIO_ROUNDROBIN_ENABLE;
+}
+
+/**
+ *  @brief      Disable round-robin priority for the DMA
+ *
+ *  When round-robin priority is disabled, the channel priorities are fixed
+ *  in ascending order (Channel 0 is the lowed priority). If multiple triggers
+ *  happen simultaneously or are pending, the channel with the highest priority
+ *  completes its transfer before the next-highest transfer can start.
+ *
+ *  @param[in]  dma  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_DMA_disableRoundRobinPriority(DMA_Regs *dma)
+{
+    dma->DMAPRIO &= ~(DMA_DMAPRIO_ROUNDROBIN_MASK);
+}
+
+/**
+ *  @brief      Check if round-robin priority is enabled for the DMA
+ *
+ *  @param[in]  dma  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of round-robin priority
+ *
+ *  @retval     true  Round-robin priority is enabled
+ *  @retval     false Round-robin priority is disabled
+ */
+__STATIC_INLINE bool DL_DMA_isRoundRobinPriorityEnabled(DMA_Regs *dma)
+{
+    return ((dma->DMAPRIO & DMA_DMAPRIO_ROUNDROBIN_MASK) ==
+            DMA_DMAPRIO_ROUNDROBIN_ENABLE);
+}
+
+/**
+ *  @brief      Set the burst size for block transfers
+ *
+ *  After the DMA transfers the amount of transfers defined by
+ *  @ref DL_DMA_BURST_SIZE, the ongoing block transfer is interrupted and the
+ *  priority encoder has the chance to assign a higher priority channel. The
+ *  previously interrupted block transfer is internally marked as pending and
+ *  when no other high priority channel is pending the block transfer will
+ *  continue with the next burst or until DMASZ counts down to 0.
+ *
+ *  @param[in]  dma           Pointer to the register overlay for the peripheral
+ *  @param[in]  burstSize     The burst size to set. One of
+ *                            @ref DL_DMA_BURST_SIZE.
+ *
+ *  @sa         DL_DMA_configTransfer
+ */
+__STATIC_INLINE void DL_DMA_setBurstSize(
+    DMA_Regs *dma, DL_DMA_BURST_SIZE burstSize)
+{
+    DL_Common_updateReg(
+        &dma->DMAPRIO, (uint32_t) burstSize, DMA_DMAPRIO_BURSTSZ_MASK);
+}
+
+/**
+ *  @brief      Get the burst size for block transfers
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *
+ *  @return     The burst size for block transfers
+ *
+ *  @retval     One of @ref DL_DMA_BURST_SIZE
+ */
+__STATIC_INLINE DL_DMA_BURST_SIZE DL_DMA_getBurstSize(DMA_Regs *dma)
+{
+    uint32_t burstSize = dma->DMAPRIO & DMA_DMAPRIO_BURSTSZ_MASK;
+
+    return (DL_DMA_BURST_SIZE)(burstSize);
+}
+
+/**
+ *  @brief      Enable a DMA channel for transfers
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ */
+__STATIC_INLINE void DL_DMA_enableChannel(DMA_Regs *dma, uint8_t channelNum)
+{
+    dma->DMACHAN[channelNum].DMACTL |= DMA_DMACTL_DMAEN_ENABLE;
+}
+
+/**
+ *  @brief      Disable a DMA channel for transfers
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ */
+__STATIC_INLINE void DL_DMA_disableChannel(DMA_Regs *dma, uint8_t channelNum)
+{
+    dma->DMACHAN[channelNum].DMACTL &= ~(DMA_DMACTL_DMAEN_MASK);
+}
+
+/**
+ *  @brief      Check if a DMA channel is enabled for transfers
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *
+ *  @return     The status of the DMA channel
+ *
+ *  @retval     true  The DMA channel is enabled
+ *  @retval     false The DMA channel is disabled
+ */
+__STATIC_INLINE bool DL_DMA_isChannelEnabled(DMA_Regs *dma, uint8_t channelNum)
+{
+    return ((dma->DMACHAN[channelNum].DMACTL & DMA_DMACTL_DMAEN_MASK) ==
+            DMA_DMACTL_DMAEN_ENABLE);
+}
+
+/**
+ *  @brief      Configure the mode for a DMA channel
+ *
+ *  @param[in]  dma          Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum   DMA channel to operate on
+ *  @param[in]  transferMode  The transfer mode to set for the channel. Refer to
+ *                            the device datasheet to determine which modes are
+ *                            supported in the selected channel. One of
+ *                            @ref DL_DMA_TRANSFER_MODE.
+ *  @param[in]  extendedMode The extended operation mode to set for the
+ *                           channel. One of @ref DL_DMA_EXTENDED_MODE.
+ *
+ *  @sa         DL_DMA_configTransfer
+ */
+__STATIC_INLINE void DL_DMA_configMode(DMA_Regs *dma, uint8_t channelNum,
+    DL_DMA_TRANSFER_MODE transferMode, DL_DMA_EXTENDED_MODE extendedMode)
+{
+    DL_Common_updateReg(&dma->DMACHAN[channelNum].DMACTL,
+        (uint32_t) transferMode | (uint32_t) extendedMode,
+        DMA_DMACTL_DMATM_MASK | DMA_DMACTL_DMAEM_MASK);
+}
+
+/**
+ *  @brief      Set a DMA channel's transfer mode
+ *
+ *  @param[in]  dma           Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum    DMA channel to operate on
+ *  @param[in]  transferMode  The transfer mode to use. Refer to the device
+ *                            datasheet to determine which modes are supported
+ *                            in the selected channel. One of
+ *                            @ref DL_DMA_TRANSFER_MODE.
+ *
+ *  @sa         DL_DMA_configMode
+ *  @sa         DL_DMA_configTransfer
+ */
+__STATIC_INLINE void DL_DMA_setTransferMode(
+    DMA_Regs *dma, uint8_t channelNum, DL_DMA_TRANSFER_MODE transferMode)
+{
+    DL_Common_updateReg(&dma->DMACHAN[channelNum].DMACTL,
+        (uint32_t) transferMode, DMA_DMACTL_DMATM_MASK);
+}
+
+/**
+ *  @brief      Get a DMA channel's transfer mode
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *
+ *  @return     The channel's transfer mode
+ *
+ *  @retval     One of @ref DL_DMA_TRANSFER_MODE
+ */
+__STATIC_INLINE DL_DMA_TRANSFER_MODE DL_DMA_getTransferMode(
+    DMA_Regs *dma, uint8_t channelNum)
+{
+    uint32_t mode = (dma->DMACHAN[channelNum].DMACTL & DMA_DMACTL_DMATM_MASK);
+
+    return (DL_DMA_TRANSFER_MODE)(mode);
+}
+
+/**
+ *  @brief      Set a DMA channel's extended mode
+ *
+ *  @param[in]  dma           Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum    DMA channel to operate on
+ *  @param[in]  extendedMode  The transfer mode to use. One of
+ *                            @ref DL_DMA_EXTENDED_MODE.
+ *
+ *  @sa         DL_DMA_configMode
+ *  @sa         DL_DMA_configTransfer
+ */
+__STATIC_INLINE void DL_DMA_setExtendedMode(
+    DMA_Regs *dma, uint8_t channelNum, DL_DMA_EXTENDED_MODE extendedMode)
+{
+    DL_Common_updateReg(&dma->DMACHAN[channelNum].DMACTL,
+        (uint32_t) extendedMode, DMA_DMACTL_DMAEM_MASK);
+}
+
+/**
+ *  @brief      Get a DMA channel's extended mode
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *
+ *  @return     The channel's transfer mode
+ *
+ *  @retval     One of @ref DL_DMA_EXTENDED_MODE
+ */
+__STATIC_INLINE DL_DMA_EXTENDED_MODE DL_DMA_getExtendedMode(
+    DMA_Regs *dma, uint8_t channelNum)
+{
+    uint32_t mode = (dma->DMACHAN[channelNum].DMACTL & DMA_DMACTL_DMAEM_MASK);
+
+    return (DL_DMA_EXTENDED_MODE)(mode);
+}
+
+/**
+ *  @brief      Start a DMA transfer using software
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ */
+__STATIC_INLINE void DL_DMA_startTransfer(DMA_Regs *dma, uint8_t channelNum)
+{
+    dma->DMACHAN[channelNum].DMACTL |= DMA_DMACTL_DMAREQ_REQUEST;
+}
+
+/**
+ *  @brief      Set a channel's trigger for a DMA transfer
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *  @param[in]  trigger     What should trigger a DMA transfer. Refer to the
+ *                          datasheet of the device for which DMA trigger
+ *                          values map to which events.
+ *  @param[in]  triggerType Whether an internal or external DMA channel is
+ *                          selected as the DMA trigger. Refer to the datasheet
+ *                          for more information on the DMA channels.
+ */
+__STATIC_INLINE void DL_DMA_setTrigger(DMA_Regs *dma, uint8_t channelNum,
+    uint8_t trigger, DL_DMA_TRIGGER_TYPE triggerType)
+{
+    DL_Common_updateReg(&dma->DMATRIG[channelNum].DMATCTL,
+        trigger | (uint32_t) triggerType,
+        DMA_DMATCTL_DMATSEL_MASK | DMA_DMATCTL_DMATINT_MASK);
+}
+
+/**
+ *  @brief      Get the current trigger for a DMA channel
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *
+ *  @return     What is configured to trigger a DMA transfer.
+ *
+ *  @retval     Check the device datasheet for what values are mapped to on
+ *              your device.
+ */
+__STATIC_INLINE uint32_t DL_DMA_getTrigger(DMA_Regs *dma, uint8_t channelNum)
+{
+    return (dma->DMATRIG[channelNum].DMATCTL & DMA_DMATCTL_DMATSEL_MASK);
+}
+
+/**
+ *  @brief      Get the current trigger type for a DMA channel
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *
+ *  @return     Whether an internal or external DMA channel is selected as the
+ *              DMA trigger.
+ *
+ *  @retval     One of @ref DL_DMA_TRIGGER_TYPE
+ */
+__STATIC_INLINE DL_DMA_TRIGGER_TYPE DL_DMA_getTriggerType(
+    DMA_Regs *dma, uint8_t channelNum)
+{
+    uint32_t triggerType =
+        (dma->DMATRIG[channelNum].DMATCTL & DMA_DMATCTL_DMATINT_MASK);
+
+    return (DL_DMA_TRIGGER_TYPE)(triggerType);
+}
+
+/**
+ *  @brief      Set a DMA channel's source address
+ *
+ *  Set the source address for a DMA channel for transferring data from. This
+ *  address can be automatically incremented/decremented after the completion
+ *  of a transfer by using the @ref DL_DMA_setSrcIncrement function.
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *  @param[in]  srcAddr     Address to set as the DMA source
+ *
+ *  @sa         DL_DMA_setSrcIncrement
+ */
+__STATIC_INLINE void DL_DMA_setSrcAddr(
+    DMA_Regs *dma, uint8_t channelNum, uint32_t srcAddr)
+{
+    dma->DMACHAN[channelNum].DMASA = srcAddr;
+}
+
+/**
+ *  @brief      Get a DMA channel's source address
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *
+ *  @return     Source address for the DMA channel
+ */
+__STATIC_INLINE uint32_t DL_DMA_getSrcAddr(DMA_Regs *dma, uint8_t channelNum)
+{
+    return dma->DMACHAN[channelNum].DMASA;
+}
+
+/**
+ *  @brief      Set a DMA channel's destination address
+ *
+ *  Set the destination address for a DMA channel for transferring data to.
+ *  This address can be automatically incremented/decremented after the
+ *  completion of a transfer by using the @ref DL_DMA_setDestIncrement
+ *  function.
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *  @param[in]  destAddr    Address to set as the DMA destination
+ *
+ *  @sa         DL_DMA_setDestIncrement
+ */
+__STATIC_INLINE void DL_DMA_setDestAddr(
+    DMA_Regs *dma, uint8_t channelNum, uint32_t destAddr)
+{
+    dma->DMACHAN[channelNum].DMADA = destAddr;
+}
+
+/**
+ *  @brief      Get a DMA channel's destination address
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *
+ *  @return     Destination address for the DMA channel
+ */
+__STATIC_INLINE uint32_t DL_DMA_getDestAddr(DMA_Regs *dma, uint8_t channelNum)
+{
+    return dma->DMACHAN[channelNum].DMADA;
+}
+
+/**
+ *  @brief      Set the size of a block for a DMA transfer
+ *
+ *  Defines the size of the block of data to transfer.
+ *
+ *  When the transfer mode @ref DL_DMA_TRANSFER_MODE is a Block transfer mode,
+ *  this is the size of the block of data transferred every trigger.
+ *
+ *  When in the transfer mode @ref DL_DMA_TRANSFER_MODE is a Single transfer
+ *  mode, this is how many triggers need to occur before the block is considered
+ *  done, which then sets the interrupt status.
+ *
+ *  @param[in]  dma           Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum    DMA channel to operate on
+ *  @param[in]  size          The size of the block of data to transfer. Value
+ *                            between 0 - 65535.
+ */
+__STATIC_INLINE void DL_DMA_setTransferSize(
+    DMA_Regs *dma, uint8_t channelNum, uint16_t size)
+{
+    dma->DMACHAN[channelNum].DMASZ = size;
+}
+
+/**
+ *  @brief      Get a channel's size of block of data for a DMA transfer
+ *
+ *  @param[in]  dma           Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum    DMA channel to operate on
+ *
+ *  @return     The channel's size of block of data to transfer
+ *
+ *  @retval     A value between 0 - 65535.
+ */
+__STATIC_INLINE uint16_t DL_DMA_getTransferSize(
+    DMA_Regs *dma, uint8_t channelNum)
+{
+    return (uint16_t)(dma->DMACHAN[channelNum].DMASZ & DMA_DMASZ_SIZE_MASK);
+}
+
+/**
+ *  @brief      Set a channel's source address increment amount
+ *
+ *  After each DMA transfer the channel source address, which can be set by
+ *  @ref DL_DMA_setSrcAddr, can be incremented, decremented or remain
+ *  unchanged. This controls if the DMA is copying from a fixed address or a
+ *  block of addresses.
+ *
+ *  The amount that is incremented/decremented is controlled by the width of
+ *  the source, set by @ref DL_DMA_setSrcWidth.
+ *
+ *  @param[in]  dma           Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum    DMA channel to operate on
+ *  @param[in]  srcIncrement  Amount to increment/decrement the DMA source
+ *                            address by. One of @ref DL_DMA_INCREMENT.
+ *
+ *  @sa         DL_DMA_configTransfer
+ *  @sa         DL_DMA_setSrcAddr
+ *  @sa         DL_DMA_setSrcWidth
+ */
+__STATIC_INLINE void DL_DMA_setSrcIncrement(
+    DMA_Regs *dma, uint8_t channelNum, DL_DMA_INCREMENT srcIncrement)
+{
+    DL_Common_updateReg(&dma->DMACHAN[channelNum].DMACTL,
+        (uint32_t) srcIncrement, DMA_DMACTL_DMASRCINCR_MASK);
+}
+
+/**
+ *  @brief      Return a channel's source address increment amount
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *
+ *  @return     The source address increment amount for selected channel
+ *
+ *  @retval     One of @ref DL_DMA_INCREMENT.
+ */
+__STATIC_INLINE DL_DMA_INCREMENT DL_DMA_getSrcIncrement(
+    DMA_Regs *dma, uint8_t channelNum)
+{
+    uint32_t incrementAmount =
+        (dma->DMACHAN[channelNum].DMACTL & DMA_DMACTL_DMASRCINCR_MASK);
+
+    return (DL_DMA_INCREMENT)(incrementAmount);
+}
+
+/**
+ *  @brief      Set a channel's destination address increment amount
+ *
+ *  After each DMA transfer the channel destination address, which can be set by
+ *  @ref DL_DMA_setDestAddr, can be incremented, decremented or remain
+ *  unchanged. This controls if the DMA is copying from a fixed address or a
+ *  block of addresses.
+ *
+ *  The amount that is incremented/decremented is controlled by the width of
+ *  the destination, set by @ref DL_DMA_setDestWidth.
+ *
+ *  @param[in]  dma           Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum    DMA channel to operate on
+ *  @param[in]  destIncrement Amount to increment/decrement the DMA destination
+ *                            address by. One of @ref DL_DMA_INCREMENT.
+ *
+ *  @sa         DL_DMA_configTransfer
+ *  @sa         DL_DMA_setDestAddr
+ *  @sa         DL_DMA_setDestWidth
+ */
+__STATIC_INLINE void DL_DMA_setDestIncrement(
+    DMA_Regs *dma, uint8_t channelNum, DL_DMA_INCREMENT destIncrement)
+{
+    /* Left shifted by 4 so the defines align with bitfield */
+    DL_Common_updateReg(&dma->DMACHAN[channelNum].DMACTL,
+        ((uint32_t) destIncrement) << 4, DMA_DMACTL_DMADSTINCR_MASK);
+}
+
+/**
+ *  @brief      Return a channel's destination address increment amount
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *
+ *  @return     The destination address increment amount for selected channel
+ *
+ *  @retval     One of @ref DL_DMA_INCREMENT.
+ */
+__STATIC_INLINE DL_DMA_INCREMENT DL_DMA_getDestIncrement(
+    DMA_Regs *dma, uint8_t channelNum)
+{
+    /* Right shifted by 4 to align with provided defines */
+    uint32_t incrementAmount =
+        (dma->DMACHAN[channelNum].DMACTL & DMA_DMACTL_DMADSTINCR_MASK) >> 4;
+
+    return (DL_DMA_INCREMENT)(incrementAmount);
+}
+
+/**
+ *  @brief      Set the width of the DMA source address for a channel
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *  @param[in]  srcWidth    The width of the DMA source. One of
+ *                          @ref DL_DMA_WIDTH.
+ *
+ *  @sa         DL_DMA_configTransfer
+ */
+__STATIC_INLINE void DL_DMA_setSrcWidth(
+    DMA_Regs *dma, uint8_t channelNum, DL_DMA_WIDTH srcWidth)
+{
+    DL_Common_updateReg(&dma->DMACHAN[channelNum].DMACTL, (uint32_t) srcWidth,
+        DMA_DMACTL_DMASRCWDTH_MASK);
+}
+
+/**
+ *  @brief      Get the width of the DMA source address for a channel
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *
+ *  @return     The width of the DMA source for selected channel
+ *
+ *  @retval     One of @ref DL_DMA_WIDTH.
+ */
+__STATIC_INLINE DL_DMA_WIDTH DL_DMA_getSrcWidth(
+    DMA_Regs *dma, uint8_t channelNum)
+{
+    uint32_t width =
+        (dma->DMACHAN[channelNum].DMACTL & DMA_DMACTL_DMASRCWDTH_MASK);
+
+    return (DL_DMA_WIDTH)(width);
+}
+
+/**
+ *  @brief      Set the width of the DMA destination address for a channel
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *  @param[in]  destWidth   The width of the DMA destination. One of
+ *                          @ref DL_DMA_WIDTH.
+ *
+ *  @sa         DL_DMA_configTransfer
+ */
+__STATIC_INLINE void DL_DMA_setDestWidth(
+    DMA_Regs *dma, uint8_t channelNum, DL_DMA_WIDTH destWidth)
+{
+    /* Left shifted by 4 to align with provided defines */
+    DL_Common_updateReg(&dma->DMACHAN[channelNum].DMACTL,
+        ((uint32_t) destWidth) << 4, DMA_DMACTL_DMADSTWDTH_MASK);
+}
+
+/**
+ *  @brief      Get the width of the DMA destination address for a channel
+ *
+ *  @param[in]  dma         Pointer to the register overlay for the peripheral
+ *  @param[in]  channelNum  DMA channel to operate on
+ *
+ *  @return     The width of the DMA destination for selected channel
+ *
+ *  @retval     One of @ref DL_DMA_WIDTH.
+ */
+__STATIC_INLINE DL_DMA_WIDTH DL_DMA_getDestWidth(
+    DMA_Regs *dma, uint8_t channelNum)
+{
+    /* Right shifted by 4 to align with provided defines */
+    uint32_t width =
+        (dma->DMACHAN[channelNum].DMACTL & DMA_DMACTL_DMADSTWDTH_MASK) >> 4;
+
+    return (DL_DMA_WIDTH)(width);
+}
+#ifdef DEVICE_HAS_DMA_FULL_CHANNEL
+/**
+ *  @brief      Set the early interrupt event.
+ *
+ *  This functionality is available for FULL-channel configuration only. Please
+ *  refer to the device datasheet to map which channels have FULL or BASIC
+ *  capability.
+ *
+ *  The DMA has the capability to generate an early interrupt with a
+ *  given amount of transfer cycles before the DMA complete-interrupt is issued.
+ *  This allows to start the ISR context switch in parallel with the completion
+ *  of the DMA, and compensates the latency for the task switch into the ISR.
+ *
+ *  Ideally when the ISR starts to execute and read IIDX, the IIDX will already
+ *  point to the channel-complete interrupt (always higher priority than the
+ *  PRE-IRQ). In this case the latency is minimal and the ISR needs to clear
+ *  the PRE-IRQ interrupt flag (RIS) manually.
+ *  Should for whatever reason the DMA not complete in time, the IIDX will point
+ *  to the PRE-IRQ handler and the handler needs to poll for the DMAEN bit in
+ *  the DMA channel control register (DMACTL) to catch the moment that the DMA
+ *  transfer has completed. Then the handler needs to clear the DMA
+ *  channel-complete IRQ flag manually.
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  channelNum     DMA channel to operate on
+ *  @param[in]  threshold      When to generate the early interrupt. One of
+ *                             @ref DL_DMA_EARLY_INTERRUPT_THRESHOLD.
+ */
+__STATIC_INLINE void DL_DMA_Full_Ch_setEarlyInterruptThreshold(DMA_Regs *dma,
+    uint8_t channelNum, DL_DMA_EARLY_INTERRUPT_THRESHOLD threshold)
+{
+    DL_Common_updateReg(&dma->DMACHAN[channelNum].DMACTL, (uint32_t) threshold,
+        DMA_DMACTL_DMAPREIRQ_MASK);
+}
+
+/**
+ *  @brief      Get the early interrupt event threshold.
+ *
+ *  This functionality is available for FULL-channel configuration only. Please
+ *  refer to the device datasheet to map which channels have FULL or BASIC
+ *  capability.
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  channelNum     DMA channel to operate on
+ *
+ *  @return     The early interrupt event threshold
+ *
+ *  @retval     One of @ref DL_DMA_EARLY_INTERRUPT_THRESHOLD.
+ */
+__STATIC_INLINE DL_DMA_EARLY_INTERRUPT_THRESHOLD
+DL_DMA_Full_Ch_getEarlyInterruptThreshold(DMA_Regs *dma, uint8_t channelNum)
+{
+    uint32_t threshold =
+        dma->DMACHAN[channelNum].DMACTL & DMA_DMACTL_DMAPREIRQ_MASK;
+
+    return (DL_DMA_EARLY_INTERRUPT_THRESHOLD)(threshold);
+}
+#endif /* DEVICE_HAS_DMA_FULL_CHANNEL */
+
+/**
+ *  @brief      Enable DMA interrupts
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_DMA_INTERRUPT.
+ */
+__STATIC_INLINE void DL_DMA_enableInterrupt(
+    DMA_Regs *dma, uint32_t interruptMask)
+{
+    dma->CPU_INT.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disable DMA interrupts
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to disable. Bitwise OR of
+ *                             @ref DL_DMA_INTERRUPT.
+ */
+__STATIC_INLINE void DL_DMA_disableInterrupt(
+    DMA_Regs *dma, uint32_t interruptMask)
+{
+    dma->CPU_INT.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief      Check which DMA interrupts are enabled
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_DMA_INTERRUPT.
+ *
+ *  @return     Which of the requested DMA interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_DMA_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_DMA_getEnabledInterrupts(
+    DMA_Regs *dma, uint32_t interruptMask)
+{
+    return (dma->CPU_INT.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled DMA interrupts
+ *
+ *  Checks if any of the DMA interrupts that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_DMA_INTERRUPT.
+ *
+ *  @return     Which of the requested DMA interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_DMA_INTERRUPT values
+ *
+ *  @sa         DL_DMA_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_DMA_getEnabledInterruptStatus(
+    DMA_Regs *dma, uint32_t interruptMask)
+{
+    return (dma->CPU_INT.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any DMA interrupt
+ *
+ *  Checks if any of the DMA interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_DMA_INTERRUPT.
+ *
+ *  @return     Which of the requested DMA interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_DMA_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_DMA_getRawInterruptStatus(
+    DMA_Regs *dma, uint32_t interruptMask)
+{
+    return (dma->CPU_INT.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending DMA interrupt
+ *
+ *  Checks if any of the DMA interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     The highest priority pending DMA interrupt
+ *
+ *  @retval     One of @ref DL_DMA_EVENT_IIDX
+ */
+__STATIC_INLINE DL_DMA_EVENT_IIDX DL_DMA_getPendingInterrupt(DMA_Regs *dma)
+{
+    return (DL_DMA_EVENT_IIDX) dma->CPU_INT.IIDX;
+}
+
+/**
+ *  @brief      Clear pending DMA interrupts
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_DMA_INTERRUPT.
+ */
+__STATIC_INLINE void DL_DMA_clearInterruptStatus(
+    DMA_Regs *dma, uint32_t interruptMask)
+{
+    dma->CPU_INT.ICLR = interruptMask;
+}
+
+/**
+ *  @brief Sets the event publisher channel id
+ *
+ *  @param[in]  dma     Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  index   Specifies the register event index to be configured
+ *  @param[in]  chanID  Channel ID number. Valid range 0-15. If ChanID == 0
+ *                      publisher is disconnected.
+ */
+__STATIC_INLINE void DL_DMA_setPublisherChanID(
+    DMA_Regs *dma, DL_DMA_PUBLISHER_INDEX index, uint8_t chanID)
+{
+    volatile uint32_t *pReg = &dma->FPUB_1;
+
+    *(pReg + (uint32_t) index) = (chanID & DMA_FPUB_1_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event publisher channel id
+ *
+ *  @param[in]  dma     Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  index   Specifies the register event index to be configured
+ *
+ *  @return     Event publisher channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_DMA_getPublisherChanID(
+    DMA_Regs *dma, DL_DMA_PUBLISHER_INDEX index)
+{
+    volatile uint32_t *pReg = &dma->FPUB_1;
+
+    return ((uint8_t)(*(pReg + (uint32_t) index) & DMA_FPUB_1_CHANID_MASK));
+}
+
+/**
+ *  @brief Sets the event subscriber channel id
+ *
+ *  @param[in]  dma     Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  index   Specifies the register event index to be configured
+ *  @param[in]  chanID  Channel ID number. Valid range 0-15. If ChanID == 0
+ *                      subscriber is disconnected.
+ */
+__STATIC_INLINE void DL_DMA_setSubscriberChanID(
+    DMA_Regs *dma, DL_DMA_SUBSCRIBER_INDEX index, uint8_t chanID)
+{
+    volatile uint32_t *pReg = &dma->FSUB_0;
+
+    *(pReg + (uint32_t) index) = (chanID & DMA_FSUB_0_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event subscriber channel id
+ *
+ *  @param[in]  dma     Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  index   Specifies the register event index to be configured
+ *
+ *  @return     Event subscriber channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_DMA_getSubscriberChanID(
+    DMA_Regs *dma, DL_DMA_SUBSCRIBER_INDEX index)
+{
+    volatile uint32_t *pReg = &dma->FSUB_0;
+
+    return ((uint8_t)(*(pReg + (uint32_t) index) & DMA_FSUB_0_CHANID_MASK));
+}
+
+/**
+ *  @brief      Enable DMA event
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of events to enable. Bitwise OR of
+ *                             @ref DL_DMA_EVENT.
+ */
+__STATIC_INLINE void DL_DMA_enableEvent(DMA_Regs *dma, uint32_t eventMask)
+{
+    dma->GEN_EVENT.IMASK |= (eventMask);
+}
+
+/**
+ *  @brief      Disable DMA event
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of events to enable. Bitwise OR of
+ *                             @ref DL_DMA_EVENT.
+ */
+__STATIC_INLINE void DL_DMA_disableEvent(DMA_Regs *dma, uint32_t eventMask)
+{
+    dma->GEN_EVENT.IMASK &= ~(eventMask);
+}
+
+/**
+ *  @brief      Check which dma events triggers are enabled
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of events to check. Bitwise OR of
+ *                             @ref DL_DMA_EVENT.
+ *
+ *  @return     Which of the requested dma events are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_DMA_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_DMA_getEnabledEvents(
+    DMA_Regs *dma, uint32_t eventMask)
+{
+    return (dma->GEN_EVENT.IMASK & eventMask);
+}
+
+/**
+ *  @brief      Check event flag of enabled dma event
+ *
+ *  Checks if any of the dma events that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of events to check. Bitwise OR of
+ *                             @ref DL_DMA_EVENT.
+ *
+ *  @return     Which of the requested dma events are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_DMA_EVENT values
+ *
+ *  @sa         DL_DMA_enableEvent
+ */
+__STATIC_INLINE uint32_t DL_DMA_getEnabledEventStatus(
+    DMA_Regs *dma, uint32_t eventMask)
+{
+    return (dma->GEN_EVENT.MIS & ~(eventMask));
+}
+
+/**
+ *  @brief      Check event flag of any dma event
+ *
+ *  Checks if any events are pending. Events do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of event to check. Bitwise OR of
+ *                             @ref DL_DMA_EVENT.
+ *
+ *  @return     Which of the requested dma event are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_DMA_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_DMA_getRawEventsStatus(
+    DMA_Regs *dma, uint32_t eventMask)
+{
+    return (dma->GEN_EVENT.RIS & ~(eventMask));
+}
+
+/**
+ *  @brief      Clear pending dma events
+ *
+ *  @param[in]  dma            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  eventMask      Bit mask of events to clear. Bitwise OR of
+ *                             @ref DL_DMA_EVENT.
+ */
+__STATIC_INLINE void DL_DMA_clearEventsStatus(
+    DMA_Regs *dma, uint32_t eventMask)
+{
+    dma->GEN_EVENT.ICLR |= (eventMask);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_dl_dl_m0p_dma__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_flashctl.c
+++ b/mspm0/source/ti/driverlib/dl_flashctl.c
@@ -1,0 +1,1597 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <ti/devices/DeviceFamily.h>
+
+#include <ti/driverlib/dl_flashctl.h>
+
+static void DL_FlashCTL_programMemoryConfig(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd);
+static DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_executeCommandFromRAM(
+    FLASHCTL_Regs *flashctl);
+static void DL_FlashCTL_programMemory8Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint8_t *data);
+static void DL_FlashCTL_programMemory16Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint16_t *data);
+static void DL_FlashCTL_programMemory32Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint32_t *data);
+static void DL_FlashCTL_programMemory64Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint32_t *data);
+
+#if defined(__ti_version__) || defined(__TI_COMPILER_VERSION__)
+#define RAMFUNC \
+    __attribute__((section(".TI.ramfunc"))) __attribute__((noinline))
+#elif defined(__GNUC__)
+#define RAMFUNC __attribute__((section(".ramfunc"))) __attribute__((noinline))
+#elif defined(__IAR_SYSTEMS_ICC__)
+#define RAMFUNC __ramfunc __attribute__((noinline))
+#else
+#error "Compiler not supported for this function"
+#endif
+RAMFUNC static DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_executeCommandFromRAM(
+    FLASHCTL_Regs *flashctl)
+{
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+
+    uint32_t status =
+        flashctl->GEN.STATCMD &
+        (FLASHCTL_STATCMD_CMDDONE_MASK | FLASHCTL_STATCMD_CMDPASS_MASK |
+            FLASHCTL_STATCMD_CMDINPROGRESS_MASK |
+            FLASHCTL_STATCMD_CMDPASS_STATFAIL);
+
+    while ((DL_FLASHCTL_COMMAND_STATUS) status ==
+           DL_FLASHCTL_COMMAND_STATUS_IN_PROGRESS) {
+        status =
+            flashctl->GEN.STATCMD &
+            (FLASHCTL_STATCMD_CMDDONE_MASK | FLASHCTL_STATCMD_CMDPASS_MASK |
+                FLASHCTL_STATCMD_CMDINPROGRESS_MASK |
+                FLASHCTL_STATCMD_CMDPASS_STATFAIL);
+    }
+
+#if (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPM0G151X_G351X)
+    /* Set COMMAND bit within CMDTYPE register to clear status*/
+    flashctl->GEN.CMDTYPE = DL_FLASHCTL_COMMAND_TYPE_CLEAR_STATUS;
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+#endif
+
+    return (DL_FLASHCTL_COMMAND_STATUS)(status);
+}
+
+void DL_FlashCTL_eraseMemory(FLASHCTL_Regs *flashctl, uint32_t address,
+    DL_FLASHCTL_COMMAND_SIZE memorySize)
+{
+    /* Set command type and size */
+    flashctl->GEN.CMDTYPE =
+        (uint32_t) memorySize | DL_FLASHCTL_COMMAND_TYPE_ERASE;
+
+    /* Set address, address should be in the desired bank or sector to erase */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_eraseMemoryFromRAM(
+    FLASHCTL_Regs *flashctl, uint32_t address,
+    DL_FLASHCTL_COMMAND_SIZE memorySize)
+{
+    /* Set command type and size */
+    flashctl->GEN.CMDTYPE =
+        (uint32_t) memorySize | DL_FLASHCTL_COMMAND_TYPE_ERASE;
+
+    /* Set address, address should be in the desired bank or sector to erase */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+bool DL_FlashCTL_massErase(FLASHCTL_Regs *flashctl)
+{
+    bool status;
+
+    DL_FlashCTL_unprotectMainMemory(flashctl);
+    DL_FlashCTL_protectNonMainMemory(flashctl);
+
+    DL_FlashCTL_eraseMemory(
+        flashctl, FLASHCTL_BANK0_ADDRESS, DL_FLASHCTL_COMMAND_SIZE_BANK);
+    status = DL_FlashCTL_waitForCmdDone(flashctl);
+
+    if (DL_FactoryRegion_getDATAFlashSize() && (status == true)) {
+        status = DL_FlashCTL_eraseDataBank(flashctl);
+    }
+    return (status);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_massEraseFromRAM(
+    FLASHCTL_Regs *flashctl)
+{
+    DL_FLASHCTL_COMMAND_STATUS status;
+
+    DL_FlashCTL_unprotectMainMemory(flashctl);
+    DL_FlashCTL_protectNonMainMemory(flashctl);
+
+    status = DL_FlashCTL_eraseMemoryFromRAM(
+        flashctl, FLASHCTL_BANK0_ADDRESS, DL_FLASHCTL_COMMAND_SIZE_BANK);
+
+    if (DL_FactoryRegion_getDATAFlashSize() &&
+        (status != DL_FLASHCTL_COMMAND_STATUS_FAILED)) {
+        status = DL_FlashCTL_eraseDataBankFromRAM(flashctl);
+    }
+
+    return (status);
+}
+
+bool DL_FlashCTL_massEraseMultiBank(FLASHCTL_Regs *flashctl)
+{
+    bool status            = true;
+    uint32_t bankStartAddr = 0x0;
+    uint8_t numBanks       = DL_FactoryRegion_getNumBanks();
+    uint32_t flashSize     = DL_FactoryRegion_getMAINFlashSize();
+    /* Assuming a sector size of 1KB */
+    uint32_t bankSize = (((uint32_t) flashSize / (uint32_t) numBanks) * 1024U);
+
+    DL_FLASHCTL_BANK_SELECT bankSelect = DL_FLASHCTL_BANK_SELECT_0;
+
+    bool eraseFlag    = true;
+    uint8_t bankIndex = 0;
+    while (bankIndex < numBanks && status != false) {
+        /* If flash bank swap policy is enabled, the primary bank will be write
+         * and erase protected. Thus, we will not attempt an erase of the
+         * primary bank.
+         */
+        if (DL_SYSCTL_isFlashBankSwapEnabled()) {
+            eraseFlag = (bankIndex < (numBanks / (uint8_t) 2)) ? false : true;
+        } else {
+            eraseFlag = true;
+        }
+        switch (bankIndex) {
+            case 0:
+                bankSelect = DL_FLASHCTL_BANK_SELECT_0;
+                break;
+            case 1:
+                bankSelect = DL_FLASHCTL_BANK_SELECT_1;
+                break;
+            case 2:
+                bankSelect = DL_FLASHCTL_BANK_SELECT_2;
+                break;
+            case 3:
+                bankSelect = DL_FLASHCTL_BANK_SELECT_3;
+                break;
+            default:
+                break;
+        }
+
+        bankStartAddr = (bankSize * bankIndex);
+
+        if (eraseFlag == true) {
+            DL_FlashCTL_enableAddressOverrideMode(flashctl);
+            DL_FlashCTL_setBankSelect(flashctl, bankSelect);
+            DL_FlashCTL_setRegionSelect(
+                flashctl, DL_FLASHCTL_REGION_SELECT_MAIN);
+
+            DL_FlashCTL_unprotectMainMemory(flashctl);
+            DL_FlashCTL_protectNonMainMemory(flashctl);
+            DL_FlashCTL_eraseMemory(
+                flashctl, bankStartAddr, DL_FLASHCTL_COMMAND_SIZE_BANK);
+            status = DL_FlashCTL_waitForCmdDone(flashctl);
+        }
+        bankIndex++;
+    }
+    DL_FlashCTL_disableAddressOverrideMode(flashctl);
+
+    if (DL_FactoryRegion_getDATAFlashSize() && status == true) {
+        status = DL_FlashCTL_eraseDataBank(flashctl);
+    }
+
+    return (status);
+}
+
+bool DL_FlashCTL_factoryReset(FLASHCTL_Regs *flashctl)
+{
+    bool status;
+
+    /* Erase Main Memory */
+    status = DL_FlashCTL_massErase(flashctl);
+
+    if (status == true) {
+        DL_FlashCTL_unprotectNonMainMemory(flashctl);
+        DL_FlashCTL_eraseMemory(flashctl, FLASHCTL_NONMAIN_ADDRESS,
+            DL_FLASHCTL_COMMAND_SIZE_SECTOR);
+
+        status = DL_FlashCTL_waitForCmdDone(flashctl);
+    }
+    return (status);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_factoryResetFromRAM(
+    FLASHCTL_Regs *flashctl)
+{
+    DL_FLASHCTL_COMMAND_STATUS status;
+
+    /* Erase Main Memory */
+    status = DL_FlashCTL_massEraseFromRAM(flashctl);
+
+    if (status == DL_FLASHCTL_COMMAND_STATUS_PASSED) {
+        DL_FlashCTL_unprotectNonMainMemory(flashctl);
+        status = DL_FlashCTL_eraseMemoryFromRAM(flashctl,
+            FLASHCTL_NONMAIN_ADDRESS, DL_FLASHCTL_COMMAND_SIZE_SECTOR);
+    }
+    return (status);
+}
+
+bool DL_FlashCTL_factoryResetMultiBank(FLASHCTL_Regs *flashctl)
+{
+    bool status;
+
+    /* Erase Main Memory */
+    status = DL_FlashCTL_massEraseMultiBank(flashctl);
+
+    if (status == true) {
+        DL_FlashCTL_unprotectNonMainMemory(flashctl);
+        DL_FlashCTL_eraseMemory(flashctl, FLASHCTL_NONMAIN_ADDRESS,
+            DL_FLASHCTL_COMMAND_SIZE_SECTOR);
+
+        status = DL_FlashCTL_waitForCmdDone(flashctl);
+    }
+    return (status);
+}
+
+static void DL_FlashCTL_programMemoryConfig(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            DL_FLASHCTL_COMMAND_TYPE_PROGRAM;
+
+    flashctl->GEN.CMDBYTEN = cmd;
+
+    /* Set address, address should be in the sector that we want to erase */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+}
+
+static void DL_FlashCTL_programMemory8Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint8_t *data)
+{
+    DL_FlashCTL_programMemoryConfig(flashctl, address, cmd);
+
+    /* Set data registers */
+    flashctl->GEN.CMDDATA0 = *data;
+}
+
+static void DL_FlashCTL_programMemory16Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint16_t *data)
+{
+    DL_FlashCTL_programMemoryConfig(flashctl, address, cmd);
+
+    /* Set data registers */
+    flashctl->GEN.CMDDATA0 = *data;
+}
+
+static void DL_FlashCTL_programMemory32Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint32_t *data)
+{
+    DL_FlashCTL_programMemoryConfig(flashctl, address, cmd);
+
+    /* Set data registers */
+    flashctl->GEN.CMDDATA0 = *data;
+}
+
+static void DL_FlashCTL_programMemory64Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint32_t *data)
+{
+    DL_FlashCTL_programMemoryConfig(flashctl, address, cmd);
+
+    /* Set data registers */
+    flashctl->GEN.CMDDATA0 = *data;
+    flashctl->GEN.CMDDATA1 = *(data + 1);
+}
+
+void DL_FlashCTL_programMemory8(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data)
+{
+    /* Only enable the bottom 8 bits for programming*/
+    DL_FlashCTL_programMemory8Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_8_WITHOUT_ECC, data);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM8(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data)
+{
+    /* Only enable the bottom 8 bits for programming*/
+    DL_FlashCTL_programMemory8Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_8_WITHOUT_ECC, data);
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+void DL_FlashCTL_programMemory16(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data)
+{
+    /* Enable 16 bits per data register for programming*/
+    DL_FlashCTL_programMemory16Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_16_WITHOUT_ECC, data);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM16(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data)
+{
+    /* Enable 16 bits per data register for programming*/
+    DL_FlashCTL_programMemory16Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_16_WITHOUT_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+void DL_FlashCTL_programMemory32(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    /* Enable 32 bits per data register for programming*/
+    DL_FlashCTL_programMemory32Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_32_WITHOUT_ECC, data);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM32(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    /* Enable 32 bits per data register for programming*/
+    DL_FlashCTL_programMemory32Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_32_WITHOUT_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+void DL_FlashCTL_programMemory64(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    /* Enable 64 bits per data register for programming*/
+    DL_FlashCTL_programMemory64Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_64_WITHOUT_ECC, data);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM64(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    /* Enable 64 bits per data register for programming*/
+    DL_FlashCTL_programMemory64Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_64_WITHOUT_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+void DL_FlashCTL_programMemory8WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data)
+{
+    /* Only enable the bottom 8 bits for programming*/
+    DL_FlashCTL_programMemory8Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_8_WITH_ECC, data);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM8WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data)
+{
+    /* Only enable the bottom 8 bits for programming*/
+    DL_FlashCTL_programMemory8Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_8_WITH_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+void DL_FlashCTL_programMemory16WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data)
+{
+    /* Enable 16 bits per data register for programming*/
+    DL_FlashCTL_programMemory16Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_16_WITH_ECC, data);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM16WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data)
+{
+    /* Enable 16 bits per data register for programming*/
+    DL_FlashCTL_programMemory16Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_16_WITH_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+void DL_FlashCTL_programMemory32WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    /* Enable 32 bits per data register for programming*/
+    DL_FlashCTL_programMemory32Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_32_WITH_ECC, data);
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM32WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    /* Enable 32 bits per data register for programming*/
+    DL_FlashCTL_programMemory32Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_32_WITH_ECC, data);
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+void DL_FlashCTL_programMemory64WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    /* Enable 64 bits per data register for programming, with ECC enabled */
+    DL_FlashCTL_programMemory64Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_64_WITH_ECC, data);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM64WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    /* Enable 64 bits per data register for programming, with ECC enabled */
+    DL_FlashCTL_programMemory64Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_64_WITH_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+void DL_FlashCTL_programMemory8WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data, uint8_t *eccCode)
+{
+    /* Enable 8 bits per data register for programming, with ECC enabled */
+    DL_FlashCTL_programMemory8Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_8_WITH_ECC, data);
+
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM8WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data, uint8_t *eccCode)
+{
+    /* Enable 8 bits per data register for programming, with ECC enabled */
+    DL_FlashCTL_programMemory8Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_8_WITH_ECC, data);
+
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+void DL_FlashCTL_programMemory16WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint16_t *data, uint8_t *eccCode)
+{
+    /* Enable 16 bits per data register for programming, with ECC enabled */
+    DL_FlashCTL_programMemory16Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_16_WITH_ECC, data);
+
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM16WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data,
+    uint8_t *eccCode)
+{
+    /* Enable 16 bits per data register for programming, with ECC enabled */
+    DL_FlashCTL_programMemory16Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_16_WITH_ECC, data);
+
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+void DL_FlashCTL_programMemory32WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint8_t *eccCode)
+{
+    /* Enable 32 bits per data register for programming, with ECC enabled */
+    DL_FlashCTL_programMemory32Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_32_WITH_ECC, data);
+
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM32WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint8_t *eccCode)
+{
+    /* Enable 32 bits per data register for programming, with ECC enabled */
+    DL_FlashCTL_programMemory32Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_32_WITH_ECC, data);
+
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+void DL_FlashCTL_programMemory64WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint8_t *eccCode)
+{
+    /* Enable 64 bits per data register for programming, with ECC enabled */
+    DL_FlashCTL_programMemory64Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_64_WITH_ECC, data);
+
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM64WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint8_t *eccCode)
+{
+    /* Enable 64 bits per data register for programming, with ECC enabled */
+    DL_FlashCTL_programMemory64Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_64_WITH_ECC, data);
+
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+bool DL_FlashCTL_programMemoryBlocking64WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint32_t dataSize, DL_FLASHCTL_REGION_SELECT regionSelect)
+{
+    bool status = true;
+
+    /* Check for valid data size */
+    if (dataSize == (uint32_t) 0 ||
+        ((dataSize & (uint32_t) 1) == (uint32_t) 1)) {
+        status = false;
+    }
+
+    while ((dataSize != (uint32_t) 0) && status) {
+        /* Unprotect sector before every write */
+        DL_FlashCTL_unprotectSector(flashctl, address, regionSelect);
+
+        DL_FlashCTL_programMemory64WithECCGenerated(flashctl, address, data);
+        dataSize = dataSize - (uint32_t) 2;
+        data     = data + 2;
+        address  = address + (uint32_t) 8;
+
+        status = DL_FlashCTL_waitForCmdDone(flashctl);
+    }
+
+    return (status);
+}
+
+DL_FLASHCTL_COMMAND_STATUS
+DL_FlashCTL_programMemoryBlockingFromRAM64WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint32_t dataSize, DL_FLASHCTL_REGION_SELECT regionSelect)
+{
+    DL_FLASHCTL_COMMAND_STATUS status = DL_FLASHCTL_COMMAND_STATUS_IN_PROGRESS;
+
+    /* Check for valid data size */
+    if (dataSize == (uint32_t) 0 ||
+        ((dataSize & (uint32_t) 1) == (uint32_t) 1)) {
+        status = DL_FLASHCTL_COMMAND_STATUS_FAILED;
+    }
+
+    while ((dataSize != (uint32_t) 0) &&
+           (status != DL_FLASHCTL_COMMAND_STATUS_FAILED)) {
+        /* Unprotect sector before every write */
+        DL_FlashCTL_unprotectSector(flashctl, address, regionSelect);
+
+        status = DL_FlashCTL_programMemoryFromRAM64WithECCGenerated(
+            flashctl, address, data);
+        dataSize = dataSize - (uint32_t) 2;
+        data     = data + 2;
+        address  = address + (uint32_t) 8;
+    }
+
+    return (status);
+}
+
+bool DL_FlashCTL_programMemoryBlocking64WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint8_t *eccCode, uint32_t dataSize,
+    DL_FLASHCTL_REGION_SELECT regionSelect)
+{
+    bool status = true;
+
+    /* Check for valid data size */
+    if (dataSize == (uint32_t) 0 ||
+        ((dataSize & (uint32_t) 1) == (uint32_t) 1)) {
+        status = false;
+    }
+
+    while ((dataSize != (uint32_t) 0) && status) {
+        /* Unprotect sector before every write */
+        DL_FlashCTL_unprotectSector(flashctl, address, regionSelect);
+
+        DL_FlashCTL_programMemory64WithECCManual(
+            flashctl, address, data, eccCode);
+        dataSize = dataSize - (uint32_t) 2;
+        data     = data + 2;
+        eccCode  = eccCode + 1;
+        address  = address + (uint32_t) 8;
+
+        status = DL_FlashCTL_waitForCmdDone(flashctl);
+    }
+
+    return (status);
+}
+
+DL_FLASHCTL_COMMAND_STATUS
+DL_FlashCTL_programMemoryBlockingFromRAM64WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint8_t *eccCode, uint32_t dataSize,
+    DL_FLASHCTL_REGION_SELECT regionSelect)
+{
+    DL_FLASHCTL_COMMAND_STATUS status = DL_FLASHCTL_COMMAND_STATUS_IN_PROGRESS;
+
+    /* Check for valid data size */
+    if (dataSize == (uint32_t) 0 ||
+        ((dataSize & (uint32_t) 1) == (uint32_t) 1)) {
+        status = DL_FLASHCTL_COMMAND_STATUS_FAILED;
+    }
+
+    while ((dataSize != (uint32_t) 0) &&
+           (status != DL_FLASHCTL_COMMAND_STATUS_FAILED)) {
+        /* Unprotect sector before every write */
+        DL_FlashCTL_unprotectSector(flashctl, address, regionSelect);
+
+        status = DL_FlashCTL_programMemoryFromRAM64WithECCManual(
+            flashctl, address, data, eccCode);
+        dataSize = dataSize - (uint32_t) 2;
+        data     = data + 2;
+        eccCode  = eccCode + 1;
+        address  = address + (uint32_t) 8;
+    }
+
+    return (status);
+}
+
+bool DL_FlashCTL_programMemoryBlocking(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint32_t dataSize,
+    DL_FLASHCTL_REGION_SELECT regionSelect)
+{
+    bool status = true;
+
+    /* Check for valid data size */
+    if (dataSize == (uint32_t) 0) {
+        status = false;
+    }
+
+    while ((dataSize != (uint32_t) 0) && status) {
+        /* Unprotect sector before every write */
+        DL_FlashCTL_unprotectSector(flashctl, address, regionSelect);
+
+        /* 32-bit case */
+        if (dataSize == (uint32_t) 1) {
+            DL_FlashCTL_programMemory32(flashctl, address, data);
+
+            dataSize = dataSize - (uint32_t) 1;
+            data     = data + 1;
+            address  = address + (uint32_t) 4;
+        } else {
+            /* 64-bit case */
+            DL_FlashCTL_programMemory64(flashctl, address, data);
+            dataSize = dataSize - (uint32_t) 2;
+            data     = data + 2;
+            address  = address + (uint32_t) 8;
+        }
+
+        status = DL_FlashCTL_waitForCmdDone(flashctl);
+    }
+
+    return (status);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint32_t dataSize, DL_FLASHCTL_REGION_SELECT regionSelect)
+{
+    DL_FLASHCTL_COMMAND_STATUS status = DL_FLASHCTL_COMMAND_STATUS_IN_PROGRESS;
+
+    /* Check for valid data size */
+    if (dataSize == (uint32_t) 0) {
+        status = DL_FLASHCTL_COMMAND_STATUS_FAILED;
+    }
+
+    while ((dataSize != (uint32_t) 0) &&
+           (status != DL_FLASHCTL_COMMAND_STATUS_FAILED)) {
+        /* Unprotect sector before every write */
+        DL_FlashCTL_unprotectSector(flashctl, address, regionSelect);
+
+        /* 32-bit case */
+        if (dataSize == (uint32_t) 1) {
+            status =
+                DL_FlashCTL_programMemoryFromRAM32(flashctl, address, data);
+
+            dataSize = dataSize - (uint32_t) 1;
+            data     = data + 1;
+            address  = address + (uint32_t) 4;
+        } else {
+            /* 64-bit case */
+            status =
+                DL_FlashCTL_programMemoryFromRAM64(flashctl, address, data);
+            dataSize = dataSize - (uint32_t) 2;
+            data     = data + 2;
+            address  = address + (uint32_t) 8;
+        }
+    }
+
+    return (status);
+}
+
+void DL_FlashCTL_unprotectMainMemory(FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDWEPROTA = 0;
+    flashctl->GEN.CMDWEPROTB = 0;
+    flashctl->GEN.CMDWEPROTC = 0;
+}
+
+void DL_FlashCTL_unprotectDataMemory(FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDWEPROTA = 0;
+    flashctl->GEN.CMDWEPROTB = 0;
+    flashctl->GEN.CMDWEPROTC = 0;
+}
+
+void DL_FlashCTL_protectMainMemory(FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDWEPROTA = FLASHCTL_CMDWEPROTA_VAL_MAXIMUM;
+    flashctl->GEN.CMDWEPROTB = FLASHCTL_CMDWEPROTB_VAL_MAXIMUM;
+    flashctl->GEN.CMDWEPROTC = FLASHCTL_CMDWEPROTC_VAL_MAXIMUM;
+}
+
+void DL_FlashCTL_unprotectNonMainMemory(FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDWEPROTNM = 0;
+}
+
+void DL_FlashCTL_protectNonMainMemory(FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDWEPROTNM = FLASHCTL_CMDWEPROTNM_VAL_MAXIMUM;
+}
+
+void DL_FlashCTL_unprotectAllMemory(FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDWEPROTA  = 0;
+    flashctl->GEN.CMDWEPROTB  = 0;
+    flashctl->GEN.CMDWEPROTC  = 0;
+    flashctl->GEN.CMDWEPROTNM = 0;
+    flashctl->GEN.CMDWEPROTTR = 0;
+    flashctl->GEN.CMDWEPROTEN = 0;
+}
+
+void DL_FlashCTL_protectAllMemory(FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDWEPROTA  = FLASHCTL_CMDWEPROTA_VAL_MAXIMUM;
+    flashctl->GEN.CMDWEPROTB  = FLASHCTL_CMDWEPROTB_VAL_MAXIMUM;
+    flashctl->GEN.CMDWEPROTC  = FLASHCTL_CMDWEPROTC_VAL_MAXIMUM;
+    flashctl->GEN.CMDWEPROTNM = FLASHCTL_CMDWEPROTNM_VAL_MAXIMUM;
+    flashctl->GEN.CMDWEPROTTR = FLASHCTL_CMDWEPROTTR_VAL_MAXIMUM;
+    flashctl->GEN.CMDWEPROTEN = FLASHCTL_CMDWEPROTEN_VAL_MAXIMUM;
+}
+
+#ifdef DEVICE_HAS_NO_CMDWEPROTA
+void DL_FlashCTL_unprotectSector(FLASHCTL_Regs *flashctl, uint32_t addr,
+    DL_FLASHCTL_REGION_SELECT regionSelect)
+{
+    uint32_t sectorNumber = DL_FlashCTL_getFlashSectorNumber(flashctl, addr);
+    uint32_t sectorInBank =
+        DL_FlashCTL_getFlashSectorNumberInBank(flashctl, addr);
+    uint32_t sectorMask;
+
+    /*
+     * Devices without CMDWEPROTA will use CMDWEPROTB to unprotect all sectors of MAIN memory
+     */
+
+    if ((uint32_t) regionSelect == FLASHCTL_CMDCTL_REGIONSEL_MAIN) {
+        sectorMask = (uint32_t) 1 << (sectorInBank / (uint32_t) 8);
+        flashctl->GEN.CMDWEPROTB &= ~sectorMask;
+    } else if ((uint32_t) regionSelect == FLASHCTL_CMDCTL_REGIONSEL_NONMAIN) {
+        sectorMask = (uint32_t) 1 << (sectorNumber % (uint32_t) 32);
+        flashctl->GEN.CMDWEPROTNM &= ~sectorMask;
+    } else {
+        ; /* Not expected to reach this else statement */
+    }
+}
+#else
+void DL_FlashCTL_unprotectSector(FLASHCTL_Regs *flashctl, uint32_t addr,
+    DL_FLASHCTL_REGION_SELECT regionSelect)
+{
+    uint32_t sectorNumber = DL_FlashCTL_getFlashSectorNumber(flashctl, addr);
+    uint32_t sectorInBank =
+        DL_FlashCTL_getFlashSectorNumberInBank(flashctl, addr);
+    uint8_t numBanks              = DL_FactoryRegion_getNumBanks();
+    uint32_t mainFlashSize        = DL_FactoryRegion_getMAINFlashSize();
+    uint32_t physicalSectorNumber = 0;
+    uint32_t sectorMask;
+
+    if ((uint32_t) regionSelect == FLASHCTL_CMDCTL_REGIONSEL_MAIN) {
+        /* If the banks have been swapped, CMDWEPROTA only protects physical
+         * bank 0 (logical bank 1 in a swap), so if the address points to this
+         * region we must protect it using CMDWEPROTA instead of CMDWEPROTB
+         */
+        if (DL_SYSCTL_isExecuteFromUpperFlashBank() && numBanks > 1) {
+            /* physical sectors are swapped. Calculate physical sector to
+             * determine use of CMDWEPROTA */
+            if (sectorNumber > (mainFlashSize / 2)) {
+                physicalSectorNumber = sectorNumber - (mainFlashSize / 2);
+            } else {
+                physicalSectorNumber = sectorNumber + (mainFlashSize / 2);
+            }
+        } else {
+            physicalSectorNumber = sectorNumber;
+        }
+
+        if (physicalSectorNumber < (uint32_t) 32) {
+            /* Use CMDWEPROTA */
+            sectorMask = (uint32_t) 1 << physicalSectorNumber;
+            flashctl->GEN.CMDWEPROTA &= ~sectorMask;
+        } else {
+            /* Use CMDWEPROTB */
+            if (sectorInBank < (uint32_t) 256) {
+                /* Single bank system */
+                if (DL_FactoryRegion_getNumBanks() == (uint32_t) 1) {
+                    sectorMask =
+                        (uint32_t) 1
+                        << ((sectorInBank - (uint32_t) 32) / (uint32_t) 8);
+                    flashctl->GEN.CMDWEPROTB &= ~sectorMask;
+                } else { /* Multi bank system */
+                    sectorMask = (uint32_t) 1 << (sectorInBank / (uint32_t) 8);
+                    flashctl->GEN.CMDWEPROTB &= ~sectorMask;
+                }
+            }
+            /* Use CMDWEPROTC */
+            else if (sectorInBank < (uint32_t) 511) {
+                sectorMask =
+                    ((uint32_t) 1
+                        << ((sectorInBank - (uint32_t) 256) / (uint32_t) 8));
+                flashctl->GEN.CMDWEPROTC &= ~sectorMask;
+            } else {
+                ; /* Not expected to reach this else statement */
+            }
+        }
+    } else if ((uint32_t) regionSelect == FLASHCTL_CMDCTL_REGIONSEL_NONMAIN) {
+        sectorMask = (uint32_t) 1 << (sectorNumber % (uint32_t) 32);
+        flashctl->GEN.CMDWEPROTNM &= ~sectorMask;
+    } else {
+        ; /* Not expected to reach this else statement */
+    }
+}
+#endif
+
+#ifdef DEVICE_HAS_NO_CMDWEPROTA
+void DL_FlashCTL_protectSector(FLASHCTL_Regs *flashctl, uint32_t addr,
+    DL_FLASHCTL_REGION_SELECT regionSelect)
+{
+    uint32_t sectorNumber = DL_FlashCTL_getFlashSectorNumber(flashctl, addr);
+    uint32_t sectorInBank =
+        DL_FlashCTL_getFlashSectorNumberInBank(flashctl, addr);
+    uint32_t sectorMask;
+
+    /*
+     * Devices without CMDWEPROTA will use CMDWEPROTB to protect all sectors of MAIN memory
+     */
+
+    if ((uint32_t) regionSelect == FLASHCTL_CMDCTL_REGIONSEL_MAIN) {
+        sectorMask = ((uint32_t) 1 << (sectorInBank / (uint32_t) 8));
+        flashctl->GEN.CMDWEPROTB |= sectorMask;
+    } else if ((uint32_t) regionSelect == FLASHCTL_CMDCTL_REGIONSEL_NONMAIN) {
+        sectorNumber = DL_FlashCTL_getFlashSectorNumber(flashctl, addr);
+        sectorMask   = (uint32_t) 1 << (sectorNumber % (uint32_t) 32);
+        flashctl->GEN.CMDWEPROTNM |= sectorMask;
+    } else {
+        ; /* Not expected to reach this else statement */
+    }
+}
+#else
+void DL_FlashCTL_protectSector(FLASHCTL_Regs *flashctl, uint32_t addr,
+    DL_FLASHCTL_REGION_SELECT regionSelect)
+{
+    uint32_t sectorNumber = DL_FlashCTL_getFlashSectorNumber(flashctl, addr);
+    uint32_t sectorInBank =
+        DL_FlashCTL_getFlashSectorNumberInBank(flashctl, addr);
+    uint8_t numBanks              = DL_FactoryRegion_getNumBanks();
+    uint32_t mainFlashSize        = DL_FactoryRegion_getMAINFlashSize();
+    uint32_t physicalSectorNumber = 0;
+    uint32_t sectorMask;
+
+    if ((uint32_t) regionSelect == FLASHCTL_CMDCTL_REGIONSEL_MAIN) {
+        /* If the banks have been swapped, CMDWEPROTA only protects physical
+         * bank 0 (logical bank 1 in a swap), so if the address points to this
+         * region we must protect it using CMDWEPROTA instead of CMDWEPROTB
+         */
+        if (DL_SYSCTL_isExecuteFromUpperFlashBank() && numBanks > 1) {
+            /* physical sectors are swapped. Calculate physical sector to
+             * determine use of CMDWEPROTA */
+            if (sectorNumber > (mainFlashSize / 2)) {
+                physicalSectorNumber = sectorNumber - (mainFlashSize / 2);
+            } else {
+                physicalSectorNumber = sectorNumber + (mainFlashSize / 2);
+            }
+        } else {
+            physicalSectorNumber = sectorNumber;
+        }
+
+        if (physicalSectorNumber < (uint32_t) 32) {
+            /* Use CMDWEPROTA */
+            sectorMask = (uint32_t) 1 << physicalSectorNumber;
+            flashctl->GEN.CMDWEPROTA |= sectorMask;
+        } else {
+            /* Use CMDWEPROTB */
+            if (sectorNumber < (uint32_t) 256) {
+                /* Single bank system */
+                if (DL_FactoryRegion_getNumBanks() == (uint32_t) 1) {
+                    sectorMask =
+                        ((uint32_t) 1 << ((
+                             sectorInBank - (uint32_t) 32 / (uint32_t) 8)));
+                    flashctl->GEN.CMDWEPROTB |= sectorMask;
+                } else { /* Multi bank system */
+                    sectorMask =
+                        ((uint32_t) 1 << (sectorInBank / (uint32_t) 8));
+                    flashctl->GEN.CMDWEPROTB |= sectorMask;
+                }
+            }
+            /* Use CMDWEPROTC */
+            else if (sectorNumber < (uint32_t) 511) {
+                sectorMask =
+                    ((uint32_t) 1
+                        << ((sectorInBank - (uint32_t) 256) / (uint32_t) 8));
+                flashctl->GEN.CMDWEPROTC |= sectorMask;
+            } else {
+                ; /* Not expected to reach this else statement */
+            }
+        }
+    } else if ((uint32_t) regionSelect == FLASHCTL_CMDCTL_REGIONSEL_NONMAIN) {
+        sectorNumber = DL_FlashCTL_getFlashSectorNumber(flashctl, addr);
+        sectorMask   = (uint32_t) 1 << (sectorNumber % (uint32_t) 32);
+        flashctl->GEN.CMDWEPROTNM |= sectorMask;
+    } else {
+        ; /* Not expected to reach this else statement */
+    }
+}
+#endif
+
+static void DL_FlashCTL_readVerifyConfig(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY;
+
+    flashctl->GEN.CMDBYTEN = cmd;
+
+    /* Set address, address should be in the sector that we want to erase */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+}
+
+static void DL_FlashCTL_readVerify8Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint8_t *data)
+{
+    DL_FlashCTL_readVerifyConfig(flashctl, address, cmd);
+
+    flashctl->GEN.CMDDATA0 = *data;
+}
+
+static void DL_FlashCTL_readVerify16Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint16_t *data)
+{
+    DL_FlashCTL_readVerifyConfig(flashctl, address, cmd);
+
+    flashctl->GEN.CMDDATA0 = *data;
+}
+
+static void DL_FlashCTL_readVerify32Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint32_t *data)
+{
+    DL_FlashCTL_readVerifyConfig(flashctl, address, cmd);
+
+    flashctl->GEN.CMDDATA0 = *data;
+}
+
+static void DL_FlashCTL_readVerify64Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint32_t *data)
+{
+    DL_FlashCTL_readVerifyConfig(flashctl, address, cmd);
+
+    /* Set data registers */
+    flashctl->GEN.CMDDATA0 = *data;
+    flashctl->GEN.CMDDATA1 = *(data + 1);
+}
+
+void DL_FlashCTL_readVerify8(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Configure bytes to use for comparison */
+    flashctl->GEN.CMDBYTEN = DL_FLASHCTL_READ_VERIFY_8_WITHOUT_ECC;
+
+    flashctl->GEN.CMDDATA0 = *data;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+void DL_FlashCTL_readVerify16(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Configure bytes to use for comparison */
+    flashctl->GEN.CMDBYTEN = DL_FLASHCTL_READ_VERIFY_16_WITHOUT_ECC;
+
+    flashctl->GEN.CMDDATA0 = *data;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+void DL_FlashCTL_readVerify32(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Configure bytes to use for comparison */
+    flashctl->GEN.CMDBYTEN = DL_FLASHCTL_READ_VERIFY_32_WITHOUT_ECC;
+
+    flashctl->GEN.CMDDATA0 = *data;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+void DL_FlashCTL_readVerify64(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Configure bytes to use for comparison */
+    flashctl->GEN.CMDBYTEN = DL_FLASHCTL_READ_VERIFY_64_WITHOUT_ECC;
+
+    flashctl->GEN.CMDDATA0 = *data;
+    flashctl->GEN.CMDDATA1 = *(data + 1);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM8(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data)
+{
+    DL_FlashCTL_readVerify8Config(
+        flashctl, address, DL_FLASHCTL_READ_VERIFY_8_WITHOUT_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM16(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data)
+{
+    DL_FlashCTL_readVerify16Config(
+        flashctl, address, DL_FLASHCTL_READ_VERIFY_16_WITHOUT_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM32(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    DL_FlashCTL_readVerify32Config(
+        flashctl, address, DL_FLASHCTL_READ_VERIFY_32_WITHOUT_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM64(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    DL_FlashCTL_readVerify64Config(
+        flashctl, address, DL_FLASHCTL_READ_VERIFY_64_WITHOUT_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM8WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data)
+{
+    DL_FlashCTL_readVerify8Config(
+        flashctl, address, DL_FLASHCTL_READ_VERIFY_8_WITH_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM16WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data)
+{
+    DL_FlashCTL_readVerify16Config(
+        flashctl, address, DL_FLASHCTL_READ_VERIFY_16_WITH_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM32WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    DL_FlashCTL_readVerify32Config(
+        flashctl, address, DL_FLASHCTL_READ_VERIFY_32_WITH_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM64WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    DL_FlashCTL_readVerify64Config(
+        flashctl, address, DL_FLASHCTL_READ_VERIFY_64_WITH_ECC, data);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM8WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data, uint8_t *eccCode)
+{
+    DL_FlashCTL_readVerify8Config(
+        flashctl, address, DL_FLASHCTL_READ_VERIFY_8_WITH_ECC, data);
+
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM16WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data,
+    uint8_t *eccCode)
+{
+    DL_FlashCTL_readVerify16Config(
+        flashctl, address, DL_FLASHCTL_READ_VERIFY_16_WITH_ECC, data);
+
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM32WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint8_t *eccCode)
+{
+    DL_FlashCTL_readVerify32Config(
+        flashctl, address, DL_FLASHCTL_READ_VERIFY_32_WITH_ECC, data);
+
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM64WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint8_t *eccCode)
+{
+    DL_FlashCTL_readVerify64Config(
+        flashctl, address, DL_FLASHCTL_READ_VERIFY_64_WITH_ECC, data);
+
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+void DL_FlashCTL_readVerify8WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Configure bytes to use for comparison, with ECC enabled */
+    flashctl->GEN.CMDBYTEN = DL_FLASHCTL_READ_VERIFY_8_WITH_ECC;
+
+    flashctl->GEN.CMDDATA0 = *data;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+void DL_FlashCTL_readVerify16WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Configure bytes to use for comparison, with ECC enabled */
+    flashctl->GEN.CMDBYTEN = DL_FLASHCTL_READ_VERIFY_16_WITH_ECC;
+
+    flashctl->GEN.CMDDATA0 = *data;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+void DL_FlashCTL_readVerify32WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Configure bytes to use for comparison, with ECC enabled */
+    flashctl->GEN.CMDBYTEN = DL_FLASHCTL_READ_VERIFY_32_WITH_ECC;
+
+    flashctl->GEN.CMDDATA0 = *data;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+void DL_FlashCTL_readVerify64WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Configure bytes to use for comparison, with ECC enabled */
+    flashctl->GEN.CMDBYTEN = DL_FLASHCTL_READ_VERIFY_64_WITH_ECC;
+
+    flashctl->GEN.CMDDATA0 = *data;
+    flashctl->GEN.CMDDATA1 = *(data + 1);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+void DL_FlashCTL_readVerify8WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data, uint8_t *eccCode)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Configure bytes to use for comparison, with ECC enabled */
+    flashctl->GEN.CMDBYTEN = DL_FLASHCTL_READ_VERIFY_8_WITH_ECC;
+
+    flashctl->GEN.CMDDATA0    = *data;
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+void DL_FlashCTL_readVerify16WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint16_t *data, uint8_t *eccCode)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Configure bytes to use for comparison, with ECC enabled */
+    flashctl->GEN.CMDBYTEN = DL_FLASHCTL_READ_VERIFY_16_WITH_ECC;
+
+    flashctl->GEN.CMDDATA0    = *data;
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+void DL_FlashCTL_readVerify32WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint8_t *eccCode)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Configure bytes to use for comparison, with ECC enabled */
+    flashctl->GEN.CMDBYTEN = DL_FLASHCTL_READ_VERIFY_32_WITH_ECC;
+
+    flashctl->GEN.CMDDATA0    = *data;
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+void DL_FlashCTL_readVerify64WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint8_t *eccCode)
+{
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Configure bytes to use for comparison, with ECC enabled */
+    flashctl->GEN.CMDBYTEN = DL_FLASHCTL_READ_VERIFY_64_WITH_ECC;
+
+    flashctl->GEN.CMDDATA0    = *data;
+    flashctl->GEN.CMDDATA1    = *(data + 1);
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+void DL_FlashCTL_blankVerify(FLASHCTL_Regs *flashctl, uint32_t address)
+{
+    /* Set command and word size. BLANKVERIFY can only be applied to a single
+     * flash word at a time */
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_BLANK_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_blankVerifyFromRAM(
+    FLASHCTL_Regs *flashctl, uint32_t address)
+{
+    /* Set command and word size. BLANKVERIFY can only be applied to a single
+     * flash word at a time */
+    flashctl->GEN.CMDTYPE = (uint32_t) DL_FLASHCTL_COMMAND_SIZE_ONE_WORD |
+                            (uint32_t) DL_FLASHCTL_COMMAND_TYPE_BLANK_VERIFY;
+
+    /* Set the address we want to verify */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+
+    /* Jump to RAM to execute command and wait for completion */
+    return DL_FlashCTL_executeCommandFromRAM(flashctl);
+}
+
+bool DL_FlashCTL_eraseDataBank(FLASHCTL_Regs *flashctl)
+{
+    bool status;
+
+    DL_FlashCTL_unprotectDataMemory(flashctl);
+    DL_FlashCTL_eraseMemory(
+        flashctl, FLASHCTL_DATA_ADDRESS, DL_FLASHCTL_COMMAND_SIZE_BANK);
+    status = DL_FlashCTL_waitForCmdDone(flashctl);
+
+    return (status);
+}
+
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_eraseDataBankFromRAM(
+    FLASHCTL_Regs *flashctl)
+{
+    DL_FLASHCTL_COMMAND_STATUS status;
+
+    DL_FlashCTL_unprotectDataMemory(flashctl);
+    status = DL_FlashCTL_eraseMemoryFromRAM(
+        flashctl, FLASHCTL_DATA_ADDRESS, DL_FLASHCTL_COMMAND_SIZE_BANK);
+
+    return (status);
+}
+
+#ifdef DEVICE_HAS_FLASH_128_BIT_WORD
+
+static void DL_FlashCTL_programMemory128Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint32_t *data);
+static void DL_FlashCTL_programMemoryConfigMultiWord(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t cmd, DL_FLASHCTL_COMMAND_SIZE cmdSize);
+
+/*!
+ * @brief Enable programming 128 bits without ECC enabled
+ */
+#define DL_FLASHCTL_PROGRAM_128_WITHOUT_ECC (0x0000FFFF)
+
+/*!
+ * @brief Enable programming 128 bits with ECC enabled
+ */
+#define DL_FLASHCTL_PROGRAM_128_WITH_ECC (0x0001FFFF)
+
+static void DL_FlashCTL_programMemoryConfigMultiWord(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t cmd, DL_FLASHCTL_COMMAND_SIZE cmdSize)
+{
+    flashctl->GEN.CMDTYPE =
+        (uint32_t) cmdSize | DL_FLASHCTL_COMMAND_TYPE_PROGRAM;
+
+    flashctl->GEN.CMDBYTEN = cmd;
+
+    /* Set address, address should be in the sector that we want to erase */
+    DL_FlashCTL_setCommandAddress(flashctl, address);
+}
+
+static void DL_FlashCTL_programMemory128Config(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t cmd, uint32_t *data)
+{
+    DL_FlashCTL_programMemoryConfigMultiWord(
+        flashctl, address, cmd, DL_FLASHCTL_COMMAND_SIZE_TWO_WORDS);
+
+    /* Set data registers */
+    flashctl->GEN.CMDDATA0 = *data;
+    flashctl->GEN.CMDDATA1 = *(data + 1);
+    flashctl->GEN.CMDDATA2 = *(data + 2);
+    flashctl->GEN.CMDDATA3 = *(data + 3);
+}
+
+void DL_FlashCTL_programMemory128(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    /* Enable 128 bits per data register for programming*/
+    DL_FlashCTL_programMemory128Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_128_WITHOUT_ECC, data);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+void DL_FlashCTL_programMemory128WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data)
+{
+    /* Enable 128 bits per data register for programming, with ECC enabled */
+    DL_FlashCTL_programMemory128Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_128_WITH_ECC, data);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+void DL_FlashCTL_programMemory128WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint8_t *eccCode)
+{
+    /* Enable 128 bits per data register for programming, with ECC enabled */
+    DL_FlashCTL_programMemory128Config(
+        flashctl, address, DL_FLASHCTL_PROGRAM_128_WITH_ECC, data);
+
+    flashctl->GEN.CMDDATAECC0 = *eccCode;
+    flashctl->GEN.CMDDATAECC1 = *(eccCode + 1);
+
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+bool DL_FlashCTL_programMemoryBlocking128WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint32_t dataSize, DL_FLASHCTL_REGION_SELECT regionSelect)
+{
+    bool status = true;
+
+    /* Check for valid data size */
+    if ((dataSize == (uint32_t) 0) || dataSize < (uint32_t) 4) {
+        status = false;
+    }
+
+    while ((dataSize != (uint32_t) 0) && status) {
+        /* Unprotect sector before every write */
+        DL_FlashCTL_unprotectSector(flashctl, address, regionSelect);
+
+        /* 32-bit case */
+        if (dataSize == (uint32_t) 1) {
+            DL_FlashCTL_programMemory32WithECCGenerated(
+                flashctl, address, data);
+
+            dataSize = dataSize - (uint32_t) 1;
+            data     = data + 1;
+            address  = address + (uint32_t) 4;
+        } else if (dataSize < (uint32_t) 4) {
+            /* 64-bit case */
+            DL_FlashCTL_programMemory64WithECCGenerated(
+                flashctl, address, data);
+            dataSize = dataSize - (uint32_t) 2;
+            data     = data + 2;
+            address  = address + (uint32_t) 8;
+        } else {
+            /* 128-bit case */
+            DL_FlashCTL_programMemory128WithECCGenerated(
+                flashctl, address, data);
+            dataSize = dataSize - (uint32_t) 4;
+            data     = data + 4;
+            address  = address + (uint32_t) 16;
+        }
+
+        status = DL_FlashCTL_waitForCmdDone(flashctl);
+    }
+
+    return (status);
+}
+
+#endif /* DEVICE_HAS_FLASH_128_BIT_WORD */

--- a/mspm0/source/ti/driverlib/dl_flashctl.h
+++ b/mspm0/source/ti/driverlib/dl_flashctl.h
@@ -1,0 +1,3140 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_flashctl.h
+ *  @brief      Flash Controller Driver Library
+ *  @defgroup   FLASHCTL Flash Controller (FLASHCTL)
+ *
+ *  @anchor ti_dl_dl_flashctl_Overview
+ *  # Overview
+ *
+ *  The Flash Controller Driver Library allows full configuration of
+ *  the MSPM0 Non-Volatile memory system.
+ *  The non-volatile memory (NVM) system provides nonvolatile flash memory for
+ *  storing executable code and data.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup FLASHCTL
+ * @{
+ */
+#ifndef ti_dl_dl_flashctl__include
+#define ti_dl_dl_flashctl__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+#include <ti/driverlib/m0p/dl_factoryregion.h>
+#include <ti/driverlib/m0p/dl_sysctl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if (FLASHCTL_SYS_DATAWIDTH == 128)
+/*!
+ * @brief Device has 128 bit flash word width
+ */
+#define DEVICE_HAS_FLASH_128_BIT_WORD
+#endif
+
+#if (FLASHCTL_SYS_WEPROTAWIDTH == 0)
+/*!
+ *  @brief Device does not have CMDWEPROTA
+ */
+#define DEVICE_HAS_NO_CMDWEPROTA
+#endif
+
+/* clang-format off */
+
+/*!
+ * @brief Address for Bank 0
+ */
+#define FLASHCTL_BANK0_ADDRESS                                      (0x00000000)
+
+/*!
+ * @brief Address for MAIN memory region
+ */
+#define FLASHCTL_MAIN_ADDRESS                                       (0x00000000)
+
+/*!
+ * @brief Address for NONMAIN memory region
+ */
+#define FLASHCTL_NONMAIN_ADDRESS                                    (0x41c00000)
+
+/*!
+ * @brief Number of NONMAIN sectors
+ */
+#define NUMBER_OF_NONMAIN_SECTORS                                            (1)
+
+/*!
+ * @brief Address for DATA memory region
+ */
+#define FLASHCTL_DATA_ADDRESS                                       (0x41d00000)
+
+/*!
+ * @brief Enable programming 8 bits without ECC enabled
+ */
+#define DL_FLASHCTL_PROGRAM_8_WITHOUT_ECC                           (0x00000001)
+
+/*!
+ * @brief Enable programming 16 bits without ECC enabled
+ */
+#define DL_FLASHCTL_PROGRAM_16_WITHOUT_ECC                          (0x00000003)
+
+/*!
+ * @brief Enable programming 32 bits without ECC enabled
+ */
+#define DL_FLASHCTL_PROGRAM_32_WITHOUT_ECC                          (0x0000000F)
+
+/*!
+ * @brief Enable programming 64 bits without ECC enabled
+ */
+#define DL_FLASHCTL_PROGRAM_64_WITHOUT_ECC                          (0x000000FF)
+
+/*!
+ * @brief Enable programming 8 bits with ECC enabled
+ */
+#define DL_FLASHCTL_PROGRAM_8_WITH_ECC                              (0x00000101)
+
+/*!
+ * @brief Enable programming 16 bits with ECC enabled
+ */
+#define DL_FLASHCTL_PROGRAM_16_WITH_ECC                             (0x00000103)
+
+/*!
+ * @brief Enable programming 32 bits with ECC enabled
+ */
+#define DL_FLASHCTL_PROGRAM_32_WITH_ECC                             (0x0000010F)
+
+/*!
+ * @brief Enable programming 64 bits with ECC enabled
+ */
+#define DL_FLASHCTL_PROGRAM_64_WITH_ECC                             (0x000001FF)
+
+/*!
+ * @brief Enable programming 64 bits with ECC enabled
+ */
+#define DL_FLASHCTL_READ_VERIFY_8_WITHOUT_ECC                       (0x00000001)
+
+/*!
+ * @brief Enable programming 64 bits with ECC enabled
+ */
+#define DL_FLASHCTL_READ_VERIFY_16_WITHOUT_ECC                      (0x00000003)
+
+/*!
+ * @brief Enable programming 64 bits with ECC enabled
+ */
+#define DL_FLASHCTL_READ_VERIFY_32_WITHOUT_ECC                      (0x0000000F)
+
+/*!
+ * @brief Enable programming 64 bits with ECC enabled
+ */
+#define DL_FLASHCTL_READ_VERIFY_64_WITHOUT_ECC                      (0x000000FF)
+
+/*!
+ * @brief Enable programming 64 bits with ECC enabled
+ */
+#define DL_FLASHCTL_READ_VERIFY_8_WITH_ECC                          (0x00000101)
+
+/*!
+ * @brief Enable programming 64 bits with ECC enabled
+ */
+#define DL_FLASHCTL_READ_VERIFY_16_WITH_ECC                         (0x00000103)
+
+/*!
+ * @brief Enable programming 64 bits with ECC enabled
+ */
+#define DL_FLASHCTL_READ_VERIFY_32_WITH_ECC                         (0x0000010F)
+
+/*!
+ * @brief Enable programming 64 bits with ECC enabled
+ */
+#define DL_FLASHCTL_READ_VERIFY_64_WITH_ECC                         (0x000001FF)
+
+/** @addtogroup DL_FLASHCTL_INTERRUPT
+ *  @{
+ */
+/*!
+ * @brief Flash Command execution has completed
+ */
+#define DL_FLASHCTL_INTERRUPT_DONE                       (FLASHCTL_MIS_DONE_SET)
+/** @}*/
+
+/** @addtogroup DL_FLASHCTL_COMMAND_TYPE
+ *  @{
+ */
+/*!
+ * @brief No Operation Flash Command
+ */
+#define DL_FLASHCTL_COMMAND_TYPE_NO_OPERATION    (FLASHCTL_CMDTYPE_COMMAND_NOOP)
+
+/*!
+ * @brief Program Command Type
+ */
+#define DL_FLASHCTL_COMMAND_TYPE_PROGRAM      (FLASHCTL_CMDTYPE_COMMAND_PROGRAM)
+
+/*!
+ * @brief Erase Command Type
+ */
+#define DL_FLASHCTL_COMMAND_TYPE_ERASE          (FLASHCTL_CMDTYPE_COMMAND_ERASE)
+
+/*!
+ * @brief Read-Verify Command Type
+ */
+#define DL_FLASHCTL_COMMAND_TYPE_READ_VERIFY                                   \
+                                           (FLASHCTL_CMDTYPE_COMMAND_READVERIFY)
+
+/*!
+ * @brief Blank Verify Command Type
+ */
+#define DL_FLASHCTL_COMMAND_TYPE_BLANK_VERIFY                                  \
+                                          (FLASHCTL_CMDTYPE_COMMAND_BLANKVERIFY)
+
+/*!
+ * @brief Mode Change Command Type
+ */
+#define DL_FLASHCTL_COMMAND_TYPE_MODE_CHANGE                                   \
+                                           (FLASHCTL_CMDTYPE_COMMAND_MODECHANGE)
+
+/*!
+ * @brief Clear Status Command Type
+ */
+#define DL_FLASHCTL_COMMAND_TYPE_CLEAR_STATUS                                  \
+                                          (FLASHCTL_CMDTYPE_COMMAND_CLEARSTATUS)
+/** @}*/
+
+/* clang-format on */
+
+/*! @enum DL_FLASHCTL_COMMAND_SIZE */
+typedef enum {
+    /*! Flash Command size is one word */
+    DL_FLASHCTL_COMMAND_SIZE_ONE_WORD = FLASHCTL_CMDTYPE_SIZE_ONEWORD,
+    /*! Flash Command size is two words */
+    DL_FLASHCTL_COMMAND_SIZE_TWO_WORDS = FLASHCTL_CMDTYPE_SIZE_TWOWORD,
+    /*! Flash Command size is four words */
+    DL_FLASHCTL_COMMAND_SIZE_FOUR_WORDS = FLASHCTL_CMDTYPE_SIZE_FOURWORD,
+    /*! Flash Command size is eight words */
+    DL_FLASHCTL_COMMAND_SIZE_EIGHT_WORDS = FLASHCTL_CMDTYPE_SIZE_EIGHTWORD,
+    /*! Flash Command size is a sector */
+    DL_FLASHCTL_COMMAND_SIZE_SECTOR = FLASHCTL_CMDTYPE_SIZE_SECTOR,
+    /*! Flash Command size is a bank */
+    DL_FLASHCTL_COMMAND_SIZE_BANK = FLASHCTL_CMDTYPE_SIZE_BANK
+
+} DL_FLASHCTL_COMMAND_SIZE;
+
+/*! @enum DL_FLASHCTL_REGION_SELECT */
+typedef enum {
+    /*! Flash Region Select Main */
+    DL_FLASHCTL_REGION_SELECT_MAIN = FLASHCTL_CMDCTL_REGIONSEL_MAIN,
+    /*! Flash Region Select Non-Main */
+    DL_FLASHCTL_REGION_SELECT_NONMAIN = FLASHCTL_CMDCTL_REGIONSEL_NONMAIN
+
+} DL_FLASHCTL_REGION_SELECT;
+
+/*! @enum DL_FLASHCTL_BANK_SELECT */
+typedef enum {
+    /*! Bank 0 */
+    DL_FLASHCTL_BANK_SELECT_0 = FLASHCTL_CMDCTL_BANKSEL_BANK0,
+    /*! Bank 1 */
+    DL_FLASHCTL_BANK_SELECT_1 = FLASHCTL_CMDCTL_BANKSEL_BANK1,
+    /*! Bank 2 */
+    DL_FLASHCTL_BANK_SELECT_2 = FLASHCTL_CMDCTL_BANKSEL_BANK2,
+    /*! Bank 3 */
+    DL_FLASHCTL_BANK_SELECT_3 = FLASHCTL_CMDCTL_BANKSEL_BANK3,
+    /*! Bank 4 */
+    DL_FLASHCTL_BANK_SELECT_4 = FLASHCTL_CMDCTL_BANKSEL_BANK4
+} DL_FLASHCTL_BANK_SELECT;
+
+/*! @enum DL_FLASHCTL_FAIL_TYPE */
+typedef enum {
+    /*! Flash Command did not fail during execution  */
+    DL_FLASHCTL_FAIL_TYPE_NO_FAILURE = 0x0,
+    /*! Flash Command failed due to write/erase protect sector violation */
+    DL_FLASHCTL_FAIL_TYPE_WRITE_ERASE_PROTECT =
+        (FLASHCTL_STATCMD_FAILWEPROT_STATFAIL),
+    /*! Flash Command failed due to verify error */
+    DL_FLASHCTL_FAIL_TYPE_VERIFY_ERROR = FLASHCTL_STATCMD_FAILVERIFY_STATFAIL,
+    /*! Flash Command failed due to the use of an illegal address */
+    DL_FLASHCTL_FAIL_TYPE_ILLEGAL_ADDRESS =
+        FLASHCTL_STATCMD_FAILILLADDR_STATFAIL,
+    /*! Flash Command failed because a bank has been set to a mode other than READ */
+    DL_FLASHCTL_FAIL_TYPE_WRONG_BANK_MODE = FLASHCTL_STATCMD_FAILMODE_STATFAIL,
+    /*! Flash Command failed due to an undefined error */
+    DL_FLASHCTL_FAIL_TYPE_MISCELLANEOUS = FLASHCTL_STATCMD_FAILMISC_STATFAIL,
+} DL_FLASHCTL_FAIL_TYPE;
+
+/*! @enum DL_FLASHCTL_COMMAND_STATUS */
+typedef enum {
+    /*! Flash Command passed */
+    DL_FLASHCTL_COMMAND_STATUS_PASSED = (FLASHCTL_STATCMD_CMDDONE_STATDONE |
+                                         FLASHCTL_STATCMD_CMDPASS_STATPASS),
+    /*! Flash Command failed */
+    DL_FLASHCTL_COMMAND_STATUS_FAILED = (FLASHCTL_STATCMD_CMDDONE_STATDONE |
+                                         FLASHCTL_STATCMD_CMDPASS_STATFAIL),
+    /*! Flash Command is still in progress */
+    DL_FLASHCTL_COMMAND_STATUS_IN_PROGRESS =
+        (FLASHCTL_STATCMD_CMDINPROGRESS_STATINPROGRESS)
+
+} DL_FLASHCTL_COMMAND_STATUS;
+
+/*! @enum DL_FLASHCTL_IIDX */
+typedef enum {
+    /*! DONE Interrupt Pending */
+    DL_FLASHCTL_IIDX_DONE = FLASHCTL_IIDX_STAT_DONE
+} DL_FLASHCTL_IIDX;
+
+/**
+ *  @brief      Enable flash interrupt
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_FlashCTL_enableInterrupt(FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.IMASK = FLASHCTL_IMASK_DONE_ENABLED;
+}
+
+/**
+ *  @brief      Disable flash interrupt
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_FlashCTL_disableInterrupt(FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.IMASK = FLASHCTL_IMASK_DONE_DISABLED;
+}
+
+/**
+ *  @brief      Check if the flash interrupt is enabled
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If the flash interrupt is enabled
+ *
+ *  @retval     false if interrupt is disabled
+ *  @retval     true if interrupt is enabled
+ */
+__STATIC_INLINE bool DL_FlashCTL_isInterruptEnabled(FLASHCTL_Regs *flashctl)
+{
+    return (flashctl->GEN.IMASK == FLASHCTL_IMASK_DONE_ENABLED);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled flash interrupt
+ *
+ *  Checks if the flash interrupt that was previously enabled is pending.
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If the flash interrupt is pending
+ *
+ *  @retval     0 if no interrupt is enabled
+ *  @retval     The value of @ref DL_FLASHCTL_INTERRUPT
+ */
+__STATIC_INLINE uint32_t DL_FlashCTL_getEnabledInterruptStatus(
+    FLASHCTL_Regs *flashctl)
+{
+    return (flashctl->GEN.MIS);
+}
+
+/**
+ *  @brief      Check interrupt flag of the flash interrupt
+ *
+ *  Checks if the flash interrupt is pending. Interrupts do not have to be
+ *  previously enabled.
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If the flash interrupt is pending
+ *
+ *  @retval     0 if no interrupt is enabled
+ *  @retval     The value of @ref DL_FLASHCTL_INTERRUPT
+ */
+__STATIC_INLINE uint32_t DL_FlashCTL_getRawInterruptStatus(
+    FLASHCTL_Regs *flashctl)
+{
+    return (flashctl->GEN.RIS);
+}
+
+/**
+ *  @brief      Get highest priority pending flash interrupt
+ *
+ *  Checks if the flash interrupt is pending. Interrupts do not have to be
+ *  previously enabled.
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The highest priority pending FLASH interrupt
+ *
+ */
+__STATIC_INLINE uint32_t DL_FlashCTL_getPendingInterrupt(
+    FLASHCTL_Regs *flashctl)
+{
+    return (flashctl->GEN.IIDX);
+}
+
+/**
+ *  @brief      Clear pending flash interrupt
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_FlashCTL_clearInterruptStatus(FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.ICLR = FLASHCTL_ICLR_DONE_CLR;
+}
+
+/**
+ *  @brief      Checks if a command execution has been initiated
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If a command has been set to execute
+ *
+ */
+__STATIC_INLINE bool DL_FlashCTL_isCommandExecuted(FLASHCTL_Regs *flashctl)
+{
+    return (flashctl->GEN.CMDEXEC == FLASHCTL_CMDEXEC_VAL_EXECUTE);
+}
+
+/**
+ *  @brief      Initiates a command execution
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_FlashCTL_setCommandExecute(FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+/**
+ *  @brief      Disable Stair-Step Erase
+ *
+ * The default VHV trim voltage setting will be used for all erase pulses.
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_FlashCTL_disbleStairStepErase(FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDCTL |= FLASHCTL_CMDCTL_SSERASEDIS_DISABLE;
+}
+
+/**
+ *  @brief      Checks if stair-step erase is disabled
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If stair-step erase is disabled
+ *
+ */
+__STATIC_INLINE bool DL_FlashCTL_isStairStepEraseDisabled(
+    FLASHCTL_Regs *flashctl)
+{
+    return ((flashctl->GEN.CMDCTL & FLASHCTL_CMDCTL_SSERASEDIS_MASK) ==
+            FLASHCTL_CMDCTL_SSERASEDIS_DISABLE);
+}
+
+/**
+ *  @brief      Enable Stair-Step Erase
+ *
+ * The VHV voltage will be stepped during successive erase pulses. The step
+ * count, step voltage, begin and end voltages are all hard-wired. This is
+ * enabled by default.
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_FlashCTL_enableStairStepErase(FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDCTL &= ~(FLASHCTL_CMDCTL_SSERASEDIS_MASK);
+}
+
+/**
+ *  @brief      Enable address override mode
+ *
+ * This overrides hardware address translation in CMDADDR from a system address
+ * to a bank address and bank ID. Use data written to CMDADDR directly as the
+ * bank address. Use the value written to CMDCTL.BANKSEL directly as the bank
+ * ID. Use the value written to CMDCTL.REGIONSEL directly as the region ID.
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ * @sa DL_FlashCTL_setCommandAddress
+ * @sa DL_FlashCTL_setBankSelect
+ * @sa DL_FlashCTL_setRegionSelect
+ */
+__STATIC_INLINE void DL_FlashCTL_enableAddressOverrideMode(
+    FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDCTL |= FLASHCTL_CMDCTL_ADDRXLATEOVR_OVERRIDE;
+}
+
+/**
+ *  @brief      Checks if address override mode is enabled
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If address override mode is enabled
+ */
+__STATIC_INLINE bool DL_FlashCTL_isAddressOverrideModeEnabled(
+    FLASHCTL_Regs *flashctl)
+{
+    return ((flashctl->GEN.CMDCTL & FLASHCTL_CMDCTL_ADDRXLATEOVR_MASK) ==
+            FLASHCTL_CMDCTL_ADDRXLATEOVR_OVERRIDE);
+}
+
+/**
+ *  @brief      Disable address override mode
+ *
+ * Disable address override mode and return to system addressed mode.
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_FlashCTL_disableAddressOverrideMode(
+    FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDCTL &= ~(FLASHCTL_CMDCTL_ADDRXLATEOVR_MASK);
+}
+
+/**
+ *  @brief      Enable overriding hardware generation of ECC code
+ *
+ * Override hardware ECC code generation by the flash controller. When enabled,
+ * the user can then manually set the ECC code to be programmed by calling
+ * @ref DL_FlashCTL_setCommandDataECC.
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ * @sa DL_FlashCTL_setCommandDataECC
+ */
+__STATIC_INLINE void DL_FlashCTL_enableOverrideHardwareGeneratedECC(
+    FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDCTL |= FLASHCTL_CMDCTL_ECCGENOVR_OVERRIDE;
+}
+
+/**
+ *  @brief      Checks if overriding hardware generation of ECC code is enabled
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If overriding hardware generation of ECC code is enabled
+ */
+__STATIC_INLINE bool DL_FlashCTL_isOverrideHardwareGeneratedECCEnabled(
+    FLASHCTL_Regs *flashctl)
+{
+    return ((flashctl->GEN.CMDCTL & FLASHCTL_CMDCTL_ECCGENOVR_MASK) ==
+            FLASHCTL_CMDCTL_ECCGENOVR_OVERRIDE);
+}
+
+/**
+ *  @brief      Disable overriding hardware generation of ECC code
+ *
+ * Disable overriding hardware generation of ECC code, so the flash controller
+ * will handle generating the needed ECC bits from the data
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_FlashCTL_disableOverrideHardwareGeneratedECC(
+    FLASHCTL_Regs *flashctl)
+{
+    flashctl->GEN.CMDCTL &= ~(FLASHCTL_CMDCTL_ECCGENOVR_MASK);
+}
+
+/**
+ *  @brief      Set the region select
+ *
+ * A specific region ID can be written to this field to indicate to which
+ * region an operation should be applied if CMDCTL.ADDRXLATEOVR is set.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  region      Region to select. One of @ref DL_FLASHCTL_REGION_SELECT
+ *
+ *  @sa DL_FlashCTL_enableAddressOverrideMode
+ */
+__STATIC_INLINE void DL_FlashCTL_setRegionSelect(
+    FLASHCTL_Regs *flashctl, DL_FLASHCTL_REGION_SELECT region)
+{
+    DL_Common_updateReg(&flashctl->GEN.CMDCTL, (uint32_t) region,
+        (uint32_t) FLASHCTL_CMDCTL_REGIONSEL_MASK);
+}
+
+/**
+ *  @brief      Get the region select
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *
+ *  @return     The region selected
+ *
+ *  @retval     One of @ref DL_FLASHCTL_REGION_SELECT
+ */
+__STATIC_INLINE DL_FLASHCTL_REGION_SELECT DL_FlashCTL_getRegionSelect(
+    FLASHCTL_Regs *flashctl)
+{
+    uint32_t region = flashctl->GEN.CMDCTL & FLASHCTL_CMDCTL_REGIONSEL_MASK;
+
+    return (DL_FLASHCTL_REGION_SELECT)(region);
+}
+
+/**
+ *  @brief      Set the bank select
+ *
+ * A specific bank ID can be written to this field to indicate which bank an
+ * operation should be applied if CMDCTL.ADDRXLATEOVR is set.
+ *
+ *  @note Refer to the device datasheet for the number of banks that are
+ *  available on your device.
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *  @param[in]  bank      Bank to select. One of @ref DL_FLASHCTL_BANK_SELECT
+ *
+ *  @sa DL_FlashCTL_enableAddressOverrideMode
+ */
+__STATIC_INLINE void DL_FlashCTL_setBankSelect(
+    FLASHCTL_Regs *flashctl, DL_FLASHCTL_BANK_SELECT bank)
+{
+    DL_Common_updateReg(&flashctl->GEN.CMDCTL, (uint32_t) bank,
+        (uint32_t) FLASHCTL_CMDCTL_BANKSEL_MASK);
+}
+
+/**
+ *  @brief      Get the bank select
+ *
+ *  @note Refer to the device datasheet for the number of banks that are
+ *  available on your device.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *
+ *  @return     The bank selected
+ *
+ *  @retval     One of @ref DL_FLASHCTL_BANK_SELECT
+ */
+__STATIC_INLINE DL_FLASHCTL_BANK_SELECT DL_FlashCTL_getBankSelect(
+    FLASHCTL_Regs *flashctl)
+{
+    uint32_t bank = flashctl->GEN.CMDCTL & FLASHCTL_CMDCTL_BANKSEL_MASK;
+
+    return (DL_FLASHCTL_BANK_SELECT)(bank);
+}
+
+/**
+ *  @brief      Set the bytes to enable for programming data
+ *
+ * This register forms a per-byte enable for programming data. Each bit in
+ * CMDBYTEN corresponds to a byte in the addressed flash word to be programmed,
+ * including the ECC byte. This allows sub-word programming (programming of
+ * less than the full 64 or 72 bit flash word) if desired.
+ *
+ * ECC data bytes are protected by the MSB bits in this register, depending on
+ * the presence of ECC and the flash word data width. Note: Refer to the TRM on
+ * how to correctly handle ECC for sub-word programs. You cannot correctly
+ * program the ECC bits if the whole 64 bits of the data word is not
+ * programmed, so the ECC byte should not be enabled until all 64 bits of the
+ * flash word are programmed.
+ *
+ * This register is written to all 0 after the completion of all FLASHCTL
+ * commands.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  byteMask   Mask of bytes to enable. Between [0,0x1FF].
+ *                         For example:
+ *                         - byteMask = 0x0, Disable all bytes for programming
+ *                         - byteMask = 0x1, Enable 8-bit programming
+ *                         - byteMask = 0x3, Enable 16-bit programming
+ *                         - byteMask = 0xF, Enable 32-bit programming
+ *                         - byteMask = 0xFF, Enable 64-bit programming
+ *                         - byteMask = 0x1FF, Enable 64-bit programming with
+ *                           ECC enabled
+ */
+__STATIC_INLINE void DL_FlashCTL_setCommandByteEnable(
+    FLASHCTL_Regs *flashctl, uint32_t byteMask)
+{
+    flashctl->GEN.CMDBYTEN = byteMask;
+}
+
+/**
+ *  @brief      Get the bytes that are enabled for programming data
+ *
+ * This register forms a per-byte enable for programming data. Each bit in
+ * CMDBYTEN corresponds to a byte in the addressed flash word to be programmed,
+ * including the ECC byte. This allows sub-word programming (programming of
+ * less than the full 64 or 72 bit flash word) if desired.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *
+ *  @return     The enabled bytes
+ *
+ *  @retval     Value between [0,0x1FF].
+ */
+__STATIC_INLINE uint32_t DL_FlashCTL_getCommandByteEnable(
+    FLASHCTL_Regs *flashctl)
+{
+    return ((uint32_t) flashctl->GEN.CMDCTL &
+            (uint32_t)(FLASHCTL_CMDBYTEN_VAL_MASK));
+}
+
+/**
+ *  @brief      Set the data for a command data register
+ *
+ * The command data registers, CMDDATAx, are used to form the data for a
+ * command. For devices which only support single word programming, only the
+ * CMDDATA0 and CMDDATA1 registers are used to load data to be programmed to
+ * the flash memory. CMDDATA0 is always loaded with BIT31-BIT0 of the target
+ * data, and CMDDATA1 is always loaded with BIT63-BIT32 of the target data.
+ * If fewer than 64 data bits are being programmed, see the special handling
+ * requirements section in the device TRM for programming less than one flash
+ * word.
+ *
+ * @note Ensure that you have enabled the correct bytes for programming enabled
+ * with @ref DL_FlashCTL_setCommandByteEnable.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  index      Select the command data register to write to.
+ *                         Please see the device TRM for the number of CMDDATA
+ *                         registers. For example:
+ *                         - index = 0, Select CMDDATA0
+ *                         - index = 1, Select CMDDATA1
+ *  @param[in]  data       Data to write to the command data register.
+ *                         Value between [0,0xFFFFFFFF]
+ */
+__STATIC_INLINE void DL_FlashCTL_setCommandData(
+    FLASHCTL_Regs *flashctl, uint8_t index, uint32_t *data)
+{
+    volatile uint32_t *pReg = &(flashctl->GEN.CMDDATA0) + index;
+
+    *pReg = *data;
+}
+
+/**
+ *  @brief      Get the data from a command data register
+ *
+ * For devices which only support single word programming, only the
+ * CMDDATA0 and CMDDATA1 registers are used to load data to be programmed to
+ * the flash memory. CMDDATA0 is always loaded with BIT31-BIT0 of the target
+ * data, and CMDDATA1 is always loaded with BIT63-BIT32 of the target data.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  index      Select the command data register to write to.
+ *                         Please see the device TRM for the number of CMDDATA
+ *                         registers. For example:
+ *                         - index = 0, Select CMDDATA0
+ *                         - index = 1, Select CMDDATA1
+ *
+ *  @return     The data in the command data register
+ *
+ *  @retval     Value between [0,0xFFFFFFFF].
+ */
+__STATIC_INLINE uint32_t DL_FlashCTL_getCommandData(
+    FLASHCTL_Regs *flashctl, uint8_t index)
+{
+    volatile uint32_t *pReg = &(flashctl->GEN.CMDDATA0);
+
+    return (
+        (uint32_t)(*(pReg + index) & (uint32_t) FLASHCTL_CMDDATA0_VAL_MASK));
+}
+
+/**
+ *  @brief      Set the ECC code in the command data ECC register
+ *
+ * This register forms the ECC portion of the data for a command.
+ *
+ * @note The ECC data can be manually set only when hardware ECC code
+ * generation is disabled with
+ * @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *
+ * @note Ensure that you have enabled the correct bytes for programming ECC
+ * enabled with @ref DL_FlashCTL_setCommandByteEnable
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  index      Select the command data ECC register to write to.
+ *                         Please see the device TRM for the number of
+ *                         CMDDATAECC registers. For example:
+ *                         - index = 0, Select CMDDATAECC0
+ *                         - index = 1, Select CMDDATAECC1
+ *  @param[in]  data       Data to write to the command data ECC register.
+ *                         Value between [0, 0xFF]
+ */
+__STATIC_INLINE void DL_FlashCTL_setCommandDataECC(
+    FLASHCTL_Regs *flashctl, uint8_t index, uint8_t *data)
+{
+    volatile uint32_t *pReg = &(flashctl->GEN.CMDDATAECC0) + index;
+
+    *pReg = *data;
+}
+
+/**
+ *  @brief      Get the ECC code in the command data ECC register
+ *
+ * This register forms the ECC portion of the data for a command.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  index      Select the command data register ECC to write to.
+ *                         Please see the device TRM for the number of
+ *                         CMDDATAECC registers. For example:
+ *                         - index = 0, Select CMDDATAECC0
+ *                         - index = 1, Select CMDDATAECC1
+ *
+ *  @return     The data in the command data ECC register
+ *
+ *  @retval     Value between [0,0xFF].
+ */
+__STATIC_INLINE uint8_t DL_FlashCTL_getCommandDataECC(
+    FLASHCTL_Regs *flashctl, uint8_t index)
+{
+    volatile uint32_t *pReg = &(flashctl->GEN.CMDDATAECC0);
+
+    return ((uint8_t)(
+        *(pReg + index) & (uint32_t) FLASHCTL_CMDDATAECC0_VAL0_MASK));
+}
+
+/**
+ *  @brief      Sets the target address for a command
+ *
+ *  The target address for a command must be flash word (64-bit) aligned. This
+ *  means that the target address must be aligned to a 0b000 boundary (for
+ *  example, the 3 LSBs in the address must be zero).
+ *
+ *  1) For single-word program, this address indicates the flash bank word to be
+ *     programmed.
+ *  2) For multi-word program, this address indicates the first flash bank
+ *     address for the program. The address will be incremented
+ *  3) For sector and bank erase, this address indicates the sector or bank to
+ *     be erased.
+ *  4) For read verify, this address forms the start address for the verify
+ *     operation.
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *  @param[in]  address   Destination address to program/erase/read
+ *
+ */
+__STATIC_INLINE void DL_FlashCTL_setCommandAddress(
+    FLASHCTL_Regs *flashctl, uint32_t address)
+{
+    flashctl->GEN.CMDADDR = address;
+}
+
+/**
+ *  @brief      Returns the status  of the current command
+ *
+ *  Checks if the command is still in progress or finished and if it passed or
+ *  failed
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of the current command
+ *
+ *  @retval     One of @ref DL_FLASHCTL_COMMAND_STATUS values
+ */
+__STATIC_INLINE DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_getCommandStatus(
+    FLASHCTL_Regs *flashctl)
+{
+    uint32_t commandStatus =
+        flashctl->GEN.STATCMD &
+        (FLASHCTL_STATCMD_CMDDONE_MASK | FLASHCTL_STATCMD_CMDPASS_MASK |
+            FLASHCTL_STATCMD_CMDINPROGRESS_MASK |
+            FLASHCTL_STATCMD_CMDPASS_STATFAIL);
+
+    return (DL_FLASHCTL_COMMAND_STATUS)(commandStatus);
+}
+
+/**
+ *  @brief      Returns the reason a command failed
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The type of command failure
+ *
+ *  @retval     One of @ref DL_FLASHCTL_FAIL_TYPE values
+ */
+__STATIC_INLINE DL_FLASHCTL_FAIL_TYPE DL_FlashCTL_getFailureStatus(
+    FLASHCTL_Regs *flashctl)
+{
+    uint32_t commandFailureType =
+        flashctl->GEN.STATCMD &
+        (FLASHCTL_STATCMD_FAILWEPROT_MASK | FLASHCTL_STATCMD_FAILVERIFY_MASK |
+            FLASHCTL_STATCMD_FAILILLADDR_MASK |
+            FLASHCTL_STATCMD_FAILMODE_MASK | FLASHCTL_STATCMD_FAILMISC_MASK);
+
+    return (DL_FLASHCTL_FAIL_TYPE)(commandFailureType);
+}
+
+/**
+ *  @brief      Blocking function that waits for a command execution to finish
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true if command was successful
+ */
+__STATIC_INLINE bool DL_FlashCTL_waitForCmdDone(FLASHCTL_Regs *flashctl)
+{
+    /* Wait for command to complete */
+    while ((flashctl->GEN.STATCMD & FLASHCTL_STATCMD_CMDDONE_MASK) !=
+           FLASHCTL_STATCMD_CMDDONE_STATDONE) {
+        ;
+    }
+
+    return ((flashctl->GEN.STATCMD & FLASHCTL_STATCMD_CMDPASS_MASK) ==
+            FLASHCTL_STATCMD_CMDPASS_STATPASS);
+}
+
+/**
+ *  @brief      Sets clear status bit and executes command
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_FlashCTL_executeClearStatus(FLASHCTL_Regs *flashctl)
+{
+    /* Set COMMAND bit within CMDTYPE register to clear status*/
+    flashctl->GEN.CMDTYPE = DL_FLASHCTL_COMMAND_TYPE_CLEAR_STATUS;
+    /* Set bit to execute command */
+    flashctl->GEN.CMDEXEC = FLASHCTL_CMDEXEC_VAL_EXECUTE;
+}
+
+/**
+ *  @brief      Gets the sector number of the input address over the whole
+ *              memory map
+ *
+ *  If the device has two 128KB banks, and the input address is 0x20000, then
+ *  this API will return the sector number as 128.
+ *  To get the sector number over the whole memory map of the device, refer to
+ *  @ref DL_FlashCTL_getFlashSectorNumberInBank.
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *  @param[in]  addr      Memory address within the desired sector
+ *
+ *  @return     The sector number that contains the input address
+ */
+__STATIC_INLINE uint32_t DL_FlashCTL_getFlashSectorNumber(
+    FLASHCTL_Regs *flashctl, uint32_t addr)
+{
+    return (addr >> (uint32_t) 10);
+}
+
+/**
+ *  @brief      Gets the sector number of the input address relative to the
+ *              bank of the address
+ *
+ *  If the device has two 128KB banks, and the input address is 0x20000, then
+ *  this API will return the sector number as 0. This is because 0x20000 is in
+ *  Sector 0 of Bank 1.
+ *  To get the sector number over the whole memory map of the device, refer to
+ *  @ref DL_FlashCTL_getFlashSectorNumber.
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *  @param[in]  addr      Memory address within the desired sector
+ *
+ *  @return     The sector number in the current bank that contains the address
+ */
+__STATIC_INLINE uint32_t DL_FlashCTL_getFlashSectorNumberInBank(
+    FLASHCTL_Regs *flashctl, uint32_t addr)
+{
+    uint8_t numBanks       = DL_FactoryRegion_getNumBanks();
+    uint32_t mainFlashSize = DL_FactoryRegion_getMAINFlashSize();
+    uint32_t sector, bankSectors, sectorInBank;
+
+    /* Current sector over the whole memory map */
+    sector = DL_FlashCTL_getFlashSectorNumber(flashctl, addr);
+    if (numBanks > 1) {
+        /* Number of sectors per bank, considered max sector
+         * count for a bank-adjusted sector. Assume banks are
+         * evenly distributed */
+        bankSectors = (mainFlashSize / numBanks);
+        /* We will not assume that the maximum number of bank sectors is a
+         * multiple of 2. Which does mean incurring a modulo operation. */
+        sectorInBank = sector % bankSectors;
+    } else {
+        sectorInBank = sector;
+    }
+
+    return sectorInBank;
+}
+
+/**
+ *  @brief      Set the number of wait states used by the Flash
+ *
+ *  Changes the number of wait states used by the Flash controller. When
+ *  changing the frequency of the clock, the number of wait states may need to
+ *  be updated.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  waitState  Number of wait states to set. Recommended values
+ *                         are based on the system clock speed:
+ *                           - 0MHz-24MHz: 0 wait state
+ *                           - 24MHz-48MHz: 1 wait state
+ *                           - 48MHz-72MHz: 2 wait states
+ *                           - 72MHz-80MHz: 3 wait states
+ */
+__STATIC_INLINE void DL_FlashCTL_setWaitState(
+    FLASHCTL_Regs *flashctl, uint32_t waitState)
+{
+    flashctl->GEN.CFGCMD = waitState;
+}
+
+/**
+ *  @brief      Get the number of wait states used by the Flash
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *
+ *  @return     The number of wait states used by the Flash
+ */
+__STATIC_INLINE uint32_t DL_FlashCTL_getWaitState(FLASHCTL_Regs *flashctl)
+{
+    return (flashctl->GEN.CFGCMD & FLASHCTL_CFGCMD_WAITSTATE_MASK);
+}
+
+/**
+ *  @brief      Performs an erase on unprotected memory
+ *
+ *  Performs an erase on unprotected memory within a sector or bank of memory
+ *  containing the input memory address.
+ *
+ *  NOTE: The user is responsible for unprotecting the regions of memory prior
+ *  to calling this API. Memory will be automatically protected following the
+ *  command execution.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address       Memory address within desired sector or bank to
+ *                            erase
+ *  @param[in]  memorySize    The size of the memory block to erase. One of:
+ *                            @arg DL_FLASHCTL_COMMAND_SIZE_BANK
+ *                            @arg DL_FLASHCTL_COMMAND_SIZE_SECTOR
+ *
+ * @post        This API just starts the erase process. Check the result of it
+ *              using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ */
+void DL_FlashCTL_eraseMemory(FLASHCTL_Regs *flashctl, uint32_t address,
+    DL_FLASHCTL_COMMAND_SIZE memorySize);
+
+/**
+ *  @brief      Performs an erase on unprotected memory, and executes command
+ *              from RAM
+ *
+ *  Performs an erase on unprotected memory within a sector or bank of memory
+ *  containing the input memory address.
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  NOTE: The user is responsible for unprotecting the regions of memory prior
+ *  to calling this API. Memory will be automatically protected following the
+ *  command execution.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address       Memory address within desired sector or bank to
+ *                            erase
+ *  @param[in]  memorySize    The size of the memory block to erase. One of:
+ *                            @arg DL_FLASHCTL_COMMAND_SIZE_BANK
+ *                            @arg DL_FLASHCTL_COMMAND_SIZE_SECTOR
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ * @post        This API just starts the erase process. Check the result of it
+ *              using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_eraseMemoryFromRAM(
+    FLASHCTL_Regs *flashctl, uint32_t address,
+    DL_FLASHCTL_COMMAND_SIZE memorySize);
+
+/**
+ *  @brief      Performs a mass erase on main memory on one bank
+ *
+ *  Performs a mass erase on main memory on Bank 0 only. This API should be used
+ *  on single bank devices.
+ *
+ *  NOTE: This API sets all main memory to unprotected from erase/program
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Whether or not the erase succeeded
+ *
+ *  @retval     false if erase didn't succeed
+ *  @retval     true  if erase was successful
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ */
+bool DL_FlashCTL_massErase(FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Performs a mass erase on main memory, and executes command
+ *              from RAM
+ *
+ *  Performs a mass erase on main memory on Bank 0 only. This API should be used
+ *  on single bank devices.
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  NOTE: This API sets all main memory to unprotected from erase/program
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Whether or not the erase succeeded
+ *
+ *  @retval     false if erase didn't succeed
+ *  @retval     true  if erase was successful
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_massEraseFromRAM(
+    FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Performs a mass erase on main memory, and erases all flash banks
+ *
+ *  Performs a mass erase on main memory within each flash bank.
+ *
+ *  NOTE: This API sets all main memory to unprotected from erase/program
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Whether or not the erase succeeded
+ *
+ *  @retval     false if erase didn't succeed
+ *  @retval     true  if erase was successful
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ */
+bool DL_FlashCTL_massEraseMultiBank(FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Performs a factory reset erase on main and non-main memory
+ *
+ *  Performs an erase on Bank 0 of main memory and non-main memory on the
+ *  device. This API should be used on single bank devices.
+ *
+ *  NOTE: This API sets all main memory to protected from erase/program if
+ *        successful. If unsuccessful, all memory will be unprotected
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Whether or not the erase succeeded
+ *
+ *  @retval     false if erase didn't succeed
+ *  @retval     true  if erase was successful
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ */
+bool DL_FlashCTL_factoryReset(FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Performs a factory reset erase on main and non-main memory, and
+ *              executes command from RAM
+ *
+ *  Performs an erase on Bank 0 of main memory and non-main memory on the
+ *  device. This API should be used on single bank devices.
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  NOTE: This API sets all main memory to protected from erase/program if
+ *        successful. If unsuccessful, all memory will be unprotected
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Whether or not the erase succeeded
+ *
+ *  @retval     false if erase didn't succeed
+ *  @retval     true  if erase was successful
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_factoryResetFromRAM(
+    FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Performs a factory reset erase on main and non-main memory
+ *
+ *  Performs an erase on all flash banks of main memory and non-main memory on
+ *  the device.
+ *
+ *  NOTE: This API sets all main memory to protected from erase/program if
+ *        successful. If unsuccessful, all memory will be unprotected
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Whether or not the erase succeeded
+ *
+ *  @retval     false if erase didn't succeed
+ *  @retval     true  if erase was successful
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ */
+bool DL_FlashCTL_factoryResetMultiBank(FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Programs 8 bit data to unprotected memory at the given address
+ *
+ * The device datasheet specifies a maximum limit on program operations per
+ * word line before erasure of the sector containing the word line is required.
+ * Exceeding this maximum may result in data corruption within the word line.
+ * If 8-bit (byte) program operations are performed, or the same memory
+ * locations are programmed more than once, the max program limit per word line
+ * must be considered and not exceeded. Because of that, it is better to buffer
+ * data and use the @ref DL_FlashCTL_programMemory16,
+ * @ref DL_FlashCTL_programMemory32 or @ref DL_FlashCTL_programMemory64 APIs to
+ * program memory to reduce in the number of program operations in a wordline.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 8-bit source data
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: This API does not enable programming the ECC code.
+ */
+void DL_FlashCTL_programMemory8(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data);
+
+/**
+ *  @brief      Programs 8 bit data to unprotected memory at the given address,
+ *              and executes command from RAM
+ *
+ * The device datasheet specifies a maximum limit on program operations per
+ * word line before erasure of the sector containing the word line is required.
+ * Exceeding this maximum may result in data corruption within the word line.
+ * If 8-bit (byte) program operations are performed, or the same memory
+ * locations are programmed more than once, the max program limit per word line
+ * must be considered and not exceeded. Because of that, it is better to buffer
+ * data and use the @ref DL_FlashCTL_programMemory16,
+ * @ref DL_FlashCTL_programMemory32 or @ref DL_FlashCTL_programMemory64 APIs to
+ * program memory to reduce in the number of program operations in a wordline.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 8-bit source data
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: This API does not enable programming the ECC code.
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM8(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data);
+
+/**
+ *  @brief      Programs 16 bit data to unprotected memory at the given address
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 16-bit source data
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: This API does not enable programming the ECC code.
+ */
+void DL_FlashCTL_programMemory16(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data);
+
+/**
+ *  @brief      Programs 16 bit data to unprotected memory at the given
+ *              address, and executes command from RAM
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 16-bit source data
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: This API does not enable programming the ECC code.
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM16(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data);
+
+/**
+ *  @brief      Programs 32 bit data to unprotected memory at the given address
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: This API does not enable programming the ECC code.
+ */
+void DL_FlashCTL_programMemory32(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Programs 32 bit data to unprotected memory at the given
+ *              address, and executes command from RAM
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: This API does not enable programming the ECC code.
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM32(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Programs 64 bit data to unprotected memory at the given address
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: This API does not enable programming the ECC code.
+ */
+void DL_FlashCTL_programMemory64(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Programs 64 bit data to unprotected memory at the given
+ *              address, and executes command from RAM
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: This API does not enable programming the ECC code.
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM64(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Programs 8 bit data with hardware generated ECC code
+ *
+ *  Programs 8 bit data, along with the 8 ECC bits which correspond to the
+ *  8-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code has NOT been disabled,
+ *  and so the flash controller will generate the ECC bits.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 8-bit source data
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_programMemory8WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data);
+
+/**
+ *  @brief      Programs 8 bit data with hardware generated ECC code, and
+ *              executes command from RAM
+ *
+ *  Programs 8 bit data, along with the 8 ECC bits which correspond to the
+ *  8-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code has NOT been disabled,
+ *  and so the flash controller will generate the ECC bits.
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 8-bit source data
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM8WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data);
+
+/**
+ *  @brief      Programs 16 bit data with hardware generated ECC code
+ *
+ *  Programs 16 bit data, along with the 8 ECC bits which correspond to the
+ *  16-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code has NOT been disabled,
+ *  and so the flash controller will generate the ECC bits.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 16-bit source data
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_programMemory16WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data);
+
+/**
+ *  @brief      Programs 16 bit data with hardware generated ECC code, and
+ *              executes command from RAM
+ *
+ *  Programs 16 bit data, along with the 8 ECC bits which correspond to the
+ *  16-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code has NOT been disabled,
+ *  and so the flash controller will generate the ECC bits.
+ *
+ *   The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 16-bit source data
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM16WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data);
+
+/**
+ *  @brief      Programs 32 bit data with hardware generated ECC code
+ *
+ *  Programs 32 bit data, along with the 8 ECC bits which correspond to the
+ *  32-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code has NOT been disabled,
+ *  and so the flash controller will generate the ECC bits.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_programMemory32WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Programs 32 bit data with hardware generated ECC code, and
+ *              executes command from RAM
+ *
+ *  Programs 16 bit data, along with the 8 ECC bits which correspond to the
+ *  16-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code has NOT been disabled,
+ *  and so the flash controller will generate the ECC bits.
+ *
+ *   The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM32WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Programs 64 bit data with hardware generated ECC code
+ *
+ *  Programs 64 bit data, along with the 8 ECC bits which correspond to the
+ *  64-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code has NOT been disabled,
+ *  and so the flash controller will generate the ECC bits.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_programMemory64WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Programs 64 bit data with hardware generated ECC code, and
+ *              executes command from RAM
+ *
+ *  Programs 16 bit data, along with the 8 ECC bits which correspond to the
+ *  16-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code has NOT been disabled,
+ *  and so the flash controller will generate the ECC bits.
+ *
+ *   The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM64WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Programs 8 bit data with user provided ECC code
+ *
+ *  Programs 8 bit data, along with the 8 ECC bits which correspond to the
+ *  8-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code HAS been disabled,
+ *  and so the user must provide the ECC code to program.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 8-bit source data
+ *  @param[in]  eccCode    Pointer to the ECC code to program
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_programMemory8WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint8_t *data, uint8_t *eccCode);
+
+/**
+ *  @brief      Programs 8 bit data with user provided ECC code, and executes
+ *              command from RAM
+ *
+ *  Programs 8 bit data, along with the 8 ECC bits which correspond to the
+ *  8-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code HAS been disabled,
+ *  and so the user must provide the ECC code to program.
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 8-bit source data
+ *  @param[in]  eccCode    Pointer to the ECC code to program
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM8WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data,
+    uint8_t *eccCode);
+
+/**
+ *  @brief      Programs 16 bit data with user provided ECC code
+ *
+ *  Programs 16 bit data, along with the 8 ECC bits which correspond to the
+ *  16-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code HAS been disabled,
+ *  and so the user must provide the ECC code to program.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 16-bit source data
+ *  @param[in]  eccCode    Pointer to the ECC code to program
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_programMemory16WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint16_t *data, uint8_t *eccCode);
+
+/**
+ *  @brief      Programs 16 bit data with user provided ECC code, and executes
+ *              command from RAM
+ *
+ *  Programs 16 bit data, along with the 8 ECC bits which correspond to the
+ *  16-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code HAS been disabled,
+ *  and so the user must provide the ECC code to program.
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 16-bit source data
+ *  @param[in]  eccCode    Pointer to the ECC code to program
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM16WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data,
+    uint8_t *eccCode);
+
+/**
+ *  @brief      Programs 32 bit data with user provided ECC code
+ *
+ *  Programs 32 bit data, along with the 8 ECC bits which correspond to the
+ *  32-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code HAS been disabled,
+ *  and so the user must provide the ECC code to program.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *  @param[in]  eccCode    Pointer to the ECC code to program
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_programMemory32WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint8_t *eccCode);
+
+/**
+ *  @brief      Programs 32 bit data with user provided ECC code, and executes
+ *              command from RAM
+ *
+ *  Programs 32 bit data, along with the 8 ECC bits which correspond to the
+ *  32-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code HAS been disabled,
+ *  and so the user must provide the ECC code to program.
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *  @param[in]  eccCode    Pointer to the ECC code to program
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM32WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint8_t *eccCode);
+
+/**
+ *  @brief      Programs 64 bit data with user provided ECC code
+ *
+ *  Programs 64 bit data, along with the 8 ECC bits which correspond to the
+ *  64-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code HAS been disabled,
+ *  and so the user must provide the ECC code to program.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *  @param[in]  eccCode    Pointer to the ECC code to program
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_programMemory64WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint8_t *eccCode);
+
+/**
+ *  @brief      Programs 64 bit data with user provided ECC code, and executes
+ *              command from RAM
+ *
+ *  Programs 64 bit data, along with the 8 ECC bits which correspond to the
+ *  64-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code HAS been disabled,
+ *  and so the user must provide the ECC code to program.
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *  @param[in]  eccCode    Pointer to the ECC code to program
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM64WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint8_t *eccCode);
+
+/**
+ *  @brief      Programs provided data with hardware generated ECC code
+ *
+ *  Blocking function that programs a set of data, along with the 8 ECC bits
+ *  which correspond to the data at the given address. This API
+ *  assumes that hardware generation of the ECC code has NOT been disabled,
+ *  and so the flash controller will generate the ECC bits.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  dataSize      The number of 32-bit words to program. Value
+ *                            should be an even number, to ensure data is
+ *                            programmed 64-bits at a time.
+ *  @param[in]  data          Pointer to the data source to program into flash
+ *  @param[in]  regionSelect  The region of memory to erase. One of
+ *                            @ref DL_FLASHCTL_REGION_SELECT
+ *
+ *  @return     Whether or not the program succeeded
+ *
+ *  @retval     false   Program didn't succeed, or invalid dataSize
+ *  @retval     true    Program was successful
+ *
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+bool DL_FlashCTL_programMemoryBlocking64WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint32_t dataSize, DL_FLASHCTL_REGION_SELECT regionSelect);
+
+/**
+ *  @brief      Programs provided data with hardware generated ECC code, and
+ *              executes command from RAM
+ *
+ *  Blocking function that programs a set of data, along with the 8 ECC bits
+ *  which correspond to the data at the given address. This API
+ *  assumes that hardware generation of the ECC code has NOT been disabled,
+ *  and so the flash controller will generate the ECC bits.
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  dataSize      The number of 32-bit words to program. Value
+ *                            should be an even number, to ensure data is
+ *                            programmed 64-bits at a time.
+ *  @param[in]  data          Pointer to the data source to program into flash
+ *  @param[in]  regionSelect  The region of memory to erase. One of
+ *                            @ref DL_FLASHCTL_REGION_SELECT
+ *
+ *  @return     Whether or not the program succeeded
+ *
+ *  @retval     false   Program didn't succeed, or invalid dataSize
+ *  @retval     true    Program was successful
+ *
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+DL_FLASHCTL_COMMAND_STATUS
+DL_FlashCTL_programMemoryBlockingFromRAM64WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint32_t dataSize, DL_FLASHCTL_REGION_SELECT regionSelect);
+
+/**
+ *  @brief      Programs provided data with user provided ECC code
+ *
+ *  Blocking function that programs a set of data, along with the 8 ECC bits
+ *  which correspond to the data at the given address. This API assumes that
+ *  hardware generation of the ECC code HAS been disabled, and so the user
+ *  must provide the ECC code to program.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  dataSize      The number of 32-bit words to program. Value
+ *                            should be an even number, to ensure data is
+ *                            programmed 64-bits at a time.
+ *  @param[in]  data          Pointer to the data source to program into flash
+ *  @param[in]  eccCode       Pointer to ECC code to program corresponding to data
+ *  @param[in]  regionSelect  The region of memory to erase. One of
+ *                            @ref DL_FLASHCTL_REGION_SELECT
+ *
+ *  @return     Whether or not the program succeeded
+ *
+ *  @retval     false   Program didn't succeed, or invalid dataSize
+ *  @retval     true    Program was successful
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+bool DL_FlashCTL_programMemoryBlocking64WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint8_t *eccCode, uint32_t dataSize,
+    DL_FLASHCTL_REGION_SELECT regionSelect);
+
+/**
+ *  @brief      Programs provided data with user provided ECC code, and
+ *              executes command from RAM
+ *
+ *  Blocking function that programs a set of data, along with the 8 ECC bits
+ *  which correspond to the data at the given address. This API assumes that
+ *  hardware generation of the ECC code HAS been disabled, and so the user
+ *  must provide the ECC code to program.
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  dataSize      The number of 32-bit words to program. Value
+ *                            should be an even number, to ensure data is
+ *                            programmed 64-bits at a time.
+ *  @param[in]  data          Pointer to the data source to program into flash
+ *  @param[in]  eccCode       Pointer to ECC code to program corresponding to data
+ *  @param[in]  regionSelect  The region of memory to erase. One of
+ *                            @ref DL_FLASHCTL_REGION_SELECT
+ *
+ *  @return     Whether or not the program succeeded
+ *
+ *  @retval     false   Program didn't succeed, or invalid dataSize
+ *  @retval     true    Program was successful
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+DL_FLASHCTL_COMMAND_STATUS
+DL_FlashCTL_programMemoryBlockingFromRAM64WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint8_t *eccCode, uint32_t dataSize,
+    DL_FLASHCTL_REGION_SELECT regionSelect);
+
+/**
+ *  @brief      Programs provided data to unprotected memory at a given address
+ *
+ *  Blocking function that programs a set of data. Data will be programmed as
+ *  flash words (64-bits). If dataSize is an odd number, then the last word
+ *  will be programmed as 32-bit data.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  dataSize      The number of 32-bit words to program
+ *  @param[in]  data          Pointer to the data source to program into flash
+ *  @param[in]  regionSelect  The region of memory to erase. One of
+ *                            @ref DL_FLASHCTL_REGION_SELECT
+ *
+ *  @return     Whether or not the program succeeded
+ *
+ *  @retval     false   Program didn't succeed
+ *  @retval     true    Program was successful
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: This API does not enable programming the ECC code.
+ */
+bool DL_FlashCTL_programMemoryBlocking(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint32_t dataSize,
+    DL_FLASHCTL_REGION_SELECT regionSelect);
+
+/**
+ *  @brief      Programs provided data to unprotected memory at a given
+ *              address, and executes command from RAM
+ *
+ *  Blocking function that programs a set of data. Data will be programmed as
+ *  flash words (64-bits). If dataSize is an odd number, then the last word
+ *  will be programmed as 32-bit data.
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  dataSize      The number of 32-bit words to program
+ *  @param[in]  data          Pointer to the data source to program into flash
+ *  @param[in]  regionSelect  The region of memory to erase. One of
+ *                            @ref DL_FLASHCTL_REGION_SELECT
+ *
+ *  @return     Whether or not the program succeeded
+ *
+ *  @retval     false   Program didn't succeed
+ *  @retval     true    Program was successful
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: This API does not enable programming the ECC code.
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_programMemoryFromRAM(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint32_t dataSize, DL_FLASHCTL_REGION_SELECT regionSelect);
+
+/**
+ *  @brief      Unprotects all main memory from erase/program
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ */
+void DL_FlashCTL_unprotectMainMemory(FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Unprotects all data memory from erase/program
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ */
+void DL_FlashCTL_unprotectDataMemory(FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Protects all main memory from erase/program
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ */
+void DL_FlashCTL_protectMainMemory(FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Unprotects all non-main memory from erase/program
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ */
+void DL_FlashCTL_unprotectNonMainMemory(FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Protects all non-main memory from erase/program
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ */
+void DL_FlashCTL_protectNonMainMemory(FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Unprotects all user memory from erase/program
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ */
+void DL_FlashCTL_unprotectAllMemory(FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Protects all user memory from erase/program
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ */
+void DL_FlashCTL_protectAllMemory(FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Sets a given sector to unprotected from erase/program
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  addr          Address of sector to unprotect
+ *  @param[in]  regionSelect  The region of memory to unprotect. One of
+ *                            @ref DL_FLASHCTL_REGION_SELECT
+ */
+void DL_FlashCTL_unprotectSector(FLASHCTL_Regs *flashctl, uint32_t addr,
+    DL_FLASHCTL_REGION_SELECT regionSelect);
+
+/**
+ *  @brief      Sets a given sector to protected from erase/program
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  addr          Address of sector to protect
+ *  @param[in]  regionSelect  The region of memory to protect. One of
+ *                            @ref DL_FLASHCTL_REGION_SELECT
+ */
+void DL_FlashCTL_protectSector(FLASHCTL_Regs *flashctl, uint32_t addr,
+    DL_FLASHCTL_REGION_SELECT regionSelect);
+
+/**
+ *  @brief      Verifies 8-bit data in specified address
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ */
+void DL_FlashCTL_readVerify8(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data);
+
+/**
+ *  @brief      Verifies 8-bit data in specified address, and executes command
+ *              from RAM
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM8(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data);
+
+/**
+ *  @brief      Verifies 16-bit data in specified address
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ */
+void DL_FlashCTL_readVerify16(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data);
+
+/**
+ *  @brief      Verifies 16-bit data in specified address, and executes command
+ *              from RAM
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM16(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data);
+
+/**
+ *  @brief      Verifies 32-bit data in specified address
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ */
+void DL_FlashCTL_readVerify32(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Verifies 32-bit data in specified address, and executes command
+ *              from RAM
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM32(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Verifies 64-bit data in specified address
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify.
+ *  @param[in]  data        Pointer to the data source to verify
+ */
+void DL_FlashCTL_readVerify64(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Verifies 64-bit data in specified address, and executes command
+ *              from RAM
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify.
+ *  @param[in]  data        Pointer to the data source to verify
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM64(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Verifies 8-bit data in specified address with hardware
+ *              generated ECC code
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code has NOT
+ * been disabled, and so the flash controller will generate the ECC bits.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_readVerify8WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data);
+
+/**
+ *  @brief      Verifies 8-bit data in specified address with hardware generated
+ *              ECC code, and executes command from RAM
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code has NOT
+ * been disabled, and so the flash controller will generate the ECC bits.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM8WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data);
+
+/**
+ *  @brief      Verifies 16-bit data in specified address with hardware
+ *              generated ECC code
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code has NOT
+ * been disabled, and so the flash controller will generate the ECC bits.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_readVerify16WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data);
+
+/**
+ *  @brief      Verifies 16-bit data in specified address with hardware
+ *              generated ECC code, and executes command from RAM
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code has NOT
+ * been disabled, and so the flash controller will generate the ECC bits.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM16WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data);
+
+/**
+ *  @brief      Verifies 32-bit data in specified address with hardware
+ *              generated ECC code
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code has NOT
+ * been disabled, and so the flash controller will generate the ECC bits.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_readVerify32WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Verifies 32-bit data in specified address with hardware
+ *              generated ECC code, and executes command from RAM
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code has NOT
+ * been disabled, and so the flash controller will generate the ECC bits.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM32WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Verifies 64-bit data in specified address with hardware
+ *              generated ECC code
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code has NOT
+ * been disabled, and so the flash controller will generate the ECC bits.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_readVerify64WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Verifies 32-bit data in specified address with hardware
+ *              generated ECC code, and executes command from RAM
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code has NOT
+ * been disabled, and so the flash controller will generate the ECC bits.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM64WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Verifies 8-bit data in specified address with user provided ECC
+ *              code
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code HAS been
+ * disabled, so the user must provide the ECC code to program.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *  @param[in]  eccCode     Pointer to ECC code to program corresponding to data
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_readVerify8WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint8_t *data, uint8_t *eccCode);
+
+/**
+ *  @brief      Verifies 8-bit data in specified address with user provided ECC
+ *              code, and executes command from RAM
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code HAS been
+ * disabled, so the user must provide the ECC code to program.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *  @param[in]  eccCode     Pointer to ECC code to program corresponding to data
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM8WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint8_t *data,
+    uint8_t *eccCode);
+
+/**
+ *  @brief      Verifies 16-bit data in specified address with user provided ECC
+ *              code
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code HAS been
+ * disabled, so the user must provide the ECC code to program.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *  @param[in]  eccCode     Pointer to ECC code to program corresponding to data
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_readVerify16WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint16_t *data, uint8_t *eccCode);
+
+/**
+ *  @brief      Verifies 16-bit data in specified address with user provided ECC
+ *              code, and executes command from RAM
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code HAS been
+ * disabled, so the user must provide the ECC code to program.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *  @param[in]  eccCode     Pointer to ECC code to program corresponding to data
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM16WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint16_t *data,
+    uint8_t *eccCode);
+
+/**
+ *  @brief      Verifies 32-bit data in specified address with user provided ECC
+ *              code
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code HAS been
+ * disabled, so the user must provide the ECC code to program.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *  @param[in]  eccCode     Pointer to ECC code to program corresponding to data
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_readVerify32WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint8_t *eccCode);
+
+/**
+ *  @brief      Verifies 32-bit data in specified address with user provided ECC
+ *              code, and executes command from RAM
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code HAS been
+ * disabled, so the user must provide the ECC code to program.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *  @param[in]  eccCode     Pointer to ECC code to program corresponding to data
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM32WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint8_t *eccCode);
+
+/**
+ *  @brief      Verifies 64-bit data in specified address with user provided ECC
+ *              code
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code HAS been
+ * disabled, so the user must provide the ECC code to program.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *  @param[in]  eccCode     Pointer to ECC code to program corresponding to data
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_readVerify64WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint8_t *eccCode);
+
+/**
+ *  @brief      Verifies 64-bit data in specified address with user provided ECC
+ *              code, and executes command from RAM
+ *
+ * The READVERIFY command may be used to read a flash location and compare it
+ * to data to be verified along with the 8 ECC bits which correspond to the
+ * data. This API assumes that hardware generation of the ECC code HAS been
+ * disabled, so the user must provide the ECC code to program.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *  @param[in]  data        Pointer to the data source to verify
+ *  @param[in]  eccCode     Pointer to ECC code to program corresponding to data
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_readVerifyFromRAM64WithECCManual(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint8_t *eccCode);
+
+/**
+ *  @brief      Verifies that a flash word is blank
+ *
+ * A blank flash word is defined as a flash word which has been successfully
+ * erased with the ERASE command and not yet programmed away from that
+ * non-erased state with the PROGRAM command. The BLANKVERIFY command may be
+ * used to test if a flash word is in a blank state, indicating it has not yet
+ * been programmed away from an erased state. The BLANKVERIFY command may only
+ * be applied to a single flash word at a time.
+ *
+ * @post        This API just starts the command process. Check if the command
+ *              completed execution using an interrupt or the
+ *              @ref DL_FlashCTL_waitForCmdDone API.
+ * @post        @ref DL_FlashCTL_getFailureStatus should be called to determine
+ *              the result of the BLANKVERIFY command. The
+ *              @ref DL_FlashCTL_getFailureStatus API will return
+ *              @ref DL_FLASHCTL_FAIL_TYPE_VERIFY_ERROR if the flash location has
+ *              not been erased, and return @ref DL_FLASHCTL_FAIL_TYPE_NO_FAILURE
+ *              if the flash location is blank.
+ *
+ *  NOTE: After this command is executed, the flash controller will
+ *  configure all memory to a protected state.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+
+ */
+void DL_FlashCTL_blankVerify(FLASHCTL_Regs *flashctl, uint32_t address);
+
+/**
+ *  @brief      Verifies that a flash word is blank, and executes command from
+ *              RAM
+ *
+ * A blank flash word is defined as a flash word which has been successfully
+ * erased with the ERASE command and not yet programmed away from that
+ * non-erased state with the PROGRAM command. The BLANKVERIFY command may be
+ * used to test if a flash word is in a blank state, indicating it has not yet
+ * been programmed away from an erased state. The BLANKVERIFY command may only
+ * be applied to a single flash word at a time.
+ *
+ * The command is executed from RAM, and blocks until the command is finished.
+ *
+ * @post        This API just starts the command process. Check if the command
+ *              completed execution using an interrupt or the
+ *              @ref DL_FlashCTL_waitForCmdDone API.
+ * @post        @ref DL_FlashCTL_getFailureStatus should be called to determine
+ *              the result of the BLANKVERIFY command. The
+ *              @ref DL_FlashCTL_getFailureStatus API will return
+ *              @ref DL_FLASHCTL_FAIL_TYPE_VERIFY_ERROR if the flash location has
+ *              not been erased, and return @ref DL_FLASHCTL_FAIL_TYPE_NO_FAILURE
+ *              if the flash location is blank.
+ *
+ *  NOTE: After this command is executed, the flash controller will
+ *  configure all memory to a protected state.
+ *
+ *  @param[in]  flashctl    Pointer to the register overlay for the peripheral
+ *  @param[in]  address     Memory address of flash to verify
+ *
+ *  @return     Whether or not the command was successful
+ *
+ *  @retval     false if command didn't succeed
+ *  @retval     true  if command was successful
+ *
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_blankVerifyFromRAM(
+    FLASHCTL_Regs *flashctl, uint32_t address);
+
+/**
+ *  @brief      Programs 128 bit data to unprotected memory at the given address
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: This API does not enable programming the ECC code.
+ */
+void DL_FlashCTL_programMemory128(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Programs 128 bit data with hardware generated ECC code
+ *
+ *  Programs 128 bit data, along with the 16 ECC bits which correspond to the
+ *  128-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code has NOT been disabled,
+ *  and so the flash controller will generate the ECC bits.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_programMemory128WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Programs 128 bit data with hardware generated ECC code
+ *
+ *  Programs 128 bit data, along with the 16 ECC bits which correspond to the
+ *  128-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code has NOT been disabled,
+ *  and so the flash controller will generate the ECC bits.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_programMemory128WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data);
+
+/**
+ *  @brief      Programs 128 bit data with user provided ECC code
+ *
+ *  Programs 128 bit data, along with the 16 ECC bits which correspond to the
+ *  128-bit data word, to unprotected memory at the given address. This API
+ *  assumes that hardware generation of the ECC code HAS been disabled,
+ *  and so the user must provide the ECC code to program.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  data       Pointer to the 32-bit source data
+ *  @param[in]  eccCode    Pointer to the ECC code to program
+ *
+ *  @pre         User must call @ref DL_FlashCTL_enableOverrideHardwareGeneratedECC
+ *               to disable hardware generation of the ECC code, so the ECC code
+ *               can be manually provided for programming. This override setting
+ *               will persist through multiple programs, until
+ *               @ref DL_FlashCTL_disableOverrideHardwareGeneratedECC is called
+ *  @pre         Before programming memory, the user must unprotect the region
+ *               of memory to program. Refer to @ref DL_FlashCTL_unprotectSector
+ *  @post        This API just starts the program process. Check the result of it
+ *               using an interrupt or the @ref DL_FlashCTL_waitForCmdDone API
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  disable programming of the ECC code (regardless of whether ECC code is
+ *  hardware generated or manually provided).
+ */
+void DL_FlashCTL_programMemory128WithECCManual(FLASHCTL_Regs *flashctl,
+    uint32_t address, uint32_t *data, uint8_t *eccCode);
+
+/**
+ *  @brief      Programs provided data up to 128-bits with ECC generated
+ *              while blocking between writes
+ *
+ *  Blocking function that programs a set of data using multi-word programming
+ *  for up to 2 flash words. Refer to the device datasheet if the device
+ *  supports multi-word programming.
+ *  When possible, the data will be programmed as either 64-bit data or as
+ *  32-bit data.
+ *
+ *  @param[in]  flashctl   Pointer to the register overlay for the peripheral
+ *  @param[in]  address    Destination memory address to program data. The
+ *                         address must be flash word (64-bit) aligned i.e.
+ *                         aligned to a 0b000 boundary.
+ *  @param[in]  dataSize      The number of 32-bit words to program
+ *  @param[in]  data          Pointer to the data source to program into flash
+ *  @param[in]  regionSelect  The region of memory to erase. One of
+ *                            @ref DL_FLASHCTL_REGION_SELECT
+ *
+ *  @return     Whether or not the program succeeded
+ *
+ *  @retval     false   Program didn't succeed
+ *  @retval     true    Program was successful
+ *
+ *  NOTE: After completion of a program operation, the flash controller will
+ *  configure all memory to a protected state.
+ *  NOTE: This API does not enable programming the ECC code.
+ */
+bool DL_FlashCTL_programMemoryBlocking128WithECCGenerated(
+    FLASHCTL_Regs *flashctl, uint32_t address, uint32_t *data,
+    uint32_t dataSize, DL_FLASHCTL_REGION_SELECT regionSelect);
+
+/**
+ *  @brief      Performs an erase on DATA bank
+ *
+ *  Performs an erase on DATA bank only. This API should be used
+ *  on devices with a DATA bank. To determine if device has DATA
+ *  bank use @ref DL_FactoryRegion_getDATAFlashSize API.
+ *
+ *  NOTE: This API erases all of DATA bank
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Whether or not the erase succeeded
+ *
+ *  @retval     false If erase didn't succeed
+ *  @retval     true  If erase was successful
+ *
+ */
+bool DL_FlashCTL_eraseDataBank(FLASHCTL_Regs *flashctl);
+
+/**
+ *  @brief      Performs an erase on DATA bank, and executes command
+ *              from RAM
+ *
+ *  Performs an erase on DATA bank only. This API should be used
+ *  on devices with a DATA bank. To determine if device has DATA
+ *  bank use @ref DL_FactoryRegion_getDATAFlashSize API.
+ *
+ *  The command is executed from RAM, and blocks until the command is finished.
+ *
+ *  NOTE: This API erases all of DATA bank
+ *
+ *  @param[in]  flashctl  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Whether or not the erase succeeded
+ *
+ *  @retval     DL_FLASHCTL_COMMAND_STATUS_FAILED If erase didn't succeed
+ *  @retval     DL_FLASHCTL_COMMAND_STATUS_PASSED If erase was successful
+ *
+ */
+DL_FLASHCTL_COMMAND_STATUS DL_FlashCTL_eraseDataBankFromRAM(
+    FLASHCTL_Regs *flashctl);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_dl_dl_flashctl__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_gpamp.h
+++ b/mspm0/source/ti/driverlib/dl_gpamp.h
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_gpamp.h
+ *  @brief      General Purpose Amplifier (GPAMP)
+ *  @defgroup   GPAMP General Purpose Amplifier (GPAMP)
+ *
+ ******************************************************************************
+ */
+/** @addtogroup GPAMP
+ * @{
+ */
+#ifndef ti_dl_m0p_dl_gpamp__include
+#define ti_dl_m0p_dl_gpamp__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_GPAMP__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*! @enum DL_GPAMP_NSEL */
+typedef enum {
+    /*! Inverting input channel is the output pin */
+    DL_GPAMP_NSEL_OUTPUT_PIN = SYSCTL_PMUOPAMP_NSEL_SEL0,
+    /*! Inverting input channel is the IN- pin */
+    DL_GPAMP_NSEL_IN_NEG = SYSCTL_PMUOPAMP_NSEL_SEL1,
+    /*! Inverting input channel is  internal GPAMP output */
+    DL_GPAMP_NSEL_INTERNAL_OUTPUT = SYSCTL_PMUOPAMP_NSEL_SEL2,
+    /*! No channel selected for the inverting input channel */
+    DL_GPAMP_NSEL_OPEN = SYSCTL_PMUOPAMP_NSEL_SEL3,
+} DL_GPAMP_NSEL;
+
+/*! @enum DL_GPAMP_PSEL */
+typedef enum {
+    /*! Non-Inverting input channel is disabled */
+    DL_GPAMP_PSEL_OPEN = SYSCTL_PMUOPAMP_PCHENABLE_FALSE,
+    /*! Non-Inverting input channel is enabled */
+    DL_GPAMP_PSEL_IN_POS = SYSCTL_PMUOPAMP_PCHENABLE_TRUE,
+} DL_GPAMP_PSEL;
+
+/*! @enum DL_GPAMP_OUTPUT_PIN_STATE */
+typedef enum {
+    /*! Output pin is disabled */
+    DL_GPAMP_OUTPUT_PIN_STATE_DISABLED = SYSCTL_PMUOPAMP_OUTENABLE_FALSE,
+    /*! Output pin is enabled */
+    DL_GPAMP_OUTPUT_PIN_STATE_ENABLED = SYSCTL_PMUOPAMP_OUTENABLE_TRUE,
+} DL_GPAMP_OUTPUT_PIN_STATE;
+
+/*! @enum DL_GPAMP_RRI_MODE */
+typedef enum {
+    /*! RRI mode is PMOS input pairs mode */
+    DL_GPAMP_RRI_MODE_PMOS_INPUT = SYSCTL_PMUOPAMP_RRI_MODE0,
+    /*! RRI mode is NMOS input pairs */
+    DL_GPAMP_RRI_MODE_NMOS_INPUT = SYSCTL_PMUOPAMP_RRI_MODE1,
+    /*! RRI mode is rail to rail*/
+    DL_GPAMP_RRI_MODE_RAIL_TO_RAIL = SYSCTL_PMUOPAMP_RRI_MODE2,
+    /*! RRI mode is sample channel 0*/
+    DL_GPAMP_RRI_MODE_SAMPLE_CHANNEL_0 = SYSCTL_PMUOPAMP_RRI_MODE3,
+
+} DL_GPAMP_RRI_MODE;
+
+/*! @enum DL_GPAMP_CHOPPING_FREQ */
+typedef enum {
+    /*! Chopping clock frequency is 16KHZ */
+    DL_GPAMP_CHOPPING_FREQ_16KHZ = SYSCTL_PMUOPAMP_CHOPCLKFREQ_CLK16KHZ,
+    /*! Chopping clock frequency is 8KHZ */
+    DL_GPAMP_CHOPPING_FREQ_8KHZ = SYSCTL_PMUOPAMP_CHOPCLKFREQ_CLK8KHZ,
+    /*! Chopping clock frequency is 4KHZ */
+    DL_GPAMP_CHOPPING_FREQ_4KHZ = SYSCTL_PMUOPAMP_CHOPCLKFREQ_CLK4KHZ,
+    /*! Chopping clock frequency is 2KHZ */
+    DL_GPAMP_CHOPPING_FREQ_2KHZ = SYSCTL_PMUOPAMP_CHOPCLKFREQ_CLK2KHZ,
+} DL_GPAMP_CHOPPING_FREQ;
+
+/*! @enum DL_GPAMP_CHOPPING_MODE */
+typedef enum {
+    /*! Chopping is disabled */
+    DL_GPAMP_CHOPPING_MODE_DISABLED = SYSCTL_PMUOPAMP_CHOPCLKMODE_CHOPDISABLED,
+    /*! Chopping mode is standard chop */
+    DL_GPAMP_CHOPPING_MODE_STANDARD = SYSCTL_PMUOPAMP_CHOPCLKMODE_REGCHOP,
+    /*! Chopping mode is ADC assisted chop */
+    DL_GPAMP_CHOPPING_MODE_ADC_ASSISTED =
+        SYSCTL_PMUOPAMP_CHOPCLKMODE_ADCASSIST,
+} DL_GPAMP_CHOPPING_MODE;
+
+/*!
+ *  @brief  Configuration struct for @ref DL_GPAMP_init
+ */
+typedef struct {
+    /*! The chopping mode to set. One of @ref DL_GPAMP_CHOPPING_MODE */
+    DL_GPAMP_CHOPPING_MODE choppingMode;
+    /*! The chopping frequency to set. One of @ref DL_GPAMP_CHOPPING_FREQ */
+    DL_GPAMP_CHOPPING_FREQ choppingFreq;
+    /*! The state of the output pin. One of @ref DL_GPAMP_OUTPUT_PIN_STATE. */
+    DL_GPAMP_OUTPUT_PIN_STATE outputPinState;
+    /*! The non-inverting input channel to set. One of @ref DL_GPAMP_PSEL */
+    DL_GPAMP_PSEL pselChannel;
+    /*! The inverting input channel to set. One of @ref DL_GPAMP_NSEL */
+    DL_GPAMP_NSEL nselChannel;
+} DL_GPAMP_Config;
+
+/* clang-format on */
+
+/**
+ *  @brief      Enable the GPAMP peripheral
+ */
+__STATIC_INLINE void DL_GPAMP_enable(void)
+{
+    SYSCTL->SOCLOCK.PMUOPAMP |= SYSCTL_PMUOPAMP_ENABLE_TRUE;
+}
+
+/**
+ *  @brief      Checks if the GPAMP peripheral is enabled
+ *
+ *  @return     Returns the enabled status of the GPAMP
+ *
+ *  @retval     true  The GPAMP peripheral is enabled
+ *  @retval     false The GPAMP peripheral is disabled
+ */
+__STATIC_INLINE bool DL_GPAMP_isEnabled(void)
+{
+    return ((SYSCTL->SOCLOCK.PMUOPAMP & SYSCTL_PMUOPAMP_ENABLE_MASK) ==
+            SYSCTL_PMUOPAMP_ENABLE_TRUE);
+}
+
+/**
+ *  @brief      Disable the GPAMP peripheral
+ */
+__STATIC_INLINE void DL_GPAMP_disable(void)
+{
+    SYSCTL->SOCLOCK.PMUOPAMP &= ~(SYSCTL_PMUOPAMP_ENABLE_MASK);
+}
+
+/**
+ *  @brief      Initialize the GPAmp peripheral
+ *
+ *  Initializes all the common configurable options for the GPAmp peripheral.
+ *  Any other custom configuration can be done after calling this API.
+ *  The GPAmp is not enabled in this API.
+ *
+ *  @param[in]  config  Configuration for gpamp peripheral
+ */
+__STATIC_INLINE void DL_GPAMP_init(DL_GPAMP_Config *config)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.PMUOPAMP,
+        (uint32_t) config->choppingMode | (uint32_t) config->choppingFreq |
+            (uint32_t) config->outputPinState |
+            (uint32_t) config->pselChannel | (uint32_t) config->nselChannel,
+        SYSCTL_PMUOPAMP_CHOPCLKMODE_MASK | SYSCTL_PMUOPAMP_CHOPCLKFREQ_MASK |
+            SYSCTL_PMUOPAMP_OUTENABLE_MASK | SYSCTL_PMUOPAMP_PCHENABLE_MASK |
+            SYSCTL_PMUOPAMP_NSEL_MASK);
+}
+
+/**
+ *  @brief      Enable the non-inverting input channel
+ */
+__STATIC_INLINE void DL_GPAMP_enableNonInvertingInputChannel(void)
+{
+    SYSCTL->SOCLOCK.PMUOPAMP |= SYSCTL_PMUOPAMP_PCHENABLE_TRUE;
+}
+
+/**
+ *  @brief      Checks if the non-inverting input channel is enabled
+ *
+ *  @return     Returns the enabled status of the GPAMP
+ *
+ *  @retval     true  The non-inverting input channel is enabled
+ *  @retval     false The non-inverting input channel is disabled
+ */
+__STATIC_INLINE bool DL_GPAMP_isNonInvertingInputChannelEnabled(void)
+{
+    return ((SYSCTL->SOCLOCK.PMUOPAMP & SYSCTL_PMUOPAMP_PCHENABLE_MASK) ==
+            SYSCTL_PMUOPAMP_PCHENABLE_TRUE);
+}
+
+/**
+ *  @brief      Disable the non-inverting input channel
+ */
+__STATIC_INLINE void DL_GPAMP_disableNonInvertingInputChannel(void)
+{
+    SYSCTL->SOCLOCK.PMUOPAMP &= ~(SYSCTL_PMUOPAMP_PCHENABLE_MASK);
+}
+
+/**
+ *  @brief      Set the inverting input channel
+ *
+ *  @param[in]  inputChannel  The inverting input channel to set.
+ *                            One of @ref DL_GPAMP_NSEL.
+ */
+__STATIC_INLINE void DL_GPAMP_setInvertingInputChannel(
+    DL_GPAMP_NSEL inputChannel)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.PMUOPAMP, (uint32_t) inputChannel,
+        SYSCTL_PMUOPAMP_NSEL_MASK);
+}
+
+/**
+ *  @brief      Get the inverting input channel
+ *
+ *  @return     The current inverting input channel
+ *
+ *  @retval     One of @ref DL_GPAMP_NSEL
+ */
+__STATIC_INLINE DL_GPAMP_NSEL DL_GPAMP_getInvertingInputChannel(void)
+{
+    uint32_t nsel = (SYSCTL->SOCLOCK.PMUOPAMP & SYSCTL_PMUOPAMP_NSEL_MASK);
+
+    return (DL_GPAMP_NSEL)(nsel);
+}
+
+/**
+ *  @brief      Set the rail-to-rail input (RRI) mode
+ *
+ *  @param[in]  mode  The RRI mode to set. One of @ref DL_GPAMP_RRI_MODE.
+ */
+__STATIC_INLINE void DL_GPAMP_setRailToRailInputMode(DL_GPAMP_RRI_MODE mode)
+{
+    DL_Common_updateReg(
+        &SYSCTL->SOCLOCK.PMUOPAMP, (uint32_t) mode, SYSCTL_PMUOPAMP_RRI_MASK);
+}
+
+/**
+ *  @brief      Get the rail-to-rail input (RRI) mode
+ *
+ *  @return     The current RRI mode
+ *
+ *  @retval     One of @ref DL_GPAMP_RRI_MODE
+ */
+__STATIC_INLINE DL_GPAMP_RRI_MODE DL_GPAMP_getRailToRailInputMode(void)
+{
+    uint32_t mode = (SYSCTL->SOCLOCK.PMUOPAMP & SYSCTL_PMUOPAMP_RRI_MASK);
+
+    return (DL_GPAMP_RRI_MODE)(mode);
+}
+
+/**
+ *  @brief      Enable output to pad
+ */
+__STATIC_INLINE void DL_GPAMP_enableOutputToPad(void)
+{
+    SYSCTL->SOCLOCK.PMUOPAMP |= SYSCTL_PMUOPAMP_OUTENABLE_TRUE;
+}
+
+/**
+ *  @brief      Checks if output to pad is enabled
+ *
+ *  @return     Returns if output to pad is enabled
+ *
+ *  @retval     true  Output to pad is enabled
+ *  @retval     false Output to pad is disabled
+ */
+__STATIC_INLINE bool DL_GPAMP_isOutputToPadEnabled(void)
+{
+    return ((SYSCTL->SOCLOCK.PMUOPAMP & SYSCTL_PMUOPAMP_OUTENABLE_MASK) ==
+            SYSCTL_PMUOPAMP_OUTENABLE_TRUE);
+}
+
+/**
+ *  @brief      Disable output to pad
+ */
+__STATIC_INLINE void DL_GPAMP_disableOutputToPad(void)
+{
+    SYSCTL->SOCLOCK.PMUOPAMP &= ~(SYSCTL_PMUOPAMP_OUTENABLE_MASK);
+}
+
+/**
+ *  @brief      Set the chopping clock frequency
+ *
+ *  @param[in]  frequency  The chopping frequency to set.
+ *                         One of @ref DL_GPAMP_CHOPPING_FREQ
+ */
+__STATIC_INLINE void DL_GPAMP_setChoppingFrequency(
+    DL_GPAMP_CHOPPING_FREQ frequency)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.PMUOPAMP, (uint32_t) frequency,
+        SYSCTL_PMUOPAMP_CHOPCLKFREQ_MASK);
+}
+
+/**
+ *  @brief      Get the chopping clock frequency
+ *
+ *  @return     The current chopping frequency
+ *
+ *  @retval     One of @ref DL_GPAMP_CHOPPING_FREQ
+ */
+__STATIC_INLINE DL_GPAMP_CHOPPING_FREQ DL_GPAMP_getChoppingFrequency(void)
+{
+    uint32_t freq =
+        (SYSCTL->SOCLOCK.PMUOPAMP & SYSCTL_PMUOPAMP_CHOPCLKFREQ_MASK);
+
+    return (DL_GPAMP_CHOPPING_FREQ)(freq);
+}
+
+/**
+ *  @brief      Set the chopping mode
+ *
+ *  @param[in]  mode  The chopping mode to set.
+ *                         One of @ref DL_GPAMP_CHOPPING_MODE
+ */
+__STATIC_INLINE void DL_GPAMP_setChoppingMode(DL_GPAMP_CHOPPING_MODE mode)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.PMUOPAMP, (uint32_t) mode,
+        SYSCTL_PMUOPAMP_CHOPCLKMODE_MASK);
+}
+
+/**
+ *  @brief      Get the chopping mode
+ *
+ *  @return     The current chopping mode
+ *
+ *  @retval     One of @ref DL_GPAMP_CHOPPING_MODE
+ */
+__STATIC_INLINE DL_GPAMP_CHOPPING_MODE DL_GPAMP_getChoppingMode(void)
+{
+    uint32_t mode =
+        (SYSCTL->SOCLOCK.PMUOPAMP & SYSCTL_PMUOPAMP_CHOPCLKMODE_MASK);
+
+    return (DL_GPAMP_CHOPPING_MODE)(mode);
+}
+
+/* clang-format on */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_GPAMP__ */
+
+#endif /* ti_dl_m0p_dl_gpamp__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_gpio.h
+++ b/mspm0/source/ti/driverlib/dl_gpio.h
@@ -1,0 +1,2907 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_gpio.h
+ *  @brief      General Purpose Input/Output Driver Library
+ *  @defgroup   GPIO General Purpose Input/Output (GPIO)
+ *
+ *  @anchor ti_dl_dl_gpio_Overview
+ *  # Overview
+ *
+ *  The GPIO Driver Library allows full configuration of
+ *  the MSPM0 GPIO module. The GPIO peripheral provides the user with a means
+ *  to write data out and read data in to and from the device pins.
+ *  It also provides a way to detect wakeup events while the device is in a
+ *  low power state.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup GPIO
+ * @{
+ */
+#ifndef ti_dl_dl_gpio__include
+#define ti_dl_dl_gpio__include
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_GPIO__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_GPIO_PIN
+ *  @{
+ */
+/*!
+ * @brief GPIO Pin 0
+ */
+#define DL_GPIO_PIN_0                                               (0x00000001)
+
+/*!
+ * @brief GPIO Pin 1
+ */
+#define DL_GPIO_PIN_1                                               (0x00000002)
+
+/*!
+ * @brief GPIO Pin 2
+ */
+#define DL_GPIO_PIN_2                                               (0x00000004)
+
+/*!
+ * @brief GPIO Pin 3
+ */
+#define DL_GPIO_PIN_3                                               (0x00000008)
+
+/*!
+ * @brief GPIO Pin 4
+ */
+#define DL_GPIO_PIN_4                                               (0x00000010)
+
+/*!
+ * @brief GPIO Pin 5
+ */
+#define DL_GPIO_PIN_5                                               (0x00000020)
+
+/*!
+ * @brief GPIO Pin 6
+ */
+#define DL_GPIO_PIN_6                                               (0x00000040)
+
+/*!
+ * @brief GPIO Pin 7
+ */
+#define DL_GPIO_PIN_7                                               (0x00000080)
+
+/*!
+ * @brief GPIO Pin 8
+ */
+#define DL_GPIO_PIN_8                                               (0x00000100)
+
+/*!
+ * @brief GPIO Pin 9
+ */
+#define DL_GPIO_PIN_9                                               (0x00000200)
+
+/*!
+ * @brief GPIO Pin 10
+ */
+#define DL_GPIO_PIN_10                                              (0x00000400)
+
+/*!
+ * @brief GPIO Pin 11
+ */
+#define DL_GPIO_PIN_11                                              (0x00000800)
+
+/*!
+ * @brief GPIO Pin 12
+ */
+#define DL_GPIO_PIN_12                                              (0x00001000)
+
+/*!
+ * @brief GPIO Pin 13
+ */
+#define DL_GPIO_PIN_13                                              (0x00002000)
+
+/*!
+ * @brief GPIO Pin 14
+ */
+#define DL_GPIO_PIN_14                                              (0x00004000)
+
+/*!
+ * @brief GPIO Pin 15
+ */
+#define DL_GPIO_PIN_15                                              (0x00008000)
+
+/*!
+ * @brief GPIO Pin 16
+ */
+#define DL_GPIO_PIN_16                                              (0x00010000)
+
+/*!
+ * @brief GPIO Pin 17
+ */
+#define DL_GPIO_PIN_17                                              (0x00020000)
+
+/*!
+ * @brief GPIO Pin 18
+ */
+#define DL_GPIO_PIN_18                                              (0x00040000)
+
+/*!
+ * @brief GPIO Pin 19
+ */
+#define DL_GPIO_PIN_19                                              (0x00080000)
+
+/*!
+ * @brief GPIO Pin 20
+ */
+#define DL_GPIO_PIN_20                                              (0x00100000)
+
+/*!
+ * @brief GPIO Pin 21
+ */
+#define DL_GPIO_PIN_21                                              (0x00200000)
+
+/*!
+ * @brief GPIO Pin 22
+ */
+#define DL_GPIO_PIN_22                                              (0x00400000)
+
+/*!
+ * @brief GPIO Pin 23
+ */
+#define DL_GPIO_PIN_23                                              (0x00800000)
+
+/*!
+ * @brief GPIO Pin 24
+ */
+#define DL_GPIO_PIN_24                                              (0x01000000)
+
+/*!
+ * @brief GPIO Pin 25
+ */
+#define DL_GPIO_PIN_25                                              (0x02000000)
+
+/*!
+ * @brief GPIO Pin 26
+ */
+#define DL_GPIO_PIN_26                                              (0x04000000)
+
+/*!
+ * @brief GPIO Pin 27
+ */
+#define DL_GPIO_PIN_27                                              (0x08000000)
+
+/*!
+ * @brief GPIO Pin 28
+ */
+#define DL_GPIO_PIN_28                                              (0x10000000)
+
+/*!
+ * @brief GPIO Pin 29
+ */
+#define DL_GPIO_PIN_29                                              (0x20000000)
+
+/*!
+ * @brief GPIO Pin 30
+ */
+#define DL_GPIO_PIN_30                                              (0x40000000)
+
+/*!
+ * @brief GPIO Pin 31
+ */
+#define DL_GPIO_PIN_31                                              (0x80000000)
+
+/** @}*/
+
+/** @addtogroup DL_GPIO_EDGE_POLARITY
+ *  @{
+ */
+/*!
+ * @brief GPIO Pin 0, disable edge detection
+ */
+#define DL_GPIO_PIN_0_EDGE_DISABLE              (GPIO_POLARITY15_0_DIO0_DISABLE)
+
+/*!
+ * @brief GPIO Pin 0, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_0_EDGE_RISE                    (GPIO_POLARITY15_0_DIO0_RISE)
+
+/*!
+ * @brief GPIO Pin 0, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_0_EDGE_FALL                    (GPIO_POLARITY15_0_DIO0_FALL)
+
+/*!
+ * @brief GPIO Pin 0, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_0_EDGE_RISE_FALL          (GPIO_POLARITY15_0_DIO0_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 1, disable edge detection
+ */
+#define DL_GPIO_PIN_1_EDGE_DISABLE              (GPIO_POLARITY15_0_DIO1_DISABLE)
+
+/*!
+ * @brief GPIO Pin 1, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_1_EDGE_RISE                    (GPIO_POLARITY15_0_DIO1_RISE)
+
+/*!
+ * @brief GPIO Pin 1, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_1_EDGE_FALL                    (GPIO_POLARITY15_0_DIO1_FALL)
+
+/*!
+ * @brief GPIO Pin 1, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_1_EDGE_RISE_FALL          (GPIO_POLARITY15_0_DIO1_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 2, disable edge detection
+ */
+#define DL_GPIO_PIN_2_EDGE_DISABLE              (GPIO_POLARITY15_0_DIO2_DISABLE)
+
+/*!
+ * @brief GPIO Pin 2, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_2_EDGE_RISE                    (GPIO_POLARITY15_0_DIO2_RISE)
+
+/*!
+ * @brief GPIO Pin 2, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_2_EDGE_FALL                    (GPIO_POLARITY15_0_DIO2_FALL)
+
+/*!
+ * @brief GPIO Pin 2, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_2_EDGE_RISE_FALL          (GPIO_POLARITY15_0_DIO2_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 3, disable edge detection
+ */
+#define DL_GPIO_PIN_3_EDGE_DISABLE              (GPIO_POLARITY15_0_DIO3_DISABLE)
+
+/*!
+ * @brief GPIO Pin 3, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_3_EDGE_RISE                    (GPIO_POLARITY15_0_DIO3_RISE)
+
+/*!
+ * @brief GPIO Pin 3, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_3_EDGE_FALL                    (GPIO_POLARITY15_0_DIO3_FALL)
+
+/*!
+ * @brief GPIO Pin 3, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_3_EDGE_RISE_FALL          (GPIO_POLARITY15_0_DIO3_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 4, disable edge detection
+ */
+#define DL_GPIO_PIN_4_EDGE_DISABLE              (GPIO_POLARITY15_0_DIO4_DISABLE)
+
+/*!
+ * @brief GPIO Pin 4, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_4_EDGE_RISE                    (GPIO_POLARITY15_0_DIO4_RISE)
+
+/*!
+ * @brief GPIO Pin 4, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_4_EDGE_FALL                    (GPIO_POLARITY15_0_DIO4_FALL)
+
+/*!
+ * @brief GPIO Pin 4, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_4_EDGE_RISE_FALL          (GPIO_POLARITY15_0_DIO4_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 5, disable edge detection
+ */
+#define DL_GPIO_PIN_5_EDGE_DISABLE              (GPIO_POLARITY15_0_DIO5_DISABLE)
+
+/*!
+ * @brief GPIO Pin 5, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_5_EDGE_RISE                    (GPIO_POLARITY15_0_DIO5_RISE)
+
+/*!
+ * @brief GPIO Pin 5, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_5_EDGE_FALL                    (GPIO_POLARITY15_0_DIO5_FALL)
+
+/*!
+ * @brief GPIO Pin 5, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_5_EDGE_RISE_FALL          (GPIO_POLARITY15_0_DIO5_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 6, disable edge detection
+ */
+#define DL_GPIO_PIN_6_EDGE_DISABLE              (GPIO_POLARITY15_0_DIO6_DISABLE)
+
+/*!
+ * @brief GPIO Pin 6, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_6_EDGE_RISE                    (GPIO_POLARITY15_0_DIO6_RISE)
+
+/*!
+ * @brief GPIO Pin 6, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_6_EDGE_FALL                    (GPIO_POLARITY15_0_DIO6_FALL)
+
+/*!
+ * @brief GPIO Pin 6, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_6_EDGE_RISE_FALL          (GPIO_POLARITY15_0_DIO6_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 7, disable edge detection
+ */
+#define DL_GPIO_PIN_7_EDGE_DISABLE              (GPIO_POLARITY15_0_DIO7_DISABLE)
+
+/*!
+ * @brief GPIO Pin 7, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_7_EDGE_RISE                    (GPIO_POLARITY15_0_DIO7_RISE)
+
+/*!
+ * @brief GPIO Pin 7, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_7_EDGE_FALL                    (GPIO_POLARITY15_0_DIO7_FALL)
+
+/*!
+ * @brief GPIO Pin 7, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_7_EDGE_RISE_FALL          (GPIO_POLARITY15_0_DIO7_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 8, disable edge detection
+ */
+#define DL_GPIO_PIN_8_EDGE_DISABLE              (GPIO_POLARITY15_0_DIO8_DISABLE)
+
+/*!
+ * @brief GPIO Pin 8, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_8_EDGE_RISE                    (GPIO_POLARITY15_0_DIO8_RISE)
+
+/*!
+ * @brief GPIO Pin 8, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_8_EDGE_FALL                    (GPIO_POLARITY15_0_DIO8_FALL)
+
+/*!
+ * @brief GPIO Pin 8, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_8_EDGE_RISE_FALL          (GPIO_POLARITY15_0_DIO8_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 9, disable edge detection
+ */
+#define DL_GPIO_PIN_9_EDGE_DISABLE              (GPIO_POLARITY15_0_DIO9_DISABLE)
+
+/*!
+ * @brief GPIO Pin 9, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_9_EDGE_RISE                    (GPIO_POLARITY15_0_DIO9_RISE)
+
+/*!
+ * @brief GPIO Pin 9, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_9_EDGE_FALL                    (GPIO_POLARITY15_0_DIO9_FALL)
+
+/*!
+ * @brief GPIO Pin 9, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_9_EDGE_RISE_FALL          (GPIO_POLARITY15_0_DIO9_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 10, disable edge detection
+ */
+#define DL_GPIO_PIN_10_EDGE_DISABLE            (GPIO_POLARITY15_0_DIO10_DISABLE)
+
+/*!
+ * @brief GPIO Pin 10, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_10_EDGE_RISE                  (GPIO_POLARITY15_0_DIO10_RISE)
+
+/*!
+ * @brief GPIO Pin 10, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_10_EDGE_FALL                  (GPIO_POLARITY15_0_DIO10_FALL)
+
+/*!
+ * @brief GPIO Pin 10, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_10_EDGE_RISE_FALL        (GPIO_POLARITY15_0_DIO10_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 11, disable edge detection
+ */
+#define DL_GPIO_PIN_11_EDGE_DISABLE            (GPIO_POLARITY15_0_DIO11_DISABLE)
+
+/*!
+ * @brief GPIO Pin 11, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_11_EDGE_RISE                  (GPIO_POLARITY15_0_DIO11_RISE)
+
+/*!
+ * @brief GPIO Pin 11, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_11_EDGE_FALL                  (GPIO_POLARITY15_0_DIO11_FALL)
+
+/*!
+ * @brief GPIO Pin 11, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_11_EDGE_RISE_FALL        (GPIO_POLARITY15_0_DIO11_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 12, disable edge detection
+ */
+#define DL_GPIO_PIN_12_EDGE_DISABLE            (GPIO_POLARITY15_0_DIO12_DISABLE)
+
+/*!
+ * @brief GPIO Pin 12, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_12_EDGE_RISE                  (GPIO_POLARITY15_0_DIO12_RISE)
+
+/*!
+ * @brief GPIO Pin 12, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_12_EDGE_FALL                  (GPIO_POLARITY15_0_DIO12_FALL)
+
+/*!
+ * @brief GPIO Pin 12, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_12_EDGE_RISE_FALL        (GPIO_POLARITY15_0_DIO12_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 13, disable edge detection
+ */
+#define DL_GPIO_PIN_13_EDGE_DISABLE            (GPIO_POLARITY15_0_DIO13_DISABLE)
+
+/*!
+ * @brief GPIO Pin 13, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_13_EDGE_RISE                  (GPIO_POLARITY15_0_DIO13_RISE)
+
+/*!
+ * @brief GPIO Pin 13, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_13_EDGE_FALL                  (GPIO_POLARITY15_0_DIO13_FALL)
+
+/*!
+ * @brief GPIO Pin 13, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_13_EDGE_RISE_FALL        (GPIO_POLARITY15_0_DIO13_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 14, disable edge detection
+ */
+#define DL_GPIO_PIN_14_EDGE_DISABLE            (GPIO_POLARITY15_0_DIO14_DISABLE)
+
+/*!
+ * @brief GPIO Pin 14, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_14_EDGE_RISE                  (GPIO_POLARITY15_0_DIO14_RISE)
+
+/*!
+ * @brief GPIO Pin 14, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_14_EDGE_FALL                  (GPIO_POLARITY15_0_DIO14_FALL)
+
+/*!
+ * @brief GPIO Pin 14, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_14_EDGE_RISE_FALL        (GPIO_POLARITY15_0_DIO14_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 15, disable edge detection
+ */
+#define DL_GPIO_PIN_15_EDGE_DISABLE            (GPIO_POLARITY15_0_DIO15_DISABLE)
+
+/*!
+ * @brief GPIO Pin 15, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_15_EDGE_RISE                  (GPIO_POLARITY15_0_DIO15_RISE)
+
+/*!
+ * @brief GPIO Pin 15, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_15_EDGE_FALL                  (GPIO_POLARITY15_0_DIO15_FALL)
+
+/*!
+ * @brief GPIO Pin 15, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_15_EDGE_RISE_FALL        (GPIO_POLARITY15_0_DIO15_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 16, disable edge detection
+ */
+#define DL_GPIO_PIN_16_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO16_DISABLE)
+
+/*!
+ * @brief GPIO Pin 16, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_16_EDGE_RISE                 (GPIO_POLARITY31_16_DIO16_RISE)
+
+/*!
+ * @brief GPIO Pin 16, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_16_EDGE_FALL                 (GPIO_POLARITY31_16_DIO16_FALL)
+
+/*!
+ * @brief GPIO Pin 16, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_16_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO16_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 17, disable edge detection
+ */
+#define DL_GPIO_PIN_17_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO17_DISABLE)
+
+/*!
+ * @brief GPIO Pin 17, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_17_EDGE_RISE                 (GPIO_POLARITY31_16_DIO17_RISE)
+
+/*!
+ * @brief GPIO Pin 17, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_17_EDGE_FALL                 (GPIO_POLARITY31_16_DIO17_FALL)
+
+/*!
+ * @brief GPIO Pin 17, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_17_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO17_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 18, disable edge detection
+ */
+#define DL_GPIO_PIN_18_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO18_DISABLE)
+
+/*!
+ * @brief GPIO Pin 18, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_18_EDGE_RISE                 (GPIO_POLARITY31_16_DIO18_RISE)
+
+/*!
+ * @brief GPIO Pin 18, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_18_EDGE_FALL                 (GPIO_POLARITY31_16_DIO18_FALL)
+
+/*!
+ * @brief GPIO Pin 18, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_18_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO18_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 19, disable edge detection
+ */
+#define DL_GPIO_PIN_19_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO19_DISABLE)
+
+/*!
+ * @brief GPIO Pin 19, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_19_EDGE_RISE                 (GPIO_POLARITY31_16_DIO19_RISE)
+
+/*!
+ * @brief GPIO Pin 19, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_19_EDGE_FALL                 (GPIO_POLARITY31_16_DIO19_FALL)
+
+/*!
+ * @brief GPIO Pin 19, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_19_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO19_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 20, disable edge detection
+ */
+#define DL_GPIO_PIN_20_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO20_DISABLE)
+
+/*!
+ * @brief GPIO Pin 20, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_20_EDGE_RISE                 (GPIO_POLARITY31_16_DIO20_RISE)
+
+/*!
+ * @brief GPIO Pin 20, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_20_EDGE_FALL                 (GPIO_POLARITY31_16_DIO20_FALL)
+
+/*!
+ * @brief GPIO Pin 20, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_20_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO20_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 21, disable edge detection
+ */
+#define DL_GPIO_PIN_21_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO21_DISABLE)
+
+/*!
+ * @brief GPIO Pin 21, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_21_EDGE_RISE                 (GPIO_POLARITY31_16_DIO21_RISE)
+
+/*!
+ * @brief GPIO Pin 21, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_21_EDGE_FALL                 (GPIO_POLARITY31_16_DIO21_FALL)
+
+/*!
+ * @brief GPIO Pin 21, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_21_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO21_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 22, disable edge detection
+ */
+#define DL_GPIO_PIN_22_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO22_DISABLE)
+
+/*!
+ * @brief GPIO Pin 22, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_22_EDGE_RISE                 (GPIO_POLARITY31_16_DIO22_RISE)
+
+/*!
+ * @brief GPIO Pin 22, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_22_EDGE_FALL                 (GPIO_POLARITY31_16_DIO22_FALL)
+
+/*!
+ * @brief GPIO Pin 22, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_22_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO22_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 23, disable edge detection
+ */
+#define DL_GPIO_PIN_23_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO23_DISABLE)
+
+/*!
+ * @brief GPIO Pin 23, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_23_EDGE_RISE                 (GPIO_POLARITY31_16_DIO23_RISE)
+
+/*!
+ * @brief GPIO Pin 23, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_23_EDGE_FALL                 (GPIO_POLARITY31_16_DIO23_FALL)
+
+/*!
+ * @brief GPIO Pin 23, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_23_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO23_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 24, disable edge detection
+ */
+#define DL_GPIO_PIN_24_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO24_DISABLE)
+
+/*!
+ * @brief GPIO Pin 24, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_24_EDGE_RISE                 (GPIO_POLARITY31_16_DIO24_RISE)
+
+/*!
+ * @brief GPIO Pin 24, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_24_EDGE_FALL                 (GPIO_POLARITY31_16_DIO24_FALL)
+
+/*!
+ * @brief GPIO Pin 24, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_24_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO24_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 25, disable edge detection
+ */
+#define DL_GPIO_PIN_25_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO25_DISABLE)
+
+/*!
+ * @brief GPIO Pin 25, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_25_EDGE_RISE                 (GPIO_POLARITY31_16_DIO25_RISE)
+
+/*!
+ * @brief GPIO Pin 25, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_25_EDGE_FALL                 (GPIO_POLARITY31_16_DIO25_FALL)
+
+/*!
+ * @brief GPIO Pin 25, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_25_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO25_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 26, disable edge detection
+ */
+#define DL_GPIO_PIN_26_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO26_DISABLE)
+
+/*!
+ * @brief GPIO Pin 26, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_26_EDGE_RISE                 (GPIO_POLARITY31_16_DIO26_RISE)
+
+/*!
+ * @brief GPIO Pin 26, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_26_EDGE_FALL                 (GPIO_POLARITY31_16_DIO26_FALL)
+
+/*!
+ * @brief GPIO Pin 26, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_26_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO26_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 27, disable edge detection
+ */
+#define DL_GPIO_PIN_27_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO27_DISABLE)
+
+/*!
+ * @brief GPIO Pin 27, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_27_EDGE_RISE                 (GPIO_POLARITY31_16_DIO27_RISE)
+
+/*!
+ * @brief GPIO Pin 27, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_27_EDGE_FALL                 (GPIO_POLARITY31_16_DIO27_FALL)
+
+/*!
+ * @brief GPIO Pin 27, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_27_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO27_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 28, disable edge detection
+ */
+#define DL_GPIO_PIN_28_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO28_DISABLE)
+
+/*!
+ * @brief GPIO Pin 28, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_28_EDGE_RISE                 (GPIO_POLARITY31_16_DIO28_RISE)
+
+/*!
+ * @brief GPIO Pin 28, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_28_EDGE_FALL                 (GPIO_POLARITY31_16_DIO28_FALL)
+
+/*!
+ * @brief GPIO Pin 28, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_28_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO28_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 29, disable edge detection
+ */
+#define DL_GPIO_PIN_29_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO29_DISABLE)
+
+/*!
+ * @brief GPIO Pin 29, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_29_EDGE_RISE                 (GPIO_POLARITY31_16_DIO29_RISE)
+
+/*!
+ * @brief GPIO Pin 29, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_29_EDGE_FALL                 (GPIO_POLARITY31_16_DIO29_FALL)
+
+/*!
+ * @brief GPIO Pin 29, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_29_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO29_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 30, disable edge detection
+ */
+#define DL_GPIO_PIN_30_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO30_DISABLE)
+
+/*!
+ * @brief GPIO Pin 30, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_30_EDGE_RISE                 (GPIO_POLARITY31_16_DIO30_RISE)
+
+/*!
+ * @brief GPIO Pin 30, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_30_EDGE_FALL                 (GPIO_POLARITY31_16_DIO30_FALL)
+
+/*!
+ * @brief GPIO Pin 30, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_30_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO30_RISE_FALL)
+
+/*!
+ * @brief GPIO Pin 31, disable edge detection
+ */
+#define DL_GPIO_PIN_31_EDGE_DISABLE           (GPIO_POLARITY31_16_DIO31_DISABLE)
+
+/*!
+ * @brief GPIO Pin 31, enable detection on rising edge
+ */
+#define DL_GPIO_PIN_31_EDGE_RISE                 (GPIO_POLARITY31_16_DIO31_RISE)
+
+/*!
+ * @brief GPIO Pin 31, enable detection on falling edge
+ */
+#define DL_GPIO_PIN_31_EDGE_FALL                 (GPIO_POLARITY31_16_DIO31_FALL)
+
+/*!
+ * @brief GPIO Pin 31, enable detection on both rising and falling edge
+ */
+#define DL_GPIO_PIN_31_EDGE_RISE_FALL       (GPIO_POLARITY31_16_DIO31_RISE_FALL)
+
+/** @}*/
+
+/** @addtogroup DL_GPIO_INPUT_FILTER
+ *  @{
+ */
+/*!
+ * @brief GPIO Pin 0, disable input filter
+ */
+#define DL_GPIO_PIN_0_INPUT_FILTER_DISABLE      (GPIO_FILTEREN15_0_DIN0_DISABLE)
+
+/*!
+ * @brief GPIO Pin 0, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_0_INPUT_FILTER_1_CYCLE    (GPIO_FILTEREN15_0_DIN0_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 0, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_0_INPUT_FILTER_3_CYCLES  \
+                                            (GPIO_FILTEREN15_0_DIN0_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 0, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_0_INPUT_FILTER_8_CYCLES \
+                                            (GPIO_FILTEREN15_0_DIN0_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 1, disable input filter
+ */
+#define DL_GPIO_PIN_1_INPUT_FILTER_DISABLE      (GPIO_FILTEREN15_0_DIN1_DISABLE)
+
+/*!
+ * @brief GPIO Pin 1, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_1_INPUT_FILTER_1_CYCLE    (GPIO_FILTEREN15_0_DIN1_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 1, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_1_INPUT_FILTER_3_CYCLES  \
+                                            (GPIO_FILTEREN15_0_DIN1_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 1, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_1_INPUT_FILTER_8_CYCLES \
+                                            (GPIO_FILTEREN15_0_DIN1_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 2, disable input filter
+ */
+#define DL_GPIO_PIN_2_INPUT_FILTER_DISABLE      (GPIO_FILTEREN15_0_DIN2_DISABLE)
+
+/*!
+ * @brief GPIO Pin 2, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_2_INPUT_FILTER_1_CYCLE    (GPIO_FILTEREN15_0_DIN2_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 2, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_2_INPUT_FILTER_3_CYCLES  \
+                                            (GPIO_FILTEREN15_0_DIN2_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 2, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_2_INPUT_FILTER_8_CYCLES \
+                                            (GPIO_FILTEREN15_0_DIN2_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 3, disable input filter
+ */
+#define DL_GPIO_PIN_3_INPUT_FILTER_DISABLE      (GPIO_FILTEREN15_0_DIN3_DISABLE)
+
+/*!
+ * @brief GPIO Pin 3, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_3_INPUT_FILTER_1_CYCLE    (GPIO_FILTEREN15_0_DIN3_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 3, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_3_INPUT_FILTER_3_CYCLES  \
+                                            (GPIO_FILTEREN15_0_DIN3_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 3, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_3_INPUT_FILTER_8_CYCLES \
+                                            (GPIO_FILTEREN15_0_DIN3_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 4, disable input filter
+ */
+#define DL_GPIO_PIN_4_INPUT_FILTER_DISABLE      (GPIO_FILTEREN15_0_DIN4_DISABLE)
+
+/*!
+ * @brief GPIO Pin 4, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_4_INPUT_FILTER_1_CYCLE    (GPIO_FILTEREN15_0_DIN4_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 4, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_4_INPUT_FILTER_3_CYCLES  \
+                                            (GPIO_FILTEREN15_0_DIN4_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 4, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_4_INPUT_FILTER_8_CYCLES \
+                                            (GPIO_FILTEREN15_0_DIN4_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 5, disable input filter
+ */
+#define DL_GPIO_PIN_5_INPUT_FILTER_DISABLE      (GPIO_FILTEREN15_0_DIN5_DISABLE)
+
+/*!
+ * @brief GPIO Pin 5, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_5_INPUT_FILTER_1_CYCLE    (GPIO_FILTEREN15_0_DIN5_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 5, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_5_INPUT_FILTER_3_CYCLES  \
+                                            (GPIO_FILTEREN15_0_DIN5_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 5, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_5_INPUT_FILTER_8_CYCLES \
+                                            (GPIO_FILTEREN15_0_DIN5_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 6, disable input filter
+ */
+#define DL_GPIO_PIN_6_INPUT_FILTER_DISABLE      (GPIO_FILTEREN15_0_DIN6_DISABLE)
+
+/*!
+ * @brief GPIO Pin 6, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_6_INPUT_FILTER_1_CYCLE    (GPIO_FILTEREN15_0_DIN6_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 6, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_6_INPUT_FILTER_3_CYCLES  \
+                                            (GPIO_FILTEREN15_0_DIN6_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 6, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_6_INPUT_FILTER_8_CYCLES \
+                                            (GPIO_FILTEREN15_0_DIN6_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 7, disable input filter
+ */
+#define DL_GPIO_PIN_7_INPUT_FILTER_DISABLE      (GPIO_FILTEREN15_0_DIN7_DISABLE)
+
+/*!
+ * @brief GPIO Pin 7, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_7_INPUT_FILTER_1_CYCLE    (GPIO_FILTEREN15_0_DIN7_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 7, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_7_INPUT_FILTER_3_CYCLES  \
+                                            (GPIO_FILTEREN15_0_DIN7_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 7, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_7_INPUT_FILTER_8_CYCLES \
+                                            (GPIO_FILTEREN15_0_DIN7_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 8, disable input filter
+ */
+#define DL_GPIO_PIN_8_INPUT_FILTER_DISABLE      (GPIO_FILTEREN15_0_DIN8_DISABLE)
+
+/*!
+ * @brief GPIO Pin 8, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_8_INPUT_FILTER_1_CYCLE    (GPIO_FILTEREN15_0_DIN8_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 8, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_8_INPUT_FILTER_3_CYCLES  \
+                                            (GPIO_FILTEREN15_0_DIN8_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 8, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_8_INPUT_FILTER_8_CYCLES \
+                                            (GPIO_FILTEREN15_0_DIN8_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 9, disable input filter
+ */
+#define DL_GPIO_PIN_9_INPUT_FILTER_DISABLE      (GPIO_FILTEREN15_0_DIN9_DISABLE)
+
+/*!
+ * @brief GPIO Pin 9, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_9_INPUT_FILTER_1_CYCLE    (GPIO_FILTEREN15_0_DIN9_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 9, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_9_INPUT_FILTER_3_CYCLES  \
+                                            (GPIO_FILTEREN15_0_DIN9_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 9, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_9_INPUT_FILTER_8_CYCLES \
+                                            (GPIO_FILTEREN15_0_DIN9_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 10, disable input filter
+ */
+#define DL_GPIO_PIN_10_INPUT_FILTER_DISABLE     (GPIO_FILTEREN15_0_DIN10_DISABLE)
+
+/*!
+ * @brief GPIO Pin 10, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_10_INPUT_FILTER_1_CYCLE   (GPIO_FILTEREN15_0_DIN10_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 10, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_10_INPUT_FILTER_3_CYCLES  \
+                                           (GPIO_FILTEREN15_0_DIN10_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 10, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_10_INPUT_FILTER_8_CYCLES \
+                                           (GPIO_FILTEREN15_0_DIN10_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 11, disable input filter
+ */
+#define DL_GPIO_PIN_11_INPUT_FILTER_DISABLE     (GPIO_FILTEREN15_0_DIN11_DISABLE)
+
+/*!
+ * @brief GPIO Pin 11, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_11_INPUT_FILTER_1_CYCLE   (GPIO_FILTEREN15_0_DIN11_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 11, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_11_INPUT_FILTER_3_CYCLES  \
+                                           (GPIO_FILTEREN15_0_DIN11_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 11, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_11_INPUT_FILTER_8_CYCLES \
+                                           (GPIO_FILTEREN15_0_DIN11_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 12, disable input filter
+ */
+#define DL_GPIO_PIN_12_INPUT_FILTER_DISABLE    (GPIO_FILTEREN15_0_DIN12_DISABLE)
+
+/*!
+ * @brief GPIO Pin 12, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_12_INPUT_FILTER_1_CYCLE  (GPIO_FILTEREN15_0_DIN12_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 12, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_12_INPUT_FILTER_3_CYCLES  \
+                                           (GPIO_FILTEREN15_0_DIN12_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 12, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_12_INPUT_FILTER_8_CYCLES \
+                                           (GPIO_FILTEREN15_0_DIN12_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 13, disable input filter
+ */
+#define DL_GPIO_PIN_13_INPUT_FILTER_DISABLE    (GPIO_FILTEREN15_0_DIN13_DISABLE)
+
+/*!
+ * @brief GPIO Pin 13, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_13_INPUT_FILTER_1_CYCLE  (GPIO_FILTEREN15_0_DIN13_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 13, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_13_INPUT_FILTER_3_CYCLES  \
+                                           (GPIO_FILTEREN15_0_DIN13_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 13, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_13_INPUT_FILTER_8_CYCLES \
+                                           (GPIO_FILTEREN15_0_DIN13_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 14, disable input filter
+ */
+#define DL_GPIO_PIN_14_INPUT_FILTER_DISABLE    (GPIO_FILTEREN15_0_DIN14_DISABLE)
+
+/*!
+ * @brief GPIO Pin 14, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_14_INPUT_FILTER_1_CYCLE  (GPIO_FILTEREN15_0_DIN14_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 14, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_14_INPUT_FILTER_3_CYCLES  \
+                                           (GPIO_FILTEREN15_0_DIN14_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 14, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_14_INPUT_FILTER_8_CYCLES \
+                                           (GPIO_FILTEREN15_0_DIN14_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 15, disable input filter
+ */
+#define DL_GPIO_PIN_15_INPUT_FILTER_DISABLE    (GPIO_FILTEREN15_0_DIN15_DISABLE)
+
+/*!
+ * @brief GPIO Pin 15, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_15_INPUT_FILTER_1_CYCLE  (GPIO_FILTEREN15_0_DIN15_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 15, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_15_INPUT_FILTER_3_CYCLES  \
+                                           (GPIO_FILTEREN15_0_DIN15_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 15, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_15_INPUT_FILTER_8_CYCLES \
+                                           (GPIO_FILTEREN15_0_DIN15_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 16, disable input filter
+ */
+#define DL_GPIO_PIN_16_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN16_DISABLE)
+
+/*!
+ * @brief GPIO Pin 16, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_16_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN16_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 16, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_16_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN16_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 16, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_16_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN16_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 17, disable input filter
+ */
+#define DL_GPIO_PIN_17_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN17_DISABLE)
+
+/*!
+ * @brief GPIO Pin 17, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_17_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN17_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 17, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_17_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN17_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 17, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_17_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN17_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 18, disable input filter
+ */
+#define DL_GPIO_PIN_18_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN18_DISABLE)
+
+/*!
+ * @brief GPIO Pin 18, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_18_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN18_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 18, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_18_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN18_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 18, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_18_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN18_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 19, disable input filter
+ */
+#define DL_GPIO_PIN_19_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN19_DISABLE)
+
+/*!
+ * @brief GPIO Pin 19, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_19_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN19_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 19, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_19_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN19_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 19, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_19_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN19_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 20, disable input filter
+ */
+#define DL_GPIO_PIN_20_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN20_DISABLE)
+
+/*!
+ * @brief GPIO Pin 20, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_20_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN20_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 20, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_20_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN20_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 20, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_20_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN20_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 21, disable input filter
+ */
+#define DL_GPIO_PIN_21_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN21_DISABLE)
+
+/*!
+ * @brief GPIO Pin 21, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_21_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN21_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 21, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_21_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN21_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 21, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_21_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN21_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 22, disable input filter
+ */
+#define DL_GPIO_PIN_22_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN22_DISABLE)
+
+/*!
+ * @brief GPIO Pin 22, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_22_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN22_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 22, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_22_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN22_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 22, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_22_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN22_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 23, disable input filter
+ */
+#define DL_GPIO_PIN_23_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN23_DISABLE)
+
+/*!
+ * @brief GPIO Pin 23, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_23_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN23_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 23, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_23_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN23_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 23, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_23_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN23_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 24, disable input filter
+ */
+#define DL_GPIO_PIN_24_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN24_DISABLE)
+
+/*!
+ * @brief GPIO Pin 24, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_24_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN24_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 24, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_24_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN24_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 24, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_24_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN24_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 25, disable input filter
+ */
+#define DL_GPIO_PIN_25_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN25_DISABLE)
+
+/*!
+ * @brief GPIO Pin 25, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_25_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN25_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 25, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_25_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN25_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 25, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_25_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN25_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 26, disable input filter
+ */
+#define DL_GPIO_PIN_26_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN26_DISABLE)
+
+/*!
+ * @brief GPIO Pin 26, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_26_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN26_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 26, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_26_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN26_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 26, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_26_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN26_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 27, disable input filter
+ */
+#define DL_GPIO_PIN_27_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN27_DISABLE)
+
+/*!
+ * @brief GPIO Pin 27, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_27_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN27_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 27, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_27_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN27_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 27, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_27_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN27_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 28, disable input filter
+ */
+#define DL_GPIO_PIN_28_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN28_DISABLE)
+
+/*!
+ * @brief GPIO Pin 28, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_28_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN28_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 28, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_28_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN28_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 28, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_28_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN28_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 29, disable input filter
+ */
+#define DL_GPIO_PIN_29_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN29_DISABLE)
+
+/*!
+ * @brief GPIO Pin 29, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_29_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN29_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 29, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_29_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN29_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 29, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_29_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN29_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 30, disable input filter
+ */
+#define DL_GPIO_PIN_30_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN30_DISABLE)
+
+/*!
+ * @brief GPIO Pin 30, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_30_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN30_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 30, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_30_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN30_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 30, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_30_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN30_EIGHT_CYCLE)
+
+/*!
+ * @brief GPIO Pin 31, disable input filter
+ */
+#define DL_GPIO_PIN_31_INPUT_FILTER_DISABLE   (GPIO_FILTEREN31_16_DIN31_DISABLE)
+
+/*!
+ * @brief GPIO Pin 31, enable input filter to 1 ulpclk period
+ */
+#define DL_GPIO_PIN_31_INPUT_FILTER_1_CYCLE (GPIO_FILTEREN31_16_DIN31_ONE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 31, enable input filter to 3 ulpclk periods
+ */
+#define DL_GPIO_PIN_31_INPUT_FILTER_3_CYCLES  \
+                                          (GPIO_FILTEREN31_16_DIN31_THREE_CYCLE)
+
+/*!
+ * @brief GPIO Pin 31, enable input filter to 8 ulpclk periods
+ */
+#define DL_GPIO_PIN_31_INPUT_FILTER_8_CYCLES \
+                                          (GPIO_FILTEREN31_16_DIN31_EIGHT_CYCLE)
+
+/** @}*/
+
+/* clang-format on */
+
+/*! @enum DL_GPIO_INVERSION */
+typedef enum {
+    /*! Enable Inversion */
+    DL_GPIO_INVERSION_ENABLE = IOMUX_PINCM_INV_ENABLE,
+    /*! Disable Inversion */
+    DL_GPIO_INVERSION_DISABLE = IOMUX_PINCM_INV_DISABLE,
+} DL_GPIO_INVERSION;
+
+/*! @enum DL_GPIO_DRIVE_STRENGTH */
+typedef enum {
+    /*! Disable High-Drive Strength */
+    DL_GPIO_DRIVE_STRENGTH_LOW = IOMUX_PINCM_DRV_DRVVAL0,
+    /*! Enable High-Drive (where allowed) */
+    DL_GPIO_DRIVE_STRENGTH_HIGH = IOMUX_PINCM_DRV_DRVVAL1,
+} DL_GPIO_DRIVE_STRENGTH;
+
+/*! @enum DL_GPIO_RESISTOR */
+typedef enum {
+    /*! Use no pull up/pull down resistors on pin */
+    DL_GPIO_RESISTOR_NONE =
+        (IOMUX_PINCM_PIPU_DISABLE | IOMUX_PINCM_PIPD_DISABLE),
+
+    /*! Use a pull up resistor on the pin */
+    DL_GPIO_RESISTOR_PULL_UP =
+        (IOMUX_PINCM_PIPU_ENABLE | IOMUX_PINCM_PIPD_DISABLE),
+
+    /*! Use a pull down resistor on the pin */
+    DL_GPIO_RESISTOR_PULL_DOWN =
+        (IOMUX_PINCM_PIPU_DISABLE | IOMUX_PINCM_PIPD_ENABLE)
+} DL_GPIO_RESISTOR;
+
+/*! @enum DL_GPIO_HYSTERESIS */
+typedef enum {
+    /*! Enable Hysteresis on pin */
+    DL_GPIO_HYSTERESIS_ENABLE = IOMUX_PINCM_HYSTEN_ENABLE,
+    /*! Disable Hysteresis on pin */
+    DL_GPIO_HYSTERESIS_DISABLE = IOMUX_PINCM_HYSTEN_DISABLE,
+} DL_GPIO_HYSTERESIS;
+
+/*! @enum DL_GPIO_WAKEUP */
+typedef enum {
+    /*! Wakeup enabled */
+    DL_GPIO_WAKEUP_ENABLE = IOMUX_PINCM_WUEN_ENABLE,
+    /*! Wakeup disabled */
+    DL_GPIO_WAKEUP_DISABLE = IOMUX_PINCM_WUEN_DISABLE,
+    /*! Wakeup when pin changes to 0 */
+    DL_GPIO_WAKEUP_ON_0 = (IOMUX_PINCM_WUEN_ENABLE | IOMUX_PINCM_WCOMP_MATCH0),
+    /*! Wakeup when pin changes to 1 */
+    DL_GPIO_WAKEUP_ON_1 = (IOMUX_PINCM_WUEN_ENABLE | IOMUX_PINCM_WCOMP_MATCH1),
+
+} DL_GPIO_WAKEUP;
+
+/*! @enum DL_GPIO_HIZ */
+typedef enum {
+    /*! Enable Hi-Z on pin */
+    DL_GPIO_HIZ_ENABLE = IOMUX_PINCM_HIZ1_ENABLE,
+    /*! Disable Hi-Z on pin */
+    DL_GPIO_HIZ_DISABLE = IOMUX_PINCM_HIZ1_DISABLE,
+} DL_GPIO_HIZ;
+
+/** @enum DL_GPIO_EVENT_ROUTE */
+typedef enum {
+    /*! GPIO event route 1 */
+    DL_GPIO_EVENT_ROUTE_1 = 0,
+    /*! GPIO event route 2 */
+    DL_GPIO_EVENT_ROUTE_2 = 12
+} DL_GPIO_EVENT_ROUTE;
+
+/** @enum DL_GPIO_PUBLISHER_INDEX */
+typedef enum {
+    /*! GPIO Publisher index 0 */
+    DL_GPIO_PUBLISHER_INDEX_0 = 0,
+    /*! GPIO Publisher index 1 */
+    DL_GPIO_PUBLISHER_INDEX_1 = 1
+} DL_GPIO_PUBLISHER_INDEX;
+
+/** @enum DL_GPIO_SUBSCRIBER_INDEX */
+typedef enum {
+    /*! GPIO Subscriber index 0 */
+    DL_GPIO_SUBSCRIBER_INDEX_0 = 0,
+    /*! GPIO Subscriber index 1 */
+    DL_GPIO_SUBSCRIBER_INDEX_1 = 1
+} DL_GPIO_SUBSCRIBER_INDEX;
+
+/** @enum DL_GPIO_SUBSCRIBER_OUT_POLICY */
+typedef enum {
+    /*! GPIO is set */
+    DL_GPIO_SUBSCRIBER_OUT_POLICY_SET = GPIO_SUB0CFG_OUTPOLICY_SET,
+    /*! GPIO is cleared */
+    DL_GPIO_SUBSCRIBER_OUT_POLICY_CLEAR = GPIO_SUB0CFG_OUTPOLICY_CLR,
+    /*! GPIO is toggled */
+    DL_GPIO_SUBSCRIBER_OUT_POLICY_TOGGLE = GPIO_SUB0CFG_OUTPOLICY_TOGGLE
+} DL_GPIO_SUBSCRIBER_OUT_POLICY;
+
+/** @enum DL_GPIO_SUBSCRIBERx_PIN */
+typedef enum {
+    /*! Selects DIO 0 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_0 = 0x00000000,
+    /*! Selects DIO 1 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_1 = 0x00010000,
+    /*! Selects DIO 2 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_2 = 0x00020000,
+    /*! Selects DIO 3 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_3 = 0x00030000,
+    /*! Selects DIO 4 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_4 = 0x00040000,
+    /*! Selects DIO 5 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_5 = 0x00050000,
+    /*! Selects DIO 6 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_6 = 0x00060000,
+    /*! Selects DIO 7 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_7 = 0x00070000,
+    /*! Selects DIO 8 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_8 = 0x00080000,
+    /*! Selects DIO 9 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_9 = 0x00090000,
+    /*! Selects DIO 10 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_10 = 0x000A0000,
+    /*! Selects DIO 11 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_11 = 0x000B0000,
+    /*! Selects DIO 12 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_12 = 0x000C0000,
+    /*! Selects DIO 13 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_13 = 0x000D0000,
+    /*! Selects DIO 14 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_14 = 0x000E0000,
+    /*! Selects DIO 15 when Subscriber index 0 is selected */
+    DL_GPIO_SUBSCRIBER0_PIN_15 = 0x000F0000,
+    /*! Selects DIO 16 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_16 = 0x00000000,
+    /*! Selects DIO 17 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_17 = 0x00010000,
+    /*! Selects DIO 18 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_18 = 0x00020000,
+    /*! Selects DIO 19 when Subscriber index 1  is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_19 = 0x00030000,
+    /*! Selects DIO 20 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_20 = 0x00040000,
+    /*! Selects DIO 21 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_21 = 0x00050000,
+    /*! Selects DIO 22 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_22 = 0x00060000,
+    /*! Selects DIO 23 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_23 = 0x00070000,
+    /*! Selects DIO 24 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_24 = 0x00080000,
+    /*! Selects DIO 25 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_25 = 0x00090000,
+    /*! Selects DIO 26 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_26 = 0x000A0000,
+    /*! Selects DIO 27 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_27 = 0x000B0000,
+    /*! Selects DIO 28 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_28 = 0x000C0000,
+    /*! Selects DIO 29 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_29 = 0x000D0000,
+    /*! Selects DIO 30 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_30 = 0x000E0000,
+    /*! Selects DIO 31 when Subscriber index 1 is selected */
+    DL_GPIO_SUBSCRIBER1_PIN_31 = 0x000F0000
+} DL_GPIO_SUBSCRIBERx_PIN;
+
+/*! @enum DL_GPIO_IIDX */
+typedef enum {
+    /*! Interrupt index for GPIO DIO0 */
+    DL_GPIO_IIDX_DIO0 = GPIO_CPU_INT_IIDX_STAT_DIO0,
+    /*! Interrupt index for GPIO DIO1 */
+    DL_GPIO_IIDX_DIO1 = GPIO_CPU_INT_IIDX_STAT_DIO1,
+    /*! Interrupt index for GPIO DIO2 */
+    DL_GPIO_IIDX_DIO2 = GPIO_CPU_INT_IIDX_STAT_DIO2,
+    /*! Interrupt index for GPIO DIO3 */
+    DL_GPIO_IIDX_DIO3 = GPIO_CPU_INT_IIDX_STAT_DIO3,
+    /*! Interrupt index for GPIO DIO4 */
+    DL_GPIO_IIDX_DIO4 = GPIO_CPU_INT_IIDX_STAT_DIO4,
+    /*! Interrupt index for GPIO DIO5 */
+    DL_GPIO_IIDX_DIO5 = GPIO_CPU_INT_IIDX_STAT_DIO5,
+    /*! Interrupt index for GPIO DIO6 */
+    DL_GPIO_IIDX_DIO6 = GPIO_CPU_INT_IIDX_STAT_DIO6,
+    /*! Interrupt index for GPIO DIO7 */
+    DL_GPIO_IIDX_DIO7 = GPIO_CPU_INT_IIDX_STAT_DIO7,
+    /*! Interrupt index for GPIO DIO8 */
+    DL_GPIO_IIDX_DIO8 = GPIO_CPU_INT_IIDX_STAT_DIO8,
+    /*! Interrupt index for GPIO DIO9 */
+    DL_GPIO_IIDX_DIO9 = GPIO_CPU_INT_IIDX_STAT_DIO9,
+    /*! Interrupt index for GPIO DIO10 */
+    DL_GPIO_IIDX_DIO10 = GPIO_CPU_INT_IIDX_STAT_DIO10,
+    /*! Interrupt index for GPIO DIO11 */
+    DL_GPIO_IIDX_DIO11 = GPIO_CPU_INT_IIDX_STAT_DIO11,
+    /*! Interrupt index for GPIO DIO12 */
+    DL_GPIO_IIDX_DIO12 = GPIO_CPU_INT_IIDX_STAT_DIO12,
+    /*! Interrupt index for GPIO DIO13 */
+    DL_GPIO_IIDX_DIO13 = GPIO_CPU_INT_IIDX_STAT_DIO13,
+    /*! Interrupt index for GPIO DIO14 */
+    DL_GPIO_IIDX_DIO14 = GPIO_CPU_INT_IIDX_STAT_DIO14,
+    /*! Interrupt index for GPIO DIO15 */
+    DL_GPIO_IIDX_DIO15 = GPIO_CPU_INT_IIDX_STAT_DIO15,
+    /*! Interrupt index for GPIO DIO16 */
+    DL_GPIO_IIDX_DIO16 = GPIO_CPU_INT_IIDX_STAT_DIO16,
+    /*! Interrupt index for GPIO DIO17 */
+    DL_GPIO_IIDX_DIO17 = GPIO_CPU_INT_IIDX_STAT_DIO17,
+    /*! Interrupt index for GPIO DIO18 */
+    DL_GPIO_IIDX_DIO18 = GPIO_CPU_INT_IIDX_STAT_DIO18,
+    /*! Interrupt index for GPIO DIO19 */
+    DL_GPIO_IIDX_DIO19 = GPIO_CPU_INT_IIDX_STAT_DIO19,
+    /*! Interrupt index for GPIO DIO20 */
+    DL_GPIO_IIDX_DIO20 = GPIO_CPU_INT_IIDX_STAT_DIO20,
+    /*! Interrupt index for GPIO DIO21 */
+    DL_GPIO_IIDX_DIO21 = GPIO_CPU_INT_IIDX_STAT_DIO21,
+    /*! Interrupt index for GPIO DIO22 */
+    DL_GPIO_IIDX_DIO22 = GPIO_CPU_INT_IIDX_STAT_DIO22,
+    /*! Interrupt index for GPIO DIO23 */
+    DL_GPIO_IIDX_DIO23 = GPIO_CPU_INT_IIDX_STAT_DIO23,
+    /*! Interrupt index for GPIO DIO24 */
+    DL_GPIO_IIDX_DIO24 = GPIO_CPU_INT_IIDX_STAT_DIO24,
+    /*! Interrupt index for GPIO DIO25 */
+    DL_GPIO_IIDX_DIO25 = GPIO_CPU_INT_IIDX_STAT_DIO25,
+    /*! Interrupt index for GPIO DIO26 */
+    DL_GPIO_IIDX_DIO26 = GPIO_CPU_INT_IIDX_STAT_DIO26,
+    /*! Interrupt index for GPIO DIO27 */
+    DL_GPIO_IIDX_DIO27 = GPIO_CPU_INT_IIDX_STAT_DIO27,
+    /*! Interrupt index for GPIO DIO28 */
+    DL_GPIO_IIDX_DIO28 = GPIO_CPU_INT_IIDX_STAT_DIO28,
+    /*! Interrupt index for GPIO DIO29 */
+    DL_GPIO_IIDX_DIO29 = GPIO_CPU_INT_IIDX_STAT_DIO29,
+    /*! Interrupt index for GPIO DIO30 */
+    DL_GPIO_IIDX_DIO30 = GPIO_CPU_INT_IIDX_STAT_DIO30,
+    /*! Interrupt index for GPIO DIO31 */
+    DL_GPIO_IIDX_DIO31 = GPIO_CPU_INT_IIDX_STAT_DIO31
+} DL_GPIO_IIDX;
+
+/**
+ * @brief Enables power on GPIO module
+ *
+ * @param gpio        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_GPIO_enablePower(GPIO_Regs* gpio)
+{
+    gpio->GPRCM.PWREN = (GPIO_PWREN_KEY_UNLOCK_W | GPIO_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power on gpio module
+ *
+ * @param gpio        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_GPIO_disablePower(GPIO_Regs* gpio)
+{
+    gpio->GPRCM.PWREN = (GPIO_PWREN_KEY_UNLOCK_W | GPIO_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief Returns if  power on gpio module
+ *
+ * @param gpio        Pointer to the register overlay for the peripheral
+ *
+ * @return true if power is enabled
+ * @return false if power is disabled
+ */
+__STATIC_INLINE bool DL_GPIO_isPowerEnabled(GPIO_Regs* gpio)
+{
+    return ((gpio->GPRCM.PWREN & GPIO_PWREN_ENABLE_MASK) ==
+            GPIO_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Resets gpio peripheral
+ *
+ * @param gpio        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_GPIO_reset(GPIO_Regs* gpio)
+{
+    gpio->GPRCM.RSTCTL =
+        (GPIO_RSTCTL_KEY_UNLOCK_W | GPIO_RSTCTL_RESETSTKYCLR_CLR |
+            GPIO_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief Returns if gpio peripheral was reset
+ *
+ * @param gpio        Pointer to the register overlay for the peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_GPIO_isReset(GPIO_Regs* gpio)
+{
+    return ((gpio->GPRCM.STAT & GPIO_STAT_RESETSTKY_MASK) ==
+            GPIO_STAT_RESETSTKY_RESET);
+}
+
+/**
+ *  @brief      Configures a pin as a basic GPIO output
+ *
+ *  @param[in]  pincmIndex  The PINCM register index that maps to the target
+ *                          GPIO pin.
+ */
+__STATIC_INLINE void DL_GPIO_initDigitalOutput(uint32_t pincmIndex)
+{
+    /* GPIO functionality is always a pin function of 0x00000001 */
+    IOMUX->SECCFG.PINCM[pincmIndex] =
+        (IOMUX_PINCM_PC_CONNECTED | ((uint32_t) 0x00000001));
+}
+
+/**
+ *  @brief      Configures a pin as a GPIO output
+ *
+ *  @param[in]  pincmIndex        The PINCM register index that maps to the target
+ *                                GPIO pin.
+ *  @param[in]  inversion         Enable Inversion of the pin output. One of @ref
+ *                                DL_GPIO_INVERSION.
+ *  @param[in]  internalResistor  Internal resistor to use. One of
+ *                                @ref DL_GPIO_RESISTOR.
+ *  @param[in]  driveStrength     Enable High-Drive for the pin. One of @ref
+ *                                DL_GPIO_DRIVE_STRENGTH.
+ *  @param[in]  hiZ               Enable/disable Hi-Z for the pin. One of
+ *                                @ref DL_GPIO_HIZ.
+ */
+__STATIC_INLINE void DL_GPIO_initDigitalOutputFeatures(uint32_t pincmIndex,
+    DL_GPIO_INVERSION inversion, DL_GPIO_RESISTOR internalResistor,
+    DL_GPIO_DRIVE_STRENGTH driveStrength, DL_GPIO_HIZ hiZ)
+{
+    /* GPIO functionality is always a pin function of 0x00000001 */
+    IOMUX->SECCFG.PINCM[pincmIndex] =
+        IOMUX_PINCM_PC_CONNECTED | ((uint32_t) 0x00000001) |
+        (uint32_t) inversion | (uint32_t) internalResistor |
+        (uint32_t) driveStrength | (uint32_t) hiZ;
+}
+
+/**
+ *  @brief      Configures internal resistor for digital pin
+ *
+ *  @param[in]  pincmIndex        The PINCM register index that maps to the target
+ *                                GPIO pin.
+ *  @param[in]  internalResistor  Internal resistor to use. One of
+ *                                @ref DL_GPIO_RESISTOR.
+ */
+__STATIC_INLINE void DL_GPIO_setDigitalInternalResistor(
+    uint32_t pincmIndex, DL_GPIO_RESISTOR internalResistor)
+{
+    /* GPIO functionality is always a pin function of 0x00000001 */
+    IOMUX->SECCFG.PINCM[pincmIndex] = IOMUX_PINCM_PC_CONNECTED |
+                                      ((uint32_t) 0x00000001) |
+                                      (uint32_t) internalResistor;
+}
+
+// TODO: verify no need to add input/output variable for the Input/Output enebale functionality
+/**
+ *  @brief      Configures internal resistor for analog pin
+ *
+ *  @param[in]  pincmIndex        The PINCM register index that maps to the target
+ *                                GPIO pin.
+ *  @param[in]  internalResistor  Internal resistor to use. One of
+ *                                @ref DL_GPIO_RESISTOR.
+ */
+__STATIC_INLINE void DL_GPIO_setAnalogInternalResistor(
+    uint32_t pincmIndex, DL_GPIO_RESISTOR internalResistor)
+{
+    /* GPIO functionality is always a pin function of 0x00000001 */
+    /* For analog use case, setting IOMUX input enable */
+    IOMUX->SECCFG.PINCM[pincmIndex] =
+        IOMUX_PINCM_INENA_ENABLE | IOMUX_PINCM_PC_UNCONNECTED |
+        ((uint32_t) 0x00000001) | (uint32_t) internalResistor;
+}
+
+/**
+ *  @brief      Configures a pin as a basic GPIO input
+ *
+ *  Configures the pin as a basic GPIO input. If you want to use additional
+ *  features of the input mode, refer to @ref DL_GPIO_initDigitalInputFeatures.
+ *
+ *  @param[in]  pincmIndex  The PINCM register index that maps to the target
+ *                          GPIO pin.
+ */
+__STATIC_INLINE void DL_GPIO_initDigitalInput(uint32_t pincmIndex)
+{
+    /* GPIO functionality is always a pin function of 0x00000001 */
+    IOMUX->SECCFG.PINCM[pincmIndex] = IOMUX_PINCM_INENA_ENABLE |
+                                      IOMUX_PINCM_PC_CONNECTED |
+                                      ((uint32_t) 0x00000001);
+}
+
+/**
+ *  @brief      Configures a pin as a GPIO input
+ *
+ *  @param[in]  pincmIndex        The PINCM register index that maps to the target
+ *                                GPIO pin.
+ *  @param[in]  inversion         Enable Inversion of the pin input. One of @ref
+ *                                DL_GPIO_INVERSION.
+ *  @param[in]  internalResistor  Internal resistor to use. One of @ref
+ *                                DL_GPIO_RESISTOR.
+ *  @param[in]  hysteresis        Enable/disable Hysteresis on the pin. One of
+ *                                @ref DL_GPIO_HYSTERESIS.
+ *  @param[in]  wakeup            Configure wakeup behavior for the pin. One of
+ *                                @ref DL_GPIO_WAKEUP.
+ */
+__STATIC_INLINE void DL_GPIO_initDigitalInputFeatures(uint32_t pincmIndex,
+    DL_GPIO_INVERSION inversion, DL_GPIO_RESISTOR internalResistor,
+    DL_GPIO_HYSTERESIS hysteresis, DL_GPIO_WAKEUP wakeup)
+{
+    /* GPIO functionality is always a pin function of 0x00000001 */
+    IOMUX->SECCFG.PINCM[pincmIndex] =
+        IOMUX_PINCM_INENA_ENABLE | IOMUX_PINCM_PC_CONNECTED |
+        ((uint32_t) 0x00000001) | (uint32_t) inversion |
+        (uint32_t) internalResistor | (uint32_t) hysteresis |
+        (uint32_t) wakeup;
+}
+
+/**
+ *  @brief      Configure a pin to operate with peripheral functionality
+ *
+ *  @param[in]  pincmIndex The PINCM register index that maps to the target
+ *                         pin to configure the peripheral functionality for
+ *  @param[in]  function   Function to configure the pin for. See definition
+ *                         of IOMUX_PINCMx_PF_xxx in the device header file.
+ */
+__STATIC_INLINE void DL_GPIO_initPeripheralFunction(
+    uint32_t pincmIndex, uint32_t function)
+{
+    IOMUX->SECCFG.PINCM[pincmIndex] = function | IOMUX_PINCM_PC_CONNECTED;
+}
+
+/**
+ *  @brief      Configure a pin to operate with peripheral output functionality
+ *
+ *  @param[in]  pincmIndex The PINCM register index that maps to the target
+ *                         pin to configure the peripheral functionality for
+ *  @param[in]  function   Function to configure the pin for. See definition
+ *                         of IOMUX_PINCMx_PF_xxx in the device header file.
+ */
+__STATIC_INLINE void DL_GPIO_initPeripheralOutputFunction(
+    uint32_t pincmIndex, uint32_t function)
+{
+    IOMUX->SECCFG.PINCM[pincmIndex] = function | IOMUX_PINCM_PC_CONNECTED;
+}
+
+/**
+ *  @brief      Configure a pin to operate with peripheral output functionality with optional features
+ *
+ *  @param[in]  pincmIndex The PINCM register index that maps to the target
+ *                         pin to configure the peripheral functionality for
+ *  @param[in]  function          Function to configure the pin for. Check
+ *                         definition of IOMUX_PINCMx_PF_xxx in the device
+ *                         header file.
+ *  @param[in]  inversion         Enable Inversion of the pin output. One of @ref
+ *                                DL_GPIO_INVERSION.
+ *  @param[in]  internalResistor  Internal resistor to use. One of
+ *                                @ref DL_GPIO_RESISTOR.
+ *  @param[in]  driveStrength     Enable High-Drive for the pin. One of @ref
+ *                                DL_GPIO_DRIVE_STRENGTH.
+ *  @param[in]  hiZ               Enable/disable Hi-Z for the pin. One of
+ *                                @ref DL_GPIO_HIZ.
+ */
+__STATIC_INLINE void DL_GPIO_initPeripheralOutputFunctionFeatures(
+    uint32_t pincmIndex, uint32_t function, DL_GPIO_INVERSION inversion,
+    DL_GPIO_RESISTOR internalResistor, DL_GPIO_DRIVE_STRENGTH driveStrength,
+    DL_GPIO_HIZ hiZ)
+{
+    IOMUX->SECCFG.PINCM[pincmIndex] =
+        function | IOMUX_PINCM_PC_CONNECTED | (uint32_t) inversion |
+        (uint32_t) internalResistor | (uint32_t) driveStrength |
+        (uint32_t) hiZ;
+}
+
+/**
+ *  @brief      Configure a pin to operate with peripheral input functionality
+ *
+ *  @param[in]  pincmIndex The PINCM register index that maps to the target
+ *                         pin to configure the peripheral functionality for
+ *  @param[in]  function   Function to configure the pin for. See definition
+ *                         of IOMUX_PINCMx_PF_xxx in the device header file.
+ */
+__STATIC_INLINE void DL_GPIO_initPeripheralInputFunction(
+    uint32_t pincmIndex, uint32_t function)
+{
+    IOMUX->SECCFG.PINCM[pincmIndex] =
+        function | IOMUX_PINCM_PC_CONNECTED | IOMUX_PINCM_INENA_ENABLE;
+}
+
+/**
+ *  @brief      Configure a pin to operate with peripheral input functionality with optional features
+ *
+ *  @param[in]  pincmIndex The PINCM register index that maps to the target
+ *                         pin to configure the peripheral functionality for
+ *  @param[in]  function   Function to configure the pin for. See definition
+ *                         of IOMUX_PINCMx_PF_xxx in the device header file.
+ *  @param[in]  inversion         Enable Inversion of the pin input. One of @ref
+ *                                DL_GPIO_INVERSION.
+ *  @param[in]  internalResistor  Internal resistor to use. One of @ref
+ *                                DL_GPIO_RESISTOR.
+ *  @param[in]  hysteresis        Enable/disable Hystersis on the pin. One of
+ *                                @ref DL_GPIO_HYSTERESIS.
+ *  @param[in]  wakeup            Configure wakeup behavior for the pin. One of
+ *                                @ref DL_GPIO_WAKEUP.
+ */
+__STATIC_INLINE void DL_GPIO_initPeripheralInputFunctionFeatures(
+    uint32_t pincmIndex, uint32_t function, DL_GPIO_INVERSION inversion,
+    DL_GPIO_RESISTOR internalResistor, DL_GPIO_HYSTERESIS hysteresis,
+    DL_GPIO_WAKEUP wakeup)
+{
+    IOMUX->SECCFG.PINCM[pincmIndex] =
+        function | IOMUX_PINCM_PC_CONNECTED | IOMUX_PINCM_INENA_ENABLE |
+        (uint32_t) inversion | (uint32_t) internalResistor |
+        (uint32_t) hysteresis | (uint32_t) wakeup;
+}
+
+/**
+ *  @brief      Configure a pin to operate with analog functionality
+ *
+ *  @param[in]  pincmIndex The PINCM register index that maps to the target
+ *                         pin to configure the analog functionality for
+ *
+ */
+__STATIC_INLINE void DL_GPIO_initPeripheralAnalogFunction(uint32_t pincmIndex)
+{
+    IOMUX->SECCFG.PINCM[pincmIndex] = IOMUX_PINCM_PC_UNCONNECTED;
+}
+
+/**
+ *  @brief Set GPIO pin's wakeup enable bit.
+ *
+ *  @param[in]  pincmIndex  The PINCM register index that maps to the target
+ *                          GPIO pin.
+ *
+ */
+__STATIC_INLINE void DL_GPIO_enableWakeUp(uint32_t pincmIndex)
+{
+    IOMUX->SECCFG.PINCM[pincmIndex] |= DL_GPIO_WAKEUP_ENABLE;
+}
+
+/**
+ *  @brief Clear GPIO pin's wakeup enable bit.
+ *
+ *  @param[in]  pincmIndex  The PINCM register index that maps to the target
+ *                          GPIO pin.
+ *
+ */
+__STATIC_INLINE void DL_GPIO_disableWakeUp(uint32_t pincmIndex)
+{
+    IOMUX->SECCFG.PINCM[pincmIndex] &= ~(IOMUX_PINCM_WUEN_MASK);
+}
+
+/**
+ *  @brief Returns if GPIO pin's wake up bit is enabled.
+ *
+ *  @param[in]  pincmIndex  The PINCM register index that maps to the target
+ *                          GPIO pin.
+ *
+ *  @return     True if wake up enabled on GPIO pin.
+ */
+__STATIC_INLINE bool DL_GPIO_isWakeUpEnabled(uint32_t pincmIndex)
+{
+    return ((IOMUX->SECCFG.PINCM[pincmIndex] & IOMUX_PINCM_WUEN_MASK) ==
+            IOMUX_PINCM_WUEN_ENABLE);
+}
+
+/**
+ *  @brief Checks if the GPIO pin's Wake State bit is active.
+ *
+ *  @param[in]  pincmIndex  The PINCM register index that maps to the target
+ *                          GPIO pin.
+ *
+ *  @return     True if 0x00002000U, False if 0x00000000U.
+ */
+__STATIC_INLINE bool DL_GPIO_isWakeStateGenerated(uint32_t pincmIndex)
+{
+    return ((IOMUX->SECCFG.PINCM[pincmIndex] & IOMUX_PINCM_WAKESTAT_MASK) ==
+            IOMUX_PINCM_WAKESTAT_ENABLE);
+}
+
+/**
+ *  @brief      Read a group of GPIO pins
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Pins to read. Bitwise OR of @ref DL_GPIO_PIN.
+ *
+ *  @return     The pins (from the selection) that are currently high
+ *
+ *  @retval     Bitwise OR of @ref DL_GPIO_PIN of pins that are currently high
+ *              from the input selection.
+ */
+__STATIC_INLINE uint32_t DL_GPIO_readPins(GPIO_Regs* gpio, uint32_t pins)
+{
+    return (gpio->DIN31_0 & pins);
+}
+
+/**
+ *  @brief      Write a group of GPIO pins
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Pins to write. All enabled GPIO pins will be set to
+ *                    the equivalent bit value in pins.
+ */
+__STATIC_INLINE void DL_GPIO_writePins(GPIO_Regs* gpio, uint32_t pins)
+{
+    gpio->DOUT31_0 = pins;
+}
+
+/**
+ *  @brief      Update the value of one or more GPIO pins
+ *
+ *  @param[in]  gpio      Pointer to the register overlay for the peripheral
+ *  @param[in]  pinsMask  The GPIO pin(s) you want to update. Bitwise OR of
+ *                        @ref DL_GPIO_PIN.
+ *  @param[in]  pinsVal   Value(s) for the GPIO pin(s) you want to update.
+ *                        Only the values for pins specified in pinsMask will
+ *                        change.
+ */
+__STATIC_INLINE void DL_GPIO_writePinsVal(
+    GPIO_Regs* gpio, uint32_t pinsMask, uint32_t pinsVal)
+{
+    uint32_t doutVal = gpio->DOUT31_0;
+    doutVal &= ~pinsMask;
+    doutVal |= (pinsVal & pinsMask);
+    gpio->DOUT31_0 = doutVal;
+}
+
+/**
+ *  @brief      Set a group of GPIO pins
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Pins to set high. Bitwise OR of @ref DL_GPIO_PIN.
+ */
+__STATIC_INLINE void DL_GPIO_setPins(GPIO_Regs* gpio, uint32_t pins)
+{
+    gpio->DOUTSET31_0 = pins;
+}
+
+/**
+ *  @brief      Clear a group of GPIO pins
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Pins to clear. Bitwise OR of @ref DL_GPIO_PIN.
+ */
+__STATIC_INLINE void DL_GPIO_clearPins(GPIO_Regs* gpio, uint32_t pins)
+{
+    gpio->DOUTCLR31_0 = pins;
+}
+
+/**
+ *  @brief      Toggle a group of GPIO pins
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Pins to toggle. Bitwise OR of @ref DL_GPIO_PIN.
+ */
+__STATIC_INLINE void DL_GPIO_togglePins(GPIO_Regs* gpio, uint32_t pins)
+{
+    gpio->DOUTTGL31_0 = pins;
+}
+
+/**
+ *  @brief      Enable output on a group of GPIO pins
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Pins to enable output. Bitwise OR of @ref DL_GPIO_PIN.
+ */
+__STATIC_INLINE void DL_GPIO_enableOutput(GPIO_Regs* gpio, uint32_t pins)
+{
+    gpio->DOESET31_0 = pins;
+}
+
+/**
+ *  @brief      Disable output on a group of GPIO pins
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Pins to disable output. Bitwise OR of @ref DL_GPIO_PIN.
+ */
+__STATIC_INLINE void DL_GPIO_disableOutput(GPIO_Regs* gpio, uint32_t pins)
+{
+    gpio->DOECLR31_0 = pins;
+}
+
+/**
+ *  @brief      Enable DMA access on a group of pins
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Pins to toggle. Bitwise OR of @ref DL_GPIO_PIN.
+ */
+__STATIC_INLINE void DL_GPIO_enableDMAAccess(GPIO_Regs* gpio, uint32_t pins)
+{
+    DL_Common_updateReg(&gpio->DMAMASK, pins, pins);
+}
+
+/**
+ *  @brief      Disable DMA access on a group of pins
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Pins to disable DMA access on. Bitwise OR of @ref
+ *                    DL_GPIO_PIN.
+ */
+__STATIC_INLINE void DL_GPIO_disableDMAAccess(GPIO_Regs* gpio, uint32_t pins)
+{
+    DL_Common_updateReg(&gpio->DMAMASK, 0x00000000, pins);
+}
+
+/**
+ *  @brief      Check if DMA access is enabled on a group of pins
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Pins to check DMA access on. Bitwise OR of @ref
+ *                    DL_GPIO_PIN.
+ *
+ *  @return     Which pins of the requested group have DMA access enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_GPIO_PIN values
+ */
+__STATIC_INLINE uint32_t DL_GPIO_isDMAccessEnabled(
+    GPIO_Regs* gpio, uint32_t pins)
+{
+    return (gpio->DMAMASK & pins);
+}
+
+/**
+ * @brief       Set the polarity of all bits [0, 15] in the group of pins
+ *
+ * @param[in]  gpio      Pointer to the register overlay for the peripheral
+ * @param[in]  polarity  Bitwise OR of @ref DL_GPIO_EDGE_POLARITY for
+ *                       pins [0, 15]
+ */
+__STATIC_INLINE void DL_GPIO_setLowerPinsPolarity(
+    GPIO_Regs* gpio, uint32_t polarity)
+{
+    gpio->POLARITY15_0 |= polarity;
+}
+
+/**
+ * @brief       Set the polarity of all bits [16, 31] in the group of pins
+ *
+ * @param[in]  gpio     Pointer to the register overlay for the peripheral
+ * @param[in]  polarity  Bitwise OR of @ref DL_GPIO_EDGE_POLARITY for
+ *                       pins [16, 31]
+ */
+__STATIC_INLINE void DL_GPIO_setUpperPinsPolarity(
+    GPIO_Regs* gpio, uint32_t polarity)
+{
+    gpio->POLARITY31_16 |= polarity;
+}
+
+/**
+ * @brief      Get the polarity of bits [0, 15] in the group of pins
+ *
+ * @param[in]  gpio     Pointer to the register overlay for the peripheral
+ *
+ * @retval     Polarity setting with bitwise OR of @ref DL_GPIO_EDGE_POLARITY
+ *             for pins [0, 15]
+ *
+ */
+__STATIC_INLINE uint32_t DL_GPIO_getLowerPinsPolarity(GPIO_Regs* gpio)
+{
+    return gpio->POLARITY15_0;
+}
+
+/**
+ * @brief      Get the polarity of bits [16, 31] in the group of pins
+ *
+ * @param[in]  gpio     Pointer to the register overlay for the peripheral
+ *
+ * @retval     Polarity setting with bitwise OR of @ref DL_GPIO_EDGE_POLARITY
+ *             for pins [16, 31]
+ *
+ */
+__STATIC_INLINE uint32_t DL_GPIO_getUpperPinsPolarity(GPIO_Regs* gpio)
+{
+    return gpio->POLARITY31_16;
+}
+
+/**
+ * @brief       Set the input filter of bits [0, 15] in the group of pins
+ *
+ * @param[in]  gpio      Pointer to the register overlay for the peripheral
+ * @param[in]  filter    Bitwise OR of @ref DL_GPIO_INPUT_FILTER for
+ *                       pins [0, 15]
+ */
+__STATIC_INLINE void DL_GPIO_setLowerPinsInputFilter(
+    GPIO_Regs* gpio, uint32_t filter)
+{
+    gpio->FILTEREN15_0 |= filter;
+}
+
+/**
+ * @brief       Set the input filter of bits [16, 31] in the group of pins
+ *
+ * @param[in]  gpio      Pointer to the register overlay for the peripheral
+ * @param[in]  filter    Bitwise OR of @ref DL_GPIO_INPUT_FILTER for
+ *                       pins [16, 31]
+ */
+__STATIC_INLINE void DL_GPIO_setUpperPinsInputFilter(
+    GPIO_Regs* gpio, uint32_t filter)
+{
+    gpio->FILTEREN31_16 |= filter;
+}
+
+/**
+ * @brief      Get the input filter of bits [0, 15] in the group of pins
+ *
+ * @param[in]  gpio     Pointer to the register overlay for the peripheral
+ *
+ * @retval     Input filter setting with bitwise OR of @ref DL_GPIO_INPUT_FILTER
+ *             for pins [0, 15]
+ *
+ */
+__STATIC_INLINE uint32_t DL_GPIO_getLowerPinsInputFilter(GPIO_Regs* gpio)
+{
+    return gpio->FILTEREN15_0;
+}
+
+/**
+ * @brief      Get the input filter of bits [16, 31] in the group of pins
+ *
+ * @param[in]  gpio     Pointer to the register overlay for the peripheral
+ *
+ * @retval     Input filter setting with bitwise OR of @ref DL_GPIO_INPUT_FILTER
+ *             for pins [16, 31]
+ *
+ */
+__STATIC_INLINE uint32_t DL_GPIO_getUpperPinsInputFilter(GPIO_Regs* gpio)
+{
+    return gpio->FILTEREN31_16;
+}
+
+/**
+ *  @brief      Enable Global Fast Wake
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_GPIO_enableGlobalFastWake(GPIO_Regs* gpio)
+{
+    gpio->CTL |= GPIO_CTL_FASTWAKEONLY_GLOBAL_EN;
+}
+
+/**
+ *  @brief      Disable Global Fast Wake
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_GPIO_disableGlobalFastWake(GPIO_Regs* gpio)
+{
+    gpio->CTL &= ~GPIO_CTL_FASTWAKEONLY_GLOBAL_EN;
+}
+
+/**
+ *  @brief      Enable fast wake for pins
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Bit mask of pins to enable fast-wake feature. Bitwise OR
+ *                    of @ref DL_GPIO_PIN.
+ */
+__STATIC_INLINE void DL_GPIO_enableFastWakePins(GPIO_Regs* gpio, uint32_t pins)
+{
+    gpio->FASTWAKE |= pins;
+}
+
+/**
+ *  @brief      Disable fast wake for pins
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Bit mask of pins to disable fast-wake feature. Bitwise OR
+ *                    of @ref DL_GPIO_PIN.
+ */
+__STATIC_INLINE void DL_GPIO_disableFastWakePins(
+    GPIO_Regs* gpio, uint32_t pins)
+{
+    gpio->FASTWAKE &= ~(pins);
+}
+
+/**
+ *  @brief      Enable Hi-Z for the pin
+ *
+ *  @param[in]  pincmIndex  The PINCM register index that maps to the target
+ *                          GPIO pin
+ */
+__STATIC_INLINE void DL_GPIO_enableHiZ(uint32_t pincmIndex)
+{
+    IOMUX->SECCFG.PINCM[pincmIndex] |= IOMUX_PINCM_HIZ1_ENABLE;
+}
+
+/**
+ *  @brief      Disable Hi-Z for the pin
+ *
+ *  @param[in]  pincmIndex  The PINCM register index that maps to the target
+ *                          GPIO pin
+ */
+__STATIC_INLINE void DL_GPIO_disableHiZ(uint32_t pincmIndex)
+{
+    IOMUX->SECCFG.PINCM[pincmIndex] &= ~(IOMUX_PINCM_HIZ1_ENABLE);
+}
+
+/**
+ *  @brief      Check which pins have fast wake feature enabled
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Bit mask of pins to check. Bitwise OR of @ref DL_GPIO_PIN.
+ *
+ *  @return     Which of the requested GPIO pins have fast wake enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_GPIO_PIN values
+ */
+__STATIC_INLINE uint32_t DL_GPIO_getEnabledFastWakePins(
+    GPIO_Regs* gpio, uint32_t pins)
+{
+    return (gpio->FASTWAKE & pins);
+}
+
+/**
+ *  @brief      Enable GPIO interrupts
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Bit mask of interrupts to enable. Bitwise OR of
+ *                    @ref DL_GPIO_PIN.
+ */
+__STATIC_INLINE void DL_GPIO_enableInterrupt(GPIO_Regs* gpio, uint32_t pins)
+{
+    gpio->CPU_INT.IMASK |= pins;
+}
+
+/**
+ *  @brief      Disable GPIO interrupts
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Bit mask of interrupts to disable. Bitwise OR of
+ *                    @ref DL_GPIO_PIN.
+ */
+__STATIC_INLINE void DL_GPIO_disableInterrupt(GPIO_Regs* gpio, uint32_t pins)
+{
+    gpio->CPU_INT.IMASK &= ~(pins);
+}
+
+/**
+ *  @brief      Check which GPIO interrupts are enabled
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Bit mask of interrupts to check. Bitwise OR of
+ *                    @ref DL_GPIO_PIN.
+ *
+ *  @return     Which of the requested GPIO interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_GPIO_PIN values
+ */
+__STATIC_INLINE uint32_t DL_GPIO_getEnabledInterrupts(
+    GPIO_Regs* gpio, uint32_t pins)
+{
+    return (gpio->CPU_INT.IMASK & pins);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled GPIO interrupts
+ *
+ *  Checks if any of the GPIO interrupts that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Bit mask of interrupts to check. Bitwise OR of
+ *                    @ref DL_GPIO_PIN.
+ *
+ *  @return     Which of the requested GPIO interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_GPIO_PIN values
+ *
+ *  @sa         DL_GPIO_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_GPIO_getEnabledInterruptStatus(
+    GPIO_Regs* gpio, uint32_t pins)
+{
+    return (gpio->CPU_INT.MIS & pins);
+}
+
+/**
+ *  @brief      Set interrupt flag of any GPIO
+ *
+ *  Manually set a GPIO interrupt to be pending
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  pins  Bit mask of interrupts to set. Bitwise OR of
+ *                    @ref DL_GPIO_PIN.
+ *
+ */
+__STATIC_INLINE void DL_GPIO_setInterrupt(GPIO_Regs* gpio, uint32_t pins)
+{
+    gpio->CPU_INT.ISET = pins;
+}
+
+/**
+ *  @brief      Check interrupt flag of any GPIO interrupt
+ *
+ *  Checks if any of the GPIO interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  pins  Bit mask of interrupts to check. Bitwise OR of
+ *                    @ref DL_GPIO_PIN.
+ *
+ *  @return     Which of the requested GPIO interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_GPIO_PIN values
+ */
+__STATIC_INLINE uint32_t DL_GPIO_getRawInterruptStatus(
+    GPIO_Regs* gpio, uint32_t pins)
+{
+    return (gpio->CPU_INT.RIS & pins);
+}
+
+/**
+ *  @brief      Get highest priority pending GPIO interrupt
+ *
+ *  Checks if any of the GPIO interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The highest priority pending GPIO interrupt
+ *
+ *  @retval     One of @ref DL_GPIO_IIDX
+ */
+__STATIC_INLINE DL_GPIO_IIDX DL_GPIO_getPendingInterrupt(GPIO_Regs* gpio)
+{
+    return (DL_GPIO_IIDX)(gpio->CPU_INT.IIDX);
+}
+
+/**
+ *  @brief      Clear pending GPIO interrupts
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  pins  Bit mask of interrupts to check. Bitwise OR of
+ *                    @ref DL_GPIO_PIN.
+ *
+ */
+__STATIC_INLINE void DL_GPIO_clearInterruptStatus(
+    GPIO_Regs* gpio, uint32_t pins)
+{
+    gpio->CPU_INT.ICLR |= pins;
+}
+
+/**
+ * @brief Configures GPIO subscriber. This API preserves enable/disbale status
+ *        of subscriber.
+ *
+ * @param[in] gpio     Pointer to the register overlay for the peripheral
+ * @param[in] index    Specifies the subscriber event index to be configured
+ * @param[in] policy   Specifies the the GPIO behavior when the subscriber
+ *                     receives publisher event.
+ * @param[in] pinIndex Specifies the GPIO bit number which will be targeted by
+ *                     the subscriber action.
+ *
+ */
+__STATIC_INLINE void DL_GPIO_configSubscriber(GPIO_Regs* gpio,
+    DL_GPIO_SUBSCRIBER_INDEX index, DL_GPIO_SUBSCRIBER_OUT_POLICY policy,
+    DL_GPIO_SUBSCRIBERx_PIN pinIndex)
+
+{
+    volatile uint32_t* pReg = &gpio->SUB0CFG;
+
+    pReg += ((uint32_t) index << 3);
+
+    DL_Common_updateReg(pReg, ((uint32_t) pinIndex | (uint32_t) policy),
+        (GPIO_SUB0CFG_INDEX_MASK | GPIO_SUB1CFG_OUTPOLICY_MASK));
+}
+
+/**
+ * @brief Enables GPIO subscriber
+ *
+ * @param[in] gpio     Pointer to the register overlay for the peripheral
+ * @param[in] index    Specifies the subscriber event index to be configured
+ *
+ */
+__STATIC_INLINE void DL_GPIO_enableSubscriber(
+    GPIO_Regs* gpio, DL_GPIO_SUBSCRIBER_INDEX index)
+{
+    volatile uint32_t* pReg = &gpio->SUB0CFG;
+
+    pReg += ((uint32_t) index << 3);
+    *(pReg) |= (GPIO_SUB1CFG_ENABLE_SET);
+}
+
+/**
+ * @brief Disables GPIO subscriber
+ *
+ * @param[in] gpio     Pointer to the register overlay for the peripheral
+ * @param[in] index    Specifies the subscriber event index to be configured
+ *
+ */
+__STATIC_INLINE void DL_GPIO_disableSubscriber(
+    GPIO_Regs* gpio, DL_GPIO_SUBSCRIBER_INDEX index)
+{
+    volatile uint32_t* pReg = &gpio->SUB0CFG;
+
+    pReg += ((uint32_t) index << 3);
+    *(pReg) &= ~(GPIO_SUB1CFG_ENABLE_SET);
+}
+
+/**
+ * @brief Returns if GPIO subscriber is enabled
+ *
+ * @param[in] gpio     Pointer to the register overlay for the peripheral
+ * @param[in] index    Specifies the subscriber event index to be configured
+ *
+ * @return true if GPIO subscriber is enabled
+ * @return false if GPIO subscriber is disabled
+ *
+ */
+__STATIC_INLINE bool DL_GPIO_isSubscriberEnabled(
+    GPIO_Regs* gpio, DL_GPIO_SUBSCRIBER_INDEX index)
+{
+    volatile uint32_t* pReg = &gpio->SUB0CFG;
+
+    pReg += ((uint32_t) index << 3);
+    return (GPIO_SUB1CFG_ENABLE_SET == (*(pReg) &GPIO_SUB1CFG_ENABLE_MASK));
+}
+
+/**
+ *  @brief Sets the event publisher channel id
+ *
+ *  @param[in]  gpio   Pointer to the register overlay for the peripheral
+ *  @param[in]  index  Specifies the register event index to be configured
+ *  @param[in]  chanID  Channel ID number. Valid range 0-15. If ChanID == 0
+ *                      subscriber is disconnected. Consult your device
+ *                      datasheet on the actual maximum number of channels.
+ *
+ */
+__STATIC_INLINE void DL_GPIO_setPublisherChanID(
+    GPIO_Regs* gpio, DL_GPIO_PUBLISHER_INDEX index, uint8_t chanID)
+{
+    volatile uint32_t* pReg = &gpio->FPUB_0;
+
+    *(pReg + (uint32_t) index) =
+        ((uint32_t) chanID & GPIO_FSUB_0_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event publisher channel id
+ *
+ *  @param[in]  gpio   Pointer to the register overlay for the peripheral
+ *  @param[in]  index  Specifies the register event index to be configured
+ *
+ *  @return     Event publisher channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_GPIO_getPublisherChanID(
+    GPIO_Regs* gpio, DL_GPIO_PUBLISHER_INDEX index)
+{
+    volatile uint32_t* pReg = &gpio->FPUB_0;
+
+    return ((uint8_t)(*(pReg + (uint32_t) index) & GPIO_FPUB_0_CHANID_MASK));
+}
+
+/**
+ *  @brief Sets the event subscriber channel id
+ *
+ *  @param[in]  gpio    Pointer to the register overlay for the peripheral
+ *  @param[in]  index   Specifies the register event index to be configured
+ *  @param[in]  chanID  Channel ID number. Valid range 0-15. If ChanID == 0
+ *                      subscriber is disconnected. Consult your device
+ *                      datasheet on the actual maximum number of channels.
+ *
+ */
+__STATIC_INLINE void DL_GPIO_setSubscriberChanID(
+    GPIO_Regs* gpio, DL_GPIO_SUBSCRIBER_INDEX index, uint8_t chanID)
+{
+    volatile uint32_t* pReg = &gpio->FSUB_0;
+
+    *(pReg + (uint32_t) index) =
+        ((uint32_t) chanID & GPIO_FSUB_0_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event subscriber channel id
+ *
+ *  @param[in]  gpio   Pointer to the register overlay for the peripheral
+ *  @param[in]  index  Specifies the register event index to be configured
+ *
+ *  @return     Event subscriber channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_GPIO_getSubscriberChanID(
+    GPIO_Regs* gpio, DL_GPIO_SUBSCRIBER_INDEX index)
+{
+    volatile uint32_t* pReg = &gpio->FSUB_0;
+
+    return ((uint8_t)(*(pReg + (uint32_t) index) & GPIO_FSUB_0_CHANID_MASK));
+}
+
+/**
+ *  @brief Enables GPIO events
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  index Specifies the register event index to be configured
+ *  @param[in]  pins  Valid options will depend on index argument. When
+ *               index == @ref DL_GPIO_EVENT_ROUTE_1, valid pins values are
+ *               bitwise OR of @ref DL_GPIO_PIN (0-15). When
+ *               index == @ref DL_GPIO_EVENT_ROUTE_2, valid pins Bitwise OR of
+ *               @ref DL_GPIO_PIN (16-31).
+ *
+ */
+__STATIC_INLINE void DL_GPIO_enableEvents(
+    GPIO_Regs* gpio, DL_GPIO_EVENT_ROUTE index, uint32_t pins)
+{
+    switch (index) {
+        case DL_GPIO_EVENT_ROUTE_1:
+            gpio->GEN_EVENT0.IMASK |= (pins & 0x0000FFFFU);
+            break;
+        case DL_GPIO_EVENT_ROUTE_2:
+            gpio->GEN_EVENT1.IMASK |= (pins & 0xFFFF0000U);
+            break;
+        default:
+            break;
+    }
+}
+
+/**
+ *  @brief      Disable GPIO events
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  index Specifies the register event index to be configured
+ *  @param[in]  pins  Valid options will depend on index argument. When
+ *               index == @ref DL_GPIO_EVENT_ROUTE_1, valid pins values are
+ *               bitwise OR of @ref DL_GPIO_PIN (0-15). When
+ *               index == @ref DL_GPIO_EVENT_ROUTE_2, valid pins Bitwise OR of
+ *               @ref DL_GPIO_PIN (16-31).
+ *
+ */
+__STATIC_INLINE void DL_GPIO_disableEvents(
+    GPIO_Regs* gpio, DL_GPIO_EVENT_ROUTE index, uint32_t pins)
+{
+    switch (index) {
+        case DL_GPIO_EVENT_ROUTE_1:
+            gpio->GEN_EVENT0.IMASK &= ~(pins & 0x0000FFFFU);
+            break;
+        case DL_GPIO_EVENT_ROUTE_2:
+            gpio->GEN_EVENT1.IMASK &= ~(pins & 0xFFFF0000U);
+            break;
+        default:
+            break;
+    }
+}
+
+/**
+ *  @brief      Check which GPIO events are enabled
+ *
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  index Specifies the register event index to be configured
+ *  @param[in]  pins  Valid options will depend on index argument. When
+ *               index == @ref DL_GPIO_EVENT_ROUTE_1, valid pins values are
+ *               bitwise OR of @ref DL_GPIO_PIN (0-15). When
+ *               index == @ref DL_GPIO_EVENT_ROUTE_2, valid pins Bitwise OR of
+ *               @ref DL_GPIO_PIN (16-31).
+ *
+ *  @return     Which of the requested GPIO events are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_GPIO_PIN values
+ */
+__STATIC_INLINE uint32_t DL_GPIO_getEnabledEvents(
+    GPIO_Regs* gpio, DL_GPIO_EVENT_ROUTE index, uint32_t pins)
+{
+    volatile uint32_t* pReg = &gpio->GEN_EVENT0.IMASK;
+
+    return ((*(pReg + (uint32_t) index) & pins));
+}
+
+/**
+ *  @brief Checks if any of the GPIO events which were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  index Specifies the register event index to be configured
+ *  @param[in]  pins  Valid options will depend on index argument. When
+ *               index == @ref DL_GPIO_EVENT_ROUTE_1, valid pins values are
+ *               bitwise OR of @ref DL_GPIO_PIN (0-15). When
+ *               index == @ref DL_GPIO_EVENT_ROUTE_2, valid pins Bitwise OR of
+ *               @ref DL_GPIO_PIN (16-31).
+ *
+ *  @return     Which of the requested GPIO events are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_GPIO_PIN values
+ *
+ *  @sa         DL_GPIO_enableEvents
+ */
+__STATIC_INLINE uint32_t DL_GPIO_getEnabledEventStatus(
+    GPIO_Regs* gpio, DL_GPIO_EVENT_ROUTE index, uint32_t pins)
+{
+    const volatile uint32_t* pReg = &gpio->GEN_EVENT0.MIS;
+
+    return ((*(pReg + (uint32_t) index) & pins));
+}
+
+/**
+ *  @brief      Clear pending GPIO event
+ *
+ *  @param[in]  gpio  Pointer to the register overlay for the peripheral
+ *  @param[in]  index Specifies the register event index to be configured
+ *  @param[in]  pins  Valid options will depend on index argument. When
+ *               index == @ref DL_GPIO_EVENT_ROUTE_1, valid pins values are
+ *               bitwise OR of @ref DL_GPIO_PIN (0-15). When
+ *               index == @ref DL_GPIO_EVENT_ROUTE_2, valid pins Bitwise OR of
+ *               @ref DL_GPIO_PIN (16-31).
+ *
+ */
+__STATIC_INLINE void DL_GPIO_clearEventStatus(
+    GPIO_Regs* gpio, DL_GPIO_EVENT_ROUTE index, uint32_t pins)
+{
+    switch (index) {
+        case DL_GPIO_EVENT_ROUTE_1:
+            gpio->GEN_EVENT0.ICLR |= (pins & 0x0000FFFFU);
+            break;
+        case DL_GPIO_EVENT_ROUTE_2:
+            gpio->GEN_EVENT1.ICLR |= (pins & 0xFFFF0000U);
+            break;
+        default:
+            break;
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_GPIO__ */
+
+#endif /* ti_dl_dl_gpio__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_i2c.c
+++ b/mspm0/source/ti/driverlib/dl_i2c.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_i2c.h>
+
+#ifdef __MSPM0_HAS_I2C__
+
+/**
+ *  @brief I2C Controller APIs
+ */
+
+void DL_I2C_setClockConfig(I2C_Regs *i2c, DL_I2C_ClockConfig *config)
+{
+    DL_Common_updateReg(&i2c->CLKSEL, (uint32_t) config->clockSel,
+        I2C_CLKSEL_BUSCLK_SEL_MASK | I2C_CLKSEL_MFCLK_SEL_MASK);
+
+    DL_Common_updateReg(
+        &i2c->CLKDIV, (uint32_t) config->divideRatio, I2C_CLKDIV_RATIO_MASK);
+}
+
+void DL_I2C_getClockConfig(I2C_Regs *i2c, DL_I2C_ClockConfig *config)
+{
+    uint32_t clockSel =
+        i2c->CLKSEL & (I2C_CLKSEL_BUSCLK_SEL_MASK | I2C_CLKSEL_MFCLK_SEL_MASK);
+    config->clockSel = (DL_I2C_CLOCK)(clockSel);
+
+    uint32_t divideRatio = i2c->CLKDIV & I2C_CLKDIV_RATIO_MASK;
+    config->divideRatio  = (DL_I2C_CLOCK_DIVIDE)(divideRatio);
+}
+
+uint16_t DL_I2C_fillControllerTXFIFO(
+    I2C_Regs *i2c, uint8_t *buffer, uint16_t count)
+{
+    uint16_t i;
+    for (i = (uint16_t) 0; i < count; i++) {
+        if (DL_I2C_isControllerTXFIFOFull(i2c) == false) {
+            DL_I2C_transmitControllerData(i2c, buffer[i]);
+        } else {  // Controller TX FIFO is full
+            break;
+        }
+    }
+    return i;
+}
+
+void DL_I2C_flushControllerTXFIFO(I2C_Regs *i2c)
+{
+    DL_I2C_startFlushControllerTXFIFO(i2c);
+    while (DL_I2C_isControllerTXFIFOEmpty(i2c) == false) {
+        ;
+    }
+    DL_I2C_stopFlushControllerTXFIFO(i2c);
+}
+
+void DL_I2C_flushControllerRXFIFO(I2C_Regs *i2c)
+{
+    DL_I2C_startFlushControllerRXFIFO(i2c);
+    while (DL_I2C_isControllerRXFIFOEmpty(i2c) == false) {
+        ;
+    }
+    DL_I2C_stopFlushControllerRXFIFO(i2c);
+}
+
+/**
+ *  @brief I2C Target APIs
+ */
+uint8_t DL_I2C_fillTargetTXFIFO(I2C_Regs *i2c, uint8_t *buffer, uint8_t count)
+{
+    uint8_t i;
+    for (i = (uint8_t) 0; i < count; i++) {
+        if (DL_I2C_isTargetTXFIFOFull(i2c) == false) {
+            DL_I2C_transmitTargetData(i2c, buffer[i]);
+        } else {  // Target TX FIFO is full
+            break;
+        }
+    }
+    return i;
+}
+
+void DL_I2C_flushTargetTXFIFO(I2C_Regs *i2c)
+{
+    DL_I2C_startFlushTargetTXFIFO(i2c);
+    while (DL_I2C_isTargetTXFIFOEmpty(i2c) == false) {
+        ;
+    }
+    DL_I2C_stopFlushTargetTXFIFO(i2c);
+}
+
+void DL_I2C_flushTargetRXFIFO(I2C_Regs *i2c)
+{
+    DL_I2C_startFlushTargetRXFIFO(i2c);
+    while (DL_I2C_isTargetRXFIFOEmpty(i2c) == false) {
+        ;
+    }
+    DL_I2C_stopFlushTargetRXFIFO(i2c);
+}
+
+void DL_I2C_transmitTargetDataBlocking(I2C_Regs *i2c, uint8_t data)
+{
+    while ((DL_I2C_getTargetStatus(i2c) &
+               DL_I2C_TARGET_STATUS_TRANSMIT_REQUEST) !=
+           DL_I2C_TARGET_STATUS_TRANSMIT_REQUEST) {
+        ;
+    }
+    DL_I2C_transmitTargetData(i2c, data);
+}
+
+bool DL_I2C_transmitTargetDataCheck(I2C_Regs *i2c, uint8_t data)
+{
+    bool status;
+    if (DL_I2C_isTargetTXFIFOFull(i2c)) {
+        status = false;
+    } else {
+        DL_I2C_transmitTargetData(i2c, data);
+        status = true;
+    }
+    return status;
+}
+
+uint8_t DL_I2C_receiveTargetDataBlocking(I2C_Regs *i2c)
+{
+    while (
+        (DL_I2C_getTargetStatus(i2c) & DL_I2C_TARGET_STATUS_RECEIVE_REQUEST) !=
+        DL_I2C_TARGET_STATUS_RECEIVE_REQUEST) {
+        ;
+    }
+    return DL_I2C_receiveTargetData(i2c);
+}
+
+bool DL_I2C_receiveTargetDataCheck(I2C_Regs *i2c, uint8_t *buffer)
+{
+    bool status;
+    if (DL_I2C_isTargetRXFIFOEmpty(i2c)) {
+        status = false;
+    } else {
+        *buffer = DL_I2C_receiveTargetData(i2c);
+        status  = true;
+    }
+    return status;
+}
+
+#endif /* __MSPM0_HAS_I2C__ */

--- a/mspm0/source/ti/driverlib/dl_i2c.h
+++ b/mspm0/source/ti/driverlib/dl_i2c.h
@@ -1,0 +1,4012 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_i2c.h
+ *  @brief      Inter-Integrated Circuit (I2C) Driver Library
+ *  @defgroup   I2C  Inter-Integrated Circuit (I2C)
+ *
+ *  @anchor ti_dl_dl_i2c_Overview
+ *  # Overview
+ *
+ *   The I2C Library allows full configuration of the MSPM0 I2C module.
+ *   The I2C module provides a standardized serial interface to transfer data
+ *   between MSP devices and other external I2C devices (such as a sensors,
+ *   memory, or DACs).
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup I2C
+ * @{
+ */
+#ifndef ti_dl_dl_i2c__include
+#define ti_dl_dl_i2c__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_I2C__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/*!
+ * @brief I2C number of bytes which could be put into the TX FIFO
+ *
+ * This variable is device specific and is calculated using the system parameter
+ * I2C_SYS_FENTRIES defined in each devices header file.
+*/
+#define DL_I2C_TX_FIFO_COUNT_MAXIMUM          ((uint32_t)I2C_SYS_FENTRIES << 8)
+
+/*!
+ * @brief I2C number of bytes which could be put into the RX FIFO
+ *
+ * This variable is device specific and is calculated using the system parameter
+ * I2C_SYS_FENTRIES defined in each devices header file.
+*/
+#define DL_I2C_RX_FIFO_COUNT_MAXIMUM               ((uint32_t)I2C_SYS_FENTRIES)
+
+/** @addtogroup DL_I2C_CONTROLLER_STATUS
+ *  @{
+ */
+/*!
+ * @brief I2C is busy
+ *
+ * The BUSY bit is set during an ongoing transaction, so is set during the
+ * transmit/receive of the amount of data set in WBLEN including START, RESTART,
+ * Address and STOP signal generation when required for the current transaction
+ */
+#define DL_I2C_CONTROLLER_STATUS_BUSY                       (I2C_MSR_BUSY_MASK)
+
+/*!
+ * @brief I2C error detected
+ *
+ * The error can be from the target address not being acknowledged or the
+ * transmit data not being acknowledged
+ */
+#define DL_I2C_CONTROLLER_STATUS_ERROR                       (I2C_MSR_ERR_MASK)
+
+/*!
+ * @brief I2C address acknowledged
+ */
+#define DL_I2C_CONTROLLER_STATUS_ADDR_ACK                 (I2C_MSR_ADRACK_MASK)
+
+/*!
+ * @brief I2C data acknowledged
+ */
+#define DL_I2C_CONTROLLER_STATUS_DATA_ACK                 (I2C_MSR_DATACK_MASK)
+
+/*!
+ * @brief I2C arbitration lost
+ */
+#define DL_I2C_CONTROLLER_STATUS_ARBITRATION_LOST         (I2C_MSR_ARBLST_MASK)
+
+/*!
+ * @brief I2C idle
+ */
+#define DL_I2C_CONTROLLER_STATUS_IDLE                       (I2C_MSR_IDLE_MASK)
+
+/*!
+ * @brief I2C bus busy
+ *
+ * The bit changes based on the START and STOP conditions
+ */
+#define DL_I2C_CONTROLLER_STATUS_BUSY_BUS                 (I2C_MSR_BUSBSY_MASK)
+
+/** @}*/
+
+
+/** @addtogroup DL_I2C_TARGET_STATUS
+ *  @{
+ */
+
+/*!
+ * @brief Indicates the address for which target address match happened
+ */
+#define DL_I2C_TARGET_STATUS_ADDRESS_MATCH             (I2C_SSR_ADDRMATCH_MASK)
+
+/*!
+ * @brief I2C Target Stale TX FIFO
+ *
+ * Set = The target TX FIFO data is stale. This occurs when the TX FIFO was not
+ *   emptied during the previous I2C transaction
+ * Clear = The target TX FIFO data is not stale
+ */
+#define DL_I2C_TARGET_STATUS_STALE_TX_FIFO          (I2C_SSR_STALE_TXFIFO_MASK)
+
+/*!
+ * @brief I2C Target TX Mode
+ *
+ * Set = Target is in the TX_DATA, TX_ACK, TX_WAIT, or ADDR_ACK state with the
+ *   bus direction set to read
+ * Clear = Target is not in the TX_DATA, TX_ACK, TX_WAIT, or ADDR_ACK state
+ *   with the bus direction set to read
+ */
+#define DL_I2C_TARGET_STATUS_TX_MODE                      (I2C_SSR_TXMODE_MASK)
+
+/*!
+ * @brief I2C Target Bus Busy
+ *
+ * Set = The I2C bus is busy. This is cleared on a timeout
+ * Clear = The I2C bus is not busy. This bit is cleared when a STOP condition is
+ *   detected on the bus.
+ */
+#define DL_I2C_TARGET_STATUS_BUS_BUSY                     (I2C_SSR_BUSBSY_MASK)
+
+/*!
+ * @brief I2C Target RX Mode
+ *
+ * Set = Target is in the RX_DATA, RX_ACK, RX_WAIT, RX_ACK_WAIT or ADDR_ACK
+ *   state with the bus direction set to write
+ * Clear = Target is not in the RX_DATA, RX_ACK, RX_WAIT, RX_ACK_WAIT or ADDR_ACK
+ *   state with the bus direction set to write
+ */
+#define DL_I2C_TARGET_STATUS_RX_MODE                      (I2C_SSR_RXMODE_MASK)
+
+
+/*!
+ * @brief Direction of I2C Quick Command
+ * Only valid when QCMDST is set. @sa DL_I2C_TARGET_STATUS_QUICK_COMMAND_STATUS.
+ * Set = Quick command was a read
+ * Clear = Quick command was a write
+ */
+#define DL_I2C_TARGET_STATUS_QUICK_COMMAND_READ_WRITE     (I2C_SSR_QCMDRW_MASK)
+
+/*!
+ * @brief Status of I2C Quick Command
+ * @sa DL_I2C_TARGET_STATUS_QUICK_COMMAND_READ_WRITE.
+ * Set = Last transaction was a Quick Comand transaction
+ * Clear = Last transaction was normal or has not occurred
+ */
+#define DL_I2C_TARGET_STATUS_QUICK_COMMAND_STATUS         (I2C_SSR_QCMDST_MASK)
+
+/*!
+ * @brief I2C Target Own Address Alternate Matched
+ */
+#define DL_I2C_TARGET_STATUS_OWN_ADDR_ALTERNATE_MATCHED  (I2C_SSR_OAR2SEL_MASK)
+
+/*!
+ * @brief I2C Target Transmit Request
+ */
+#define DL_I2C_TARGET_STATUS_TRANSMIT_REQUEST               (I2C_SSR_TREQ_MASK)
+
+/*!
+ * @brief I2C Target Receive Request
+ */
+#define DL_I2C_TARGET_STATUS_RECEIVE_REQUEST                (I2C_SSR_RREQ_MASK)
+
+/** @}*/
+
+/** @addtogroup DL_I2C_INTERRUPT
+ *  @{
+ */
+/*!
+ * @brief Controller Receive Transaction completed Interrupt
+ */
+#define DL_I2C_INTERRUPT_CONTROLLER_RX_DONE  (I2C_CPU_INT_IMASK_MRXDONE_SET)
+
+/*!
+ * @brief Controller Transmit Transaction completed Interrupt
+ */
+#define DL_I2C_INTERRUPT_CONTROLLER_TX_DONE  (I2C_CPU_INT_IMASK_MTXDONE_SET)
+
+/*!
+ * @brief Controller Receive FIFO Trigger when >= defined bytes
+ */
+#define DL_I2C_INTERRUPT_CONTROLLER_RXFIFO_TRIGGER                            \
+                                          (I2C_CPU_INT_IMASK_MRXFIFOTRG_SET)
+
+/*!
+ * @brief Controller Transmit FIFO Trigger when <= defined bytes
+ */
+#define DL_I2C_INTERRUPT_CONTROLLER_TXFIFO_TRIGGER                            \
+                                          (I2C_CPU_INT_IMASK_MTXFIFOTRG_SET)
+
+/*!
+ * @brief Controller Receive FIFO is full
+ */
+#define DL_I2C_INTERRUPT_CONTROLLER_RXFIFO_FULL                               \
+                                         (I2C_CPU_INT_IMASK_MRXFIFOFULL_SET)
+
+/*!
+ * @brief Controller Transmit FIFO is empty
+ */
+#define DL_I2C_INTERRUPT_CONTROLLER_TXFIFO_EMPTY                              \
+                                            (I2C_CPU_INT_IMASK_MTXEMPTY_SET)
+
+/*!
+ * @brief Address/Data NACK Interrupt
+ */
+#define DL_I2C_INTERRUPT_CONTROLLER_NACK       (I2C_CPU_INT_IMASK_MNACK_SET)
+
+/*!
+ * @brief START Detection Interrupt
+ */
+#define DL_I2C_INTERRUPT_CONTROLLER_START     (I2C_CPU_INT_IMASK_MSTART_SET)
+
+/*!
+ * @brief STOP Detection Interrupt
+ */
+#define DL_I2C_INTERRUPT_CONTROLLER_STOP       (I2C_CPU_INT_IMASK_MSTOP_SET)
+
+/*!
+ * @brief Arbitration Lost Interrupt
+ */
+#define DL_I2C_INTERRUPT_CONTROLLER_ARBITRATION_LOST                          \
+                                            (I2C_CPU_INT_IMASK_MARBLOST_SET)
+
+/*!
+ * @brief Controller DMA Done on Event 1 publisher
+ */
+#define DL_I2C_INTERRUPT_CONTROLLER_EVENT1_DMA_DONE                           \
+                                       (I2C_CPU_INT_IMASK_MDMA_DONE_TX_SET)
+
+/*!
+ * @brief Controller DMA Done on Event 2 publisher
+ */
+#define DL_I2C_INTERRUPT_CONTROLLER_EVENT2_DMA_DONE                           \
+                                       (I2C_CPU_INT_IMASK_MDMA_DONE_RX_SET)
+
+
+/*!
+ * @brief Controller SMBus/PMBus PEC Receive Error Interrupt
+ */
+#define DL_I2C_INTERRUPT_CONTROLLER_PEC_RX_ERROR                              \
+                                         (I2C_CPU_INT_IMASK_MPEC_RX_ERR_SET)
+
+
+/*!
+ * @brief Target Receive Data Interrupt (byte has been received)
+ */
+#define DL_I2C_INTERRUPT_TARGET_RX_DONE      (I2C_CPU_INT_IMASK_SRXDONE_SET)
+
+/*!
+ * @brief Target Transmit Transaction completed Interrupt
+ */
+#define DL_I2C_INTERRUPT_TARGET_TX_DONE      (I2C_CPU_INT_IMASK_STXDONE_SET)
+
+/*!
+ * @brief Target Receive FIFO Trigger
+ */
+#define DL_I2C_INTERRUPT_TARGET_RXFIFO_TRIGGER                                \
+                                          (I2C_CPU_INT_IMASK_SRXFIFOTRG_SET)
+
+/*!
+ * @brief Target Transmit FIFO Trigger
+ */
+#define DL_I2C_INTERRUPT_TARGET_TXFIFO_TRIGGER                                \
+                                          (I2C_CPU_INT_IMASK_STXFIFOTRG_SET)
+
+/*!
+ * @brief Target RX FIFO full
+ */
+#define DL_I2C_INTERRUPT_TARGET_RXFIFO_FULL                                   \
+                                         (I2C_CPU_INT_IMASK_SRXFIFOFULL_SET)
+
+/*!
+ * @brief Target TX FIFO empty. All data in Transmit FIFO shifted out and
+ * transmit goes into idle mode.
+ */
+#define DL_I2C_INTERRUPT_TARGET_TXFIFO_EMPTY                                  \
+                                            (I2C_CPU_INT_IMASK_STXEMPTY_SET)
+
+/*!
+ * @brief Target Start Condition detected
+ */
+#define DL_I2C_INTERRUPT_TARGET_START                                         \
+                                              (I2C_CPU_INT_IMASK_SSTART_SET)
+
+/*!
+ * @brief Target Stop Condition detected
+ */
+#define DL_I2C_INTERRUPT_TARGET_STOP           (I2C_CPU_INT_IMASK_SSTOP_SET)
+
+/*!
+ * @brief General Call Interrupt
+ */
+#define DL_I2C_INTERRUPT_TARGET_GENERAL_CALL                                  \
+                                            (I2C_CPU_INT_IMASK_SGENCALL_SET)
+
+/*!
+ * @brief Target DMA Done on Event 1 Publisher
+ */
+#define DL_I2C_INTERRUPT_TARGET_EVENT1_DMA_DONE                               \
+                                        (I2C_CPU_INT_IMASK_SDMA_DONE_TX_SET)
+
+/*!
+ * @brief Target DMA Done on Event 2 Publisher
+ */
+#define DL_I2C_INTERRUPT_TARGET_EVENT2_DMA_DONE                               \
+                                        (I2C_CPU_INT_IMASK_SDMA_DONE_RX_SET)
+
+
+/*!
+ * @brief Target SMBus/PMBus PEC Receive Error Interrupt
+ */
+#define DL_I2C_INTERRUPT_TARGET_PEC_RX_ERROR                                  \
+                                         (I2C_CPU_INT_IMASK_SPEC_RX_ERR_SET)
+
+/*!
+ * @brief Target TX FIFO Underflow Interrupt
+ */
+#define DL_I2C_INTERRUPT_TARGET_TXFIFO_UNDERFLOW                              \
+                                            (I2C_CPU_INT_IMASK_STX_UNFL_SET)
+
+/*!
+ * @brief Target RX FIFO Overflow Interrupt
+ */
+#define DL_I2C_INTERRUPT_TARGET_RXFIFO_OVERFLOW                              \
+                                            (I2C_CPU_INT_IMASK_SRX_OVFL_SET)
+
+/*!
+ * @brief Target Arbitration Lost Interrupt
+ */
+#define DL_I2C_INTERRUPT_TARGET_ARBITRATION_LOST                              \
+                                            (I2C_CPU_INT_IMASK_SARBLOST_SET)
+
+/*!
+ * @brief Interrupt Overflow Interrupt. Occurs when Target START or STOP
+ *        interrupts overflow (i.e. occurs twice without being serviced)
+ */
+#define DL_I2C_TARGET_INTERRUPT_OVERFLOW   (I2C_CPU_INT_IMASK_INTR_OVFL_SET)
+
+/*!
+ * @brief Timeout A Interrupt
+ */
+#define DL_I2C_INTERRUPT_TIMEOUT_A          (I2C_CPU_INT_IMASK_TIMEOUTA_SET)
+
+/*!
+ * @brief Timeout B Interrupt
+ */
+#define DL_I2C_INTERRUPT_TIMEOUT_B          (I2C_CPU_INT_IMASK_TIMEOUTB_SET)
+
+
+/** @}*/
+
+/** @addtogroup DL_I2C_DMA_INTERRUPT
+ *  @{
+ */
+/*!
+ * @brief Peripheral Transmit FIFO Trigger interrupt for DMA trigger
+ */
+#define DL_I2C_DMA_INTERRUPT_TARGET_TXFIFO_TRIGGER                            \
+                                          (I2C_DMA_TRIG1_IMASK_STXFIFOTRG_SET)
+
+/*!
+ * @brief Peripheral Receive FIFO Trigger interrupt for DMA trigger
+ */
+#define DL_I2C_DMA_INTERRUPT_TARGET_RXFIFO_TRIGGER                            \
+                                          (I2C_DMA_TRIG1_IMASK_SRXFIFOTRG_SET)
+
+/*!
+ * @brief Controller Transmit FIFO Trigger when <= defined bytes for DMA trigger
+ */
+#define DL_I2C_DMA_INTERRUPT_CONTROLLER_TXFIFO_TRIGGER                        \
+                                          (I2C_DMA_TRIG1_IMASK_MTXFIFOTRG_SET)
+
+/*!
+ * @brief Controller Receive FIFO Trigger when >= defined bytes for DMA trigger
+ */
+#define DL_I2C_DMA_INTERRUPT_CONTROLLER_RXFIFO_TRIGGER                        \
+                                          (I2C_DMA_TRIG1_IMASK_MRXFIFOTRG_SET)
+
+/** @}*/
+
+/* clang-format on */
+
+/*! @enum DL_I2C_DMA_IIDX */
+typedef enum {
+    /*! I2C interrupt index for enabling I2C Target Transmit FIFO Trigger as DMA trigger */
+    DL_I2C_DMA_IIDX_TARGET_TXFIFO_TRIGGER = I2C_DMA_TRIG1_IIDX_STAT_MTXFIFOTRG,
+    /*! I2C interrupt index for enabling I2C Target Receive FIFO Trigger as DMA trigger */
+    DL_I2C_DMA_IIDX_TARGET_RXFIFO_TRIGGER = I2C_DMA_TRIG1_IIDX_STAT_MRXFIFOTRG,
+    /*! I2C interrupt index for enabling I2C Controller Transmit FIFO Trigger as DMA trigger */
+    DL_I2C_DMA_IIDX_CONTROLLER_TXFIFO_TRIGGER =
+        I2C_DMA_TRIG1_IIDX_STAT_STXFIFOTRG,
+    /*! I2C interrupt index for enabling I2C Controller Receive FIFO Trigger as DMA trigger */
+    DL_I2C_DMA_IIDX_CONTROLLER_RXFIFO_TRIGGER =
+        I2C_DMA_TRIG1_IIDX_STAT_SRXFIFOTRG
+} DL_I2C_DMA_IIDX;
+
+/** @enum DL_I2C_EVENT_ROUTE */
+typedef enum {
+    /*! I2C event route 1 */
+    DL_I2C_EVENT_ROUTE_1 = 0,
+    /*! I2C event route 2 */
+    DL_I2C_EVENT_ROUTE_2 = 12
+} DL_I2C_EVENT_ROUTE;
+
+/** @enum DL_I2C_CLOCK */
+typedef enum {
+    /*!  BUSCLK enabled as I2C clock source */
+    DL_I2C_CLOCK_BUSCLK = I2C_CLKSEL_BUSCLK_SEL_ENABLE,
+    /*!  MFCLK enabled as I2C clock source */
+    DL_I2C_CLOCK_MFCLK = I2C_CLKSEL_MFCLK_SEL_ENABLE,
+} DL_I2C_CLOCK;
+
+/** @enum DL_I2C_CLOCK_DIVIDE */
+typedef enum {
+    /*!  I2C Clock Divided by 1 */
+    DL_I2C_CLOCK_DIVIDE_1 = I2C_CLKDIV_RATIO_DIV_BY_1,
+    /*!  I2C Clock Divided by 2 */
+    DL_I2C_CLOCK_DIVIDE_2 = I2C_CLKDIV_RATIO_DIV_BY_2,
+    /*!  I2C Clock Divided by 3 */
+    DL_I2C_CLOCK_DIVIDE_3 = I2C_CLKDIV_RATIO_DIV_BY_3,
+    /*!  I2C Clock Divided by 4 */
+    DL_I2C_CLOCK_DIVIDE_4 = I2C_CLKDIV_RATIO_DIV_BY_4,
+    /*!  I2C Clock Divided by 5 */
+    DL_I2C_CLOCK_DIVIDE_5 = I2C_CLKDIV_RATIO_DIV_BY_5,
+    /*!  I2C Clock Divided by 6 */
+    DL_I2C_CLOCK_DIVIDE_6 = I2C_CLKDIV_RATIO_DIV_BY_6,
+    /*!  I2C Clock Divided by 7 */
+    DL_I2C_CLOCK_DIVIDE_7 = I2C_CLKDIV_RATIO_DIV_BY_7,
+    /*!  I2C Clock Divided by 8 */
+    DL_I2C_CLOCK_DIVIDE_8 = I2C_CLKDIV_RATIO_DIV_BY_8,
+} DL_I2C_CLOCK_DIVIDE;
+
+/** @enum DL_I2C_TARGET_ADDRESSING_MODE */
+typedef enum {
+    /*! Enable Target in 7-bit addressing mode */
+    DL_I2C_TARGET_ADDRESSING_MODE_7_BIT = I2C_SOAR_SMODE_MODE7,
+    /*! Enable Target in 10-bit addressing mode */
+    DL_I2C_TARGET_ADDRESSING_MODE_10_BIT = I2C_SOAR_SMODE_MODE10,
+} DL_I2C_TARGET_ADDRESSING_MODE;
+
+/** @enum DL_I2C_TARGET_PEC_STATUS */
+typedef enum {
+    /*!  I2C Target SMBus/PMBus PEC was checked in the transaction that occurred
+     *   before the last Stop */
+    DL_I2C_TARGET_PEC_STATUS_CHECKED = I2C_TARGET_PECSR_PECSTS_CHECK_SET,
+    /*!  I2C Target SMBus/PMBus PEC was not checked in the transaction that
+     *   occurred before the last Stop */
+    DL_I2C_TARGET_PEC_STATUS_NOT_CHECKED =
+        I2C_TARGET_PECSR_PECSTS_CHECK_CLEARED,
+} DL_I2C_TARGET_PEC_STATUS;
+
+/** @enum DL_I2C_ANALOG_GLITCH_FILTER_WIDTH */
+typedef enum {
+    /*!  Pulses shorter than 5ns in length are filtered.  */
+    DL_I2C_ANALOG_GLITCH_FILTER_WIDTH_5NS = I2C_GFCTL_AGFSEL_AGLIT_5,
+    /*!  Pulses shorter than 10ns in length are filtered.  */
+    DL_I2C_ANALOG_GLITCH_FILTER_WIDTH_10NS = I2C_GFCTL_AGFSEL_AGLIT_10,
+    /*!  Pulses shorter than 25ns in length are filtered.  */
+    DL_I2C_ANALOG_GLITCH_FILTER_WIDTH_25NS = I2C_GFCTL_AGFSEL_AGLIT_25,
+    /*!  Pulses shorter than 50ns in length are filtered.  */
+    DL_I2C_ANALOG_GLITCH_FILTER_WIDTH_50NS = I2C_GFCTL_AGFSEL_AGLIT_50,
+} DL_I2C_ANALOG_GLITCH_FILTER_WIDTH;
+
+/** @enum DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH */
+typedef enum {
+    /*!  Pulses filtering disabled.  */
+    DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH_DISABLED = I2C_GFCTL_DGFSEL_DISABLED,
+    /*!  Pulses shorter than 1 functional clock tick in length are filtered.  */
+    DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH_CLOCKS_1 = I2C_GFCTL_DGFSEL_CLK_1,
+    /*!  Pulses shorter than 2 functional clock ticks in length are filtered.  */
+    DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH_CLOCKS_2 = I2C_GFCTL_DGFSEL_CLK_2,
+    /*!  Pulses shorter than 3 functional clock ticks in length are filtered.  */
+    DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH_CLOCKS_3 = I2C_GFCTL_DGFSEL_CLK_3,
+    /*!  Pulses shorter than 4 functional clock ticks in length are filtered.  */
+    DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH_CLOCKS_4 = I2C_GFCTL_DGFSEL_CLK_4,
+    /*!  Pulses shorter than 8 functional clock ticks in length are filtered.  */
+    DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH_CLOCKS_8 = I2C_GFCTL_DGFSEL_CLK_8,
+    /*!  Pulses shorter than 16 functional clock ticks in length are filtered.  */
+    DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH_CLOCKS_16 = I2C_GFCTL_DGFSEL_CLK_16,
+    /*!  Pulses shorter than 31 functional clock ticks in length are filtered.  */
+    DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH_CLOCKS_31 = I2C_GFCTL_DGFSEL_CLK_31,
+} DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH;
+
+/** @enum DL_I2C_CONTROLLER_DIRECTION */
+typedef enum {
+    /*! Set direction to controller transmitting to target */
+    DL_I2C_CONTROLLER_DIRECTION_TX = I2C_MSA_DIR_TRANSMIT,
+    /*! Set direction to controller receiving from target */
+    DL_I2C_CONTROLLER_DIRECTION_RX = I2C_MSA_DIR_RECEIVE,
+} DL_I2C_CONTROLLER_DIRECTION;
+
+/** @enum DL_I2C_CONTROLLER_ADDRESSING_MODE */
+typedef enum {
+    /*! Enable Controller in 7-bit addressing mode */
+    DL_I2C_CONTROLLER_ADDRESSING_MODE_7_BIT = I2C_MSA_MMODE_MODE7,
+    /*! Enable Controller in 10-bit addressing mode */
+    DL_I2C_CONTROLLER_ADDRESSING_MODE_10_BIT = I2C_MSA_MMODE_MODE10,
+} DL_I2C_CONTROLLER_ADDRESSING_MODE;
+
+/** @enum DL_I2C_CONTROLLER_PEC_STATUS */
+typedef enum {
+    /*!  I2C Controller SMBus/PMBus PEC was checked in the transaction that
+     *   occurred before the last Stop */
+    DL_I2C_CONTROLLER_PEC_STATUS_CHECKED =
+        I2C_CONTROLLER_PECSR_PECSTS_CHECK_SET,
+    /*!  I2C Controller SMBus/PMBus PEC was not checked in the transaction that
+     *   occurred the last Stop */
+    DL_I2C_CONTROLLER_PEC_STATUS_NOT_CHECKED =
+        I2C_CONTROLLER_PECSR_PECSTS_CHECK_CLEARED,
+} DL_I2C_CONTROLLER_PEC_STATUS;
+
+/** @enum DL_I2C_CONTROLLER_PEC_CHECK_ERROR */
+typedef enum {
+    /*! I2C Controller SMBus/PMBus PEC check error occurred in the transaction
+     *  before the last stop */
+    DL_I2C_CONTROLLER_PEC_CHECK_ERROR_SET =
+        I2C_CONTROLLER_PECSR_PECSTS_ERROR_SET,
+    /*! I2C Controller SMBus/PMBus PEC check error did not occur in the
+     *  transaction before the last stop */
+    DL_I2C_CONTROLLER_PEC_CHECK_ERROR_CLEARED =
+        I2C_CONTROLLER_PECSR_PECSTS_ERROR_CLEARED,
+} DL_I2C_CONTROLLER_PEC_CHECK_ERROR;
+
+/** @enum DL_I2C_CONTROLLER_SCL */
+typedef enum {
+    /*!  I2C SCL signal high */
+    DL_I2C_CONTROLLER_SCL_HIGH = I2C_MBMON_SCL_SET,
+    /*!  I2C SCL signal low */
+    DL_I2C_CONTROLLER_SCL_LOW = I2C_MBMON_SCL_CLEARED,
+} DL_I2C_CONTROLLER_SCL;
+
+/** @enum DL_I2C_CONTROLLER_SDA */
+typedef enum {
+    /*!  I2C SDA signal high */
+    DL_I2C_CONTROLLER_SDA_HIGH = I2C_MBMON_SDA_SET,
+    /*!  I2C SDA signal low */
+    DL_I2C_CONTROLLER_SDA_LOW = I2C_MBMON_SDA_CLEARED,
+} DL_I2C_CONTROLLER_SDA;
+
+/** @enum DL_I2C_CONTROLLER_START */
+typedef enum {
+    /*!  Controller generates START condition */
+    DL_I2C_CONTROLLER_START_ENABLE = I2C_MCTR_START_ENABLE,
+    /*!  Controller doesn't generate START condition */
+    DL_I2C_CONTROLLER_START_DISABLE = I2C_MCTR_START_DISABLE,
+} DL_I2C_CONTROLLER_START;
+
+/** @enum DL_I2C_CONTROLLER_STOP */
+typedef enum {
+    /*!  Controller generates STOP condition */
+    DL_I2C_CONTROLLER_STOP_ENABLE = I2C_MCTR_STOP_ENABLE,
+    /*!  Controller doesn't generate STOP condition */
+    DL_I2C_CONTROLLER_STOP_DISABLE = I2C_MCTR_STOP_DISABLE,
+} DL_I2C_CONTROLLER_STOP;
+
+/** @enum DL_I2C_CONTROLLER_ACK */
+typedef enum {
+    /*!  Last received data byte of a transaction is not ACKed automatically */
+    DL_I2C_CONTROLLER_ACK_ENABLE = I2C_MCTR_ACK_ENABLE,
+    /*!  Last received data byte of a transaction is ACKed automatically */
+    DL_I2C_CONTROLLER_ACK_DISABLE = I2C_MCTR_ACK_DISABLE,
+} DL_I2C_CONTROLLER_ACK;
+
+/** @enum DL_I2C_TX_FIFO_LEVEL */
+typedef enum {
+    /*!  Trigger when the TX FIFO is empty */
+    DL_I2C_TX_FIFO_LEVEL_EMPTY = I2C_MFIFOCTL_TXTRIG_EMPTY,
+    /*!  Trigger when TX FIFO contains 1 byte */
+    DL_I2C_TX_FIFO_LEVEL_BYTES_1 = I2C_MFIFOCTL_TXTRIG_LEVEL_1,
+    /*!  Trigger when TX FIFO contains 2 bytes */
+    DL_I2C_TX_FIFO_LEVEL_BYTES_2 = I2C_MFIFOCTL_TXTRIG_LEVEL_2,
+    /*!  Trigger when TX FIFO contains 3 bytes */
+    DL_I2C_TX_FIFO_LEVEL_BYTES_3 = I2C_MFIFOCTL_TXTRIG_LEVEL_3,
+    /*!  Trigger when TX FIFO contains 4 bytes */
+    DL_I2C_TX_FIFO_LEVEL_BYTES_4 = I2C_MFIFOCTL_TXTRIG_LEVEL_4,
+    /*!  Trigger when TX FIFO contains 5 bytes */
+    DL_I2C_TX_FIFO_LEVEL_BYTES_5 = I2C_MFIFOCTL_TXTRIG_LEVEL_5,
+    /*!  Trigger when TX FIFO contains 6 bytes */
+    DL_I2C_TX_FIFO_LEVEL_BYTES_6 = I2C_MFIFOCTL_TXTRIG_LEVEL_6,
+    /*!  Trigger when TX FIFO contains 7 bytes */
+    DL_I2C_TX_FIFO_LEVEL_BYTES_7 = I2C_MFIFOCTL_TXTRIG_LEVEL_7,
+} DL_I2C_TX_FIFO_LEVEL;
+
+/** @enum DL_I2C_RX_FIFO_LEVEL */
+typedef enum {
+    /*!  Trigger when RX FIFO contains at least 1 byte */
+    DL_I2C_RX_FIFO_LEVEL_BYTES_1 = I2C_MFIFOCTL_RXTRIG_LEVEL_1,
+    /*!  Trigger when RX FIFO contains at least 2 bytes */
+    DL_I2C_RX_FIFO_LEVEL_BYTES_2 = I2C_MFIFOCTL_RXTRIG_LEVEL_2,
+    /*!  Trigger when RX FIFO contains at least 3 bytes */
+    DL_I2C_RX_FIFO_LEVEL_BYTES_3 = I2C_MFIFOCTL_RXTRIG_LEVEL_3,
+    /*!  Trigger when RX FIFO contains at least 4 bytes */
+    DL_I2C_RX_FIFO_LEVEL_BYTES_4 = I2C_MFIFOCTL_RXTRIG_LEVEL_4,
+    /*!  Trigger when RX FIFO contains at least 5 bytes */
+    DL_I2C_RX_FIFO_LEVEL_BYTES_5 = I2C_MFIFOCTL_RXTRIG_LEVEL_5,
+    /*!  Trigger when RX FIFO contains at least 6 bytes */
+    DL_I2C_RX_FIFO_LEVEL_BYTES_6 = I2C_MFIFOCTL_RXTRIG_LEVEL_6,
+    /*!  Trigger when RX FIFO contains at least 7 bytes */
+    DL_I2C_RX_FIFO_LEVEL_BYTES_7 = I2C_MFIFOCTL_RXTRIG_LEVEL_7,
+    /*!  Trigger when RX FIFO contains at least 8 bytes */
+    DL_I2C_RX_FIFO_LEVEL_BYTES_8 = I2C_MFIFOCTL_RXTRIG_LEVEL_8,
+} DL_I2C_RX_FIFO_LEVEL;
+
+/** @enum DL_I2C_TARGET_RESPONSE_OVERRIDE_VALUE */
+typedef enum {
+    /*!  Target manual ACK for valid data or command.  */
+    DL_I2C_TARGET_RESPONSE_OVERRIDE_VALUE_ACK = I2C_SACKCTL_ACKOVAL_DISABLE,
+    /*!  Target manual NACK for invalid data or command.  */
+    DL_I2C_TARGET_RESPONSE_OVERRIDE_VALUE_NACK = I2C_SACKCTL_ACKOVAL_ENABLE,
+} DL_I2C_TARGET_RESPONSE_OVERRIDE_VALUE;
+
+/*! @enum DL_I2C_IIDX */
+typedef enum {
+    /*! Interrupt index for I2C if no interrupt is pending */
+    DL_I2C_IIDX_NO_INT = I2C_CPU_INT_IIDX_STAT_NO_INTR,
+    /*! Interrupt index for I2C Controller Receive Transaction completed */
+    DL_I2C_IIDX_CONTROLLER_RX_DONE = I2C_CPU_INT_IIDX_STAT_MRXDONEFG,
+    /*! Interrupt index for Controller Transmit Transaction completed */
+    DL_I2C_IIDX_CONTROLLER_TX_DONE = I2C_CPU_INT_IIDX_STAT_MTXDONEFG,
+    /*! Interrupt index for I2C Controller Receive FIFO Trigger */
+    DL_I2C_IIDX_CONTROLLER_RXFIFO_TRIGGER = I2C_CPU_INT_IIDX_STAT_MRXFIFOTRG,
+    /*! Interrupt index for I2C Controller Transmit FIFO Trigger */
+    DL_I2C_IIDX_CONTROLLER_TXFIFO_TRIGGER = I2C_CPU_INT_IIDX_STAT_MTXFIFOTRG,
+    /*! Interrupt index for I2C Controller Receive when FIFO is full */
+    DL_I2C_IIDX_CONTROLLER_RXFIFO_FULL = I2C_CPU_INT_IIDX_STAT_MRXFIFOFULL,
+    /*! Interrupt index for I2C Controller when Transmit FIFO is empty */
+    DL_I2C_IIDX_CONTROLLER_TXFIFO_EMPTY = I2C_CPU_INT_IIDX_STAT_MTX_EMPTY,
+    /*! Interrupt index for Address/Data NACK */
+    DL_I2C_IIDX_CONTROLLER_NACK = I2C_CPU_INT_IIDX_STAT_MNACKFG,
+    /*! Interrupt index for I2C controller START Detection */
+    DL_I2C_IIDX_CONTROLLER_START = I2C_CPU_INT_IIDX_STAT_MSTARTFG,
+    /*! Interrupt index for I2C controller STOP Detection */
+    DL_I2C_IIDX_CONTROLLER_STOP = I2C_CPU_INT_IIDX_STAT_MSTOPFG,
+    /*! Interrupt index for I2C controller Arbitration Lost */
+    DL_I2C_IIDX_CONTROLLER_ARBITRATION_LOST = I2C_CPU_INT_IIDX_STAT_MARBLOSTFG,
+    /*! Interrupt index for I2C controller Event 1 DMA Done */
+    DL_I2C_IIDX_CONTROLLER_EVENT1_DMA_DONE =
+        I2C_CPU_INT_IIDX_STAT_MDMA_DONE_TX,
+    /*! Interrupt index for I2C controller Event 2 DMA Done */
+    DL_I2C_IIDX_CONTROLLER_EVENT2_DMA_DONE =
+        I2C_CPU_INT_IIDX_STAT_MDMA_DONE_RX,
+
+    /*! Interrupt index for I2C controller SMBus/PMBus PEC Receive Error Event */
+    DL_I2C_IIDX_CONTROLLER_PEC_RX_ERROR = I2C_CPU_INT_IIDX_STAT_MPEC_RX_ERR,
+    /*! Interrupt index for I2C Timeout A Event */
+    DL_I2C_IIDX_TIMEOUT_A = I2C_CPU_INT_IIDX_STAT_TIMEOUTA,
+    /*! Interrupt index for I2C Timeout B Event */
+    DL_I2C_IIDX_TIMEOUT_B = I2C_CPU_INT_IIDX_STAT_TIMEOUTB,
+
+    /*! Interrupt index for I2C Target Receive Data */
+    DL_I2C_IIDX_TARGET_RX_DONE = I2C_CPU_INT_IIDX_STAT_SRXDONEFG,
+    /*! Interrupt index for I2C Target Transmit Transaction completed */
+    DL_I2C_IIDX_TARGET_TX_DONE = I2C_CPU_INT_IIDX_STAT_STXDONEFG,
+    /*! Interrupt index for I2C Target Receive FIFO Trigger */
+    DL_I2C_IIDX_TARGET_RXFIFO_TRIGGER = I2C_CPU_INT_IIDX_STAT_SRXFIFOTRG,
+    /*! Interrupt index for I2C Target Transmit FIFO Trigger */
+    DL_I2C_IIDX_TARGET_TXFIFO_TRIGGER = I2C_CPU_INT_IIDX_STAT_STXFIFOTRG,
+    /*! Interrupt index for I2C Target RX FIFO full */
+    DL_I2C_IIDX_TARGET_RXFIFO_FULL = I2C_CPU_INT_IIDX_STAT_SRXFIFOFULL,
+    /*! Interrupt index for I2C Target TX FIFO empty.
+     * All data in Transmit FIFO shifted out and transmit goes into idle mode. */
+    DL_I2C_IIDX_TARGET_TXFIFO_EMPTY = I2C_CPU_INT_IIDX_STAT_STXEMPTY,
+    /*! Interrupt index for I2C Target Start Condition detected */
+    DL_I2C_IIDX_TARGET_START = I2C_CPU_INT_IIDX_STAT_SSTARTFG,
+    /*! Interrupt index for I2C Target Stop Condition detected */
+    DL_I2C_IIDX_TARGET_STOP = I2C_CPU_INT_IIDX_STAT_SSTOPFG,
+    /*! Interrupt index for I2C General Call */
+    DL_I2C_IIDX_TARGET_GENERAL_CALL = I2C_CPU_INT_IIDX_STAT_SGENCALL,
+    /*! Interrupt index for I2C Target Event 1 DMA Done */
+    DL_I2C_IIDX_TARGET_EVENT1_DMA_DONE = I2C_CPU_INT_IIDX_STAT_SDMA_DONE_TX,
+    /*! Interrupt index for I2C Target Event 2 DMA Done */
+    DL_I2C_IIDX_TARGET_EVENT2_DMA_DONE = I2C_CPU_INT_IIDX_STAT_SDMA_DONE_RX,
+
+    /*! Interrupt index for I2C Target SMBus/PMBus PEC Receive Error Event */
+    DL_I2C_IIDX_TARGET_PEC_RX_ERROR = I2C_CPU_INT_IIDX_STAT_SPEC_RX_ERR,
+    /*! Interrupt index for I2C Target TX FIFO underflow event */
+    DL_I2C_IIDX_TARGET_TXFIFO_UNDERFLOW = I2C_CPU_INT_IIDX_STAT_STX_UNFL,
+    /*! Interrupt index for I2C Target RX FIFO overflow event */
+    DL_I2C_IIDX_TARGET_RXFIFO_OVERFLOW = I2C_CPU_INT_IIDX_STAT_SRX_OVFL,
+    /*! Interrupt index for I2C Target arbitration lost event */
+    DL_I2C_IIDX_TARGET_ARBITRATION_LOST = I2C_CPU_INT_IIDX_STAT_SARBLOST,
+    /*! Interrupt index for I2C interrupt overflow event */
+    DL_I2C_IIDX_INTERRUPT_OVERFLOW = I2C_CPU_INT_IIDX_STAT_INTR_OVFL,
+
+} DL_I2C_IIDX;
+
+/**
+ * @brief  Configuration struct for @ref DL_I2C_setClockConfig.
+ */
+typedef struct {
+    /*! I2C module clock source. One of @ref DL_I2C_CLOCK */
+    DL_I2C_CLOCK clockSel;
+    /*! I2C clock divider selection. One of @ref DL_I2C_CLOCK_DIVIDE */
+    DL_I2C_CLOCK_DIVIDE divideRatio;
+} DL_I2C_ClockConfig;
+
+/**
+ *  @brief      Configure I2C source clock
+ *
+ *  @param[in]  i2c    Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  config  Pointer to the clock configuration struct
+ *                       @ref DL_I2C_ClockConfig.
+ */
+void DL_I2C_setClockConfig(I2C_Regs *i2c, DL_I2C_ClockConfig *config);
+
+/**
+ *  @brief      Get I2C source clock configuration
+ *
+ *  @param[in]  i2c    Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  config  Pointer to the clock configuration struct
+ *                      @ref DL_I2C_ClockConfig.
+ */
+void DL_I2C_getClockConfig(I2C_Regs *i2c, DL_I2C_ClockConfig *config);
+
+/**
+ *  @brief      Fills the controller TX FIFO with data
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  buffer  Pointer to buffer of bytes
+ *  @param[in]  count   Number of bytes to fill controller TX FIFO from buffer
+ *
+ *  @return     Number of bytes that were successfully written
+ */
+uint16_t DL_I2C_fillControllerTXFIFO(
+    I2C_Regs *i2c, uint8_t *buffer, uint16_t count);
+
+/**
+ *  @brief      Flushes/removes all elements in the controller TX FIFO
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+void DL_I2C_flushControllerTXFIFO(I2C_Regs *i2c);
+
+/**
+ *  @brief      Flushes/removes all elements in the controller RX FIFO
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+void DL_I2C_flushControllerRXFIFO(I2C_Regs *i2c);
+
+/**
+ *  @brief      Checks if controller TX FIFO is full
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If controller TX FIFO is full
+ *
+ *  @retval     true if controller TX FIFO is full
+ *  @retval     false if controller TX FIFO is not full
+ */
+__STATIC_INLINE bool DL_I2C_isControllerTXFIFOFull(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MFIFOSR & I2C_MFIFOSR_TXFIFOCNT_MASK) ==
+            I2C_MFIFOSR_TXFIFOCNT_MINIMUM);
+}
+
+/**
+ *  @brief      Checks if controller TX FIFO is empty
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If controller TX FIFO is empty
+ *
+ *  @retval     true if controller TX FIFO is empty
+ *  @retval     false if controller TX FIFO is not empty
+ */
+__STATIC_INLINE bool DL_I2C_isControllerTXFIFOEmpty(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MFIFOSR & I2C_MFIFOSR_TXFIFOCNT_MASK) ==
+            I2C_MFIFOSR_TXFIFOCNT_MAXIMUM);
+}
+
+/**
+ *  @brief      Checks if controller RX FIFO is empty
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If controller RX FIFO is empty
+ *
+ *  @retval     true if controller RX FIFO is empty
+ *  @retval     false if controller RX FIFO is not empty
+ */
+__STATIC_INLINE bool DL_I2C_isControllerRXFIFOEmpty(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MFIFOSR & I2C_MFIFOSR_RXFIFOCNT_MASK) ==
+            I2C_MFIFOSR_RXFIFOCNT_MINIMUM);
+}
+
+/**
+ *  @brief      Reset transfers from from I2C controller
+ *
+ *  Resets transfer register to initialize I2C
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_resetControllerTransfer(I2C_Regs *i2c)
+{
+    // Resets all Controller functionality
+    i2c->MASTER.MCTR = 0x00;
+}
+
+/**
+ *  @brief      Sets up a transfer from I2C controller
+ *
+ *  Set target address, transfer direction, burst length, START+STOP generation.
+ *  @note   Reading/writing data must be done separately.
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *  @param[in]  targetAddr  Target address [0x00, 0x3FF]
+ *  @param[in]  direction   One of @ref DL_I2C_CONTROLLER_DIRECTION
+ *  @param[in]  length      Intended burst length in number of bytes
+ */
+__STATIC_INLINE void DL_I2C_startControllerTransfer(I2C_Regs *i2c,
+    uint32_t targetAddr, DL_I2C_CONTROLLER_DIRECTION direction,
+    uint16_t length)
+{
+    // Specify target address and read/write mode
+    DL_Common_updateReg(&i2c->MASTER.MSA,
+        ((targetAddr << I2C_MSA_SADDR_OFS) | (uint32_t) direction),
+        (I2C_MSA_SADDR_MASK | I2C_MSA_DIR_MASK));
+
+    // STOP bit is generated after burst length number of bytes transferred
+    DL_Common_updateReg(&i2c->MASTER.MCTR,
+        (((uint32_t) length << I2C_MCTR_MBLEN_OFS) | I2C_MCTR_BURSTRUN_ENABLE |
+            I2C_MCTR_START_ENABLE | I2C_MCTR_STOP_ENABLE),
+        (I2C_MCTR_MBLEN_MASK | I2C_MCTR_BURSTRUN_MASK | I2C_MCTR_START_MASK |
+            I2C_MCTR_STOP_MASK));
+}
+
+/**
+ *  @brief      Sets up a transfer from I2C controller with control of START,
+ *  STOP and ACK
+ *
+ *  @note   Reading/writing data must be done separately.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  targetAddr  7-bit target address [0x00, 0x7f]
+ *  @param[in]  direction   One of @ref DL_I2C_CONTROLLER_DIRECTION
+ *  @param[in]  length      Intended burst length in number of bytes
+ *  @param[in]  start       One of @ref DL_I2C_CONTROLLER_START
+ *  @param[in]  stop        One of @ref DL_I2C_CONTROLLER_STOP
+ *  @param[in]  ack         One of @ref DL_I2C_CONTROLLER_ACK
+ */
+__STATIC_INLINE void DL_I2C_startControllerTransferAdvanced(I2C_Regs *i2c,
+    uint32_t targetAddr, DL_I2C_CONTROLLER_DIRECTION direction,
+    uint16_t length, DL_I2C_CONTROLLER_START start,
+    DL_I2C_CONTROLLER_STOP stop, DL_I2C_CONTROLLER_ACK ack)
+{
+    // Specify target address and read/write mode
+    DL_Common_updateReg(&i2c->MASTER.MSA,
+        ((targetAddr << I2C_MSA_SADDR_OFS) | (uint32_t) direction),
+        (I2C_MSA_SADDR_MASK | I2C_MSA_DIR_MASK));
+
+    DL_Common_updateReg(&i2c->MASTER.MCTR,
+        (((uint32_t) length << I2C_MCTR_MBLEN_OFS) | I2C_MCTR_BURSTRUN_ENABLE |
+            (uint32_t) start | (uint32_t) stop | (uint32_t) ack),
+        (I2C_MCTR_MBLEN_MASK | I2C_MCTR_BURSTRUN_MASK | I2C_MCTR_START_MASK |
+            I2C_MCTR_STOP_MASK | I2C_MCTR_ACK_MASK));
+}
+
+/**
+ *  @brief      Checks if target TX FIFO is full
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target TX FIFO is full
+ *
+ *  @retval     true if target TX FIFO is full
+ *  @retval     false if target TX FIFO is not full
+ */
+__STATIC_INLINE bool DL_I2C_isTargetTXFIFOFull(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SFIFOSR & I2C_SFIFOSR_TXFIFOCNT_MASK) ==
+            I2C_SFIFOSR_TXFIFOCNT_MINIMUM);
+}
+
+/**
+ *  @brief      Checks if target TX FIFO is empty
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target TX FIFO is empty
+ *
+ *  @retval     true if target TX FIFO is empty
+ *  @retval     false if target TX FIFO is not empty
+ */
+__STATIC_INLINE bool DL_I2C_isTargetTXFIFOEmpty(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SFIFOSR & I2C_SFIFOSR_TXFIFOCNT_MASK) ==
+            DL_I2C_TX_FIFO_COUNT_MAXIMUM);
+}
+
+/**
+ *  @brief      Checks if target RX FIFO is empty
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target RX FIFO is empty
+ *
+ *  @retval     true if target RX FIFO is empty
+ *  @retval     false if target RX FIFO is not empty
+ */
+__STATIC_INLINE bool DL_I2C_isTargetRXFIFOEmpty(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SFIFOSR & I2C_SFIFOSR_RXFIFOCNT_MASK) ==
+            I2C_SFIFOSR_RXFIFOCNT_MINIMUM);
+}
+
+/**
+ *  @brief      Fills the target TX FIFO with data
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  buffer  Pointer to buffer of bytes
+ *  @param[in]  count   Number of bytes to fill target TX FIFO from buffer
+ *
+ *  @return     Number of bytes that were successfully written
+ */
+uint8_t DL_I2C_fillTargetTXFIFO(I2C_Regs *i2c, uint8_t *buffer, uint8_t count);
+
+/**
+ *  @brief      Flushes/removes all elements in the target TX FIFO
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+void DL_I2C_flushTargetTXFIFO(I2C_Regs *i2c);
+
+/**
+ *  @brief      Flushes/removes all elements in the target RX FIFO
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+void DL_I2C_flushTargetRXFIFO(I2C_Regs *i2c);
+
+/**
+ *  @brief  Transmit target data, waiting until transmit request
+ *
+ *  @note   Setting own target addresses and enabling target should be done
+ *  separately.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  data    Byte of data to transmit
+ */
+void DL_I2C_transmitTargetDataBlocking(I2C_Regs *i2c, uint8_t data);
+
+/**
+ *  @brief  Transmit target data
+ *
+ *  @note   Setting own target addresses and enabling target should be done
+ *  separately.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  data    Byte of data to transmit
+ *
+ *  @return Whether data could be transmitted or not
+ *  @retval true if data could be transmitted
+ *  @retval false if data could not be transmitted
+ */
+bool DL_I2C_transmitTargetDataCheck(I2C_Regs *i2c, uint8_t data);
+
+/**
+ *  @brief  Receive target data, waiting until receive request
+ *
+ *  @note   Setting own target addresses and enabling target should be done
+ *  separately.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return Data received from target
+ */
+uint8_t DL_I2C_receiveTargetDataBlocking(I2C_Regs *i2c);
+
+/**
+ *  @brief  Receive target data
+ *
+ *  @note   Setting own target addresses and enabling target should be done
+ *  separately.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  buffer  Pointer to where byte of received data should be stored
+ *
+ *  @return Whether data could be received or not
+ *  @retval true if data could be received
+ *  @retval false if data could not be received
+ */
+bool DL_I2C_receiveTargetDataCheck(I2C_Regs *i2c, uint8_t *buffer);
+
+/**
+ * @brief Enables power on I2C module
+ *
+ * @param i2c        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enablePower(I2C_Regs *i2c)
+{
+    i2c->GPRCM.PWREN = (I2C_PWREN_KEY_UNLOCK_W | I2C_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power on i2c module
+ *
+ * @param i2c        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disablePower(I2C_Regs *i2c)
+{
+    i2c->GPRCM.PWREN = (I2C_PWREN_KEY_UNLOCK_W | I2C_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief Returns if  power on i2c module
+ *
+ * @param i2c        Pointer to the register overlay for the peripheral
+ *
+ * @return true if power is enabled
+ * @return false if power is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isPowerEnabled(I2C_Regs *i2c)
+{
+    return (
+        (i2c->GPRCM.PWREN & I2C_PWREN_ENABLE_MASK) == I2C_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Resets i2c peripheral
+ *
+ * @param i2c        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_reset(I2C_Regs *i2c)
+{
+    i2c->GPRCM.RSTCTL =
+        (I2C_RSTCTL_KEY_UNLOCK_W | I2C_RSTCTL_RESETSTKYCLR_CLR |
+            I2C_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief Returns if i2c peripheral was reset
+ *
+ * @param i2c        Pointer to the register overlay for the peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_I2C_isReset(I2C_Regs *i2c)
+{
+    return ((i2c->GPRCM.STAT & I2C_STAT_RESETSTKY_MASK) ==
+            I2C_STAT_RESETSTKY_RESET);
+}
+
+/**
+ * @brief Set Clock Source
+ *
+ *  Clock sources depend on device and clock should be enabled
+ *
+ *  @param[in]  i2c            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  clockSource    One of @ref DL_I2C_CLOCK.
+ *
+ */
+__STATIC_INLINE void DL_I2C_selectClockSource(
+    I2C_Regs *i2c, DL_I2C_CLOCK clockSource)
+{
+    DL_Common_updateReg(&i2c->CLKSEL, (uint32_t) clockSource,
+        I2C_CLKSEL_BUSCLK_SEL_MASK | I2C_CLKSEL_MFCLK_SEL_MASK);
+}
+
+/**
+ * @brief Set Clock Divider
+ *
+ *  @param[in]  i2c            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  clockDivider   One of @ref DL_I2C_CLOCK_DIVIDE.
+ *
+ */
+__STATIC_INLINE void DL_I2C_selectClockDivider(
+    I2C_Regs *i2c, DL_I2C_CLOCK_DIVIDE clockDivider)
+{
+    DL_Common_updateReg(
+        &i2c->CLKDIV, (uint32_t) clockDivider, I2C_CLKDIV_RATIO_MASK);
+}
+
+/**
+ *  @brief      Get Analog Glitch Suppression Pulse Width
+ *
+ *  Pulse width for the analog glitch suppression on SCL/SDA lines.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     Analog glitch suppression pulse width
+ *
+ *  @retval     One of @ref DL_I2C_ANALOG_GLITCH_FILTER_WIDTH.
+ */
+__STATIC_INLINE DL_I2C_ANALOG_GLITCH_FILTER_WIDTH
+DL_I2C_getAnalogGlitchFilterPulseWidth(I2C_Regs *i2c)
+{
+    uint32_t filterWidth = i2c->GFCTL & I2C_GFCTL_AGFSEL_MASK;
+
+    return (DL_I2C_ANALOG_GLITCH_FILTER_WIDTH)(filterWidth);
+}
+
+/**
+ *  @brief      Set Analog Glitch Suppression Pulse Width
+ *
+ *  Pulse width for the analog glitch suppression on SCL/SDA lines.
+ *
+ *  @param[in]  i2c            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  filterWidth    One of @ref DL_I2C_ANALOG_GLITCH_FILTER_WIDTH.
+ */
+__STATIC_INLINE void DL_I2C_setAnalogGlitchFilterPulseWidth(
+    I2C_Regs *i2c, DL_I2C_ANALOG_GLITCH_FILTER_WIDTH filterWidth)
+{
+    DL_Common_updateReg(
+        &i2c->GFCTL, (uint32_t) filterWidth, I2C_GFCTL_AGFSEL_MASK);
+}
+
+/**
+ *  @brief      Get Digital Glitch Suppression Pulse Width
+ *
+ *  Pulse width for the digital glitch suppression on SCL/SDA lines.
+ *  Values are in terms of functional clock ticks.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     Digital glitch suppression pulse width
+ *
+ *  @retval     One of @ref DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH.
+ */
+__STATIC_INLINE DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH
+DL_I2C_getDigitalGlitchFilterPulseWidth(I2C_Regs *i2c)
+{
+    uint32_t filterWidth = i2c->GFCTL & I2C_GFCTL_DGFSEL_MASK;
+
+    return (DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH)(filterWidth);
+}
+
+/**
+ *  @brief      Set Digital Glitch Suppression Pulse Width
+ *
+ *  Pulse width for the digital glitch suppression on SCL/SDA lines.
+ *  Values are in terms of functional clock ticks.
+ *
+ *  @param[in]  i2c             Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in]  filterWidth     One of @ref DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH.
+ */
+__STATIC_INLINE void DL_I2C_setDigitalGlitchFilterPulseWidth(
+    I2C_Regs *i2c, DL_I2C_DIGITAL_GLITCH_FILTER_WIDTH filterWidth)
+{
+    DL_Common_updateReg(
+        &i2c->GFCTL, (uint32_t) filterWidth, I2C_GFCTL_DGFSEL_MASK);
+}
+
+/**
+ *  @brief      Disable Analog Glitch Suppression
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableAnalogGlitchFilter(I2C_Regs *i2c)
+{
+    i2c->GFCTL &= ~(I2C_GFCTL_AGFEN_MASK);
+}
+
+/**
+ *  @brief      Checks if analog glitch suppression is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If analog glitch suppression is enabled
+ *
+ *  @retval     true if analog glitch suppression is enabled
+ *  @retval     false if analog glitch suppression is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isAnalogGlitchFilterEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->GFCTL & I2C_GFCTL_AGFEN_MASK) == I2C_GFCTL_AGFEN_ENABLE);
+}
+
+/**
+ *  @brief      Enable Analog Glitch Suppression
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableAnalogGlitchFilter(I2C_Regs *i2c)
+{
+    i2c->GFCTL |= I2C_GFCTL_AGFEN_ENABLE;
+}
+
+/**
+ *  @brief      Get direction of next controller operation
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     Direction of next controller operation
+ *
+ *  @retval     One of @ref DL_I2C_CONTROLLER_DIRECTION
+ */
+__STATIC_INLINE DL_I2C_CONTROLLER_DIRECTION DL_I2C_getControllerDirection(
+    I2C_Regs *i2c)
+{
+    uint32_t direction = i2c->MASTER.MSA & I2C_MSA_DIR_MASK;
+
+    return (DL_I2C_CONTROLLER_DIRECTION)(direction);
+}
+
+/**
+ *  @brief      Set direction of next controller operation
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  direction   Direction of next controller operation.
+ *                          One of @ref DL_I2C_CONTROLLER_DIRECTION.
+ */
+__STATIC_INLINE void DL_I2C_setControllerDirection(
+    I2C_Regs *i2c, DL_I2C_CONTROLLER_DIRECTION direction)
+{
+    DL_Common_updateReg(
+        &i2c->MASTER.MSA, (uint32_t) direction, I2C_MSA_DIR_MASK);
+}
+
+/**
+ *  @brief      Get the address of the target being addressed when configured
+ *              as an I2C controller
+ *
+ *  Specifies bits A9 through A0 of the target address.
+ *  In 7-bit addressing mode as selected by @ref DL_I2C_setTargetAddressingMode,
+ *  the top 3 bits are don't care.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The target address
+ *
+ *  @retval     [0x00, 0x07FE]
+ *
+ *  @sa         DL_I2C_setTargetAddressingMode
+ */
+__STATIC_INLINE uint32_t DL_I2C_getTargetAddress(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MSA & I2C_MSA_SADDR_MASK) >> I2C_MSA_SADDR_OFS);
+}
+
+/**
+ *  @brief      Set the address of the target being addressed when configured
+ *              as an I2C controller
+ *
+ *  Specifies bits A9 through A0 of the target address.
+ *  In 7-bit addressing mode as selected by @ref DL_I2C_setTargetAddressingMode,
+ *  the top 3 bits are don't care.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  targetAddress    Target address to set [0x00, 0x07FE]
+ *
+ *  @sa         DL_I2C_setTargetAddressingMode
+ */
+__STATIC_INLINE void DL_I2C_setTargetAddress(
+    I2C_Regs *i2c, uint32_t targetAddress)
+{
+    DL_Common_updateReg(&i2c->MASTER.MSA, (targetAddress << I2C_MSA_SADDR_OFS),
+        I2C_MSA_SADDR_MASK);
+}
+
+/**
+ *  @brief      Get controller addressing mode
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     Addressing mode the controller is set to
+ *
+ *  @retval     One of @ref DL_I2C_CONTROLLER_ADDRESSING_MODE
+ *
+ */
+__STATIC_INLINE DL_I2C_CONTROLLER_ADDRESSING_MODE
+DL_I2C_getControllerAddressingMode(I2C_Regs *i2c)
+{
+    uint32_t mode = i2c->MASTER.MSA & I2C_MSA_MMODE_MASK;
+
+    return (DL_I2C_CONTROLLER_ADDRESSING_MODE)(mode);
+}
+
+/**
+ *  @brief      Set controller addressing mode between 7-bit and 10-bit mode
+ *
+ *  Selects the addressing mode between 7-bit and 10-bit mode to be used when
+ *  device is configured as a controller
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  mode    Addressing mode to set the target to.
+ *                      One of @ref DL_I2C_CONTROLLER_ADDRESSING_MODE.
+ */
+__STATIC_INLINE void DL_I2C_setControllerAddressingMode(
+    I2C_Regs *i2c, DL_I2C_CONTROLLER_ADDRESSING_MODE mode)
+{
+    DL_Common_updateReg(&i2c->MASTER.MSA, (uint32_t) mode, I2C_MSA_MMODE_MASK);
+}
+
+/**
+ *  @brief      Disable controller ACK override
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableControllerACKOverride(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCTR &= ~(I2C_MCTR_MACKOEN_MASK);
+}
+
+/**
+ *  @brief      Checks if controller ACK override is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If controller ACK override is enabled
+ *
+ *  @retval     true if controller ACK override is enabled
+ *  @retval     false if controller ACK override is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isControllerACKOverrideEnabled(I2C_Regs *i2c)
+{
+    return (
+        (i2c->MASTER.MCTR & I2C_MCTR_MACKOEN_MASK) == I2C_MCTR_MACKOEN_ENABLE);
+}
+
+/**
+ *  @brief      Enable controller ACK override
+ *
+ *  When enabled and the controller is receiving data and the number of bytes
+ *  indicated in MCTR.MBLEN have been received, the state machine will generate
+ *  an RXDONE interrupt and wait at the start of the ACK for FW to indicate if
+ *  an ACK or NACK should be sent. The ACK or NACK is selected by writing the
+ *  MCTR register and setting ACK accordingly. The other fields in this register
+ *  can also be written at this time to continue on with the transaction. If a
+ *  NACK is sent the state machine will automatically send a Stop.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ * @sa          DL_I2C_setTransactionLength
+ */
+__STATIC_INLINE void DL_I2C_enableControllerACKOverride(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCTR |= I2C_MCTR_MACKOEN_ENABLE;
+}
+
+/**
+ *  @brief      Disable controller read on TX empty
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableControllerReadOnTXEmpty(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCTR &= ~(I2C_MCTR_RD_ON_TXEMPTY_MASK);
+}
+
+/**
+ *  @brief      Checks if controller read on TX empty is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If controller read on TX empty is enabled
+ *
+ *  @retval     true if controller read on TX empty is enabled
+ *  @retval     false if controller read on TX empty is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isControllerReadOnTXEmptyEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MCTR & I2C_MCTR_RD_ON_TXEMPTY_MASK) ==
+            I2C_MCTR_RD_ON_TXEMPTY_ENABLE);
+}
+
+/**
+ *  @brief      Enable controller read on TX empty
+ *
+ *  When enabled, the controller will transmit all bytes from the TX FIFO
+ *  before continuing with the programmed Burst Run Read. If the DIR is not
+ *  set to Read in the MSA then this bit is ignored. The Start must be set in
+ *  the MCTR for proper I2C protocol. The controller will first send the Start
+ *  Condition, I2C Address with R/W bit set to write, before sending the bytes
+ *  in the TX FIFO. When the TX FIFO is empty, the I2C transaction will
+ *  continue as programmed in MTCR and MSA without sending a Stop Condition.
+ *  This is intended to be used to perform simple I2C command based reads
+ *  transition that will complete after initiating them without having to get
+ *  an interrupt to turn the bus around.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_I2C_enableControllerReadOnTXEmpty(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCTR |= I2C_MCTR_RD_ON_TXEMPTY_ENABLE;
+}
+
+/**
+ *  @brief      Get the SMBus/PMBus Packet Error Checking (PEC) count value
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The value the PEC count is set to
+ *
+ *  @retval     Value between [0x0, 0x01FF]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getControllerPECCountValue(I2C_Regs *i2c)
+{
+    return (i2c->MASTER.CONTROLLER_I2CPECCTL &
+            I2C_CONTROLLER_I2CPECCTL_PECCNT_MASK);
+}
+
+/**
+ *  @brief      Set the SMBus/PMBus Packet Error Checking (PEC) count value
+ *
+ *  When this field is non zero, the number of I2C data bytes are counted.
+ *  Refer to the device TRM for more details.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  count   The value to set the PEC count to.
+ *                      Value between [0x0, 0x01FF]
+ */
+__STATIC_INLINE void DL_I2C_setControllerPECCountValue(
+    I2C_Regs *i2c, uint32_t count)
+{
+    DL_Common_updateReg(&i2c->MASTER.CONTROLLER_I2CPECCTL, count,
+        I2C_CONTROLLER_I2CPECCTL_PECCNT_MASK);
+}
+
+/**
+ *  @brief      Disable controller SMBus/PMBus Packet Error Checking (PEC)
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableControllerPEC(I2C_Regs *i2c)
+{
+    i2c->MASTER.CONTROLLER_I2CPECCTL &= ~(I2C_CONTROLLER_I2CPECCTL_PECEN_MASK);
+}
+
+/**
+ *  @brief      Checks if controller SMBus/PMBus Packet Error Checking (PEC)
+ *              is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If controller PEC is enabled
+ *
+ *  @retval     true if controller PEC is enabled
+ *  @retval     false if controller PEC is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isControllerPECEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.CONTROLLER_I2CPECCTL &
+                I2C_CONTROLLER_I2CPECCTL_PECEN_MASK) ==
+            I2C_CONTROLLER_I2CPECCTL_PECEN_ENABLE);
+}
+
+/**
+ *  @brief      Enable controller SMBus/PMBus Packet Error Checking (PEC)
+ *
+ *  When enabled, the PEC is calculated on all bits accept the Start, Stop, ACK
+ *  and NACK. The PEC LSFR and the Byte Counter is set to 0 when the State
+ *  Machine is in the IDLE state, which occurs following a Stop or when a
+ *  timeout occurs. The Counter is also set to 0 after the PEC byte is sent or
+ *  received. Note that the NACK is automatically sent following a PEC byte
+ *  that results in a PEC error.
+ *  The PEC Polynomial is x^8 + x^2 + x^1 + 1.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_I2C_enableControllerPEC(I2C_Regs *i2c)
+{
+    i2c->MASTER.CONTROLLER_I2CPECCTL |= I2C_CONTROLLER_I2CPECCTL_PECEN_ENABLE;
+}
+
+/**
+ *  @brief      Get the current SMBus/PMBus PEC byte count of the controller
+ *              state machine
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current PEC byte count of the controller state machine
+ *
+ *  @retval     Value between [0x0, 0x01FF]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getControllerCurrentPECCount(I2C_Regs *i2c)
+{
+    return (
+        i2c->MASTER.CONTROLLER_PECSR & I2C_CONTROLLER_PECSR_PECSTS_CHECK_MASK);
+}
+
+/**
+ *  @brief      If controller SMBus/PMBus PEC was checked in last transaction
+ *
+ *  The status of if the controller PEC was checked in the transaction that
+ *  occurred before the last Stop. Latched on Stop.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     Status of controller PEC checked in last transaction
+ *
+ *  @retval     One of @ref DL_I2C_CONTROLLER_PEC_STATUS
+ */
+__STATIC_INLINE DL_I2C_CONTROLLER_PEC_STATUS
+DL_I2C_getControllerPECCheckedStatus(I2C_Regs *i2c)
+{
+    uint32_t status =
+        i2c->MASTER.CONTROLLER_PECSR & I2C_CONTROLLER_PECSR_PECSTS_CHECK_MASK;
+
+    return (DL_I2C_CONTROLLER_PEC_STATUS)(status);
+}
+
+/**
+ *  @brief      Get the status of the controller SMBus/PMBus PEC Check error
+ *
+ *  The status of if a PEC check error occurred in the transaction that
+ *  occurred before the last Stop. Latched on Stop.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     Status of controller PEC check error
+ *
+ *  @retval     One of @ref DL_I2C_CONTROLLER_PEC_CHECK_ERROR
+ */
+__STATIC_INLINE DL_I2C_CONTROLLER_PEC_CHECK_ERROR
+DL_I2C_getControllerPECCheckError(I2C_Regs *i2c)
+{
+    uint32_t error =
+        i2c->MASTER.CONTROLLER_PECSR & I2C_CONTROLLER_PECSR_PECSTS_ERROR_MASK;
+
+    return (DL_I2C_CONTROLLER_PEC_CHECK_ERROR)(error);
+}
+
+/**
+ *  @brief      Disable I2C controller burst mode
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableControllerBurst(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCTR &= ~(I2C_MCTR_BURSTRUN_MASK);
+}
+
+/**
+ *  @brief      Checks if I2C controller burst mode is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If I2C controller burst mode is enabled
+ *
+ *  @retval     true if I2C controller burst mode is enabled
+ *  @retval     false if I2C controller burst mode is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isControllerBurstEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->GFCTL & I2C_MCTR_BURSTRUN_MASK) == I2C_MCTR_BURSTRUN_ENABLE);
+}
+
+/**
+ *  @brief      Enable I2C controller burst mode
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableControllerBurst(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCTR |= I2C_MCTR_BURSTRUN_ENABLE;
+}
+
+/**
+ *  @brief      Disable I2C START generation
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableStartCondition(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCTR &= ~(I2C_MCTR_START_MASK);
+}
+
+/**
+ *  @brief      Checks if I2C START generation is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If I2C START generation is enabled
+ *
+ *  @retval     true if I2C START generation is enabled
+ *  @retval     false if I2C START generation is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isStartConditionEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MCTR & I2C_MCTR_START_MASK) == I2C_MCTR_START_ENABLE);
+}
+
+/**
+ *  @brief      Enable I2C START generation
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableStartCondition(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCTR |= I2C_MCTR_START_ENABLE;
+}
+
+/**
+ *  @brief      Disable I2C STOP generation
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableStopCondition(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCTR &= ~(I2C_MCTR_STOP_MASK);
+}
+
+/**
+ *  @brief      Checks if I2C STOP generation is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If I2C STOP generation is enabled
+ *
+ *  @retval     true if I2C STOP generation is enabled
+ *  @retval     false if I2C STOP generation is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isStopConditionEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MCTR & I2C_MCTR_STOP_MASK) == I2C_MCTR_STOP_ENABLE);
+}
+
+/**
+ *  @brief      Enable I2C STOP generation
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableStopCondition(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCTR |= I2C_MCTR_STOP_ENABLE;
+}
+
+/**
+ *  @brief      Disable I2C controller data acknowledge (ACK or NACK)
+ *
+ *  When the I2C module operates in Controller receiver mode, the ACK bit can be
+ *  cleared when no further data needs to be received from the target
+ *  transmitter.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableControllerACK(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCTR &= ~(I2C_MCTR_ACK_MASK);
+}
+
+/**
+ *  @brief      Checks if I2C controller data acknowledge (ACK or NACK) is
+ *              enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If I2C controller data acknowledge is enabled
+ *
+ *  @retval     true if I2C controller data acknowledge is enabled
+ *  @retval     false if I2C controller data acknowledge is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isControllerACKEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MCTR & I2C_MCTR_ACK_MASK) == I2C_MCTR_ACK_ENABLE);
+}
+
+/**
+ *  @brief      Enable I2C controller data acknowledge (ACK or NACK)
+ *
+ *  When the I2C module operates in Controller receiver mode, the ACK bit is
+ *  normally set causing the I2C bus controller to transmit an acknowledge
+ *  automatically after each byte.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableControllerACK(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCTR |= I2C_MCTR_ACK_MASK;
+}
+
+/**
+ *  @brief      Get transaction length in bytes
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     Length of I2C transaction in bytes
+ *
+ *  @retval     [0x000, 0xfff]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getTransactionLength(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MCTR & I2C_MCTR_MBLEN_MASK) >> I2C_MCTR_MBLEN_OFS);
+}
+
+/**
+ *  @brief      Set transaction length in bytes
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  length      Length of I2C transaction in bytes [0x000, 0xfff]
+ */
+__STATIC_INLINE void DL_I2C_setTransactionLength(
+    I2C_Regs *i2c, uint32_t length)
+{
+    DL_Common_updateReg(&i2c->MASTER.MCTR, (length << I2C_MCTR_MBLEN_OFS),
+        I2C_MCTR_MBLEN_MASK);
+}
+
+/**
+ *  @brief      Get status of I2C bus controller for controller
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *
+ *  @return     Status of I2C bus controller for controller
+ *
+ *  @retval     Bitwise OR of @ref DL_I2C_CONTROLLER_STATUS
+ */
+__STATIC_INLINE uint32_t DL_I2C_getControllerStatus(I2C_Regs *i2c)
+{
+    return (i2c->MASTER.MSR);
+}
+
+/**
+ *  @brief      Get transaction count in bytes
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *
+ *  @return     Current 12-bit countdown value of the transaction
+ *
+ *  @retval     [0x000, 0xfff]
+ */
+__STATIC_INLINE uint16_t DL_I2C_getTransactionCount(I2C_Regs *i2c)
+{
+    return ((uint16_t)(
+        (i2c->MASTER.MSR & I2C_MSR_MBCNT_MASK) >> I2C_MSR_MBCNT_OFS));
+}
+
+/**
+ *  @brief      Get byte of data from I2C controller
+ *
+ *  If using FIFO, it is first byte from the RX FIFO.
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *
+ *  @return     Last received byte of data
+ *
+ *  @retval     [0x00, 0xff]
+ */
+__STATIC_INLINE uint8_t DL_I2C_receiveControllerData(I2C_Regs *i2c)
+{
+    return ((uint8_t)(i2c->MASTER.MRXDATA & I2C_MRXDATA_VALUE_MASK));
+}
+
+/**
+ *  @brief      Set next byte to be transferred during the next transaction
+ *
+ *  Does not transmit data until @ref DL_I2C_startControllerTransfer
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  data    Data to be transferred during the next transaction.
+ *                      [0x00, 0xff]
+ */
+__STATIC_INLINE void DL_I2C_transmitControllerData(I2C_Regs *i2c, uint8_t data)
+{
+    i2c->MASTER.MTXDATA = data;
+}
+
+/**
+ *  @brief      Get timer period
+ *  This field is used in the equation to configure SCL_PERIOD:
+ *
+ *  SCL_PERIOD = (1 + TPR) * (SCL_LP + SCL_HP) * INT_CLK_PRD
+ *
+ *  where:
+ *  SCL_PRD is the SCL line period (I2C clock)
+ *
+ *  TPR is the Timer Period register value (range of 1 to 127)
+ *
+ *  SCL_LP is the SCL Low period (fixed at 6)
+ *  SCL_HP is the SCL High period (fixed at 4)
+ *
+ *  CLK_PRD is the functional clock period in ns
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @return     Timer period
+ *
+ *  @retval     [0x00, 0x7f]
+ */
+__STATIC_INLINE uint8_t DL_I2C_getTimerPeriod(I2C_Regs *i2c)
+{
+    return ((uint8_t)(i2c->MASTER.MTPR & I2C_MTPR_TPR_MASK));
+}
+
+/**
+ *  @brief      Set timer period
+ *  This field is used in the equation to configure SCL_PERIOD:
+ *
+ *  SCL_PERIOD = (1 + TPR) * (SCL_LP + SCL_HP) * INT_CLK_PRD
+ *
+ *  where:
+ *  SCL_PRD is the SCL line period (I2C clock)
+ *
+ *  TPR is the Timer Period register value (range of 1 to 127)
+ *
+ *  SCL_LP is the SCL Low period (fixed at 6)
+ *  SCL_HP is the SCL High period (fixed at 4)
+ *
+ *  CLK_PRD is the functional clock period in ns
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  period  Timer period [0x00, 0x7f]
+ */
+__STATIC_INLINE void DL_I2C_setTimerPeriod(I2C_Regs *i2c, uint8_t period)
+{
+    i2c->MASTER.MTPR = period;
+}
+
+/**
+ *  @brief      Disable loopback mode
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableLoopbackMode(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCR &= ~(I2C_MCR_LPBK_MASK);
+}
+
+/**
+ *  @brief      Checks if loopback mode is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If loopback mode is enabled
+ *
+ *  @retval     true if loopback mode is enabled
+ *  @retval     false if loopback mode is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isLoopbackModeEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MCR & I2C_MCR_LPBK_MASK) == I2C_MCR_LPBK_ENABLE);
+}
+
+/**
+ *  @brief      Enable loopback mode
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableLoopbackMode(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCR |= I2C_MCR_LPBK_ENABLE;
+}
+
+/**
+ *  @brief      Disable multicontroller mode
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableMultiControllerMode(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCR &= ~(I2C_MCR_MMST_MASK);
+}
+
+/**
+ *  @brief      Checks if multicontroller mode is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If multicontroller mode is enabled
+ *
+ *  @retval     true if multicontroller mode is enabled
+ *  @retval     false if multicontroller mode is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isMultiControllerModeEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MCR & I2C_MCR_MMST_MASK) == I2C_MCR_MMST_ENABLE);
+}
+
+/**
+ *  @brief      Enable multicontroller mode
+ *
+ *  In multicontroller mode, the SCL high time counts once the SCL line has been
+ *  detected high. If this is not enabled, the high time counts as soon as the
+ *  SCL line has been set high by the I2C controller
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableMultiControllerMode(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCR |= I2C_MCR_MMST_ENABLE;
+}
+
+/**
+ *  @brief      Disable controller
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableController(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCR &= ~(I2C_MCR_ACTIVE_MASK);
+}
+
+/**
+ *  @brief      Checks if controller is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If controller is enabled
+ *
+ *  @retval     true if controller is enabled
+ *  @retval     false if controller is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isControllerEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MCR & I2C_MCR_ACTIVE_MASK) == I2C_MCR_ACTIVE_ENABLE);
+}
+
+/**
+ *  @brief      Enable controller
+ *
+ *  After controller has enabled, it should not be re-enabled unless it has been
+ *  disabled or by a reset, otherwise transfer failures may occur.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableController(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCR |= I2C_MCR_ACTIVE_ENABLE;
+}
+
+/**
+ *  @brief      Disable controller clock stretching
+ *
+ *  Clock stretching can be disabled if no target on the bus supports clock
+ *  stretching; however, it should be typically enabled to be compliant with
+ *  I2C specification.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableControllerClockStretching(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCR &= ~(I2C_MCR_CLKSTRETCH_MASK);
+}
+
+/**
+ *  @brief      Checks if controller clock stretching is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If controller clock stretching is enabled
+ *
+ *  @retval     true if controller clock stretching is enabled
+ *  @retval     false if controller clock stretching is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isControllerClockStretchingEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MCR & I2C_MCR_CLKSTRETCH_MASK) ==
+            I2C_MCR_CLKSTRETCH_ENABLE);
+}
+
+/**
+ *  @brief      Enable controller clock stretching
+ *
+ *  Clock stretching can be disabled if no target on the bus supports clock
+ *  stretching; however, it should be typically enabled to be compliant with I2C
+ *  specification.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableControllerClockStretching(I2C_Regs *i2c)
+{
+    i2c->MASTER.MCR |= I2C_MCR_CLKSTRETCH_ENABLE;
+}
+
+/**
+ *  @brief      Get SCL signal status
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *
+ *  @return     Status of SCL signal
+ *
+ *  @retval     One of @ref DL_I2C_CONTROLLER_SCL
+ */
+__STATIC_INLINE DL_I2C_CONTROLLER_SCL DL_I2C_getSCLStatus(I2C_Regs *i2c)
+{
+    uint32_t sclStatus = i2c->MASTER.MBMON & I2C_MBMON_SCL_MASK;
+
+    return (DL_I2C_CONTROLLER_SCL)(sclStatus);
+}
+
+/**
+ *  @brief      Get SDA signal status
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *
+ *  @return     Status of SDA signal
+ *
+ *  @retval     One of @ref DL_I2C_CONTROLLER_SDA
+ */
+__STATIC_INLINE DL_I2C_CONTROLLER_SDA DL_I2C_getSDAStatus(I2C_Regs *i2c)
+{
+    uint32_t sdaStatus = i2c->MASTER.MBMON & I2C_MBMON_SDA_MASK;
+
+    return (DL_I2C_CONTROLLER_SDA)(sdaStatus);
+}
+
+/**
+ *  @brief      Get controller TX FIFO threshold level
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @return     Indicates at what fill level in the TX FIFO a threshold will be
+ *              generated
+ *
+ *  @retval     One of @ref DL_I2C_TX_FIFO_LEVEL
+ */
+__STATIC_INLINE DL_I2C_TX_FIFO_LEVEL DL_I2C_getControllerTXFIFOThreshold(
+    I2C_Regs *i2c)
+{
+    uint32_t level = i2c->MASTER.MFIFOCTL & I2C_MFIFOCTL_TXTRIG_MASK;
+
+    return (DL_I2C_TX_FIFO_LEVEL)(level);
+}
+
+/**
+ *  @brief      Set controller TX FIFO threshold level
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  level   Indicates at what fill level in the TX FIFO a threshold
+ *                      will be generated.
+ *                      One of @ref DL_I2C_TX_FIFO_LEVEL.
+ */
+__STATIC_INLINE void DL_I2C_setControllerTXFIFOThreshold(
+    I2C_Regs *i2c, DL_I2C_TX_FIFO_LEVEL level)
+{
+    DL_Common_updateReg(
+        &i2c->MASTER.MFIFOCTL, (uint32_t) level, I2C_MFIFOCTL_TXTRIG_MASK);
+}
+
+/**
+ *  @brief      Stop controller TX FIFO flush
+ *
+ *  Before stopping the flush, check if @ref DL_I2C_isControllerTXFIFOEmpty,
+ *  indicating flush is complete.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_stopFlushControllerTXFIFO(I2C_Regs *i2c)
+{
+    i2c->MASTER.MFIFOCTL &= ~(I2C_MFIFOCTL_TXFLUSH_MASK);
+}
+
+/**
+ *  @brief      Start controller TX FIFO flush
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_startFlushControllerTXFIFO(I2C_Regs *i2c)
+{
+    i2c->MASTER.MFIFOCTL |= I2C_MFIFOCTL_TXFLUSH_MASK;
+}
+
+/**
+ *  @brief      Get controller RX FIFO threshold level
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @return     Indicates at what fill level in the RX FIFO a threshold will be
+ *              generated
+ *
+ *  @retval     One of @ref DL_I2C_RX_FIFO_LEVEL
+ */
+__STATIC_INLINE DL_I2C_RX_FIFO_LEVEL DL_I2C_getControllerRXFIFOThreshold(
+    I2C_Regs *i2c)
+{
+    uint32_t level = i2c->MASTER.MFIFOCTL & I2C_MFIFOCTL_RXTRIG_MASK;
+
+    return (DL_I2C_RX_FIFO_LEVEL)(level);
+}
+
+/**
+ *  @brief      Set controller RX FIFO threshold level
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  level   Indicates at what fill level in the RX FIFO a threshold
+ *                      will be generated.
+ *                      One of @ref DL_I2C_RX_FIFO_LEVEL.
+ */
+__STATIC_INLINE void DL_I2C_setControllerRXFIFOThreshold(
+    I2C_Regs *i2c, DL_I2C_RX_FIFO_LEVEL level)
+{
+    DL_Common_updateReg(
+        &i2c->MASTER.MFIFOCTL, (uint32_t) level, I2C_MFIFOCTL_RXTRIG_MASK);
+}
+
+/**
+ *  @brief      Stop controller RX FIFO flush
+ *
+ *  Before stopping the flush, check if @ref DL_I2C_isControllerRXFIFOEmpty,
+ *  indicating flush is complete.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_stopFlushControllerRXFIFO(I2C_Regs *i2c)
+{
+    i2c->MASTER.MFIFOCTL &= ~(I2C_MFIFOCTL_RXFLUSH_MASK);
+}
+
+/**
+ *  @brief      Start controller RX FIFO flush
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_startFlushControllerRXFIFO(I2C_Regs *i2c)
+{
+    i2c->MASTER.MFIFOCTL |= I2C_MFIFOCTL_RXFLUSH_MASK;
+}
+
+/**
+ *  @brief      Get number of bytes which can be read from RX FIFO
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *
+ *  @return     Number of bytes which can be read from RX FIFO
+ *
+ *  @retval     [0x0, 0x8]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getControllerRXFIFOCounter(I2C_Regs *i2c)
+{
+    return (i2c->MASTER.MFIFOSR & I2C_MFIFOSR_RXFIFOCNT_MASK);
+}
+
+/**
+ *  @brief      Get number of bytes which can be put into TX FIFO
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *
+ *  @return     Number of bytes which can be put into TX FIFO
+ *
+ *  @retval     [0x0, 0x8]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getControllerTXFIFOCounter(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MFIFOSR & I2C_MFIFOSR_TXFIFOCNT_MASK) >>
+            I2C_MFIFOSR_TXFIFOCNT_OFS);
+}
+
+/**
+ *  @brief      Checks if controller RX FIFO flush is active
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If controller RX FIFO flush is active
+ *
+ *  @retval     true if controller RX FIFO flush is active
+ *  @retval     false if controller RX FIFO flush is not active
+ */
+__STATIC_INLINE bool DL_I2C_isControllerRXFIFOFlushActive(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MFIFOSR & I2C_MFIFOSR_RXFLUSH_MASK) ==
+            I2C_MFIFOSR_RXFLUSH_ACTIVE);
+}
+
+/**
+ *  @brief      Checks if controller TX FIFO flush is active
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If controller TX FIFO flush is active
+ *
+ *  @retval     true if controller TX FIFO flush is active
+ *  @retval     false if controller TX FIFO flush is not active
+ */
+__STATIC_INLINE bool DL_I2C_isControllerTXFIFOFlushActive(I2C_Regs *i2c)
+{
+    return ((i2c->MASTER.MFIFOSR & I2C_MFIFOSR_TXFLUSH_MASK) ==
+            I2C_MFIFOSR_TXFLUSH_ACTIVE);
+}
+
+/**
+ *  @brief      Set target own address
+ *
+ * This field specifies bits A9 through A0 of the target own address.
+ *
+ * In 7-bit addressing mode as selected by @ref DL_I2C_setTargetAddressingMode,
+ * the top 3 bits are don't care
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  addr    Value of target own address [0x00, 0x3FF]
+ */
+__STATIC_INLINE void DL_I2C_setTargetOwnAddress(I2C_Regs *i2c, uint32_t addr)
+{
+    DL_Common_updateReg(&i2c->SLAVE.SOAR, addr, I2C_SOAR_OAR_MASK);
+}
+
+/**
+ *  @brief      Get target own address
+ *
+ * Get bits A9 through A0 of the target own address.
+ *
+ * In 7-bit addressing mode as selected by @ref DL_I2C_setTargetAddressingMode,
+ * the top 3 bits are don't care
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @return     Target own address
+ *
+ *  @retval     [0x00, 0x3FF]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getTargetOwnAddress(I2C_Regs *i2c)
+{
+    return (i2c->SLAVE.SOAR & I2C_SOAR_OAR_MASK);
+}
+
+/**
+ *  @brief      Enable target own address
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @sa DL_I2C_setTargetOwnAddress
+ */
+__STATIC_INLINE void DL_I2C_enableTargetOwnAddress(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SOAR |= I2C_SOAR_OAREN_ENABLE;
+}
+
+/**
+ *  @brief      Disable target own address
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableTargetOwnAddress(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SOAR &= ~(I2C_SOAR_OAREN_MASK);
+}
+
+/**
+ *  @brief      Checks if target own address is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target own address is enabled
+ *
+ *  @retval     true if target own address is enabled
+ *  @retval     false if target own address is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isTargetOwnAddressEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SOAR & I2C_SOAR_OAREN_MASK) == I2C_SOAR_OAREN_ENABLE);
+}
+
+/**
+ *  @brief      Set target addressing mode
+ *
+ *  Selects the addressing mode to be used when device is configured as a
+ *  target
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  mode    Addressing mode to set the target to.
+ *                      One of @ref DL_I2C_TARGET_ADDRESSING_MODE.
+ */
+__STATIC_INLINE void DL_I2C_setTargetAddressingMode(
+    I2C_Regs *i2c, DL_I2C_TARGET_ADDRESSING_MODE mode)
+{
+    DL_Common_updateReg(
+        &i2c->SLAVE.SOAR, (uint32_t) mode, I2C_SOAR_SMODE_MASK);
+}
+
+/**
+ *  @brief      Get target addressing mode
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     Addressing mode the target is set to
+ *
+ *  @retval     One of @ref DL_I2C_TARGET_ADDRESSING_MODE
+ */
+__STATIC_INLINE DL_I2C_TARGET_ADDRESSING_MODE DL_I2C_getTargetAddressingMode(
+    I2C_Regs *i2c)
+{
+    uint32_t mode = i2c->SLAVE.SOAR & I2C_SOAR_SMODE_MASK;
+
+    return (DL_I2C_TARGET_ADDRESSING_MODE)(mode);
+}
+
+/**
+ *  @brief      Get target own address alternate
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @return     Target own address alternate
+ *
+ *  @retval     [0x00, 0x7f]
+ */
+__STATIC_INLINE uint32_t I2C_getTargetOwnAddressAlternate(I2C_Regs *i2c)
+{
+    return (i2c->SLAVE.SOAR2 & I2C_SOAR2_OAR2_MASK);
+}
+
+/**
+ *  @brief      Set target own address alternate
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  addr    Value of target own address alternate [0x00, 0x7f]
+ */
+__STATIC_INLINE void DL_I2C_setTargetOwnAddressAlternate(
+    I2C_Regs *i2c, uint32_t addr)
+{
+    DL_Common_updateReg(&i2c->SLAVE.SOAR2, addr, I2C_SOAR2_OAR2_MASK);
+}
+
+/**
+ *  @brief      Get target own address alternate mask
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     Which bits of the target address are matched
+ *
+ *  @retval     Bit mask with each bit corresponding to bits A6 through A0 of
+ *              the target address. Value between [0x00, 0x7F]
+ */
+__STATIC_INLINE uint32_t I2C_getTargetOwnAddressAlternateMask(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SOAR2 & I2C_SOAR2_OAR2_MASK_MASK) >>
+            I2C_SOAR2_OAR2_MASK_OFS);
+}
+
+/**
+ *  @brief      Set target own address alternate mask
+ *
+ * This field specifies bits A6 through A0 of the target address. The bits with
+ * a value of 1 in the SOAR2.OAR2_MASK field will make the corresponding
+ * incoming address bits to match by default regardless of the value inside
+ * SOAR2.OAR2 i.e. corresponding SOAR2.OAR2 bit is a don't care.
+ *
+ *  @param[in]  i2c           Pointer to the register overlay for the peripheral
+ *  @param[in]  addressMask   Bit mask of address bits to match.
+ *                            Value between [0x00, 0x7F]
+ */
+__STATIC_INLINE void DL_I2C_setTargetOwnAddressAlternateMask(
+    I2C_Regs *i2c, uint32_t addressMask)
+{
+    DL_Common_updateReg(&i2c->SLAVE.SOAR2,
+        addressMask << I2C_SOAR2_OAR2_MASK_OFS, I2C_SOAR2_OAR2_MASK_MASK);
+}
+
+/**
+ *  @brief      Disable usage of target own address alternate
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableTargetOwnAddressAlternate(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SOAR2 &= ~(I2C_SOAR2_OAR2EN_MASK);
+}
+
+/**
+ *  @brief      Checks if target own address alternate is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target own address alternate is enabled
+ *
+ *  @retval     true if target own address alternate is enabled
+ *  @retval     false if target own address alternate is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isTargetOwnAddressAlternateEnabled(I2C_Regs *i2c)
+{
+    return (
+        (i2c->SLAVE.SOAR2 & I2C_SOAR2_OAR2EN_MASK) == I2C_SOAR2_OAR2EN_ENABLE);
+}
+
+/**
+ *  @brief      Enable usage of target own address alternate
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableTargetOwnAddressAlternate(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SOAR2 |= I2C_SOAR2_OAR2EN_ENABLE;
+}
+
+/**
+ *  @brief      Get the address for which address match happened
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     Matched Target address
+ *
+ *  @retval     Bit mask with each bit corresponding to the target address.
+ *  Value between [0x00, 0x7F] in 7-bit mode, or [0x00, 0x3FF] in 10-bit mode.
+ */
+__STATIC_INLINE uint32_t DL_I2C_getTargetAddressMatch(I2C_Regs *i2c)
+{
+    return (
+        (i2c->SLAVE.SSR & I2C_SSR_ADDRMATCH_MASK) >> I2C_SSR_ADDRMATCH_OFS);
+}
+
+/**
+ *  @brief      Disable target clock stretching
+ *
+ *  Clock stretching should be enabled to be compliant with I2C specification
+ *  and the SCL will be stretched when data must be read or written from the
+ *  FIFO. It can optionally be disabled if a controller does not support it or
+ *  to achieve maximum I2C frequency; however the developer should ensure that
+ *  the FIFO is written or read on time.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableTargetClockStretching(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR &= ~(I2C_SCTR_SCLKSTRETCH_MASK);
+}
+
+/**
+ *  @brief      Checks if target clock stretching is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target clock stretching is enabled
+ *
+ *  @retval     true if target clock stretching is enabled
+ *  @retval     false if target clock stretching is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isTargetClockStretchingEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SCTR & I2C_SCTR_SCLKSTRETCH_MASK) ==
+            I2C_SCTR_SCLKSTRETCH_ENABLE);
+}
+
+/**
+ *  @brief      Enable target clock stretching
+ *
+ *  Clock stretching should be enabled to be compliant with I2C specification
+ *  and the SCL will be stretched when data must be read or written from the
+ *  FIFO. It can optionally be disabled if a controller does not support it or
+ *  to achieve maximum I2C frequency; however the developer should ensure that
+ *  the FIFO is written or read on time.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableTargetClockStretching(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR |= I2C_SCTR_SCLKSTRETCH_ENABLE;
+}
+
+/**
+ *  @brief      Disable target TX empty interrupt on transmit request
+ *
+ * When disabled, RIS.STXEMPTY will be set when only the Target TX FIFO is
+ * empty. This allows the STXEMPTY interrupt to be used to indicate that the
+ * I2C bus is being clock stretched and that Target TX data is required.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @sa         DL_I2C_isTargetClockStretchEnabled
+ */
+__STATIC_INLINE void DL_I2C_disableTargetTXEmptyOnTXRequest(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR &= ~(I2C_SCTR_TXEMPTY_ON_TREQ_MASK);
+}
+
+/**
+ *  @brief      Checks if target TX empty interrupt on transmit request is
+ *              enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If TX empty interrupt on transmit request is enabled
+ *
+ *  @retval     true if TX empty interrupt on transmit request is enabled
+ *  @retval     false if TX empty interrupt on transmit request disabled
+ */
+__STATIC_INLINE bool DL_I2C_isTargetTXEmptyOnTXRequestEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SCTR & I2C_SCTR_TXEMPTY_ON_TREQ_MASK) ==
+            I2C_SCTR_TXEMPTY_ON_TREQ_ENABLE);
+}
+
+/**
+ *  @brief      Enable target TX empty interrupt on transmit request
+ *
+ *  When enabled, RIS.STXEMPTY will be set when the Target state machine is in
+ *  the TX_WAIT state which occurs when the TX FIFO is empty AND the I2C
+ *  transaction is clock stretched waiting for the FIFO to receive data.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableTargetTXEmptyOnTXRequest(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR |= I2C_SCTR_TXEMPTY_ON_TREQ_ENABLE;
+}
+
+/**
+ *  @brief      Disable target TX trigger in TX mode
+ *
+ * When disabled, RIS.TXFIFOTRG will only be set when the Target TX FIFO is at
+ * or above the trigger level.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableTargetTXTriggerInTXMode(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR &= ~(I2C_SCTR_TXTRIG_TXMODE_MASK);
+}
+
+/**
+ *  @brief      Checks if target TX trigger in TX mode is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target TX trigger in TX mode is enabled
+ *
+ *  @retval     true if target TX trigger in TX mode is enabled
+ *  @retval     false if target TX trigger in TX mode is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isTargetTXTriggerInTXModeEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SCTR & I2C_SCTR_TXTRIG_TXMODE_MASK) ==
+            I2C_SCTR_TXTRIG_TXMODE_ENABLE);
+}
+
+/**
+ *  @brief      Enable TX trigger when target is in TX mode
+ *
+ *  When enabled, RIS.TXFIFOTRG will be set when the Target TX FIFO has reached
+ *  the trigger level AND the Target state machine is in the TXMODE as defined
+ *  in the SSR register. When cleared RIS.TXFIFOTRG will be set when the Target
+ *  TX FIFO is at or above the trigger level. This setting can be used to hold
+ *  off the TX DMA until a transaction starts. This allows the DMA to be
+ *  configured when the I2C is idle but have it wait till the transaction
+ *  starts to load the Target TX FIFO, so it can load from a memory buffer that
+ *  might be changing over time.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @sa                 DL_I2C_INTERRUPT_CONTROLLER_TXFIFO_TRIGGER
+ */
+__STATIC_INLINE void DL_I2C_enableTargetTXTriggerInTXMode(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR |= I2C_SCTR_TXTRIG_TXMODE_ENABLE;
+}
+
+/**
+ *  @brief      Disable target TX transfer waits when stale data in TX FIFO
+ *
+ *  When disabled, the TX FIFO empty signal to the Target state machine
+ *  indicates that the TX FIFO is empty.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableTargetTXWaitWhenTXFIFOStale(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR &= ~(I2C_SCTR_TXWAIT_STALE_TXFIFO_MASK);
+}
+
+/**
+ *  @brief      Checks if target TX transfer waits when stale data in TX FIFO
+ *              is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target TX transfer waits when stale data in TX FIFO is
+ *              enabled
+ *
+ *  @retval     true   if target TX transfer waits when stale data in TX FIFO
+ *                     is enabled
+ *  @retval     false  if target TX transfer waits when stale data in TX FIFO
+ *                     is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isTargetTXWaitWhenTXFIFOStaleEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SCTR & I2C_SCTR_TXWAIT_STALE_TXFIFO_MASK) ==
+            I2C_SCTR_TXWAIT_STALE_TXFIFO_ENABLE);
+}
+
+/**
+ *  @brief      Enable target TX transfer waits when stale data in TX FIFO
+ *
+ *  When enabled, the TX FIFO empty signal to the Target state machine will
+ *  indicate that the TX FIFO is empty or that the TX FIFO data is stale. The
+ *  TX FIFO data is determined to be stale when there is data in the TX FIFO
+ *  when the Target state machine leaves the TXMODE as defined in the SSR
+ *  register. This can occur is a Stop or timeout occur when there are bytes
+ *  left in the TX FIFO.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableTargetTXWaitWhenTXFIFOStale(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR |= I2C_SCTR_TXWAIT_STALE_TXFIFO_ENABLE;
+}
+
+/**
+ *  @brief      Disable target RX full interrupt on receive request
+ *
+ *  When disabled, RIS.SRXFULL will be set when only the Target RX FIFO is
+ *  full. This allows the SRXFULL interrupt to be used to indicate that the
+ *  I2C bus is being clock stretched and that the FW must either read the RX
+ *  FIFO or ACK/NACK the current RX byte.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @sa         DL_I2C_isTargetClockStretchEnabled
+ */
+__STATIC_INLINE void DL_I2C_disableTargetRXFullOnRXRequest(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR &= ~(I2C_SCTR_RXFULL_ON_RREQ_MASK);
+}
+
+/**
+ *  @brief      Checks if target RX full interrupt on receive request is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target RX full interrupt on receive request enabled
+ *
+ *  @retval     true   if target RX full interrupt on receive request enabled
+ *  @retval     false  if target RX full interrupt on receive request disabled
+ */
+__STATIC_INLINE bool DL_I2C_isTargetRXFullOnRXRequestEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SCTR & I2C_SCTR_RXFULL_ON_RREQ_MASK) ==
+            I2C_SCTR_RXFULL_ON_RREQ_ENABLE);
+}
+
+/**
+ *  @brief      Enable target RX full interrupt on receive request
+ *
+ *  When enabled, RIS.SRXFULL will be set when the Target state machine is in
+ *  the RX_WAIT or RX_ACK_WAIT states which occurs when the I2C transaction is
+ *  clock stretched because the RX FIFO is full or the ACKOEN has been set and
+ *  the state machine is waiting for FW to ACK/NACK the current byte.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_I2C_enableTargetRXFullOnRXRequest(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR |= I2C_SCTR_RXFULL_ON_RREQ_ENABLE;
+}
+
+/**
+ *  @brief      Disable SMBus/PMBus default host address of 000 1000b
+ *
+ *  When disabled, the default host address is not matched.
+ *  NOTE: The host address may still be matched if programmed as an own address.
+ *    The I2C module can still be addressed as a target if enabled and own
+ *  address match is enabled.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableDefaultHostAddress(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR &= ~(I2C_SCTR_EN_DEFHOSTADR_MASK);
+}
+
+/**
+ *  @brief      Checks if SMBus/PMBus default host address of 000 1000b is
+ *              enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If default host address is enabled
+ *
+ *  @retval     true   if default host address is enabled
+ *  @retval     false  if default host address disabled
+ */
+__STATIC_INLINE bool DL_I2C_isDefaultHostAddressEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SCTR & I2C_SCTR_EN_DEFHOSTADR_MASK) ==
+            I2C_SCTR_EN_DEFHOSTADR_ENABLE);
+}
+
+/**
+ *  @brief      Enable SMBus/PMBus default host address of 000 1000b
+ *
+ *  When enabled, default host address of 0x0001000 is always matched by the
+ *  target address match logic
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableDefaultHostAddress(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR |= I2C_SCTR_EN_DEFHOSTADR_ENABLE;
+}
+
+/**
+ *  @brief      Disable SMBus/PMBus Alert response address (ARA) of 000 1100b
+ *
+ *  When disabled, the alert response address 0x0001100 is not matched.
+ *  NOTE: The alert response address may still be matched if programmed as an
+ *  own address.
+ *    The I2C module can still be addressed as a target if enabled and own
+ *  address match is enabled.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableAlertResponseAddress(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR &= ~(I2C_SCTR_EN_ALRESPADR_MASK);
+}
+
+/**
+ *  @brief      Checks if SMBus/PMBus Alert response address (ARA) of 000 1100b
+ * is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If alert response address is enabled
+ *
+ *  @retval     true   if alert response address is enabled
+ *  @retval     false  if alert response address disabled
+ */
+__STATIC_INLINE bool DL_I2C_isAlertResponseAddressEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SCTR & I2C_SCTR_EN_ALRESPADR_MASK) ==
+            I2C_SCTR_EN_ALRESPADR_ENABLE);
+}
+
+/**
+ *  @brief      Enable SMBus/PMBus Alert response address (ARA) of 000 1100b
+ *
+ *  When enabled, default alert response address of 0x0001100 is always matched
+ *  by the target address match logic
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableAlertResponseAddress(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR |= I2C_SCTR_EN_ALRESPADR_ENABLE;
+}
+
+/**
+ *  @brief      Disable SMBus/PMBus default device address of 110 0001b
+ *
+ *  Used for Address Resolution Protocol. When disabled, the default device
+ *  address is not matched.
+ *  NOTE: The host address may still be matched if programmed as an own address.
+ *    The I2C module can still be addressed as a target if enabled and own
+ *  address match is enabled.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableDefaultDeviceAddress(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR &= ~(I2C_SCTR_EN_DEFDEVADR_MASK);
+}
+
+/**
+ *  @brief      Checks SMBus/PMBus default device address of 110 0001b is
+ *              enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If default device address is enabled
+ *
+ *  @retval     true   if default device address is enabled
+ *  @retval     false  if default device address disabled
+ */
+__STATIC_INLINE bool DL_I2C_isDefaultDeviceAddressEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SCTR & I2C_SCTR_EN_DEFDEVADR_MASK) ==
+            I2C_SCTR_EN_DEFDEVADR_ENABLE);
+}
+
+/**
+ *  @brief      Enable SMBus/PMBus default device address of 110 0001b
+ *
+ *  Used for Address Resolution Protocol. When enabled, default device address
+ *  of 110 0001b is always matched by the target address match logic.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableDefaultDeviceAddress(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR |= I2C_SCTR_EN_DEFDEVADR_ENABLE;
+}
+
+/**
+ *  @brief      Disable target wakeup
+ *
+ *  When disabled, the target is not allowed to clock stretch on START
+ *  detection.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableTargetWakeup(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR &= ~(I2C_SCTR_SWUEN_MASK);
+}
+
+/**
+ *  @brief      Checks if target wakeup is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target wakeup is enabled
+ *
+ *  @retval     true   if target wakeup is enabled
+ *  @retval     false  if target wakeup disabled
+ */
+__STATIC_INLINE bool DL_I2C_isTargetWakeupEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SCTR & I2C_SCTR_SWUEN_MASK) == I2C_SCTR_SWUEN_ENABLE);
+}
+
+/**
+ *  @brief      Enable target wakeup
+ *
+ *  Enables low-power wake-up, however it is recommended to enable target clock
+ *  stretching to stretch the clock while the module is waking up.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @sa         DL_I2C_enableTargetClockStretching
+ */
+__STATIC_INLINE void DL_I2C_enableTargetWakeup(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR |= I2C_SCTR_SWUEN_ENABLE;
+}
+
+/**
+ *  @brief      Disable target functionality
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableTarget(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR &= ~(I2C_SCTR_ACTIVE_MASK);
+}
+
+/**
+ *  @brief      Checks if target functionality is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target functionality is enabled
+ *
+ *  @retval     true if target functionality is enabled
+ *  @retval     false if target functionality is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isTargetEnabled(I2C_Regs *i2c)
+{
+    return (
+        (i2c->SLAVE.SCTR & I2C_SCTR_ACTIVE_MASK) == I2C_SCTR_ACTIVE_ENABLE);
+}
+
+/**
+ *  @brief      Enable usage of target functionality
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableTarget(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR |= I2C_SCTR_ACTIVE_ENABLE;
+}
+
+/**
+ *  @brief      Disable general call address of 000 0000b
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableGeneralCall(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR &= ~(I2C_SCTR_GENCALL_MASK);
+}
+
+/**
+ *  @brief      Checks if general call address of 000 0000b is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If general call is enabled
+ *
+ *  @retval     true if general call is enabled
+ *  @retval     false if general call is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isGeneralCallEnabled(I2C_Regs *i2c)
+{
+    return (
+        (i2c->SLAVE.SCTR & I2C_SCTR_GENCALL_MASK) == I2C_SCTR_GENCALL_ENABLE);
+}
+
+/**
+ *  @brief      Enable usage of general call address of 000 0000b
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableGeneralCall(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SCTR |= I2C_SCTR_GENCALL_ENABLE;
+}
+
+/**
+ *  @brief      Get status of I2C bus controller for target
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *
+ *  @return     Status of I2C bus controller for target
+ *
+ *  @retval     Bitwise OR of @ref DL_I2C_TARGET_STATUS
+ */
+__STATIC_INLINE uint32_t DL_I2C_getTargetStatus(I2C_Regs *i2c)
+{
+    return (i2c->SLAVE.SSR);
+}
+
+/**
+ *  @brief      Get byte of data from I2C target
+ *
+ *  If using FIFO, it is first byte from the RX FIFO.
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *
+ *  @return     Last received byte of data
+ *
+ *  @retval     [0x00, 0xff]
+ */
+__STATIC_INLINE uint8_t DL_I2C_receiveTargetData(I2C_Regs *i2c)
+{
+    return (uint8_t)(i2c->SLAVE.SRXDATA & I2C_SRXDATA_VALUE_MASK);
+}
+
+/**
+ *  @brief      Set next byte to be transferred during the next transaction
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  data    Byte of data to be transferred during the next
+ *                      transaction. [0x00, 0xff]
+ */
+__STATIC_INLINE void DL_I2C_transmitTargetData(I2C_Regs *i2c, uint8_t data)
+{
+    i2c->SLAVE.STXDATA = data;
+}
+
+/**
+ *  @brief      Disable target ACK override
+ *
+ *  Disable manual ACK override to automatically ACK all received bytes until
+ *  the RX FIFO is full.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableTargetACKOverride(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SACKCTL &= ~(I2C_SACKCTL_ACKOEN_MASK);
+}
+
+/**
+ *  @brief      Checks if target ACK override is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target ACK override is enabled
+ *
+ *  @retval     true if target ACK override is enabled
+ *  @retval     false if target ACK override is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isTargetACKOverrideEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SACKCTL & I2C_SACKCTL_ACKOEN_MASK) ==
+            I2C_SACKCTL_ACKOEN_ENABLE);
+}
+
+/**
+ *  @brief      Enable target ACK override
+ *
+ *  When manual ACK override is enabled, the I2C target SCL is pulled low after
+ *  the last data is received until the ACK override value (through
+ *  @ref DL_I2C_setTargetACKOverrideValue) is written.
+ *  Disable manual ACK override to automatically ACK all received bytes until
+ *  the RX FIFO is full.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableTargetACKOverride(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SACKCTL |= I2C_SACKCTL_ACKOEN_ENABLE;
+}
+
+/**
+ *  @brief      Get target acknowledge override value
+ *
+ *  @note for General Call this bit will be ignored if set to NACK and target
+ *  continues to receive data.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     What type of response will be generated
+ *
+ *  @retval     One of @ref DL_I2C_TARGET_RESPONSE_OVERRIDE_VALUE.
+ */
+__STATIC_INLINE DL_I2C_TARGET_RESPONSE_OVERRIDE_VALUE
+DL_I2C_getTargetACKOverrideValue(I2C_Regs *i2c)
+{
+    uint32_t value = i2c->SLAVE.SACKCTL & I2C_SACKCTL_ACKOVAL_MASK;
+
+    return (DL_I2C_TARGET_RESPONSE_OVERRIDE_VALUE)(value);
+}
+
+/**
+ *  @brief      Set target acknowledge override value
+ *
+ *  @note for General Call this bit will be ignored if set to NACK and target
+ *  continues to receive data.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  value   Indicates what type of response will be generated.
+ *                      One of @ref DL_I2C_TARGET_RESPONSE_OVERRIDE_VALUE.
+ *
+ *  @sa         DL_I2C_enableTargetACKOverride
+ */
+__STATIC_INLINE void DL_I2C_setTargetACKOverrideValue(
+    I2C_Regs *i2c, DL_I2C_TARGET_RESPONSE_OVERRIDE_VALUE value)
+{
+    DL_Common_updateReg(
+        &i2c->SLAVE.SACKCTL, (uint32_t) value, I2C_SACKCTL_ACKOVAL_MASK);
+}
+
+/**
+ *  @brief      Disable target ACK override on Start Condition
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableACKOverrideOnStart(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SACKCTL &= ~(I2C_SACKCTL_ACKOEN_ON_START_MASK);
+}
+
+/**
+ *  @brief      Checks if target ACK override on Start condition is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target ACK override on Start condition is enabled
+ *
+ *  @retval     true if target ACK override on Start condition is enabled
+ *  @retval     false if target ACK override on Start condition is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isACKOverrideOnStartEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SACKCTL & I2C_SACKCTL_ACKOEN_ON_START_MASK) ==
+            I2C_SACKCTL_ACKOEN_ON_START_ENABLE);
+}
+
+/**
+ *  @brief      Enable target ACK override on Start condition
+ *
+ *  When enabled, this bit will automatically turn on the Target ACKOEN field
+ *  following a Start condition.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @sa                 DL_I2C_enableTargetACKOverride
+ */
+__STATIC_INLINE void DL_I2C_enableACKOverrideOnStart(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SACKCTL |= I2C_SACKCTL_ACKOEN_ON_START_ENABLE;
+}
+
+/**
+ *  @brief      Disable target ACK override when SMBus/PMBus PEC is next byte
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableACKOverrideOnPECNext(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SACKCTL &= ~(I2C_SACKCTL_ACKOEN_ON_PECNEXT_MASK);
+}
+
+/**
+ *  @brief      Checks if target ACK override when SMBus/PMBus PEC is next byte
+ *              is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target ACK override when PEC is next byte is enabled
+ *
+ *  @retval     true if target ACK override when PEC is next byte is enabled
+ *  @retval     false if target ACK override when PEC is next byte is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isACKOverrideOnPECNextEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SACKCTL & I2C_SACKCTL_ACKOEN_ON_PECNEXT_MASK) ==
+            I2C_SACKCTL_ACKOEN_ON_PECNEXT_ENABLE);
+}
+
+/**
+ *  @brief      Enable target ACK override when SMBus/PMBus PEC is next byte
+ *
+ *  When enabled, this bit will automatically turn on the Target ACKOEN field
+ *  following the ACK/NACK of the byte received just prior to the PEC byte.
+ *  Note that when ACKOEN is set, the PEC byte will not automatically be
+ *  ACKed/NACKed by the state machine and FW must perform this function by
+ *  writing SLAVE_SACKCTL.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @sa                 DL_I2C_enableTargetACKOverride
+ */
+__STATIC_INLINE void DL_I2C_enableACKOverrideOnPECNext(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SACKCTL |= I2C_SACKCTL_ACKOEN_ON_PECNEXT_ENABLE;
+}
+
+/**
+ *  @brief      Disable target ACK override when SMBus/PMBus PEC is next byte
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableACKOverrideOnPECDone(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SACKCTL &= ~(I2C_SACKCTL_ACKOEN_ON_PECDONE_MASK);
+}
+
+/**
+ *  @brief      Checks if target ACK override when SMBus/PMBus PEC is next byte
+ *              is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target ACK override when PEC is next byte is enabled
+ *
+ *  @retval     true if target ACK override when PEC is next byte is enabled
+ *  @retval     false if target ACK override when PEC is next byte is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isACKOverrideOnPECDoneEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SACKCTL & I2C_SACKCTL_ACKOEN_ON_PECDONE_MASK) ==
+            I2C_SACKCTL_ACKOEN_ON_PECDONE_ENABLE);
+}
+
+/**
+ *  @brief      Enable target ACK override when SMBus/PMBus PEC is done
+ *
+ *  When enabled, this bit will automatically turn on the Target ACKOEN field
+ * following the ACK/NACK of the received PEC byte.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @sa                 DL_I2C_enableTargetACKOverride
+ */
+__STATIC_INLINE void DL_I2C_enableACKOverrideOnPECDone(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SACKCTL |= I2C_SACKCTL_ACKOEN_ON_PECDONE_ENABLE;
+}
+
+/**
+ *  @brief      Get the target SMBus/PMBus Packet Error Checking (PEC) count
+ *              value
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The value the PEC count is set to
+ *
+ *  @retval     Value between [0x0, 0x01FF]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getTargetPECCountValue(I2C_Regs *i2c)
+{
+    return (i2c->SLAVE.TARGET_PECCTL & I2C_TARGET_PECCTL_PECCNT_MASK);
+}
+
+/**
+ *  @brief      Set the target SMBus/PMBus Packet Error Checking (PEC) count
+ *              value
+ *
+ *  When this field is non zero, the number of I2C data bytes are counted.
+ *  Refer to the device TRM for more details.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  count   The value to set the PEC count to.
+ *                      Value between [0x0, 0x01FF]
+ */
+__STATIC_INLINE void DL_I2C_setTargetPECCountValue(
+    I2C_Regs *i2c, uint32_t count)
+{
+    DL_Common_updateReg(
+        &i2c->SLAVE.TARGET_PECCTL, count, I2C_TARGET_PECCTL_PECCNT_MASK);
+}
+
+/**
+ *  @brief      Disable target SMBus/PMBus Packet Error Checking (PEC)
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableTargetPEC(I2C_Regs *i2c)
+{
+    i2c->SLAVE.TARGET_PECCTL &= ~(I2C_TARGET_PECCTL_PECEN_MASK);
+}
+
+/**
+ *  @brief      Checks if target SMBus/PMBus Packet Error Checking (PEC) is
+ *              enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target PEC is enabled
+ *
+ *  @retval     true if target PEC is enabled
+ *  @retval     false if target PEC is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isTargetPECEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.TARGET_PECCTL & I2C_TARGET_PECCTL_PECEN_MASK) ==
+            I2C_TARGET_PECCTL_PECEN_ENABLE);
+}
+
+/**
+ *  @brief      Enable target SMBus/PMBus Packet Error Checking (PEC)
+ *
+ *  When enabled, the PEC is calculated on all bits accept the Start, Stop, ACK
+ *  and NACK. The PEC LSFR and the Byte Counter is set to 0 when the State
+ *  Machine is in the IDLE state, which occurs following a Stop or when a
+ *  timeout occurs. The Counter is also set to 0 after the PEC byte is sent or
+ *  received. Note that the NACK is automatically sent following a PEC byte
+ *  that results in a PEC error.
+ *  The PEC Polynomial is x^8 + x^2 + x^1 + 1.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_I2C_enableTargetPEC(I2C_Regs *i2c)
+{
+    i2c->SLAVE.TARGET_PECCTL |= I2C_TARGET_PECCTL_PECEN_ENABLE;
+}
+
+/**
+ *  @brief      Get the current SMBus/PMBus PEC byte count of the Target state
+ *              machine
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current PEC byte count of the target state macione
+ *
+ *  @retval     Value between [0x0, 0x01FF]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getTargetCurrentPECCount(I2C_Regs *i2c)
+{
+    return (i2c->SLAVE.TARGET_PECCTL & I2C_TARGET_PECSR_PECBYTECNT_MASK);
+}
+
+/**
+ *  @brief      Get status if SMBus/PMBus target PEC was checked in last
+ *              transaction
+ *
+ *  The status of if the target PEC was checked in the transaction that
+ *  occurred before the last Stop. Latched on Stop.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     Status of PEC target checked
+ *
+ *  @retval     One of @ref DL_I2C_TARGET_PEC_STATUS
+ */
+__STATIC_INLINE DL_I2C_TARGET_PEC_STATUS DL_I2C_getTargetPECCheckedStatus(
+    I2C_Regs *i2c)
+{
+    uint32_t status =
+        i2c->SLAVE.TARGET_PECSR & I2C_TARGET_PECSR_PECSTS_CHECK_MASK;
+
+    return (DL_I2C_TARGET_PEC_STATUS)(status);
+}
+
+/**
+ *  @brief      Get target TX FIFO threshold level
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @return     Indicates at what fill level in the TX FIFO a threshold will be
+ *              generated
+ *
+ *  @retval     One of @ref DL_I2C_TX_FIFO_LEVEL
+ */
+__STATIC_INLINE DL_I2C_TX_FIFO_LEVEL DL_I2C_getTargetTXFIFOThreshold(
+    I2C_Regs *i2c)
+{
+    uint32_t level = i2c->SLAVE.SFIFOCTL & I2C_SFIFOCTL_TXTRIG_MASK;
+
+    return (DL_I2C_TX_FIFO_LEVEL)(level);
+}
+
+/**
+ *  @brief      Set target TX FIFO threshold level
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  level   Indicates at what fill level in the TX FIFO a threshold
+ *                      will be generated.
+ *                      One of @ref DL_I2C_TX_FIFO_LEVEL.
+ */
+__STATIC_INLINE void DL_I2C_setTargetTXFIFOThreshold(
+    I2C_Regs *i2c, DL_I2C_TX_FIFO_LEVEL level)
+{
+    DL_Common_updateReg(&i2c->SLAVE.SFIFOCTL, (uint32_t) level,
+        (uint32_t) I2C_SFIFOCTL_TXTRIG_MASK);
+}
+
+/**
+ *  @brief      Stop target TX FIFO flush
+ *
+ *  Before stopping the flush, check if @ref DL_I2C_isTargetTXFIFOEmpty,
+ *  indicating flush is complete.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_stopFlushTargetTXFIFO(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SFIFOCTL &= ~(I2C_SFIFOCTL_TXFLUSH_MASK);
+}
+
+/**
+ *  @brief      Start target TX FIFO flush
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_startFlushTargetTXFIFO(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SFIFOCTL |= I2C_SFIFOCTL_TXFLUSH_MASK;
+}
+
+/**
+ *  @brief      Stop target RX FIFO flush
+ *
+ *  Before stopping the flush, check if @ref DL_I2C_isTargetRXFIFOEmpty,
+ *  indicating flush is complete.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_stopFlushTargetRXFIFO(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SFIFOCTL &= ~(I2C_SFIFOCTL_RXFLUSH_MASK);
+}
+
+/**
+ *  @brief      Start target RX FIFO flush
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_startFlushTargetRXFIFO(I2C_Regs *i2c)
+{
+    i2c->SLAVE.SFIFOCTL |= I2C_SFIFOCTL_RXFLUSH_MASK;
+}
+
+/**
+ *  @brief      Get target RX FIFO threshold level
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @return     Indicates at what fill level in the RX FIFO a threshold will be
+ *              generated
+ *
+ *  @retval     One of @ref DL_I2C_RX_FIFO_LEVEL
+ */
+__STATIC_INLINE DL_I2C_RX_FIFO_LEVEL DL_I2C_getTargetRXFIFOThreshold(
+    I2C_Regs *i2c)
+{
+    uint32_t level = i2c->SLAVE.SFIFOCTL & I2C_SFIFOCTL_RXTRIG_MASK;
+
+    return (DL_I2C_RX_FIFO_LEVEL)(level);
+}
+
+/**
+ *  @brief      Set target RX FIFO threshold level
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *  @param[in]  level   Indicates at what fill level in the RX FIFO a threshold
+ *                      will be generated.
+ *                      One of @ref DL_I2C_RX_FIFO_LEVEL.
+ */
+__STATIC_INLINE void DL_I2C_setTargetRXFIFOThreshold(
+    I2C_Regs *i2c, DL_I2C_RX_FIFO_LEVEL level)
+{
+    DL_Common_updateReg(
+        &i2c->SLAVE.SFIFOCTL, (uint32_t) level, I2C_SFIFOCTL_RXTRIG_MASK);
+}
+
+/**
+ *  @brief      Get number of bytes which can be read from RX FIFO
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *
+ *  @return     Number of bytes which can be read from RX FIFO
+ *
+ *  @retval     [0x0, 0x8]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getTargetRXFIFOCounter(I2C_Regs *i2c)
+{
+    return (i2c->SLAVE.SFIFOSR & I2C_SFIFOSR_RXFIFOCNT_MASK);
+}
+
+/**
+ *  @brief      Get number of bytes which can be put into TX FIFO
+ *
+ *  @param[in]  i2c         Pointer to the register overlay for the peripheral
+ *
+ *  @return     Number of bytes which can be put into TX FIFO
+ *
+ *  @retval     [0x0, 0x8]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getTargetTXFIFOCounter(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SFIFOSR & I2C_SFIFOSR_TXFIFOCNT_MASK) >>
+            I2C_SFIFOSR_TXFIFOCNT_OFS);
+}
+
+/**
+ *  @brief      Checks if target RX FIFO flush is active
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target RX FIFO flush is active
+ *
+ *  @retval     true if target RX FIFO flush is active
+ *  @retval     false if target RX FIFO flush is not active
+ */
+__STATIC_INLINE bool DL_I2C_isTargetRXFIFOFlushActive(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SFIFOSR & I2C_SFIFOSR_RXFLUSH_MASK) ==
+            I2C_SFIFOSR_RXFLUSH_ACTIVE);
+}
+
+/**
+ *  @brief      Checks if target TX FIFO flush is active
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If target TX FIFO flush is active
+ *
+ *  @retval     true if target TX FIFO flush is active
+ *  @retval     false if target TX FIFO flush is not active
+ */
+__STATIC_INLINE bool DL_I2C_isTargetTXFIFOFlushActive(I2C_Regs *i2c)
+{
+    return ((i2c->SLAVE.SFIFOSR & I2C_SFIFOSR_TXFLUSH_MASK) ==
+            I2C_SFIFOSR_TXFLUSH_ACTIVE);
+}
+
+/**
+ *  @brief      Enable I2C interrupts
+ *
+ *  @param[in]  i2c            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_I2C_INTERRUPT.
+ */
+__STATIC_INLINE void DL_I2C_enableInterrupt(
+    I2C_Regs *i2c, uint32_t interruptMask)
+{
+    i2c->CPU_INT.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disable I2C interrupts
+ *
+ *  @param[in]  i2c            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to disable. Bitwise OR of
+ *                             @ref DL_I2C_INTERRUPT.
+ */
+__STATIC_INLINE void DL_I2C_disableInterrupt(
+    I2C_Regs *i2c, uint32_t interruptMask)
+{
+    i2c->CPU_INT.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief      Check which I2C interrupts are enabled
+ *
+ *  @param[in]  i2c            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_I2C_INTERRUPT.
+ *
+ *  @return     Which of the requested I2C interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_I2C_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_I2C_getEnabledInterrupts(
+    I2C_Regs *i2c, uint32_t interruptMask)
+{
+    return (i2c->CPU_INT.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled I2C interrupts
+ *
+ *  Checks if any of the I2C interrupts that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  i2c            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_I2C_INTERRUPT.
+ *
+ *  @return     Which of the requested I2C interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_I2C_INTERRUPT values
+ *
+ *  @sa         DL_I2C_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_I2C_getEnabledInterruptStatus(
+    I2C_Regs *i2c, uint32_t interruptMask)
+{
+    return (i2c->CPU_INT.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any I2C interrupt
+ *
+ *  Checks if any of the I2C interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  i2c            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_I2C_INTERRUPT.
+ *
+ *  @return     Which of the requested I2C interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_I2C_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_I2C_getRawInterruptStatus(
+    I2C_Regs *i2c, uint32_t interruptMask)
+{
+    return (i2c->CPU_INT.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending I2C interrupt
+ *
+ *  Checks if any of the I2C interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  i2c  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The highest priority pending I2C interrupt
+ *
+ *  @retval     One of @ref DL_I2C_IIDX
+ */
+__STATIC_INLINE DL_I2C_IIDX DL_I2C_getPendingInterrupt(I2C_Regs *i2c)
+{
+    return ((DL_I2C_IIDX) i2c->CPU_INT.IIDX);
+}
+
+/**
+ *  @brief      Clear pending I2C interrupts
+ *
+ *  @param[in]  i2c            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_I2C_INTERRUPT.
+ */
+__STATIC_INLINE void DL_I2C_clearInterruptStatus(
+    I2C_Regs *i2c, uint32_t interruptMask)
+{
+    i2c->CPU_INT.ICLR = interruptMask;
+}
+
+/**
+ *  @brief Enables I2C interrupt for triggering DMA events
+ *
+ * Enables the I2C interrupt to be used as the condition to generate an
+ * event to directly trigger the DMA.
+ *
+ * Each event publisher @ref DL_I2C_EVENT_ROUTE can set any one of
+ * @ref DL_I2C_DMA_INTERRUPT.
+ *
+ * @note Only one interrupt source should be enabled at a time.
+ *
+ *  @param[in]  i2c        Pointer to the register overlay for the peripheral
+ *  @param[in]  index      Specifies the register event publisher to configure
+ *  @param[in]  interrupt  Interrupt to enable as the trigger condition for
+ *                         the DMA. One of @ref DL_I2C_DMA_INTERRUPT.
+ */
+__STATIC_INLINE void DL_I2C_enableDMAEvent(
+    I2C_Regs *i2c, DL_I2C_EVENT_ROUTE index, uint32_t interrupt)
+{
+    switch (index) {
+        case DL_I2C_EVENT_ROUTE_1:
+            i2c->DMA_TRIG1.IMASK = interrupt;
+            break;
+        case DL_I2C_EVENT_ROUTE_2:
+            i2c->DMA_TRIG0.IMASK = interrupt;
+            break;
+        default:
+            break;
+    }
+}
+
+/**
+ *  @brief Disables I2C interrupt from triggering DMA events
+ *
+ * Disables the I2C interrupt from being used as the condition to generate an
+ * event to directly trigger the DMA.
+ *
+ * Each event publisher @ref DL_I2C_EVENT_ROUTE can set any one of
+ * @ref DL_I2C_DMA_INTERRUPT.
+ *
+ *  @param[in]  i2c        Pointer to the register overlay for the peripheral
+ *  @param[in]  index      Specifies the register event publisher to configure
+ *  @param[in]  interrupt  Interrupt to disable as the trigger condition for
+ *                         the DMA. One of @ref DL_I2C_DMA_INTERRUPT.
+ */
+__STATIC_INLINE void DL_I2C_disableDMAEvent(
+    I2C_Regs *i2c, DL_I2C_EVENT_ROUTE index, uint32_t interrupt)
+{
+    switch (index) {
+        case DL_I2C_EVENT_ROUTE_1:
+            i2c->DMA_TRIG1.IMASK &= ~(interrupt);
+            break;
+        case DL_I2C_EVENT_ROUTE_2:
+            i2c->DMA_TRIG0.IMASK &= ~(interrupt);
+            break;
+        default:
+            break;
+    }
+}
+
+/**
+ *  @brief Check which I2C interrupt for DMA receive events is enabled
+ *
+ *  This API checks the event publisher register as selected by
+ *  @ref DL_I2C_EVENT_ROUTE, which are used for triggering the DMA for
+ *  Controller or Target and receive or transmit events.
+ *
+ *  @param[in]  i2c            Pointer to the register overlay for the peripheral
+ *  @param[in]  index          Specifies the register event publisher to configure
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_I2C_DMA_INTERRUPT.
+ *
+ *  @note Only one interrupt source should be enabled at a time.
+ *
+ *  @return     The requested I2C interrupt status
+ *
+ *  @retval     One of @ref DL_I2C_DMA_INTERRUPT
+ */
+__STATIC_INLINE uint32_t DL_I2C_getEnabledDMAEvents(
+    I2C_Regs *i2c, DL_I2C_EVENT_ROUTE index, uint32_t interruptMask)
+{
+    volatile uint32_t *pReg = &i2c->DMA_TRIG1.IMASK;
+
+    return ((*(pReg + (uint32_t) index) & interruptMask));
+}
+
+/**
+ *  @brief Check interrupt flag of enabled I2C interrupt for DMA event
+ *
+ *  Checks if any of the I2C interrupts for the DMA receive event that were
+ *  previously enabled are pending.
+ *  This API checks the event publisher register as selected by
+ *  @ref DL_I2C_EVENT_ROUTE, which are used for triggering the DMA for
+ *  Controller or Target and receive or transmit events.
+ *
+ *  @param[in]  i2c            Pointer to the register overlay for the peripheral
+ *  @param[in]  index          Specifies the register event publisher to configure
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_I2C_DMA_INTERRUPT.
+ *
+ *  @note Only one interrupt source should be enabled at a time.
+ *
+ *  @return     The requested I2C interrupt status
+ *
+ *  @retval     One of @ref DL_I2C_DMA_INTERRUPT
+ *
+ *  @sa         DL_I2C_enableDMAEvent
+ */
+__STATIC_INLINE uint32_t DL_I2C_getEnabledDMAEventStatus(
+    I2C_Regs *i2c, DL_I2C_EVENT_ROUTE index, uint32_t interruptMask)
+{
+    const volatile uint32_t *pReg = &i2c->DMA_TRIG1.MIS;
+
+    return ((*(pReg + (uint32_t) index) & interruptMask));
+}
+
+/**
+ *  @brief Check interrupt flag of any I2C interrupt for DMA event
+ *
+ *  Checks if any of the I2C interrupts for DMA receive event are pending.
+ *  Interrupts do not have to be previously enabled.
+ *  This API checks the event publisher register as selected by
+ *  @ref DL_I2C_EVENT_ROUTE, which are used for triggering the DMA for
+ *  Controller or Target and receive or transmit events.
+ *
+ *  @param[in]  i2c            Pointer to the register overlay for the peripheral
+ *  @param[in]  index          Specifies the register event publisher to configure
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_I2C_DMA_INTERRUPT.
+ *
+ *  @return     Which of the requested I2C interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_I2C_DMA_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_I2C_getRawDMAEventStatus(
+    I2C_Regs *i2c, DL_I2C_EVENT_ROUTE index, uint32_t interruptMask)
+{
+    const volatile uint32_t *pReg = &i2c->DMA_TRIG1.RIS;
+
+    return ((*(pReg + (uint32_t) index) & interruptMask));
+}
+
+/**
+ *  @brief Get highest priority pending I2C interrupt for DMA  event
+ *
+ *  Checks if any of the I2C interrupts for DMA receive event are pending.
+ *  Interrupts do not have to be previously enabled.
+ *  This API checks the event publisher register as selected by
+ *  @ref DL_I2C_EVENT_ROUTE, which are used for triggering the DMA for
+ *  Controller or Target and receive or transmit events.
+ *
+ *  @param[in]  i2c        Pointer to the register overlay for the peripheral
+ *  @param[in]  index      Specifies the register event publisher to configure
+ *
+ *  @return     The highest priority pending I2C interrupt
+ *
+ *  @retval     One of @ref DL_I2C_DMA_IIDX
+ */
+__STATIC_INLINE DL_I2C_DMA_IIDX DL_I2C_getPendingDMAEvent(
+    I2C_Regs *i2c, DL_I2C_EVENT_ROUTE index)
+{
+    const volatile uint32_t *pReg = &i2c->DMA_TRIG1.IIDX;
+
+    return (DL_I2C_DMA_IIDX)((*(pReg + (uint32_t) index)));
+}
+
+/**
+ *  @brief Clear pending SPI interrupts for DMA events
+ *
+ *  This API checks the event publisher register as selected by
+ *  @ref DL_I2C_EVENT_ROUTE, which are used for triggering the DMA for
+ *  Controller or Target and receive or transmit events.
+ *
+ *  @param[in]  i2c        Pointer to the register overlay for the peripheral
+ *  @param[in]  index      Specifies the register event publisher to configure
+ *  @param[in]  interrupt  Interrupt to clear. One of @ref DL_I2C_DMA_INTERRUPT
+ */
+__STATIC_INLINE void DL_I2C_clearDMAEvent(
+    I2C_Regs *i2c, DL_I2C_EVENT_ROUTE index, uint32_t interrupt)
+{
+    switch (index) {
+        case DL_I2C_EVENT_ROUTE_1:
+            i2c->DMA_TRIG1.ICLR |= interrupt;
+            break;
+        case DL_I2C_EVENT_ROUTE_2:
+            i2c->DMA_TRIG0.ICLR |= interrupt;
+            break;
+        default:
+            break;
+    }
+}
+
+/**
+ *  @brief      Disable analog and digital glitch filter chaining
+ *
+ *  Chaining is disabled and only digital filter output is available to IP
+ *  sampling logic.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableGlitchFilterChaining(I2C_Regs *i2c)
+{
+    i2c->GFCTL &= ~(I2C_GFCTL_CHAIN_MASK);
+}
+
+/**
+ *  @brief      Checks if analog and digital glitch filter chaining is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If glitch filter chaining is enabled
+ *
+ *  @retval     true if glitch filter chaining is enabled
+ *  @retval     false if glitch filter chaining is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isGlitchFilterChainingEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->GFCTL & I2C_GFCTL_CHAIN_MASK) == I2C_GFCTL_CHAIN_ENABLE);
+}
+
+/**
+ *  @brief      Enable analog and digitial glitch filter chaining
+ *
+ *  When enabled, analog and digital glitch filters are chained and the output
+ *  of the combination is made available to IP sampling logic.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableGlitchFilterChaining(I2C_Regs *i2c)
+{
+    i2c->GFCTL |= I2C_GFCTL_CHAIN_ENABLE;
+}
+
+/**
+ *  @brief      Get the Timeout Counter A value
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The Timeout A counter value
+ *
+ *  @retval     Value between [0x0, 0xFF]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getTimeoutACount(I2C_Regs *i2c)
+{
+    return (i2c->TIMEOUT_CTL & I2C_TIMEOUT_CTL_TCNTLA_MASK);
+}
+
+/**
+ *  @brief      Set the Timeout Counter A value
+ *
+ *  Timeout A is used for SCL low detection. This field contains the upper 8
+ *  bits of a 12-bit pre-load value for the Timeout A count.
+ *  NOTE: The value of the counter must be greater than 1 to enable the
+ *  timeout. Each count is equal to 520 times the timeout period of the
+ *  functional clock. For example, with 8MHz functional clock and a
+ *  100KHz operating I2C clock, one timeout period will be equal to
+ *  (1 / 8MHz) * 520 = 65us.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  count   The value to set the Timeout A counter to.
+ *                      Value between [0x0, 0xFF]
+ */
+__STATIC_INLINE void DL_I2C_setTimeoutACount(I2C_Regs *i2c, uint32_t count)
+{
+    DL_Common_updateReg(&i2c->TIMEOUT_CTL, count, I2C_TIMEOUT_CTL_TCNTLA_MASK);
+}
+
+/**
+ *  @brief      Disable Timeout Counter A
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableTimeoutA(I2C_Regs *i2c)
+{
+    i2c->TIMEOUT_CTL &= ~(I2C_TIMEOUT_CTL_TCNTAEN_MASK);
+}
+
+/**
+ *  @brief      Checks if Timeout Counter A is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If Timeout Counter A is enabled
+ *
+ *  @retval     true if Timeout Counter A is enabled
+ *  @retval     false if Timeout Counter A is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isTimeoutAEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->TIMEOUT_CTL & I2C_TIMEOUT_CTL_TCNTAEN_MASK) ==
+            I2C_TIMEOUT_CTL_TCNTAEN_ENABLE);
+}
+
+/**
+ *  @brief      Enable Timeout Counter A
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableTimeoutA(I2C_Regs *i2c)
+{
+    i2c->TIMEOUT_CTL |= I2C_TIMEOUT_CTL_TCNTAEN_ENABLE;
+}
+
+/**
+ *  @brief      Get the current Timer Counter A value
+ *
+ *  This field contains the upper 8 bits of a 12-bit current counter for
+ *  Timeout Counter A.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The Timeout A counter value
+ *
+ *  @retval     Value between [0x0, 0xFF]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getCurrentTimeoutACounter(I2C_Regs *i2c)
+{
+    return (i2c->TIMEOUT_CNT & I2C_TIMEOUT_CNT_TCNTA_MASK);
+}
+
+/**
+ *  @brief      Get the Timeout Counter B value
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The Timeout B counter value
+ *
+ *  @retval     Value between [0x0, 0xFF]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getTimeoutBCount(I2C_Regs *i2c)
+{
+    return ((i2c->TIMEOUT_CTL & I2C_TIMEOUT_CTL_TCNTLB_MASK) >>
+            I2C_TIMEOUT_CTL_TCNTLB_OFS);
+}
+
+/**
+ *  @brief      Set the Timeout Counter B value
+ *
+ *  Timeout B is used for SCL high detection. This field contains the upper 8
+ *  bits of a 12-bit pre-load value for the Timeout A count.
+ *  NOTE: The value of the counter must be greater than 1 to enable the
+ *  timeout. Each count is equal to 1* clock period. For example, with 10MHz
+ *  functional clock one timeout period will be equal to 1 * 10ns.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  count   The value to set the Timeout A counter to.
+ *                      Value between [0x0, 0xFF]
+ */
+__STATIC_INLINE void DL_I2C_setTimeoutBCount(I2C_Regs *i2c, uint32_t count)
+{
+    DL_Common_updateReg(&i2c->TIMEOUT_CTL,
+        (count << I2C_TIMEOUT_CTL_TCNTLB_OFS), I2C_TIMEOUT_CTL_TCNTLB_MASK);
+}
+
+/**
+ *  @brief      Disable Timeout Counter B
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_disableTimeoutB(I2C_Regs *i2c)
+{
+    i2c->TIMEOUT_CTL &= ~(I2C_TIMEOUT_CTL_TCNTBEN_MASK);
+}
+
+/**
+ *  @brief      Checks if Timeout Counter B is enabled
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     If Timeout Counter B is enabled
+ *
+ *  @retval     true if Timeout Counter B is enabled
+ *  @retval     false if Timeout Counter B is disabled
+ */
+__STATIC_INLINE bool DL_I2C_isTimeoutBEnabled(I2C_Regs *i2c)
+{
+    return ((i2c->TIMEOUT_CTL & I2C_TIMEOUT_CTL_TCNTBEN_MASK) ==
+            I2C_TIMEOUT_CTL_TCNTBEN_ENABLE);
+}
+
+/**
+ *  @brief      Enable Timeout Counter B
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_I2C_enableTimeoutB(I2C_Regs *i2c)
+{
+    i2c->TIMEOUT_CTL |= I2C_TIMEOUT_CTL_TCNTBEN_ENABLE;
+}
+
+/**
+ *  @brief      Get the current Timer Counter B value
+ *
+ *  This field contains the upper 8 bits of a 12-bit current counter for
+ *  Timeout Counter B.
+ *
+ *  @param[in]  i2c     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The Timeout B counter value
+ *
+ *  @retval     Value between [0x0, 0xFF]
+ */
+__STATIC_INLINE uint32_t DL_I2C_getCurrentTimeoutBCounter(I2C_Regs *i2c)
+{
+    return (i2c->TIMEOUT_CNT & I2C_TIMEOUT_CNT_TCNTB_MASK);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_I2C__ */
+
+#endif /* ti_dl_dl_i2c__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_iwdt.h
+++ b/mspm0/source/ti/driverlib/dl_iwdt.h
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_iwdt.h
+ *  @brief      Independent Watchdog Timer (iWDT) Driver Library
+ *  @defgroup   iWDT Independent Watchdog Timer (iWDT)
+ *
+ *  @anchor ti_dl_dl_iwdt_Overview
+ *  # Overview
+ *
+ *  The Independent Watchdog Timer Driver Library allows full configuration of
+ *  the MSPM0 iWDT module.
+ *  The independent window watchdog timer (iWDT) in the LFSS IP is an SoC independent supervisor
+ *  which monitors code execution and overall hang up scenarios of the SoC. Due to
+ *  the nature of the LFSS IP, this iWDT has its own system independent power and clock source.
+ *  If the application software does not successfully reset the watchdog within the programmed time,
+ *  the watchdog generates a POR reset to the SoC
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup IWDT
+ * @{
+ */
+#ifndef ti_dl_dl_iwdt__include
+#define ti_dl_dl_iwdt__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/driverlib/dl_lfss.h>
+
+#ifdef __MSPM0_HAS_IWDT__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_CLOCK_DIVIDE_1
+ */
+#define DL_IWDT_CLOCK_DIVIDE_1                           DL_LFSS_IWDT_CLOCK_DIVIDE_1
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_CLOCK_DIVIDE_2
+ */
+#define DL_IWDT_CLOCK_DIVIDE_2                           DL_LFSS_IWDT_CLOCK_DIVIDE_2
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_CLOCK_DIVIDE_3
+ */
+#define DL_IWDT_CLOCK_DIVIDE_3                           DL_LFSS_IWDT_CLOCK_DIVIDE_3
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_CLOCK_DIVIDE_4
+ */
+#define DL_IWDT_CLOCK_DIVIDE_4                           DL_LFSS_IWDT_CLOCK_DIVIDE_4
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_CLOCK_DIVIDE_5
+ */
+#define DL_IWDT_CLOCK_DIVIDE_5                           DL_LFSS_IWDT_CLOCK_DIVIDE_5
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_CLOCK_DIVIDE_6
+ */
+#define DL_IWDT_CLOCK_DIVIDE_6                           DL_LFSS_IWDT_CLOCK_DIVIDE_6
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_CLOCK_DIVIDE_7
+ */
+#define DL_IWDT_CLOCK_DIVIDE_7                           DL_LFSS_IWDT_CLOCK_DIVIDE_7
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_CLOCK_DIVIDE_8
+ */
+#define DL_IWDT_CLOCK_DIVIDE_8                           DL_LFSS_IWDT_CLOCK_DIVIDE_8
+
+/*!
+ * @brief Redirects to common @ref  DL_LFSS_IWDT_TIMER_PERIOD_6_BITS
+ */
+#define DL_IWDT_TIMER_PERIOD_6_BITS                     DL_LFSS_IWDT_TIMER_PERIOD_6_BITS
+
+/*!
+ * @brief Redirects to common @ref  DL_LFSS_IWDT_TIMER_PERIOD_8_BITS
+ */
+#define DL_IWDT_TIMER_PERIOD_8_BITS                     DL_LFSS_IWDT_TIMER_PERIOD_8_BITS
+
+/*!
+ * @brief Redirects to common @ref  DL_LFSS_IWDT_TIMER_PERIOD_10_BITS
+ */
+#define DL_IWDT_TIMER_PERIOD_10_BITS                    DL_LFSS_IWDT_TIMER_PERIOD_10_BITS
+
+/*!
+ * @brief Redirects to common @ref  DL_LFSS_IWDT_TIMER_PERIOD_12_BITS
+ */
+#define DL_IWDT_TIMER_PERIOD_12_BITS                    DL_LFSS_IWDT_TIMER_PERIOD_12_BITS
+
+/*!
+ * @brief Redirects to common @ref  DL_LFSS_IWDT_TIMER_PERIOD_15_BITS
+ */
+#define DL_IWDT_TIMER_PERIOD_15_BITS                    DL_LFSS_IWDT_TIMER_PERIOD_15_BITS
+
+/*!
+ * @brief Redirects to common @ref  DL_LFSS_IWDT_TIMER_PERIOD_18_BITS
+ */
+#define DL_IWDT_TIMER_PERIOD_18_BITS                    DL_LFSS_IWDT_TIMER_PERIOD_18_BITS
+
+/*!
+ * @brief Redirects to common @ref  DL_LFSS_IWDT_TIMER_PERIOD_21_BITS
+ */
+#define DL_IWDT_TIMER_PERIOD_21_BITS                    DL_LFSS_IWDT_TIMER_PERIOD_21_BITS
+
+/*!
+ * @brief Redirects to common @ref  DL_LFSS_IWDT_TIMER_PERIOD_25_BITS
+ */
+#define DL_IWDT_TIMER_PERIOD_25_BITS                    DL_LFSS_IWDT_TIMER_PERIOD_25_BITS
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_enableModule
+ */
+#define DL_IWDT_enableModule                             DL_LFSS_IWDT_enableModule
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_disableModule
+ */
+#define DL_IWDT_disableModule                            DL_LFSS_IWDT_disableModule
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_isModuleEnabled
+ */
+#define DL_IWDT_isModuleEnabled                          DL_LFSS_IWDT_isModuleEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_enableFreeRun
+ */
+#define DL_IWDT_enableFreeRun                            DL_LFSS_IWDT_enableFreeRun
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_disableFreeRun
+ */
+#define DL_IWDT_disableFreeRun                           DL_LFSS_IWDT_disableFreeRun
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_isFreeRunEnabled
+ */
+#define DL_IWDT_isFreeRunEnabled                         DL_LFSS_IWDT_isFreeRunEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_setClockDivider
+ */
+#define DL_IWDT_setClockDivider                          DL_LFSS_IWDT_setClockDivider
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_getClockDivider
+ */
+#define DL_IWDT_getClockDivider                          DL_LFSS_IWDT_getClockDivider
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_setTimerPeriod
+ */
+#define DL_IWDT_setTimerPeriod                           DL_LFSS_IWDT_setTimerPeriod
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_getTimerPeriod
+ */
+#define DL_IWDT_getTimerPeriod                           DL_LFSS_IWDT_getTimerPeriod
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_restart
+ */
+#define DL_IWDT_restart                                  DL_LFSS_IWDT_restart
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_isWatchdogRunning
+ */
+#define DL_IWDT_isWatchDogRunning                        DL_LFSS_IWDT_isWatchdogRunning
+
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_enableWriteProtect
+ */
+#define DL_IWDT_enableWriteProtect                       DL_LFSS_IWDT_enableWriteProtect
+
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_isWriteProtectEnabled
+ */
+#define DL_IWDT_isWriteProtectEnabled                    DL_LFSS_IWDT_isWriteProtectEnabled
+
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_IWDT_disableWriteProtect
+ */
+#define DL_IWDT_disableWriteProtect                      DL_LFSS_IWDT_disableWriteProtect
+
+/* clang-format on */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_IWDT__ */
+
+#endif /* ti_dl_dl_iwdt__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_keystorectl.c
+++ b/mspm0/source/ti/driverlib/dl_keystorectl.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_keystorectl.h>
+
+#ifdef __MSPM0_HAS_KEYSTORE_CTL__
+
+static void DL_KEYSTORECTL_loadData(
+    volatile uint32_t *pDest, uint32_t *pSrc, uint8_t len);
+static uint8_t DL_KEYSTORECTL_getWordsFromSize(
+    DL_KEYSTORECTL_KEY_SIZE keySize);
+
+void DL_KEYSTORECTL_loadKey(KEYSTORECTL_Regs *keystorectl, uint32_t *key)
+{
+    DL_KEYSTORECTL_KEY_SIZE keySize;
+    uint8_t numWords;
+    volatile uint32_t *destPtr = (volatile uint32_t *) &keystorectl->KEYIN;
+    uint32_t *srcPtr           = (uint32_t *) key;
+
+    keySize  = DL_KEYSTORECTL_getDestinationKeySize(keystorectl);
+    numWords = DL_KEYSTORECTL_getWordsFromSize(keySize);
+
+    DL_KEYSTORECTL_loadData(destPtr, srcPtr, numWords);
+}
+
+DL_KEYSTORECTL_STATUS DL_KEYSTORECTL_writeKey(
+    KEYSTORECTL_Regs *keystorectl, DL_KEYSTORECTL_KeyWrConfig *keyWrConfig)
+{
+    DL_KEYSTORECTL_STATUS status = DL_KEYSTORECTL_STATUS_VALID;
+    uint32_t validSlot;
+    uint8_t numWords;
+    volatile uint32_t *destPtr = (volatile uint32_t *) &keystorectl->KEYIN;
+
+    /* 1. Confirm valid status on the KEYSTORECTL */
+    status = DL_KEYSTORECTL_getStatus(keystorectl);
+
+    /* 2. Configure the key write by writing size and slot */
+    if (status == DL_KEYSTORECTL_STATUS_VALID) {
+        DL_Common_updateReg(&keystorectl->KEYWR,
+            (((uint32_t) keyWrConfig->keySize) |
+                ((uint32_t) keyWrConfig->keySlot)),
+            (KEYSTORECTL_KEYWR_KEYSZSEL_MASK |
+                KEYSTORECTL_KEYWR_KEYSLOTSEL_MASK));
+
+        /* 3. Confirm a valid write configuration */
+        status = DL_KEYSTORECTL_getStatus(keystorectl);
+    }
+
+    /* 4. Write key to the input buffer*/
+    if (status == DL_KEYSTORECTL_STATUS_VALID) {
+        numWords = DL_KEYSTORECTL_getWordsFromSize(keyWrConfig->keySize);
+
+        DL_KEYSTORECTL_loadData(destPtr, keyWrConfig->key, numWords);
+
+        /* 5. Loop until status is back to valid (no longer busy) */
+        status = DL_KEYSTORECTL_getStatus(keystorectl);
+        while (status == DL_KEYSTORECTL_STATUS_BUSY_RX) {
+            status = DL_KEYSTORECTL_getStatus(keystorectl);
+        }
+    }
+
+    /* 6. Confirm key slots were successfully written */
+    if (status == DL_KEYSTORECTL_STATUS_VALID) {
+        validSlot = (keyWrConfig->keySlot &
+                     DL_KEYSTORECTL_getValidKeySlots(keystorectl));
+        if (validSlot != keyWrConfig->keySlot) {
+            status = DL_KEYSTORECTL_STATUS_WRITE_FAILED;
+        }
+    }
+
+    return status;
+}
+
+DL_KEYSTORECTL_STATUS DL_KEYSTORECTL_transferKey(
+    KEYSTORECTL_Regs *keystorectl, DL_KEYSTORECTL_Config *config)
+{
+    DL_KEYSTORECTL_STATUS status = DL_KEYSTORECTL_STATUS_VALID;
+
+    /* 1. Confirm valid status on the KEYSTORECTL */
+    status = DL_KEYSTORECTL_getStatus(keystorectl);
+
+    /* 2. Configure the read transfer by writing size, slot, and recipient */
+    if (status == DL_KEYSTORECTL_STATUS_VALID) {
+        DL_Common_updateReg(&keystorectl->KEYRD,
+            (((uint32_t) config->keySize) | ((uint32_t) config->cryptoSel) |
+                ((uint32_t) config->keySlot)),
+            (KEYSTORECTL_KEYRD_KEYSZSEL_MASK |
+                KEYSTORECTL_KEYRD_CRYPTOSEL_MASK |
+                KEYSTORECTL_KEYRD_KEYSLOTSEL_MASK));
+
+        /* 3. Confirm a valid status and transfer configuration */
+        status = DL_KEYSTORECTL_getStatus(keystorectl);
+    }
+
+    /* 4. Loop until status is back to valid */
+    if (status == DL_KEYSTORECTL_STATUS_VALID) {
+        status = DL_KEYSTORECTL_getStatus(keystorectl);
+        while (status == DL_KEYSTORECTL_STATUS_BUSY_TX) {
+            status = DL_KEYSTORECTL_getStatus(keystorectl);
+        }
+    }
+
+    return status;
+}
+
+static void DL_KEYSTORECTL_loadData(
+    volatile uint32_t *pDest, uint32_t *pSrc, uint8_t len)
+{
+    uint8_t i;
+    uint32_t *pTemp;
+
+    pTemp = pSrc;
+
+    for (i = 0; i < len; i++) {
+        *pDest = *pTemp++;
+    }
+}
+
+static uint8_t DL_KEYSTORECTL_getWordsFromSize(DL_KEYSTORECTL_KEY_SIZE keySize)
+{
+    uint8_t numWords;
+
+    switch (keySize) {
+        case DL_KEYSTORECTL_KEY_SIZE_128_BITS:
+            numWords = 4;
+            break;
+        case DL_KEYSTORECTL_KEY_SIZE_256_BITS:
+            numWords = 8;
+            break;
+        default:
+            numWords = 0;
+            break;
+    }
+
+    return numWords;
+}
+
+#endif /* __MSPM0_HAS_KEYSTORE_CTL__ */

--- a/mspm0/source/ti/driverlib/dl_keystorectl.h
+++ b/mspm0/source/ti/driverlib/dl_keystorectl.h
@@ -1,0 +1,563 @@
+/*
+ * Copyright (c) 2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_keystorectl.h
+ *  @brief      KEYSTORECTL (Keystore Controller) Driver Library
+ *  @defgroup   KEYSTORECTL Keystore Controller (KEYSTORECTL)
+ *
+ *  @anchor ti_dl_dl_keystorectl_Overview
+ *  # Overview
+ *
+ *  The Keystore Controller (KEYSTORECTL) DriverLib allows full configuration
+ *  of the MSPM0 KEYSTORECTL Module.
+ *
+ *  <hr>
+ ******************************************************************************/
+/** @addtogroup KEYSTORECTL
+ * @{
+ */
+#ifndef ti_dl_dl_keystorectl__include
+#define ti_dl_dl_keystorectl__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_KEYSTORE_CTL__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_KEYSTORECTL_KEY_SLOT
+ * @{
+ */
+
+/*! @brief Keystore Controller Key Slot 0 */
+#define DL_KEYSTORECTL_KEY_SLOT_0           (KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT0)
+
+/*! @brief Keystore Controller Key Slot 1 */
+#define DL_KEYSTORECTL_KEY_SLOT_1           (KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT1)
+
+/*! @brief Keystore Controller Key Slot 2 */
+#define DL_KEYSTORECTL_KEY_SLOT_2           (KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT2)
+
+/*! @brief Keystore Controller Key Slot 3 */
+#define DL_KEYSTORECTL_KEY_SLOT_3           (KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT3)
+
+/*! @brief Keystore Controller Key Slot 4 */
+#define DL_KEYSTORECTL_KEY_SLOT_4           (KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT4)
+
+/*! @brief Keystore Controller Key Slot 5 */
+#define DL_KEYSTORECTL_KEY_SLOT_5           (KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT5)
+
+/*! @brief Keystore Controller Key Slot 6 */
+#define DL_KEYSTORECTL_KEY_SLOT_6           (KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT6)
+
+/*! @brief Keystore Controller Key Slot 7 */
+#define DL_KEYSTORECTL_KEY_SLOT_7           (KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT7)
+
+
+/*! @brief Keystore Controller Key Combined Slot 0 and 1 */
+#define DL_KEYSTORECTL_KEY_SLOT_0_AND_1    ((KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT0) | \
+                                            (KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT1))
+
+/*! @brief Keystore Controller Key Combined Slot 2 and 3 */
+#define DL_KEYSTORECTL_KEY_SLOT_2_AND_3    ((KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT2) | \
+                                            (KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT3))
+
+/*! @brief Keystore Controller Key Combined Slot 4 and 5 */
+#define DL_KEYSTORECTL_KEY_SLOT_4_AND_5    ((KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT4) | \
+                                            (KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT5))
+
+/*! @brief Keystore Controller Key Combined Slot 6 and 7 */
+#define DL_KEYSTORECTL_KEY_SLOT_6_AND_7    ((KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT6) | \
+                                            (KEYSTORECTL_KEYWR_KEYSLOTSEL_SLOT7))
+
+/** @}*/
+
+/* clang-format on */
+
+/*! @enum DL_KEYSTORECTL_NUM_256_KEYS */
+typedef enum {
+    /*! No 256-bit keys */
+    DL_KEYSTORECTL_NUM_256_KEYS_ZERO = KEYSTORECTL_CFG_NK256_ZERO,
+    /*! One 256-bit keys */
+    DL_KEYSTORECTL_NUM_256_KEYS_ONE = KEYSTORECTL_CFG_NK256_ONE,
+    /*! Two 256-bit keys */
+    DL_KEYSTORECTL_NUM_256_KEYS_TWO = KEYSTORECTL_CFG_NK256_TWO,
+    /*! Three 256-bit keys */
+    DL_KEYSTORECTL_NUM_256_KEYS_THREE = KEYSTORECTL_CFG_NK256_THREE,
+    /*! Four 256-bit keys */
+    DL_KEYSTORECTL_NUM_256_KEYS_FOUR = KEYSTORECTL_CFG_NK256_FOUR,
+} DL_KEYSTORECTL_NUM_256_KEYS;
+
+/*! @enum DL_KEYSTORECTL_KEY_SIZE */
+typedef enum {
+    /*! Key size set to 128 */
+    DL_KEYSTORECTL_KEY_SIZE_128_BITS = KEYSTORECTL_KEYWR_KEYSZSEL_K128,
+    /*! Key size set to 256  */
+    DL_KEYSTORECTL_KEY_SIZE_256_BITS = KEYSTORECTL_KEYWR_KEYSZSEL_K256,
+} DL_KEYSTORECTL_KEY_SIZE;
+
+/*! @enum DL_KEYSTORECTL_NUM_SLOTS */
+typedef enum {
+    /*! Two 128-bit key slots present on device */
+    DL_KEYSTORECTL_NUM_SLOTS_TWO = KEYSTORECTL_STATUS_NKEYSLOTS_TWO,
+    /*! Three 128-bit key slots present on device */
+    DL_KEYSTORECTL_NUM_SLOTS_THREE = KEYSTORECTL_STATUS_NKEYSLOTS_THREE,
+    /*! Four 128-bit key slots present on device */
+    DL_KEYSTORECTL_NUM_SLOTS_FOUR = KEYSTORECTL_STATUS_NKEYSLOTS_FOUR,
+} DL_KEYSTORECTL_NUM_SLOTS;
+
+/*! @enum DL_KEYSTORECTL_CRYPTO_SEL */
+typedef enum {
+    /*! Transfer the key from keystore KEYSTORECTL to the AES engine */
+    DL_KEYSTORECTL_CRYPTO_SEL_AES = KEYSTORECTL_KEYRD_CRYPTOSEL_AES,
+} DL_KEYSTORECTL_CRYPTO_SEL;
+
+/*! @enum DL_KEYSTORECTL_STATUS */
+typedef enum {
+    /*! Valid status bit. Configuration is valid or operation completed. */
+    DL_KEYSTORECTL_STATUS_VALID = KEYSTORECTL_STATUS_STAT_VALID,
+    /*! No Configuration Status bit, no number of 256 keys has been identified.
+     *  The user must call @ref DL_KEYSTORECTL_setNumberOf256Keys. */
+    DL_KEYSTORECTL_STATUS_NO_CONFIG = KEYSTORECTL_STATUS_STAT_NO_CFG,
+    /*! Invalid number set during @ref DL_KEYSTORECTL_setNumberOf256Keys */
+    DL_KEYSTORECTL_STATUS_INVALID_NUM_KEYS =
+        KEYSTORECTL_STATUS_STAT_INVALID_NK256,
+    /*! Busy RX status bit. The engine is busy receiving a key deposit. */
+    DL_KEYSTORECTL_STATUS_BUSY_RX = KEYSTORECTL_STATUS_STAT_BUSY_RECEIVE,
+    /*! Busy TX status bit. The engine is busy transmitting a key to a crypto engine */
+    DL_KEYSTORECTL_STATUS_BUSY_TX = KEYSTORECTL_STATUS_STAT_BUSY_TRANSMIT,
+    /*! Invalid key write configuration. This means one or more of the
+     *  following: the selected slot exceeds available slots, the selected slot
+     *  already contains a valid programmed key, the selected slot has a
+     *  mismatched key size compared to the KEYSTORECTL configuration. */
+    DL_KEYSTORECTL_STATUS_INVALID_SLOT_WR =
+        KEYSTORECTL_STATUS_STAT_INVALID_KEYSLOTSELW,
+    /*! Invalid key read configuration (transmitting a key). This means one or
+     *  more of the following: the selected slot exceeds available slots, the
+     *  selected slot does not contain a valid programmed key, the selected slot
+     *  has a mismatched key size */
+    DL_KEYSTORECTL_STATUS_INVALID_SLOT_RD =
+        KEYSTORECTL_STATUS_STAT_INVALID_KEYSLOTSELR,
+    /*! Key slots are not valid after a write. Write failed during the
+        @ref DL_KEYSTORECTL_writeKey (driver library specific). */
+    DL_KEYSTORECTL_STATUS_WRITE_FAILED = 0x0BAD,
+} DL_KEYSTORECTL_STATUS;
+
+/*!
+ *  @brief Configuration struct for @ref DL_KEYSTORECTL_writeKey
+ */
+typedef struct {
+    /*! The key slot (or slots in the case of 256-bit keys) to be written.
+     *  One of @ref DL_KEYSTORECTL_KEY_SLOT */
+    uint32_t keySlot;
+    /*! The size of the key (128-bit or 256-bit).
+     *  One of @ref DL_KEYSTORECTL_KEY_SIZE */
+    DL_KEYSTORECTL_KEY_SIZE keySize;
+    /*! uint32_t pointer to the current key in memory */
+    uint32_t *key;
+} DL_KEYSTORECTL_KeyWrConfig;
+
+/*!
+ *  @brief Configuration struct for @ref DL_KEYSTORECTL_transferKey
+ */
+typedef struct {
+    /*! The key slot (or slots in the case of 256-bit keys) to be transferred.
+     *  One of @ref DL_KEYSTORECTL_KEY_SLOT */
+    uint32_t keySlot;
+    /*! The size of the key (128-bit or 256-bit).
+     *  One of @ref DL_KEYSTORECTL_KEY_SIZE */
+    DL_KEYSTORECTL_KEY_SIZE keySize;
+    /*! The intended crypto recipient. One of @ref DL_KEYSTORECTL_CRYPTO_SEL */
+    DL_KEYSTORECTL_CRYPTO_SEL cryptoSel;
+} DL_KEYSTORECTL_Config;
+
+/**
+ *  @brief Sets the number of combined 256 key slots
+ *
+ *  For a given number of 128-bit key slots n, there can be up to n/2 slots
+ *  combined to work as one 256-bit key slot. These larger slots are added to
+ *  earlier slots first. Thus, a 4-slot device with one 256-key slot will have
+ *  slots 0 and 1 combined, and slot 2 and 3 will remain 128-bit key slots.
+ *      Refer to the device datasheet for the specific number of key slots.
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *  @param[in] numKeys      Number of 256-bit keys, one of
+ *                          @ref DL_KEYSTORECTL_NUM_256_KEYS. Must be less than
+ *                          the total key slots on the device divided by two
+ *
+ *  @note this function can only be written in a secure operating state before
+ *        the INITDONE signal is asserted.
+ */
+__STATIC_INLINE void DL_KEYSTORECTL_setNumberOf256Keys(
+    KEYSTORECTL_Regs *keystorectl, DL_KEYSTORECTL_NUM_256_KEYS numKeys)
+{
+    DL_Common_updateReg(
+        &keystorectl->CFG, (uint32_t) numKeys, KEYSTORECTL_CFG_NK256_MASK);
+}
+
+/**
+ *  @brief Returns the current number of combined 256 key slots
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *
+ *  @return number of 256-bit keys. One of @ref DL_KEYSTORECTL_NUM_256_KEYS
+ *
+ *  @sa DL_KEYSTORECTL_setNumberOf256Keys
+ */
+__STATIC_INLINE DL_KEYSTORECTL_NUM_256_KEYS DL_KEYSTORECTL_getNumberOf256Keys(
+    KEYSTORECTL_Regs *keystorectl)
+{
+    uint32_t numKeys = (keystorectl->CFG & KEYSTORECTL_CFG_NK256_MASK);
+
+    return (DL_KEYSTORECTL_NUM_256_KEYS)(numKeys);
+}
+
+/**
+ *  @brief Sets the intended destination key slot for the next write
+ *
+ *  Sets the destination key slot for a data write to that region. In the case
+ *  of 128-bit key slot, only one slot should be selected. In the case of a 256-
+ *  bit key slot, both registers should be selected and the key size should also
+ *  reflect this change. If 256- it keys are desired, they should be configured
+ *  using @ref DL_KEYSTORECTL_NUM_256_KEYS.
+ *      Refer to the device datasheet for the specific number of key slots.
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *  @param[in] keySlot      The intended key slot. Can be 128-bit or a 256-bit.
+ *                          One of @ref DL_KEYSTORECTL_KEY_SLOT
+ *
+ *  @note this function can only be written in a secure operating state before
+ *        the INITDONE signal is asserted.
+ *
+ *  @sa DL_KEYSTORECTL_setNumberOf256Keys
+ *  @sa DL_KEYSTORECTL_setDestinationKeySize
+ */
+__STATIC_INLINE void DL_KEYSTORECTL_setDestinationKeySlot(
+    KEYSTORECTL_Regs *keystorectl, uint32_t keySlot)
+{
+    DL_Common_updateReg(
+        &keystorectl->KEYWR, keySlot, KEYSTORECTL_KEYWR_KEYSLOTSEL_MASK);
+}
+
+/**
+ *  @brief Returns the intended destination key slot for the next write
+ *
+ *  Refer to the device datasheet for the specific number of key slots.
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *
+ *  @returns   The intended key slot. Can be 128-bit or a 256-bit. One of
+ *             @ref DL_KEYSTORECTL_KEY_SLOT
+ *
+ *  @note this function can only be read in a secure operating state before
+ *        the INITDONE signal is asserted.
+ *
+ *  @sa DL_KEYSTORECTL_setDestinationKeySlot
+ */
+__STATIC_INLINE uint32_t DL_KEYSTORECTL_getDestinationKeySlot(
+    KEYSTORECTL_Regs *keystorectl)
+{
+    return (keystorectl->KEYWR & KEYSTORECTL_KEYWR_KEYSLOTSEL_MASK);
+}
+
+/**
+ *  @brief Sets the intended destination key slot size for next write
+ *
+ *  Sets the destination key slot size for a data write to that region. If 256-
+ *  bit keys are desired, they should be  configured using
+ *  @ref DL_KEYSTORECTL_NUM_256_KEYS.
+ *      Refer to the device datasheet for the specific number of key slots.
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *  @param[in] keySize      The intended key size. One of
+ *                          @ref DL_KEYSTORECTL_KEY_SIZE
+ *
+ *  @note this function can only be written in a secure operating state before
+ *        the INITDONE signal is asserted.
+ *
+ *  @sa DL_KEYSTORECTL_setNumberOf256Keys
+ *  @sa DL_KEYSTORECTL_setDestinationKeySlot
+ */
+__STATIC_INLINE void DL_KEYSTORECTL_setDestinationKeySize(
+    KEYSTORECTL_Regs *keystorectl, DL_KEYSTORECTL_KEY_SIZE keySize)
+{
+    DL_Common_updateReg(&keystorectl->KEYWR, (uint32_t) keySize,
+        KEYSTORECTL_KEYWR_KEYSZSEL_MASK);
+}
+
+/**
+ *  @brief Returns the intended destination key size for the next write
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *
+ *  @returns   The intended key size. One of @ref DL_KEYSTORECTL_KEY_SIZE
+ *
+ *  @note this function can only be read in a secure operating state before
+ *        the INITDONE signal is asserted.
+ *
+ *  @sa DL_KEYSTORECTL_setDestinationKeySize
+ */
+__STATIC_INLINE DL_KEYSTORECTL_KEY_SIZE DL_KEYSTORECTL_getDestinationKeySize(
+    KEYSTORECTL_Regs *keystorectl)
+{
+    uint32_t keySize = (keystorectl->KEYWR & KEYSTORECTL_KEYWR_KEYSZSEL_MASK);
+
+    return (DL_KEYSTORECTL_KEY_SIZE)(keySize);
+}
+
+/**
+ *  @brief Sets the intended destination key slot size for next write
+ *
+ *  Loads a key of the provided size into the KEYSTORECTL provided there is a
+ *  valid bit set. The specific intended slot and size should already be set by
+ *  the user before using this.
+ *      Refer to the device datasheet for the specific number of key slots.
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *  @param[in] key          Pointer to an uint32_t array containing the key.
+ *
+ *  @note this function can only be written in a secure operating state before
+ *        the INITDONE signal is asserted.
+ *
+ *  @sa DL_KEYSTORECTL_setDestinationKeySlot
+ *  @sa DL_KEYSTORECTL_setDestinationKeySize
+ */
+void DL_KEYSTORECTL_loadKey(KEYSTORECTL_Regs *keystorectl, uint32_t *key);
+
+/**
+ *  @brief Gets the intended source key slot for the next transfer
+ *
+ *  Sets the source key slot for a data transfer to another crypto peripheral.
+ *  In the case of 128-bit key slot, only one slot should be selected. In the
+ *  case of a 256-bit key slot, both registers should be selected and the key
+ *  size should also reflect this change. If 256- it keys are desired, they
+ *  can be accessed using @ref DL_KEYSTORECTL_getNumberOf256Keys.
+ *      Refer to the device datasheet for the specific number of key slots.
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *  @param[in] keySlot      The intended key slot. Can be 128-bit or a 256-bit.
+ *                          One of @ref DL_KEYSTORECTL_KEY_SLOT
+ *
+ *  @sa DL_KEYSTORECTL_getNumOf256Keys
+ *  @sa DL_KEYSTORECTL_setSourceKeySize
+ */
+__STATIC_INLINE void DL_KEYSTORECTL_setSourceKeySlot(
+    KEYSTORECTL_Regs *keystorectl, uint32_t keySlot)
+{
+    DL_Common_updateReg(
+        &keystorectl->KEYRD, keySlot, KEYSTORECTL_KEYRD_KEYSLOTSEL_MASK);
+}
+
+/**
+ *  @brief Gets the intended source key slot for the next transfer
+ *
+ *  Refer to the device datasheet for the specific number of key slots.
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *
+ *  @returns   The intended key slot. Can be 128-bit or a 256-bit. One of
+ *             @ref DL_KEYSTORECTL_KEY_SLOT
+ *
+ *  @sa DL_KEYSTORECTL_setSourceKeySlot
+ */
+__STATIC_INLINE uint32_t DL_KEYSTORECTL_getSourceKeySlot(
+    KEYSTORECTL_Regs *keystorectl)
+{
+    return (keystorectl->KEYRD & KEYSTORECTL_KEYRD_KEYSLOTSEL_MASK);
+}
+
+/**
+ *  @brief Gets the intended source key slot size for next transfer
+ *
+ *  Sets the source key slot size for a data transfer to that region. If 256-
+ *  bit keys are desired, they should be  configured using
+ *  @ref DL_KEYSTORECTL_NUM_256_KEYS.
+ *      Refer to the device datasheet for the specific number of key slots.
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *  @param[in] keySize      The intended key size. One of
+ *                          @ref DL_KEYSTORECTL_KEY_SIZE
+ *
+ *  @sa DL_KEYSTORECTL_setNumberOf256Keys
+ *  @sa DL_KEYSTORECTL_setSourceKeySlot
+ */
+__STATIC_INLINE void DL_KEYSTORECTL_setSourceKeySize(
+    KEYSTORECTL_Regs *keystorectl, DL_KEYSTORECTL_KEY_SIZE keySize)
+{
+    DL_Common_updateReg(&keystorectl->KEYRD, (uint32_t) keySize,
+        KEYSTORECTL_KEYRD_KEYSZSEL_MASK);
+}
+
+/**
+ *  @brief Gets the intended source key size for the next transfer
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *
+ *  @returns   The intended key size. One of @ref DL_KEYSTORECTL_KEY_SIZE
+ *
+ *  @sa DL_KEYSTORECTL_setSourceKeySize
+ */
+__STATIC_INLINE DL_KEYSTORECTL_KEY_SIZE DL_KEYSTORECTL_getSourceKeySize(
+    KEYSTORECTL_Regs *keystorectl)
+{
+    uint32_t keySize = (keystorectl->KEYRD & KEYSTORECTL_KEYRD_KEYSZSEL_MASK);
+
+    return (DL_KEYSTORECTL_KEY_SIZE)(keySize);
+}
+
+/**
+ *  @brief Gets the current status of the KEYSTORECTL module
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *
+ *  @return    The status of the keystorectl. One of @ref DL_KEYSTORECTL_STATUS
+ */
+__STATIC_INLINE DL_KEYSTORECTL_STATUS DL_KEYSTORECTL_getStatus(
+    KEYSTORECTL_Regs *keystorectl)
+{
+    uint32_t status = (keystorectl->STATUS & KEYSTORECTL_STATUS_STAT_MASK);
+
+    return (DL_KEYSTORECTL_STATUS)(status);
+}
+
+/**
+ *  @brief Gets currently written key slots
+ *
+ *  To understand the key slot configuration, consider the configuration of the
+ *  keys including the number of 256-bit keys, and the number of available key
+ *  slots
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *
+ *  @return    Bitwise OR of all valid slots, corresponding to
+ *             @ref DL_KEYSTORECTL_KEY_SLOT values.
+ */
+__STATIC_INLINE uint32_t DL_KEYSTORECTL_getValidKeySlots(
+    KEYSTORECTL_Regs *keystorectl)
+{
+    return (keystorectl->STATUS & KEYSTORECTL_STATUS_VALID_MASK);
+}
+
+/**
+ *  @brief Gets the total number of 128-bit key slots in HW on the device
+ *
+ *  This is the number of key slots that the KEYSTORECTL module has in HW on the
+ *  device. It does not reflect the configuration or the number of 256-bit keys,
+ *  only the total number of slots. This also governs the valid configurations,
+ *  and the number of 256-bit keys must be less than or equal to half the value.
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *
+ *  @return    The number of 128-bit slots on the device. One of
+ *             @ref DL_KEYSTORECTL_NUM_SLOTS
+ */
+__STATIC_INLINE DL_KEYSTORECTL_NUM_SLOTS DL_KEYSTORECTL_getNumSlots(
+    KEYSTORECTL_Regs *keystorectl)
+{
+    uint32_t numSlots =
+        (keystorectl->STATUS & KEYSTORECTL_STATUS_NKEYSLOTS_MASK);
+
+    return (DL_KEYSTORECTL_NUM_SLOTS)(numSlots);
+}
+
+/**
+ *  @brief Writes a key into the KEYSTORE
+ *
+ *  The sequence this function will follow:
+ *
+ *  1. Confirm valid status on the KEYSTORECTL
+ *  2. Configure the key write by writing size and slot to the key that is to be
+ *          written. Passed in via @ref DL_KEYSTORECTL_KeyWrConfig
+ *  3. Confirm a valid write configuration
+ *  4. Write key to the input buffer
+ *  5. Loop until status is back to valid
+ *  6. Confirm key slots are successfully written
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in] keyWrConfig  Pointer to the write key configuration struct
+ *                          @ref DL_KEYSTORECTL_KeyWrConfig
+ *
+ *  @return    Status of the operation of type @ref DL_KEYSTORECTL_STATUS. Type
+ *             will be DL_KEYSTORECTL_STATUS_VALID if successful, or return the
+ *             error status.
+ *
+ *  @note The function @ref DL_KEYSTORECTL_setNumberOf256Keys must be run
+ *        before this can be executed.
+ *  @note It is not possible to overwrite a previously configured key. A full
+ *        BOOTRST must be executed before the KEYSTORECTL is erased and can be
+ *        re-initialized and written.
+ *  @note this function can only be written in a secure operating state before
+ *        the INITDONE signal is asserted.
+ */
+DL_KEYSTORECTL_STATUS DL_KEYSTORECTL_writeKey(
+    KEYSTORECTL_Regs *keystorectl, DL_KEYSTORECTL_KeyWrConfig *keyWrConfig);
+
+/**
+ *  @brief Transfers key loaded in KEYSTORE into intended crypto
+ *
+ *  Combination of previous functions in order to give the entire operation.
+ *  Expected runtime sequence:
+ *
+ *  1. Confirm valid status on the KEYSTORECTL
+ *  2. Configure the read transfer by writing size, slot, and recipient
+ *        This is passed in via the struct @ref DL_KEYSTORECTL_Config
+ *  3. Confirm a valid status and transfer configuration of the KEYSTORECTL
+ *  4. Loop until status is back to valid
+ *
+ *  @param[in] keystorectl  Pointer to the register overlay for the peripheral
+ *  @param[in] config       Pointer to a filled out config struct of type
+ *                          @ref DL_KEYSTORECTL_Config
+ *
+ *  @return    Status of the operation of type @ref DL_KEYSTORECTL_STATUS. Type
+ *             will be DL_KEYSTORECTL_STATUS_VALID if successful, or return the
+ *             error status.
+ */
+DL_KEYSTORECTL_STATUS DL_KEYSTORECTL_transferKey(
+    KEYSTORECTL_Regs *keystorectl, DL_KEYSTORECTL_Config *config);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_KEYSTORE_CTL__ */
+
+#endif /* ti_dl_dl_KEYSTORECTL__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_lcd.c
+++ b/mspm0/source/ti/driverlib/dl_lcd.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <ti/driverlib/dl_lcd.h>
+
+#ifdef __MSPM0_HAS_LCD__
+
+/**
+ *  @brief LCD APIs
+ */
+
+void DL_LCD_init(LCD_Regs *lcd, DL_LCD_Config *config)
+{
+    DL_Common_updateReg(&lcd->LCDCTL0,
+        (uint32_t) config->frequencyDivider | (uint32_t) config->muxRate |
+            (uint32_t) config->lowPowerWaveform,
+        LCD_LCDCTL0_LCDDIVX_MASK | LCD_LCDCTL0_LCDMXX_MASK |
+            LCD_LCDCTL0_LCDLP_MASK);
+}
+
+void DL_LCD_setPinAsLCDFunction(LCD_Regs *lcd, uint32_t pin)
+{
+    lcd->LCDCTL0 &= ~(LCD_LCDCTL0_LCDON_MASK); /* turn off LCD module */
+
+    uint8_t idx  = pin >> 4; /* get index in corresponding port control reg */
+    uint16_t val = 1 << (pin & 0x0F); /* get mask to set that specific bit */
+
+    switch (idx) {
+        case 0:
+            lcd->LCDPCTL0 |= val;
+            break;
+        case 1:
+            lcd->LCDPCTL1 |= val;
+            break;
+        case 2:
+            lcd->LCDPCTL2 |= val;
+            break;
+        case 3:
+            lcd->LCDPCTL3 |= val;
+            break;
+        default:
+            break;
+    }
+}
+
+void DL_LCD_setPinAsPortFunction(LCD_Regs *lcd, uint8_t pin)
+{
+    lcd->LCDCTL0 &= ~(LCD_LCDCTL0_LCDON_MASK); /* turn off LCD module */
+
+    uint8_t idx  = pin >> 4; /* get index in corresponding port control reg */
+    uint16_t val = 1 << (pin & 0x0F); /* get mask to set that specific bit */
+
+    switch (idx) {
+        case 0:
+            lcd->LCDPCTL0 &= ~(val);
+            break;
+        case 1:
+            lcd->LCDPCTL1 &= ~(val);
+            break;
+        case 2:
+            lcd->LCDPCTL2 &= ~(val);
+            break;
+        case 3:
+            lcd->LCDPCTL3 &= ~(val);
+            break;
+        default:
+            break;
+    }
+}
+
+void DL_LCD_setPinAsCommon(LCD_Regs *lcd, uint8_t pin, uint32_t com)
+{
+    lcd->LCDCTL0 &= ~(LCD_LCDCTL0_LCDON_MASK);
+
+    uint8_t idx  = pin >> 4;          /* 0-15 -> 0, 16-31 -> 1, etc. */
+    uint16_t val = 1 << (pin & 0x0F); /* getting mask for val based on pin */
+    uint8_t muxRate = lcd->LCDCTL0 & (LCD_LCDCTL0_LCDMXX_MASK);
+
+    switch (idx) {
+        case 0:
+            lcd->LCDCSSEL0 |= val;
+            break;
+        case 1:
+            lcd->LCDCSSEL1 |= val;
+            break;
+        case 2:
+            lcd->LCDCSSEL2 |= val;
+            break;
+        case 3:
+            lcd->LCDCSSEL3 |= val;
+            break;
+        default:
+            break;
+    }
+
+    /* Set LCDMem to COM as well for corresponding pins */
+    if (muxRate == (LCD_LCDCTL0_LCDMXX_MX_STATIC | LCD_LCDCTL0_LCDMXX_MX_2 |
+                       LCD_LCDCTL0_LCDMXX_MX_3 | LCD_LCDCTL0_LCDMXX_MX_4)) {
+        if (pin & 1) {
+            /* upper nibble */
+            lcd->LCDM[pin / 2] |= (com & 0xF) << 4;
+            lcd->LCDBM[pin / 2] |= (com & 0xF) << 4;
+        } else {
+            /* lower nibble */
+            lcd->LCDM[pin / 2] |= (com & 0xF);
+            lcd->LCDBM[pin / 2] |= (com & 0xF);
+        }
+    } else {
+        /* 5-mux, 6-mux, 7-mux, 8-mux, whole byte per segment pin */
+        lcd->LCDM[pin] |= com;
+        lcd->LCDBM[pin] |= com;
+    }
+}
+
+void DL_LCD_setPinAsSegment(LCD_Regs *lcd, uint8_t pin)
+{
+    lcd->LCDCTL0 &= ~(LCD_LCDCTL0_LCDON_MASK);
+
+    uint8_t idx  = pin >> 4;          /* 0-15 -> 0, 16-31 -> 1, etc. */
+    uint16_t val = 1 << (pin & 0x0F); /* getting mask for val based on pin */
+
+    switch (idx) {
+        case 0:
+            lcd->LCDCSSEL0 &= ~val;
+            break;
+        case 1:
+            lcd->LCDCSSEL1 &= ~val;
+            break;
+        case 2:
+            lcd->LCDCSSEL2 &= ~val;
+            break;
+        case 3:
+            lcd->LCDCSSEL3 &= ~val;
+            break;
+        default:
+            break;
+    }
+}
+
+#endif /* __MSPM0_HAS_LCD__ */

--- a/mspm0/source/ti/driverlib/dl_lcd.h
+++ b/mspm0/source/ti/driverlib/dl_lcd.h
@@ -1,0 +1,2093 @@
+/*
+ * Copyright (c) 2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_lcd.h
+ *  @brief      Liquid Crystal Display (LCD) Driver Library
+ *  @defgroup   LCD Liquid Crystal Display (LCD)
+ *
+ *  @anchor ti_dl_dl_lcd_Overview
+ *  # Overview
+ *
+ *  The LCD Library allows full configuration of the MSPM0 LCD module.
+ *  The LCD controller creates the AC segment and common voltage signals to
+ *  directly drive LCD displays.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup LCD
+ * @{
+ */
+#ifndef ti_dl_dl_lcd__include
+#define ti_dl_dl_lcd__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_LCD__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_LCD_INTERRUPT
+ *  @{
+ */
+/*!
+ *  @brief Interrupt raised when there is the start of a new LCD frame
+ */
+#define DL_LCD_INTERRUPT_FRAME_START                    (LCD_IMASK_FRMSTART_SET)
+
+/*!
+ *  @brief Interrupt raised when blinking segments are turned off
+ */
+#define DL_LCD_INTERRUPT_BLINKING_SEGMENTS_OFF            (LCD_IMASK_BLKOFF_SET)
+
+/*!
+ *  @brief Interrupt raised when blinking segments are turned on
+ */
+#define DL_LCD_INTERRUPT_BLINKING_SEGMENTS_ON              (LCD_IMASK_BLKON_SET)
+
+/** @}*/
+
+/** @addtogroup DL_LCD_SEGMENT_LINE
+ *  @{
+ */
+/*!
+ *  @brief LCD Pin 0
+ */
+#define DL_LCD_SEGMENT_LINE_0                                                (0)
+/*!
+ *  @brief LCD Pin 1
+ */
+#define DL_LCD_SEGMENT_LINE_1                                                (1)
+/*!
+ *  @brief LCD Pin 2
+ */
+#define DL_LCD_SEGMENT_LINE_2                                                (2)
+/*!
+ *  @brief LCD Pin 3
+ */
+#define DL_LCD_SEGMENT_LINE_3                                                (3)
+/*!
+ *  @brief LCD Pin 4
+ */
+#define DL_LCD_SEGMENT_LINE_4                                                (4)
+/*!
+ *  @brief LCD Pin 5
+ */
+#define DL_LCD_SEGMENT_LINE_5                                                (5)
+/*!
+ *  @brief LCD Pin 6
+ */
+#define DL_LCD_SEGMENT_LINE_6                                                (6)
+/*!
+ *  @brief LCD Pin 7
+ */
+#define DL_LCD_SEGMENT_LINE_7                                                (7)
+/*!
+ *  @brief LCD Pin 8
+ */
+#define DL_LCD_SEGMENT_LINE_8                                                (8)
+/*!
+ *  @brief LCD Pin 9
+ */
+#define DL_LCD_SEGMENT_LINE_9                                                (9)
+/*!
+ *  @brief LCD Pin 10
+ */
+#define DL_LCD_SEGMENT_LINE_10                                              (10)
+/*!
+ *  @brief LCD Pin 11
+ */
+#define DL_LCD_SEGMENT_LINE_11                                              (11)
+/*!
+ *  @brief LCD Pin 12
+ */
+#define DL_LCD_SEGMENT_LINE_12                                              (12)
+/*!
+ *  @brief LCD Pin 13
+ */
+#define DL_LCD_SEGMENT_LINE_13                                              (13)
+/*!
+ *  @brief LCD Pin 14
+ */
+#define DL_LCD_SEGMENT_LINE_14                                              (14)
+/*!
+ *  @brief LCD Pin 15
+ */
+#define DL_LCD_SEGMENT_LINE_15                                              (15)
+/*!
+ *  @brief LCD Pin 16
+ */
+#define DL_LCD_SEGMENT_LINE_16                                              (16)
+/*!
+ *  @brief LCD Pin 17
+ */
+#define DL_LCD_SEGMENT_LINE_17                                              (17)
+/*!
+ *  @brief LCD Pin 18
+ */
+#define DL_LCD_SEGMENT_LINE_18                                              (18)
+/*!
+ *  @brief LCD Pin 19
+ */
+#define DL_LCD_SEGMENT_LINE_19                                              (19)
+/*!
+ *  @brief LCD Pin 20
+ */
+#define DL_LCD_SEGMENT_LINE_20                                              (20)
+/*!
+ *  @brief LCD Pin 21
+ */
+#define DL_LCD_SEGMENT_LINE_21                                              (21)
+/*!
+ *  @brief LCD Pin 22
+ */
+#define DL_LCD_SEGMENT_LINE_22                                              (22)
+/*!
+ *  @brief LCD Pin 23
+ */
+#define DL_LCD_SEGMENT_LINE_23                                              (23)
+/*!
+ *  @brief LCD Pin 24
+ */
+#define DL_LCD_SEGMENT_LINE_24                                              (24)
+/*!
+ *  @brief LCD Pin 25
+ */
+#define DL_LCD_SEGMENT_LINE_25                                              (25)
+/*!
+ *  @brief LCD Pin 26
+ */
+#define DL_LCD_SEGMENT_LINE_26                                              (26)
+/*!
+ *  @brief LCD Pin 27
+ */
+#define DL_LCD_SEGMENT_LINE_27                                              (27)
+/*!
+ *  @brief LCD Pin 28
+ */
+#define DL_LCD_SEGMENT_LINE_28                                              (28)
+/*!
+ *  @brief LCD Pin 29
+ */
+#define DL_LCD_SEGMENT_LINE_29                                              (29)
+/*!
+ *  @brief LCD Pin 30
+ */
+#define DL_LCD_SEGMENT_LINE_30                                              (30)
+/*!
+ *  @brief LCD Pin 31
+ */
+#define DL_LCD_SEGMENT_LINE_31                                              (31)
+/*!
+ *  @brief LCD Pin 32
+ */
+#define DL_LCD_SEGMENT_LINE_32                                              (32)
+/*!
+ *  @brief LCD Pin 33
+ */
+#define DL_LCD_SEGMENT_LINE_33                                              (33)
+/*!
+ *  @brief LCD Pin 34
+ */
+#define DL_LCD_SEGMENT_LINE_34                                              (34)
+/*!
+ *  @brief LCD Pin 35
+ */
+#define DL_LCD_SEGMENT_LINE_35                                              (35)
+/*!
+ *  @brief LCD Pin 36
+ */
+#define DL_LCD_SEGMENT_LINE_36                                              (36)
+/*!
+ *  @brief LCD Pin 37
+ */
+#define DL_LCD_SEGMENT_LINE_37                                              (37)
+/*!
+ *  @brief LCD Pin 38
+ */
+#define DL_LCD_SEGMENT_LINE_38                                              (38)
+/*!
+ *  @brief LCD Pin 39
+ */
+#define DL_LCD_SEGMENT_LINE_39                                              (39)
+/*!
+ *  @brief LCD Pin 40
+ */
+#define DL_LCD_SEGMENT_LINE_40                                              (40)
+/*!
+ *  @brief LCD Pin 41
+ */
+#define DL_LCD_SEGMENT_LINE_41                                              (41)
+/*!
+ *  @brief LCD Pin 42
+ */
+#define DL_LCD_SEGMENT_LINE_42                                              (42)
+/*!
+ *  @brief LCD Pin 43
+ */
+#define DL_LCD_SEGMENT_LINE_43                                              (43)
+/*!
+ *  @brief LCD Pin 44
+ */
+#define DL_LCD_SEGMENT_LINE_44                                              (44)
+/*!
+ *  @brief LCD Pin 45
+ */
+#define DL_LCD_SEGMENT_LINE_45                                              (45)
+/*!
+ *  @brief LCD Pin 46
+ */
+#define DL_LCD_SEGMENT_LINE_46                                              (46)
+/*!
+ *  @brief LCD Pin 47
+ */
+#define DL_LCD_SEGMENT_LINE_47                                              (47)
+/*!
+ *  @brief LCD Pin 48
+ */
+#define DL_LCD_SEGMENT_LINE_48                                              (48)
+/*!
+ *  @brief LCD Pin 49
+ */
+#define DL_LCD_SEGMENT_LINE_49                                              (49)
+/*!
+ *  @brief LCD Pin 50
+ */
+#define DL_LCD_SEGMENT_LINE_50                                              (50)
+/*!
+ *  @brief LCD Pin 51
+ */
+#define DL_LCD_SEGMENT_LINE_51                                              (51)
+/*!
+ *  @brief LCD Pin 52
+ */
+#define DL_LCD_SEGMENT_LINE_52                                              (52)
+/*!
+ *  @brief LCD Pin 53
+ */
+#define DL_LCD_SEGMENT_LINE_53                                              (53)
+/*!
+ *  @brief LCD Pin 54
+ */
+#define DL_LCD_SEGMENT_LINE_54                                              (54)
+/*!
+ *  @brief LCD Pin 55
+ */
+#define DL_LCD_SEGMENT_LINE_55                                              (55)
+/*!
+ *  @brief LCD Pin 56
+ */
+#define DL_LCD_SEGMENT_LINE_56                                              (56)
+/*!
+ *  @brief LCD Pin 57
+ */
+#define DL_LCD_SEGMENT_LINE_57                                              (57)
+/*!
+ *  @brief LCD Pin 58
+ */
+#define DL_LCD_SEGMENT_LINE_58                                              (58)
+/*!
+ *  @brief LCD Pin 59
+ */
+#define DL_LCD_SEGMENT_LINE_59                                              (59)
+/*!
+ *  @brief LCD Pin 60
+ */
+#define DL_LCD_SEGMENT_LINE_60                                              (60)
+/*!
+ *  @brief LCD Pin 61
+ */
+#define DL_LCD_SEGMENT_LINE_61                                              (61)
+/*!
+ *  @brief LCD Pin 62
+ */
+#define DL_LCD_SEGMENT_LINE_62                                              (62)
+/*!
+ *  @brief LCD Pin 63
+ */
+#define DL_LCD_SEGMENT_LINE_63                                              (63)
+ /** @}*/
+
+/** @addtogroup DL_LCD_MEMORY_BIT
+ *  @{
+ */
+/*!
+ *  @brief  Bit 0 inside LCD memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM0
+ *  1b = Pin L[2*index] is used as COM0
+ */
+#define DL_LCD_MEMORY_BIT_0                                (LCD_LCDM_MBIT0_MASK)
+
+/*!
+ *  @brief  Bit 1 inside LCD memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM1
+ *  1b = Pin L[2*index] is used as COM1
+ */
+#define DL_LCD_MEMORY_BIT_1                                (LCD_LCDM_MBIT1_MASK)
+
+/*!
+ *  @brief  Bit 2 inside LCD memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM2
+ *  1b = Pin L[2*index] is used as COM2
+ */
+#define DL_LCD_MEMORY_BIT_2                                (LCD_LCDM_MBIT2_MASK)
+
+/*!
+ *  @brief  Bit 3 inside LCD memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM3
+ *  1b = Pin L[2*index] is used as COM3
+ */
+#define DL_LCD_MEMORY_BIT_3                                (LCD_LCDM_MBIT3_MASK)
+
+/*!
+ *  @brief  Bit 4 inside LCD memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM4
+ *  1b = Pin L[2*index] is used as COM4
+ */
+#define DL_LCD_MEMORY_BIT_4                                (LCD_LCDM_MBIT4_MASK)
+
+/*!
+ *  @brief  Bit 5 inside LCD memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM5
+ *  1b = Pin L[2*index] is used as COM5
+ */
+#define DL_LCD_MEMORY_BIT_5                                (LCD_LCDM_MBIT5_MASK)
+
+/*!
+ *  @brief  Bit 6 inside LCD memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM6
+ *  1b = Pin L[2*index] is used as COM6
+ */
+#define DL_LCD_MEMORY_BIT_6                                (LCD_LCDM_MBIT6_MASK)
+
+/*!
+ *  @brief  Bit 7 inside LCD memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM7
+ *  1b = Pin L[2*index] is used as COM7
+ */
+#define DL_LCD_MEMORY_BIT_7                                (LCD_LCDM_MBIT7_MASK)
+
+/** @}*/
+
+/** @addtogroup DL_LCD_BLINK_MEMORY_BIT
+ *  @{
+ */
+/*!
+ *  @brief  Bit 0 inside LCD blink memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM0
+ *  1b = Pin L[2*index] is used as COM0
+ */
+#define DL_LCD_BLINK_MEMORY_BIT_0                         (LCD_LCDBM_MBIT0_MASK)
+
+/*!
+ *  @brief  Bit 1 inside LCD blink memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM1
+ *  1b = Pin L[2*index] is used as COM1
+ */
+#define DL_LCD_BLINK_MEMORY_BIT_1                         (LCD_LCDBM_MBIT1_MASK)
+
+/*!
+ *  @brief  Bit 2 inside LCD blink memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM2
+ *  1b = Pin L[2*index] is used as COM2
+ */
+#define DL_LCD_BLINK_MEMORY_BIT_2                         (LCD_LCDBM_MBIT2_MASK)
+
+/*!
+ *  @brief Bit 3 inside LCD blink memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM3
+ *  1b = Pin L[2*index] is used as COM3
+ */
+#define DL_LCD_BLINK_MEMORY_BIT_3                         (LCD_LCDBM_MBIT3_MASK)
+
+/*!
+ *  @brief  Bit 4 inside LCD blink memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM4
+ *  1b = Pin L[2*index] is used as COM4
+ */
+#define DL_LCD_BLINK_MEMORY_BIT_4                         (LCD_LCDBM_MBIT4_MASK)
+
+/*!
+ *  @brief  Bit 5 inside LCD blink memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM5
+ *  1b = Pin L[2*index] is used as COM5
+ */
+#define DL_LCD_BLINK_MEMORY_BIT_5                         (LCD_LCDBM_MBIT5_MASK)
+
+/*!
+ *  @brief  Bit 6 inside LCD blink memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM6
+ *  1b = Pin L[2*index] is used as COM6
+ */
+#define DL_LCD_BLINK_MEMORY_BIT_6                         (LCD_LCDBM_MBIT6_MASK)
+
+/*!
+ *  @brief  Bit 7 inside LCD blink memory index registers
+ *
+ *  If LCD L[2*index] is selected as (1) segment line: 0b = LCD segment off
+ *  1b = LCD segment on (2) common line: 0b = Pin L[2*index] not used as COM7
+ *  1b = Pin L[2*index] is used as COM7
+ */
+#define DL_LCD_BLINK_MEMORY_BIT_7                         (LCD_LCDBM_MBIT7_MASK)
+
+/** @}*/
+
+/*! @enum DL_LCD_FREQ_DIVIDE */
+typedef enum {
+    /*! Divide fLCD by 1 */
+    DL_LCD_FREQ_DIVIDE_1 = LCD_LCDCTL0_LCDDIVX_DIV_BY_1,
+    /*! Divide fLCD by 2 */
+    DL_LCD_FREQ_DIVIDE_2 = LCD_LCDCTL0_LCDDIVX_DIV_BY_2,
+    /*! Divide fLCD by 3 */
+    DL_LCD_FREQ_DIVIDE_3 = LCD_LCDCTL0_LCDDIVX_DIV_BY_3,
+    /*! Divide fLCD by 4 */
+    DL_LCD_FREQ_DIVIDE_4 = LCD_LCDCTL0_LCDDIVX_DIV_BY_4,
+    /*! Divide fLCD by 5 */
+    DL_LCD_FREQ_DIVIDE_5 = LCD_LCDCTL0_LCDDIVX_DIV_BY_5,
+    /*! Divide fLCD by 6 */
+    DL_LCD_FREQ_DIVIDE_6 = LCD_LCDCTL0_LCDDIVX_DIV_BY_6,
+    /*! Divide fLCD by 7 */
+    DL_LCD_FREQ_DIVIDE_7 = LCD_LCDCTL0_LCDDIVX_DIV_BY_7,
+    /*! Divide fLCD by 8 */
+    DL_LCD_FREQ_DIVIDE_8 = LCD_LCDCTL0_LCDDIVX_DIV_BY_8,
+    /*! Divide fLCD by 9 */
+    DL_LCD_FREQ_DIVIDE_9 = LCD_LCDCTL0_LCDDIVX_DIV_BY_9,
+    /*! Divide fLCD by 10 */
+    DL_LCD_FREQ_DIVIDE_10 = LCD_LCDCTL0_LCDDIVX_DIV_BY_10,
+    /*! Divide fLCD by 11 */
+    DL_LCD_FREQ_DIVIDE_11 = LCD_LCDCTL0_LCDDIVX_DIV_BY_11,
+    /*! Divide fLCD by 12 */
+    DL_LCD_FREQ_DIVIDE_12 = LCD_LCDCTL0_LCDDIVX_DIV_BY_12,
+    /*! Divide fLCD by 13 */
+    DL_LCD_FREQ_DIVIDE_13 = LCD_LCDCTL0_LCDDIVX_DIV_BY_13,
+    /*! Divide fLCD by 14 */
+    DL_LCD_FREQ_DIVIDE_14 = LCD_LCDCTL0_LCDDIVX_DIV_BY_14,
+    /*! Divide fLCD by 15 */
+    DL_LCD_FREQ_DIVIDE_15 = LCD_LCDCTL0_LCDDIVX_DIV_BY_15,
+    /*! Divide fLCD by 16 */
+    DL_LCD_FREQ_DIVIDE_16 = LCD_LCDCTL0_LCDDIVX_DIV_BY_16,
+    /*! Divide fLCD by 17 */
+    DL_LCD_FREQ_DIVIDE_17 = LCD_LCDCTL0_LCDDIVX_DIV_BY_17,
+    /*! Divide fLCD by 18 */
+    DL_LCD_FREQ_DIVIDE_18 = LCD_LCDCTL0_LCDDIVX_DIV_BY_18,
+    /*! Divide fLCD by 19 */
+    DL_LCD_FREQ_DIVIDE_19 = LCD_LCDCTL0_LCDDIVX_DIV_BY_19,
+    /*! Divide fLCD by 20 */
+    DL_LCD_FREQ_DIVIDE_20 = LCD_LCDCTL0_LCDDIVX_DIV_BY_20,
+    /*! Divide fLCD by 21 */
+    DL_LCD_FREQ_DIVIDE_21 = LCD_LCDCTL0_LCDDIVX_DIV_BY_21,
+    /*! Divide fLCD by 22 */
+    DL_LCD_FREQ_DIVIDE_22 = LCD_LCDCTL0_LCDDIVX_DIV_BY_22,
+    /*! Divide fLCD by 23 */
+    DL_LCD_FREQ_DIVIDE_23 = LCD_LCDCTL0_LCDDIVX_DIV_BY_23,
+    /*! Divide fLCD by 24 */
+    DL_LCD_FREQ_DIVIDE_24 = LCD_LCDCTL0_LCDDIVX_DIV_BY_24,
+    /*! Divide fLCD by 25 */
+    DL_LCD_FREQ_DIVIDE_25 = LCD_LCDCTL0_LCDDIVX_DIV_BY_25,
+    /*! Divide fLCD by 26 */
+    DL_LCD_FREQ_DIVIDE_26 = LCD_LCDCTL0_LCDDIVX_DIV_BY_26,
+    /*! Divide fLCD by 27 */
+    DL_LCD_FREQ_DIVIDE_27 = LCD_LCDCTL0_LCDDIVX_DIV_BY_27,
+    /*! Divide fLCD by 28 */
+    DL_LCD_FREQ_DIVIDE_28 = LCD_LCDCTL0_LCDDIVX_DIV_BY_28,
+    /*! Divide fLCD by 29 */
+    DL_LCD_FREQ_DIVIDE_29 = LCD_LCDCTL0_LCDDIVX_DIV_BY_29,
+    /*! Divide fLCD by 30 */
+    DL_LCD_FREQ_DIVIDE_30 = LCD_LCDCTL0_LCDDIVX_DIV_BY_30,
+    /*! Divide fLCD by 31 */
+    DL_LCD_FREQ_DIVIDE_31 = LCD_LCDCTL0_LCDDIVX_DIV_BY_31,
+    /*! Divide fLCD by 32 */
+    DL_LCD_FREQ_DIVIDE_32 = LCD_LCDCTL0_LCDDIVX_DIV_BY_32,
+} DL_LCD_FREQ_DIVIDE;
+
+/*! @enum DL_LCD_MUX_RATE */
+typedef enum {
+    /*! Select LCD Mode: static */
+    DL_LCD_MUX_RATE_STATIC = LCD_LCDCTL0_LCDMXX_MX_STATIC,
+    /*! Select LCD Mode: 2-mux */
+    DL_LCD_MUX_RATE_2 = LCD_LCDCTL0_LCDMXX_MX_2,
+    /*! Select LCD Mode: 3-mux */
+    DL_LCD_MUX_RATE_3 = LCD_LCDCTL0_LCDMXX_MX_3,
+    /*! Select LCD Mode: 4-mux */
+    DL_LCD_MUX_RATE_4 = LCD_LCDCTL0_LCDMXX_MX_4,
+    /*! Select LCD Mode: 5-mux */
+    DL_LCD_MUX_RATE_5 = LCD_LCDCTL0_LCDMXX_MX_5,
+    /*! Select LCD Mode: 6-mux */
+    DL_LCD_MUX_RATE_6 = LCD_LCDCTL0_LCDMXX_MX_6,
+    /*! Select LCD Mode: 7-mux */
+    DL_LCD_MUX_RATE_7 = LCD_LCDCTL0_LCDMXX_MX_7,
+    /*! Select LCD Mode: 8-mux */
+    DL_LCD_MUX_RATE_8 = LCD_LCDCTL0_LCDMXX_MX_8,
+} DL_LCD_MUX_RATE;
+
+/*! @enum DL_LCD_WAVEFORM_POWERMODE */
+typedef enum {
+    /*! Select low power LCD waveforms */
+    DL_LCD_WAVEFORM_POWERMODE_LOWPOWER = LCD_LCDCTL0_LCDLP_LP_LCD,
+    /*! Select standard LCD waveforms */
+    DL_LCD_WAVEFORM_POWERMODE_STANDARD = LCD_LCDCTL0_LCDLP_STD_LCD,
+} DL_LCD_WAVEFORM_POWERMODE;
+
+/*! @enum DL_LCD_BLINKING_DIVIDE */
+typedef enum {
+    /*! Divide LCD blinking frequency by 2 */
+    DL_LCD_BLINKING_DIVIDE_BY_2 = LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_2,
+    /*! Divide LCD blinking frequency by 4 */
+    DL_LCD_BLINKING_DIVIDE_BY_4 = LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_4,
+    /*! Divide LCD blinking frequency by 8 */
+    DL_LCD_BLINKING_DIVIDE_BY_8 = LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_8,
+    /*! Divide LCD blinking frequency by 16 */
+    DL_LCD_BLINKING_DIVIDE_BY_16 = LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_16,
+    /*! Divide LCD blinking frequency by 32 */
+    DL_LCD_BLINKING_DIVIDE_BY_32 = LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_32,
+    /*! Divide LCD blinking frequency by 64 */
+    DL_LCD_BLINKING_DIVIDE_BY_64 = LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_64,
+    /*! Divide LCD blinking frequency by 128 */
+    DL_LCD_BLINKING_DIVIDE_BY_128 = LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_128,
+    /*! Divide LCD blinking frequency by 256 */
+    DL_LCD_BLINKING_DIVIDE_BY_256 = LCD_LCDBLKCTL_LCDBLKPREX_DIV_BY_256,
+} DL_LCD_BLINKING_DIVIDE;
+
+/*! @enum DL_LCD_BLINKING_MODE */
+typedef enum {
+    /*! Blinking disabled */
+    DL_LCD_BLINKING_MODE_DISABLED = LCD_LCDBLKCTL_LCDBLKMODX_BLINK_DISABLE,
+    /*! Blinking of individual segments as enabled in LCDBMx */
+    DL_LCD_BLINKING_MODE_INDIVIDUAL_SEGMENTS =
+        LCD_LCDBLKCTL_LCDBLKMODX_BLINK_SELECED,
+    /*! Blinking of all segments */
+    DL_LCD_BLINKING_MODE_ALL_SEGMENTS = LCD_LCDBLKCTL_LCDBLKMODX_BLINK_ALL,
+    /*! Switch between display contents stored in LCDMx and LCDMBx */
+    DL_LCD_BLINKING_MODE_TOGGLE = LCD_LCDBLKCTL_LCDBLKMODX_BKINK_TOGGLE,
+} DL_LCD_BLINKING_MODE;
+
+/*! @enum DL_LCD_CHARGE_PUMP_FREQUENCY */
+typedef enum {
+    /*! 32.768 kHz / 1 / 8 = 4.096 kHz  */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_4096HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_1_BY_8,
+    /*! 32.768 kHz / 2 / 8 = 2.048 kHz  */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_2048HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_2_BY_8,
+    /*! 32.768 kHz / 3 / 8 = 1.365 kHz  */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_1365HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_3_BY_8,
+    /*! 32.768 kHz / 4 / 8 = 1.024 kHz  */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_1024HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_4_BY_8,
+    /*! 32.768 kHz / 5 / 8 = 819 Hz     */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_819HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_5_BY_8,
+    /*! 32.768 kHz / 6 / 8 = 682 Hz     */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_682HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_6_BY_8,
+    /*! 32.768 kHz / 7 / 8 = 585 Hz     */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_585HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_7_BY_8,
+    /*! 32.768 kHz / 8 / 8 = 512 Hz     */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_512HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_8_BY_8,
+    /*! 32.768 kHz / 9 / 8 = 455 Hz     */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_455HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_9_BY_8,
+    /*! 32.768 kHz / 10 / 8 = 409 Hz    */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_409HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_10_BY_8,
+    /*! 32.768 kHz / 11 / 8 = 372 Hz    */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_372HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_11_BY_8,
+    /*! 32.768 kHz / 12 / 8 = 341 Hz    */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_341HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_12_BY_8,
+    /*! 32.768 kHz / 13 / 8 = 315 Hz    */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_315HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_13_BY_8,
+    /*! 32.768 kHz / 14 / 8 = 292 Hz    */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_292HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_14_BY_8,
+    /*! 32.768 kHz / 15 / 8 = 273 Hz    */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_273HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_15_BY_8,
+    /*! 32.768 kHz / 16 / 8 = 256 Hz   */
+    DL_LCD_CHARGE_PUMP_FREQUENCY_256HZ = LCD_LCDVCTL_LCDCPFSELX_DIV_BY_16_BY_8,
+} DL_LCD_CHARGE_PUMP_FREQUENCY;
+
+/*! @enum DL_LCD_VREF_INTERNAL */
+typedef enum {
+    /*! 2.60 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_2_60V = LCD_LCDVCTL_VLCDX_SEL_2P60V,
+    /*! 2.66 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_2_66V = LCD_LCDVCTL_VLCDX_SEL_2P66V,
+    /*! 2.72 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_2_72V = LCD_LCDVCTL_VLCDX_SEL_2P72V,
+    /*! 2.78 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_2_78V = LCD_LCDVCTL_VLCDX_SEL_2P78V,
+    /*! 2.84 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_2_84V = LCD_LCDVCTL_VLCDX_SEL_2P84V,
+    /*! 2.90 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_2_90V = LCD_LCDVCTL_VLCDX_SEL_2P90V,
+    /*! 2.96 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_2_96V = LCD_LCDVCTL_VLCDX_SEL_2P96V,
+    /*! 3.02 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_3_02V = LCD_LCDVCTL_VLCDX_SEL_3P02V,
+    /*! 3.08 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_3_08V = LCD_LCDVCTL_VLCDX_SEL_3P08V,
+    /*! 3.14 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_3_14V = LCD_LCDVCTL_VLCDX_SEL_3P14V,
+    /*! 3.20 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_3_20V = LCD_LCDVCTL_VLCDX_SEL_3P20V,
+    /*! 3.26 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_3_26V = LCD_LCDVCTL_VLCDX_SEL_3P26V,
+    /*! 3.32 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_3_32V = LCD_LCDVCTL_VLCDX_SEL_3P32V,
+    /*! 3.38 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_3_38V = LCD_LCDVCTL_VLCDX_SEL_3P38V,
+    /*! 3.44 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_3_44V = LCD_LCDVCTL_VLCDX_SEL_3P44V,
+    /*! 3.50 V internal reference voltage select on R13  */
+    DL_LCD_VREF_INTERNAL_3_50V = LCD_LCDVCTL_VLCDX_SEL_3P50V,
+} DL_LCD_VREF_INTERNAL;
+
+/*! @enum DL_LCD_R33_SOURCE */
+typedef enum {
+    /*! R33 is supplied from charge pump */
+    DL_LCD_R33_SOURCE_EXTERNAL = LCD_LCDVCTL_LCDSELVDD_SEL_EXT_SUPPLY,
+    /*! R33 is supplied from AVDD internally */
+    DL_LCD_R33_SOURCE_INTERNAL = LCD_LCDVCTL_LCDSELVDD_SEL_AVDD,
+} DL_LCD_R33_SOURCE;
+
+/*! @enum DL_LCD_POWER_MODE */
+typedef enum {
+    /*! Low power resistor ladder generates bias voltage for the LCD */
+    DL_LCD_POWER_MODE_LOW = LCD_LCDVCTL_LCD_HP_LP_LP_MODE,
+    /*! Higher power resistor ladder generates bias voltage for the LCD */
+    DL_LCD_POWER_MODE_HIGH = LCD_LCDVCTL_LCD_HP_LP_HP_MODE,
+} DL_LCD_POWER_MODE;
+
+/*! @enum DL_LCD_BIAS_VOLTAGE_SOURCE */
+typedef enum {
+    /*! Bias voltage sourced from R33 pin */
+    DL_LCD_BIAS_VOLTAGE_SOURCE_R33 = LCD_LCDVCTL_VLCDSEL_VDD_R33_SEL_R33,
+    /*! Bias voltage sourced from internal supply voltage AVDD */
+    DL_LCD_BIAS_VOLTAGE_SOURCE_AVDD = LCD_LCDVCTL_VLCDSEL_VDD_R33_SEL_AVDD,
+} DL_LCD_BIAS_VOLTAGE_SOURCE;
+
+/*! @enum DL_LCD_BIAS */
+typedef enum {
+    /*! For 5-mux to 8-mux modes only. 1/3 bias */
+    DL_LCD_BIAS_ONE_THIRD = LCD_LCDVCTL_LCDBIASSEL_ONE_BY_3_BIAS,
+    /*! For 5-mux to 8-mux modes only. 1/4 bias */
+    DL_LCD_BIAS_ONE_FOURTH = LCD_LCDVCTL_LCDBIASSEL_ONE_BY_4_BIAS,
+} DL_LCD_BIAS;
+
+/*! @enum DL_LCD_REFERENCE_MODE */
+typedef enum {
+    /*! R13 voltage in static mode */
+    DL_LCD_REFERENCE_MODE_STATIC = LCD_LCDVCTL_LCDREFMODE_STATIC_MODE,
+    /*! R13 voltage in switched mode */
+    DL_LCD_REFERENCE_MODE_SWITCHED = LCD_LCDVCTL_LCDREFMODE_SWITCHED_MODE,
+} DL_LCD_REFERENCE_MODE;
+
+/*! @enum DL_LCD_DISP */
+typedef enum {
+    /*! Display content of LCD memory registers LCDMx */
+    DL_LCD_DISPLAY_REGISTERS_MEMORY = LCD_LCDMEMCTL_LCDDISP_SEL_LCD_MEM_REGS,
+    /*! Display content of LCD blinking memory registers LCDBMx */
+    DL_LCD_DISPLAY_REGISTERS_BLINKING_MEMORY =
+        LCD_LCDMEMCTL_LCDDISP_SEL_BLNK_MEM_REGS,
+} DL_LCD_DISP;
+
+/*! @enum DL_LCD_EVENT_LINE_MODE */
+typedef enum {
+    /*! The interrupt or event line is disabled. */
+    DL_LCD_EVENT_LINE_MODE_DISABLED = LCD_EVT_MODE_INT0_CFG_DISABLE,
+    /*! The interrupt/event line is in sw mode. Software must clear the RIS. */
+    DL_LCD_EVENT_LINE_MODE_SOFTWARE = LCD_EVT_MODE_INT0_CFG_SOFTWARE,
+    /*! The interrupt/event line is in hw mode. The hardware clears RIS flag. */
+    DL_LCD_EVENT_LINE_MODE_HARDWARE = LCD_EVT_MODE_INT0_CFG_HARDWARE,
+} DL_LCD_EVENT_LINE_MODE;
+
+/*! @enum DL_LCD_IIDX */
+typedef enum {
+    /*! LCD interrupt index for no interrupt pending */
+    DL_LCD_IIDX_NO_INT = LCD_IIDX_STAT_NO_INTR,
+    /*! LCD interrupt index when start of new frame interrupt */
+    DL_LCD_IIDX_FRAME_START = LCD_IIDX_STAT_FRAME_START,
+    /*! LCD interrupt index when blinking segments off */
+    DL_LCD_IIDX_BLINKING_SEGMENTS_OFF = LCD_IIDX_STAT_BLK_OFF,
+    /*! LCD interrupt index when blinking segments on */
+    DL_LCD_IIDX_BLINKING_SEGMENTS_ON = LCD_IIDX_STAT_BLK_ON,
+} DL_LCD_IIDX;
+
+/*! @enum DL_LCD_MEMORY */
+typedef enum {
+    /*! Index to access LCD memory register 0 */
+    DL_LCD_MEMORY_0 = 0,
+    /*! Index to access LCD memory register 1 */
+    DL_LCD_MEMORY_1 = 1,
+    /*! Index to access LCD memory register 2 */
+    DL_LCD_MEMORY_2 = 2,
+    /*! Index to access LCD memory register 3 */
+    DL_LCD_MEMORY_3 = 3,
+    /*! Index to access LCD memory register 4 */
+    DL_LCD_MEMORY_4 = 4,
+    /*! Index to access LCD memory register 5 */
+    DL_LCD_MEMORY_5 = 5,
+    /*! Index to access LCD memory register 6 */
+    DL_LCD_MEMORY_6 = 6,
+    /*! Index to access LCD memory register 7 */
+    DL_LCD_MEMORY_7 = 7,
+    /*! Index to access LCD memory register 8 */
+    DL_LCD_MEMORY_8 = 8,
+    /*! Index to access LCD memory register 9 */
+    DL_LCD_MEMORY_9 = 9,
+    /*! Index to access LCD memory register 10 */
+    DL_LCD_MEMORY_10 = 10,
+    /*! Index to access LCD memory register 11 */
+    DL_LCD_MEMORY_11 = 11,
+    /*! Index to access LCD memory register 12 */
+    DL_LCD_MEMORY_12 = 12,
+    /*! Index to access LCD memory register 13 */
+    DL_LCD_MEMORY_13 = 13,
+    /*! Index to access LCD memory register 14 */
+    DL_LCD_MEMORY_14 = 14,
+    /*! Index to access LCD memory register 15 */
+    DL_LCD_MEMORY_15 = 15,
+    /*! Index to access LCD memory register 16 */
+    DL_LCD_MEMORY_16 = 16,
+    /*! Index to access LCD memory register 17 */
+    DL_LCD_MEMORY_17 = 17,
+    /*! Index to access LCD memory register 18 */
+    DL_LCD_MEMORY_18 = 18,
+    /*! Index to access LCD memory register 19 */
+    DL_LCD_MEMORY_19 = 19,
+    /*! Index to access LCD memory register 20 */
+    DL_LCD_MEMORY_20 = 20,
+    /*! Index to access LCD memory register 21 */
+    DL_LCD_MEMORY_21 = 21,
+    /*! Index to access LCD memory register 22 */
+    DL_LCD_MEMORY_22 = 22,
+    /*! Index to access LCD memory register 23 */
+    DL_LCD_MEMORY_23 = 23,
+    /*! Index to access LCD memory register 24 */
+    DL_LCD_MEMORY_24 = 24,
+    /*! Index to access LCD memory register 25 */
+    DL_LCD_MEMORY_25 = 25,
+    /*! Index to access LCD memory register 26 */
+    DL_LCD_MEMORY_26 = 26,
+    /*! Index to access LCD memory register 27 */
+    DL_LCD_MEMORY_27 = 27,
+    /*! Index to access LCD memory register 28 */
+    DL_LCD_MEMORY_28 = 28,
+    /*! Index to access LCD memory register 29 */
+    DL_LCD_MEMORY_29 = 29,
+    /*! Index to access LCD memory register 30 */
+    DL_LCD_MEMORY_30 = 30,
+    /*! Index to access LCD memory register 31 */
+    DL_LCD_MEMORY_31 = 31,
+    /*! Index to access LCD memory register 32 */
+    DL_LCD_MEMORY_32 = 32,
+    /*! Index to access LCD memory register 33 */
+    DL_LCD_MEMORY_33 = 33,
+    /*! Index to access LCD memory register 34 */
+    DL_LCD_MEMORY_34 = 34,
+    /*! Index to access LCD memory register 35 */
+    DL_LCD_MEMORY_35 = 35,
+    /*! Index to access LCD memory register 36 */
+    DL_LCD_MEMORY_36 = 36,
+    /*! Index to access LCD memory register 37 */
+    DL_LCD_MEMORY_37 = 37,
+    /*! Index to access LCD memory register 38 */
+    DL_LCD_MEMORY_38 = 38,
+    /*! Index to access LCD memory register 39 */
+    DL_LCD_MEMORY_39 = 39,
+    /*! Index to access LCD memory register 40 */
+    DL_LCD_MEMORY_40 = 40,
+    /*! Index to access LCD memory register 41 */
+    DL_LCD_MEMORY_41 = 41,
+    /*! Index to access LCD memory register 42 */
+    DL_LCD_MEMORY_42 = 42,
+    /*! Index to access LCD memory register 43 */
+    DL_LCD_MEMORY_43 = 43,
+    /*! Index to access LCD memory register 44 */
+    DL_LCD_MEMORY_44 = 44,
+    /*! Index to access LCD memory register 45 */
+    DL_LCD_MEMORY_45 = 45,
+    /*! Index to access LCD memory register 46 */
+    DL_LCD_MEMORY_46 = 46,
+    /*! Index to access LCD memory register 47 */
+    DL_LCD_MEMORY_47 = 47,
+    /*! Index to access LCD memory register 48 */
+    DL_LCD_MEMORY_48 = 48,
+    /*! Index to access LCD memory register 49 */
+    DL_LCD_MEMORY_49 = 49,
+    /*! Index to access LCD memory register 50 */
+    DL_LCD_MEMORY_50 = 50,
+    /*! Index to access LCD memory register 51 */
+    DL_LCD_MEMORY_51 = 51,
+    /*! Index to access LCD memory register 52 */
+    DL_LCD_MEMORY_52 = 52,
+    /*! Index to access LCD memory register 53*/
+    DL_LCD_MEMORY_53 = 53,
+    /*! Index to access LCD memory register 54 */
+    DL_LCD_MEMORY_54 = 54,
+    /*! Index to access LCD memory register 55 */
+    DL_LCD_MEMORY_55 = 55,
+    /*! Index to access LCD memory register 56 */
+    DL_LCD_MEMORY_56 = 56,
+    /*! Index to access LCD memory register 57 */
+    DL_LCD_MEMORY_57 = 57,
+    /*! Index to access LCD memory register 58 */
+    DL_LCD_MEMORY_58 = 58,
+    /*! Index to access LCD memory register 59 */
+    DL_LCD_MEMORY_59 = 59,
+    /*! Index to access LCD memory register 60 */
+    DL_LCD_MEMORY_60 = 60,
+    /*! Index to access LCD memory register 61 */
+    DL_LCD_MEMORY_61 = 61,
+    /*! Index to access LCD memory register 62 */
+    DL_LCD_MEMORY_62 = 62,
+    /*! Index to access LCD memory register 63 */
+    DL_LCD_MEMORY_63 = 63,
+} DL_LCD_MEMORY;
+
+/*! @enum DL_LCD_BLINKING_MEMORY */
+typedef enum {
+    /*! Index to access LCD blink memory register 0 */
+    DL_LCD_BLINKING_MEMORY_0 = 0,
+    /*! Index to access LCD blink memory register 1 */
+    DL_LCD_BLINKING_MEMORY_1 = 1,
+    /*! Index to access LCD blink memory register 2 */
+    DL_LCD_BLINKING_MEMORY_2 = 2,
+    /*! Index to access LCD blink memory register 3 */
+    DL_LCD_BLINKING_MEMORY_3 = 3,
+    /*! Index to access LCD blink memory register 4 */
+    DL_LCD_BLINKING_MEMORY_4 = 4,
+    /*! Index to access LCD blink memory register 5 */
+    DL_LCD_BLINKING_MEMORY_5 = 5,
+    /*! Index to access LCD blink memory register 6 */
+    DL_LCD_BLINKING_MEMORY_6 = 6,
+    /*! Index to access LCD blink memory register 7 */
+    DL_LCD_BLINKING_MEMORY_7 = 7,
+    /*! Index to access LCD blink memory register 8 */
+    DL_LCD_BLINKING_MEMORY_8 = 8,
+    /*! Index to access LCD blink memory register 9 */
+    DL_LCD_BLINKING_MEMORY_9 = 9,
+    /*! Index to access LCD blink memory register 10 */
+    DL_LCD_BLINKING_MEMORY_10 = 10,
+    /*! Index to access LCD blink memory register 11 */
+    DL_LCD_BLINKING_MEMORY_11 = 11,
+    /*! Index to access LCD blink memory register 12 */
+    DL_LCD_BLINKING_MEMORY_12 = 12,
+    /*! Index to access LCD blink memory register 13 */
+    DL_LCD_BLINKING_MEMORY_13 = 13,
+    /*! Index to access LCD blink memory register 14 */
+    DL_LCD_BLINKING_MEMORY_14 = 14,
+    /*! Index to access LCD blink memory register 15 */
+    DL_LCD_BLINKING_MEMORY_15 = 15,
+    /*! Index to access LCD blink memory register 16 */
+    DL_LCD_BLINKING_MEMORY_16 = 16,
+    /*! Index to access LCD blink memory register 17 */
+    DL_LCD_BLINKING_MEMORY_17 = 17,
+    /*! Index to access LCD blink memory register 18 */
+    DL_LCD_BLINKING_MEMORY_18 = 18,
+    /*! Index to access LCD blink memory register 19 */
+    DL_LCD_BLINKING_MEMORY_19 = 19,
+    /*! Index to access LCD blink memory register 20 */
+    DL_LCD_BLINKING_MEMORY_20 = 20,
+    /*! Index to access LCD blink memory register 21 */
+    DL_LCD_BLINKING_MEMORY_21 = 21,
+    /*! Index to access LCD blink memory register 22 */
+    DL_LCD_BLINKING_MEMORY_22 = 22,
+    /*! Index to access LCD blink memory register 23 */
+    DL_LCD_BLINKING_MEMORY_23 = 23,
+    /*! Index to access LCD blink memory register 24 */
+    DL_LCD_BLINKING_MEMORY_24 = 24,
+    /*! Index to access LCD blink memory register 25 */
+    DL_LCD_BLINKING_MEMORY_25 = 25,
+    /*! Index to access LCD blink memory register 26 */
+    DL_LCD_BLINKING_MEMORY_26 = 26,
+    /*! Index to access LCD blink memory register 27 */
+    DL_LCD_BLINKING_MEMORY_27 = 27,
+    /*! Index to access LCD blink memory register 28 */
+    DL_LCD_BLINKING_MEMORY_28 = 28,
+    /*! Index to access LCD blink memory register 29 */
+    DL_LCD_BLINKING_MEMORY_29 = 29,
+    /*! Index to access LCD blink memory register 30*/
+    DL_LCD_BLINKING_MEMORY_30 = 30,
+    /*! Index to access LCD blink memory register 31 */
+    DL_LCD_BLINKING_MEMORY_31 = 31,
+} DL_LCD_BLINKING_MEMORY;
+
+/*! @enum DL_LCD_COM */
+typedef enum {
+    /*! Index to access COM 0 */
+    DL_LCD_COM_0 = 0x01,
+    /*! Index to access COM 1 */
+    DL_LCD_COM_1 = 0x02,
+    /*! Index to access COM 2 */
+    DL_LCD_COM_2 = 0x04,
+    /*! Index to access COM 3 */
+    DL_LCD_COM_3 = 0x08,
+    /*! Index to access COM 4 */
+    DL_LCD_COM_4 = 0x10,
+    /*! Index to access COM 5 */
+    DL_LCD_COM_5 = 0x20,
+    /*! Index to access COM 6 */
+    DL_LCD_COM_6 = 0x40,
+    /*! Index to access COM 7 */
+    DL_LCD_COM_7 = 0x80,
+} DL_LCD_COM;
+
+/*! @enum DL_LCD_VREFGEN_CYCLES */
+typedef enum {
+    /*! Turn on VREF generation circuitry for 16 clock cycles */
+    DL_LCD_VREFGEN_CYCLES_16 = LCD_LCDVREFCFG_ONTIME_ONTIME16,
+    /*! Turn on VREF generation circuitry for 32 clock cycles */
+    DL_LCD_VREFGEN_CYCLES_32 = LCD_LCDVREFCFG_ONTIME_ONTIME32,
+    /*! Turn on VREF generation circuitry for 128 clock cycles */
+    DL_LCD_VREFGEN_CYCLES_128 = LCD_LCDVREFCFG_ONTIME_ONTIME128,
+    /*! Turn on VREF generation circuitry for 256 clock cycles */
+    DL_LCD_VREFGEN_CYCLES_256 = LCD_LCDVREFCFG_ONTIME_ONTIME256,
+} DL_LCD_VREFGEN_CYCLES;
+
+/**
+ * @brief Configuration struct for @ref DL_LCD_init
+ */
+typedef struct {
+    /*! The frequency divider to set. One of @ref DL_LCD_FREQ_DIVIDE */
+    DL_LCD_FREQ_DIVIDE frequencyDivider;
+    /*! The mux rate. One of @ref DL_LCD_MUX_RATE. */
+    DL_LCD_MUX_RATE muxRate;
+    /*! Select waveforms power mode. One of @ref DL_LCD_WAVEFORM_POWERMODE */
+    DL_LCD_WAVEFORM_POWERMODE lowPowerWaveform;
+} DL_LCD_Config;
+
+/**
+ *  @brief Initialize the LCD peripheral
+ *
+ *  Initializes all the common configurable options for the LCD peripheral. Any
+ *  other custom configuration can be done after calling this API. The LCD is
+ *  not enabled in this API.
+ *
+ *  @param[in] lcd      Pointer to the register overlay for the peripheral
+ *  @param[in] config   Configuration for LCD peripheral
+ */
+void DL_LCD_init(LCD_Regs *lcd, DL_LCD_Config *config);
+
+/**
+ *  @brief Enable a pin as LCD function
+ *
+ *  @param[in] lcd      Pointer to the register overlay for the peripheral
+ *  @param[in] pin      Pin to set as LCD function
+ *                      One of @ref DL_LCD_SEGMENT_LINE
+ *  @note               This function will disable power to the LCD module.
+ *                      If needed, enable the module after by calling
+ *                      @ref DL_LCD_enable
+ */
+
+void DL_LCD_setPinAsLCDFunction(LCD_Regs *lcd, uint32_t pin);
+
+/**
+ *  @brief Enable a pin as port function
+ *
+ *  @param[in] lcd      Pointer to the register overlay for the peripheral
+ *  @param[in] pin      Pin to set as port function.
+ *                      One of @ref DL_LCD_SEGMENT_LINE
+ *  @note               This function will disable power to the LCD module.
+ *                      If needed, enable the module after by calling
+ *                      @ref DL_LCD_enable
+ */
+void DL_LCD_setPinAsPortFunction(LCD_Regs *lcd, uint8_t pin);
+
+/**
+ *  @brief Enable an LCD function pin as COM
+ *
+ *  @param[in] lcd      Pointer to the register overlay for the peripheral
+ *  @param[in] pin      Pin to set as common.
+ *                      One of @ref DL_LCD_SEGMENT_LINE
+ *  @param[in] com      The selected COM number for the common line.
+ *                      One of @ref DL_LCD_COM
+ */
+void DL_LCD_setPinAsCommon(LCD_Regs *lcd, uint8_t pin, uint32_t com);
+
+/**
+ *  @brief Enable an LCD function pin as Segment
+ *
+ *  @param[in] lcd      Pointer to the register overlay for the peripheral
+ *  @param[in] pin      Pin to set as segment line.
+ *                      One of @ref DL_LCD_SEGMENT_LINE
+ */
+void DL_LCD_setPinAsSegment(LCD_Regs *lcd, uint8_t pin);
+
+/**
+ *  @brief Enables power to the LCD module
+ *
+ *  @param[in] lcd  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_LCD_enablePower(LCD_Regs *lcd)
+{
+    lcd->PWREN |= (LCD_PWREN_KEY_UNLOCK_W | LCD_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power to the LCD module
+ *
+ * @param lcd   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_disablePower(LCD_Regs *lcd)
+{
+    lcd->PWREN = (LCD_PWREN_KEY_UNLOCK_W | LCD_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ *  @brief Checks if power module on LCD is enabled
+ *
+ *  @param[in]  lcd  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If power module on LCD is enabled
+ *
+ *  @retval     true if power module on LCD is enabled
+ *  @retval     false if power module on LCD is disabled
+ */
+__STATIC_INLINE bool DL_LCD_isPowerEnabled(LCD_Regs *lcd)
+{
+    return ((lcd->PWREN & LCD_PWREN_ENABLE_MASK) ==
+            LCD_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ *  @brief Resets LCD peripheral
+ *
+ *  @param[in] lcd  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_LCD_reset(LCD_Regs *lcd)
+{
+    lcd->RSTCTL = (LCD_RSTCTL_KEY_UNLOCK_W | LCD_RSTCTL_RESETSTKYCLR_CLR |
+            LCD_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ *  @brief Checks if LCD peripheral was reset
+ *
+ *  @param[in]  lcd  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If peripheral was reset
+ *
+ *  @retval     true if peripheral was reset since this bit was last cleared by
+ *              RESETSTKYCLR in the RSTCTL register
+ *  @retval     false if peripheral was not reset since the last bit clear
+ */
+__STATIC_INLINE bool DL_LCD_isReset(LCD_Regs *lcd)
+{
+    return ((lcd->STAT & LCD_STAT_RESETSTKY_MASK) ==
+            LCD_STAT_RESETSTKY_RESET);
+}
+
+/**
+ *  @brief Get the event line mode
+ *
+ *  @param[in]  lcd  Pointer to the register overlay for the peripheral
+ *
+ *  @return     event line mode
+ *
+ *  @retval     One of @ref DL_LCD_EVENT_LINE_MODE
+ */
+__STATIC_INLINE DL_LCD_EVENT_LINE_MODE DL_LCD_getEventLineMode(LCD_Regs *lcd)
+{
+    uint32_t eventLineMode = (lcd->EVT_MODE & LCD_EVT_MODE_INT0_CFG_MASK);
+
+    return (DL_LCD_EVENT_LINE_MODE)(eventLineMode);
+}
+
+/**
+ *  @brief Gets the highest priority pending interrupt
+ *
+ *  Accesses and reads the IIDX register to obtain the highest currently
+ *  pending interrupt. A read clears the corresponding interrupt flag in RIS
+ *  and MIS.
+ *
+ *  @param[in]  lcd  pointer to the register overlay of the peripheral
+ *
+ *  @return     The highest priority pending interrupt
+ *
+ *  @retval     One of @ref DL_LCD_IIDX
+ */
+__STATIC_INLINE DL_LCD_IIDX DL_LCD_getPendingInterrupt(LCD_Regs *lcd)
+{
+    return ((DL_LCD_IIDX) lcd->INT_EVENT0.IIDX);
+}
+
+/**
+ *  @brief Enable LCD interrupts
+ *
+ *  @param[in] lcd              Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in] interruptMask    Bit mask of interrupts to enable. Bitwise OR of
+ *                              @ref DL_LCD_INTERRUPT.
+ */
+__STATIC_INLINE void DL_LCD_enableInterrupt(
+    LCD_Regs *lcd, uint32_t interruptMask)
+{
+    lcd->INT_EVENT0.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief Disable LCD interrupts
+ *
+ *  @param[in] lcd              Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in] interruptMask    Bit mask of interrupts to disable. Bitwise OR of
+ *                              @ref DL_LCD_INTERRUPT.
+ */
+__STATIC_INLINE void DL_LCD_disableInterrupt(
+    LCD_Regs *lcd, uint32_t interruptMask)
+{
+    lcd->INT_EVENT0.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief Check which LCD interrupts are enabled
+ *
+ *  @param[in]  lcd             Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in]  interruptMask   Bit mask of interrupts to check. Bitwise OR of
+ *                              @ref DL_LCD_INTERRUPT.
+ *
+ *  @return     Which of the requested LCD interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_LCD_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_LCD_getEnabledInterrupts(
+    LCD_Regs *lcd, uint32_t interruptMask)
+{
+    return (lcd->INT_EVENT0.IMASK & interruptMask);
+}
+
+/**
+ *  @brief Check interrupt flag of any LCD interrupt
+ *
+ *  Checks if any of the LCD interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  lcd             Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in]  interruptMask   Bit mask of interrupts to check. Bitwise OR of
+ *                              @ref DL_LCD_INTERRUPT.
+ *
+ *  @return     Which of the requested LCD interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_LCD_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_LCD_getRawInterruptStatus(
+    LCD_Regs *lcd, uint32_t interruptMask)
+{
+    return (lcd->INT_EVENT0.RIS & interruptMask);
+}
+
+/**
+ *  @brief Check interrupt flag of enabled LCD interrupts
+ *
+ *  Checks if any of the LCD interrupts that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  lcd             Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in]  interruptMask   Bit mask of interrupts to check. Bitwise OR of
+ *                              @ref DL_LCD_INTERRUPT.
+ *
+ *  @return     Which of the requested LCD interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_LCD_INTERRUPT values
+ *
+ *  @sa         DL_LCD_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_LCD_getEnabledInterruptStatus(
+    LCD_Regs *lcd, uint32_t interruptMask)
+{
+    return (lcd->INT_EVENT0.MIS & interruptMask);
+}
+
+/**
+ *  @brief Set LCD interrupts
+ *
+ *  @param[in] lcd              Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in] interruptMask    Bit mask of interrupts to set. Bitwise OR of
+ *                              @ref DL_LCD_INTERRUPT.
+ */
+__STATIC_INLINE void DL_LCD_setInterrupts(
+    LCD_Regs *lcd, uint32_t interruptMask)
+{
+    lcd->INT_EVENT0.ISET = interruptMask;
+}
+
+/**
+ *  @brief Clear pending LCD interrupts
+ *
+ *  @param[in] lcd              Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in] interruptMask    Bit mask of interrupts to clear. Bitwise OR of
+ *                              @ref DL_LCD_INTERRUPT.
+ */
+__STATIC_INLINE void DL_LCD_clearInterruptStatus(
+    LCD_Regs *lcd, uint32_t interruptMask)
+{
+    lcd->INT_EVENT0.ICLR = interruptMask;
+}
+
+/**
+ *  @brief Enable external synchronization
+ *
+ *  @param[in] lcd  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_enableExternalSync(LCD_Regs *lcd)
+{
+    lcd->LCDCTL0 |= LCD_LCDCTL0_LCDSYNCEXT_LCD_EXT_SYNC_ON;
+}
+
+/**
+ *  @brief Disable external synchronization
+ *
+ *  @param[in] lcd  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_disableExternalSync(LCD_Regs *lcd)
+{
+    lcd->LCDCTL0 &= ~(LCD_LCDCTL0_LCDSYNCEXT_MASK);
+}
+
+/**
+ *  @brief Checks if external synchronization is enabled
+ *
+ *  @param[in]  lcd  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If external synchronization is enabled
+ *
+ *  @retval     true if external synchronization enabled
+ *  @retval     false if external synchronization is disabled
+ */
+__STATIC_INLINE bool DL_LCD_isExternalSyncEnabled(LCD_Regs *lcd)
+{
+    return ((lcd->LCDCTL0 & LCD_LCDCTL0_LCDSYNCEXT_MASK) ==
+            LCD_LCDCTL0_LCDSYNCEXT_LCD_EXT_SYNC_ON);
+}
+
+/**
+ *  @brief Set the LCD frequency divider.
+ *
+ *  fLCD = fSOURCE / ((LCDDIVx + 1) × Value[LCDMXx])
+ *
+ *  @param[in]  lcd     Pointer to the register overlay for the peripheral
+ *  @param[in]  fDiv    The frequency divider to set.
+ *                      One of @ref DL_LCD_FREQ_DIVIDE
+ *
+ *  @pre        The LCD module must be off (LCDCTL0.LCDON == 0) before setting
+ *              this configuration.
+ */
+__STATIC_INLINE void DL_LCD_setFreqDiv(
+    LCD_Regs *lcd, DL_LCD_FREQ_DIVIDE fDiv)
+{
+    DL_Common_updateReg(
+        &lcd->LCDCTL0, (uint32_t) fDiv, LCD_LCDCTL0_LCDDIVX_MASK);
+}
+
+/**
+ *  @brief Get the LCD frequency divider
+ *
+ *  @param[in]  lcd     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current frequency divider
+ *
+ *  @retval     One of @ref DL_LCD_FREQ_DIVIDE
+ */
+__STATIC_INLINE DL_LCD_FREQ_DIVIDE DL_LCD_getFreqDiv(LCD_Regs *lcd)
+{
+    uint32_t fDiv = (lcd->LCDCTL0 & LCD_LCDCTL0_LCDDIVX_MASK);
+
+    return (DL_LCD_FREQ_DIVIDE)(fDiv);
+}
+
+/**
+ *  @brief Set the LCD mux rate
+ *
+ *  @param[in]  lcd        Pointer to the register overlay for the peripheral
+ *  @param[in]  muxRate    The mux rate to set. One of @ref DL_LCD_MUX_RATE
+ *
+ *
+ *  @pre        The LCD module must be off (LCDCTL0.LCDON == 0) before setting
+ *              this configuration. The LCD module can be disabled by calling
+ *              DL_LCD_disableModule.
+ *
+ */
+__STATIC_INLINE void DL_LCD_setMuxRate(
+    LCD_Regs *lcd, DL_LCD_MUX_RATE muxRate)
+{
+    DL_Common_updateReg(
+        &lcd->LCDCTL0, (uint32_t) muxRate, LCD_LCDCTL0_LCDMXX_MASK);
+}
+
+/**
+ *  @brief Get the LCD mux rate
+ *
+ *  @param[in]  lcd     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The mux rate
+ *
+ *  @retval     One of @ref DL_LCD_MUX_RATE
+ */
+__STATIC_INLINE DL_LCD_MUX_RATE DL_LCD_getMuxRate(LCD_Regs *lcd)
+{
+    uint32_t muxRate = (lcd->LCDCTL0 & LCD_LCDCTL0_LCDMXX_MASK);
+
+    return (DL_LCD_MUX_RATE)(muxRate);
+}
+
+/**
+ * @brief Turns LCD segments on
+ *
+ * @param lcd   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_turnSegmentsOn(LCD_Regs *lcd)
+{
+    lcd->LCDCTL0 |= LCD_LCDCTL0_LCDSON_LCD_SEG_ON;
+}
+
+/**
+ * @brief Turns LCD segments off
+ *
+ * Can be used to flash LCD applications by turning off segment lines
+ * and leaving LCD timing generator and R33 enabled.
+ *
+ * @param lcd   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_turnSegmentsOff(LCD_Regs *lcd)
+{
+    lcd->LCDCTL0 &= ~(LCD_LCDCTL0_LCDSON_MASK);
+}
+
+/**
+ *  @brief Set the waveform power mode
+ *
+ *  @param[in]  lcd                 Pointer to the register overlay for the
+ *                                  peripheral
+ *  @param[in]  waveformPowerMode   The power mode for LCD waveforms.
+ *                                  One of @ref DL_LCD_WAVEFORM_POWERMODE
+ *
+ *  @pre        The LCD module must be in 1/3 bias mode (LCDBIASSEL == 0)
+ *              before setting this configuration.
+ */
+__STATIC_INLINE void DL_LCD_setWaveformPowerMode(
+    LCD_Regs *lcd, DL_LCD_WAVEFORM_POWERMODE waveformPowerMode)
+{
+    DL_Common_updateReg(
+        &lcd->LCDCTL0, (uint32_t) waveformPowerMode, LCD_LCDCTL0_LCDLP_MASK);
+}
+
+/**
+ *  @brief Get the waveform power mode
+ *
+ *  @param[in]  lcd Pointer to the register overlay for the peripheral
+ *
+ *  @return     The waveform power mode
+ *
+ *  @retval     One of @ref DL_LCD_WAVEFORM_POWERMODE
+ */
+__STATIC_INLINE DL_LCD_WAVEFORM_POWERMODE DL_LCD_getWaveformPowerMode(
+    LCD_Regs *lcd)
+{
+    uint32_t waveformPowerMode = (lcd->LCDCTL0 & LCD_LCDCTL0_LCDLP_MASK);
+
+    return (DL_LCD_WAVEFORM_POWERMODE)(waveformPowerMode);
+}
+
+/**
+ * @brief Enables the LCD module
+ *
+ * @param lcd   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_enable(LCD_Regs *lcd)
+{
+    lcd->LCDCTL0 |= LCD_LCDCTL0_LCDON_LCD_MOD_ENABLE;
+}
+
+/**
+ * @brief Disables the LCD module
+ *
+ * @param lcd   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_disable(LCD_Regs *lcd)
+{
+    lcd->LCDCTL0 &= ~(LCD_LCDCTL0_LCDON_MASK);
+}
+
+/**
+ *  @brief Set the blinking frequency divider and blinking mode
+ *
+ *  @param[in] lcd          Pointer to the register overlay for the peripheral
+ *  @param[in] blinkFreqDiv The blinking frequency divider to set.
+ *                          One of @ref DL_LCD_BLINKING_DIVIDE
+ *  @param[in] blinkMode    The blinking mode to select.
+ *                          One of @ref DL_LCD_BLINKING_MODE
+ */
+__STATIC_INLINE void DL_LCD_setBlinkingControl(
+    LCD_Regs *lcd, DL_LCD_BLINKING_DIVIDE blinkFreqDiv,
+    DL_LCD_BLINKING_MODE blinkMode)
+{
+    DL_Common_updateReg(&lcd->LCDBLKCTL, (uint32_t) blinkFreqDiv |
+        (uint32_t) blinkMode, LCD_LCDBLKCTL_LCDBLKPREX_MASK |
+        LCD_LCDBLKCTL_LCDBLKMODX_MASK);
+}
+
+/**
+ *  @brief Get the blinking frequency divider
+ *
+ *  @param[in]  lcd Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current blinking frequency divider
+ *
+ *  @retval     One of @ref DL_LCD_BLINKING_DIVIDE
+ */
+__STATIC_INLINE DL_LCD_BLINKING_DIVIDE DL_LCD_getBlinkingFreqDiv(LCD_Regs *lcd)
+{
+    uint32_t blinkFreqDiv = (lcd->LCDBLKCTL & LCD_LCDBLKCTL_LCDBLKPREX_MASK);
+
+    return (DL_LCD_BLINKING_DIVIDE)(blinkFreqDiv);
+}
+
+/**
+ *  @brief Get the blinking mode
+ *
+ *  @param[in]  lcd Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current blinking mode
+ *
+ *  @retval     One of @ref DL_LCD_BLINKING_MODE
+ */
+__STATIC_INLINE DL_LCD_BLINKING_MODE DL_LCD_getBlinkingMode(LCD_Regs *lcd)
+{
+    uint32_t blinkMode = (lcd->LCDBLKCTL & LCD_LCDBLKCTL_LCDBLKMODX_MASK);
+
+    return (DL_LCD_BLINKING_MODE)(blinkMode);
+}
+
+/**
+ *  @brief Clear LCD blinking memory
+ *
+ *  Clears all blinking memory registers LCDBMx.
+ *  The bit is automatically reset when blinking memory cleared.
+ *
+ *  @param lcd   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_clearAllBlinkingMemoryRegs(LCD_Regs *lcd)
+{
+    DL_Common_updateReg(&lcd->LCDMEMCTL,
+        LCD_LCDMEMCTL_LCDCLRBM_CLR_BLNK_MEM_REGS, LCD_LCDMEMCTL_LCDCLRBM_MASK);
+}
+
+/**
+ *  @brief Clear LCD memory
+ *
+ *  Clears all memory registers LCDMx.
+ *  The bit is automatically reset when LCD memory cleared.
+ *
+ *  @param lcd   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_clearAllMemoryRegs(LCD_Regs *lcd)
+{
+    DL_Common_updateReg(&lcd->LCDMEMCTL, LCD_LCDMEMCTL_LCDCLRM_CLR_LCD_MEM_REGS,
+        LCD_LCDMEMCTL_LCDCLRM_MASK);
+}
+
+/**
+ *  @brief Select LCD memory registers for display
+ *
+ *  @param[in]  lcd     Pointer to the register overlay for the peripheral
+ *  @param[in]  dispSel The memory registers to select. One of @ref DL_LCD_DISP
+ *
+ *  @pre        LCDDISP can only be set by software when LCDBLKMODx is disabled.
+ *              Bit cleared/cannot be changed by software when
+ *              LCDBLKMODx == DL_LCD_BLINKING_MODE_INDIVIDUAL_SEGMENTS,
+ *              DL_LCD_BLINKING_MODE_ALL_SEGMENTS or if a mux mode = 5 selected.
+ */
+__STATIC_INLINE void DL_LCD_selectMemRegsForDisplay(
+    LCD_Regs *lcd, DL_LCD_DISP dispSel)
+{
+    DL_Common_updateReg(&lcd->LCDMEMCTL, (uint32_t) dispSel,
+        LCD_LCDMEMCTL_LCDDISP_MASK);
+}
+
+/**
+ *  @brief Get the LCD memory registers selected for display
+ *
+ *  When LCDBLKMODx = DL_LCD_BLINKING_MODE_TOGGLE, this bit reflects the
+ *  currently displayed memory but cannot be changed by software.
+ *  When returning to LCDBLKMODx is disabled, bit is cleared.
+ *
+ *  @param[in]  lcd Pointer to the register overlay for the peripheral
+ *
+ *  @return     LCD memory registers selected for display
+ *
+ *  @retval     One of @ref DL_LCD_DISP
+ */
+__STATIC_INLINE DL_LCD_DISP DL_LCD_getSelectedMemRegsForDisplay(LCD_Regs *lcd)
+{
+    uint32_t dispSel = (lcd->LCDMEMCTL & LCD_LCDMEMCTL_LCDDISP_MASK);
+
+    return (DL_LCD_DISP)(dispSel);
+}
+
+/**
+ * @brief Enables VBOOST on LCD module
+ *
+ * @param lcd   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_enableVBOOST(LCD_Regs *lcd)
+{
+    lcd->LCDVCTL |= LCD_LCDVCTL_LCDVBSTEN_ENABLE;
+}
+
+/**
+ * @brief Disables VBOOST on LCD module
+ *
+ * @param lcd   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_disableVBOOST(LCD_Regs *lcd)
+{
+    lcd->LCDVCTL &= ~(LCD_LCDVCTL_LCDVBSTEN_MASK);
+}
+
+/**
+ *  @brief Set charge pump frequency
+ *
+ *  @param[in] lcd              Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in] chargePumpFreq   The charge pump frequency to select.
+ *                              One of @ref DL_LCD_CHARGE_PUMP_FREQUENCY
+ *
+ */
+__STATIC_INLINE void DL_LCD_setChargePumpFreq(
+    LCD_Regs *lcd, DL_LCD_CHARGE_PUMP_FREQUENCY chargePumpFreq)
+{
+    DL_Common_updateReg(&lcd->LCDVCTL, (uint32_t) chargePumpFreq,
+        LCD_LCDVCTL_LCDCPFSELX_MASK);
+}
+
+/**
+ *  @brief Get the charge pump frequency
+ *
+ *  @param[in]  lcd Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current charge pump frequency
+ *
+ *  @retval     One of @ref DL_LCD_CHARGE_PUMP_FREQUENCY
+ */
+__STATIC_INLINE DL_LCD_CHARGE_PUMP_FREQUENCY DL_LCD_getChargePumpFreq(
+    LCD_Regs *lcd)
+{
+    uint32_t chargePumpFreq = (lcd->LCDVCTL & LCD_LCDVCTL_LCDCPFSELX_MASK);
+
+    return (DL_LCD_CHARGE_PUMP_FREQUENCY)(chargePumpFreq);
+}
+
+/**
+ *  @brief Set internal reference voltage
+ *
+ *  @param[in] lcd          Pointer to the register overlay for the peripheral
+ *  @param[in] vrefInternal The internal reference voltage to select.
+ *                          One of @ref DL_LCD_VREF_INTERNAL
+ *
+ */
+__STATIC_INLINE void DL_LCD_setVREFInternal(
+    LCD_Regs *lcd, DL_LCD_VREF_INTERNAL vrefInternal)
+{
+    DL_Common_updateReg(&lcd->LCDVCTL, (uint32_t) vrefInternal,
+        LCD_LCDVCTL_VLCDX_MASK);
+}
+
+/**
+ *  @brief Get the internal reference voltage
+ *
+ *  @param[in]  lcd Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current internal reference voltage
+ *
+ *  @retval     One of @ref DL_LCD_VREF_INTERNAL
+ */
+__STATIC_INLINE DL_LCD_VREF_INTERNAL DL_LCD_getVREFInternal(LCD_Regs *lcd)
+{
+    uint32_t vrefInternal = (lcd->LCDVCTL & LCD_LCDVCTL_VLCDX_MASK);
+
+    return (DL_LCD_VREF_INTERNAL)(vrefInternal);
+}
+
+/**
+ * @brief Enables charge pump
+ *
+ * @param   lcd    Pointer to the register overlay for the peripheral
+ *
+ * @pre     VLCD must be generated internally (VLCDEXT = 0) and VLCD > 0 or
+ *          VLCDREFx > 0 in order to use this configuration.
+ */
+__STATIC_INLINE void DL_LCD_enableChargePump(LCD_Regs *lcd)
+{
+    lcd->LCDVCTL |= LCD_LCDVCTL_LCDCPEN_CP_ENABLE;
+}
+
+/**
+ * @brief Disables charge pump
+ *
+ * @param lcd   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_disableChargePump(LCD_Regs *lcd)
+{
+    lcd->LCDVCTL &= ~(LCD_LCDVCTL_LCDCPEN_MASK);
+}
+
+/**
+ * @brief Enables internal reference voltage
+ *
+ * @param lcd   Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_LCD_enableVREFInternal(LCD_Regs *lcd)
+{
+    lcd->LCDVCTL |= LCD_LCDVCTL_LCDREFEN_INT_REF_ENABLE;
+}
+
+/**
+ * @brief Disables internal reference voltage
+ *
+ * @param lcd   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_disableVREFInternal(LCD_Regs *lcd)
+{
+    lcd->LCDVCTL &= ~(LCD_LCDVCTL_LCDREFEN_MASK);
+}
+
+/**
+ *  @brief Set source for R33
+ *
+ *  @param[in] lcd          Pointer to the register overlay for the peripheral
+ *  @param[in] r33Source    The internal reference voltage to select.
+ *                          One of @ref DL_LCD_R33_SOURCE
+ *
+ */
+__STATIC_INLINE void DL_LCD_setR33source(
+    LCD_Regs *lcd, DL_LCD_R33_SOURCE r33Source)
+{
+    DL_Common_updateReg(&lcd->LCDVCTL, (uint32_t) r33Source,
+        LCD_LCDVCTL_LCDSELVDD_MASK);
+}
+
+/**
+ *  @brief Get the source for R33
+ *
+ *  @param[in]  lcd Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current source for R33
+ *
+ *  @retval     One of @ref DL_LCD_R33_SOURCE
+ */
+__STATIC_INLINE DL_LCD_R33_SOURCE DL_LCD_getR33Source(LCD_Regs *lcd)
+{
+    uint32_t r33Source = (lcd->LCDVCTL & LCD_LCDVCTL_LCDSELVDD_MASK);
+
+    return (DL_LCD_R33_SOURCE)(r33Source);
+}
+
+/**
+ *  @brief Select internal bias power mode
+ *
+ *  @param[in]  lcd         Pointer to the register overlay for the peripheral
+ *  @param[in]  powerMode   The power mode to use for generating bias voltage
+ *                          for LCD. One of @ref DL_LCD_POWER_MODE
+ *
+ *  @pre    The user must first enable the internal bias voltage resistor
+ *          divider by calling @ref DL_LCD_enableInternalBias
+ */
+__STATIC_INLINE void DL_LCD_setInternalBiasPowerMode(
+    LCD_Regs *lcd, DL_LCD_POWER_MODE powerMode)
+{
+    DL_Common_updateReg(&lcd->LCDVCTL, (uint32_t) powerMode,
+        LCD_LCDVCTL_LCD_HP_LP_MASK);
+}
+
+/**
+ *  @brief Get power mode
+ *
+ *  @param[in]  lcd Pointer to the register overlay for the peripheral
+ *
+ *  @return     The power mode
+ *
+ *  @retval     One of @ref DL_LCD_POWER_MODE
+ */
+__STATIC_INLINE DL_LCD_POWER_MODE DL_LCD_getPowerMode(LCD_Regs *lcd)
+{
+    uint32_t powerMode = (lcd->LCDVCTL & LCD_LCDVCTL_LCDSELVDD_MASK);
+
+    return (DL_LCD_POWER_MODE)(powerMode);
+}
+
+/**
+ *  @brief Set bias voltage source
+ *
+ *  @param[in]  lcd                 Pointer to the register overlay for the
+ *                                  peripheral
+ *  @param[in]  biasVoltageSource   The bias voltage source.
+ *                                  One of @ref DL_LCD_BIAS_VOLTAGE_SOURCE
+ *
+ *  @pre        The user must first enable the internal bias voltage resistor
+                divider by calling @ref DL_LCD_enableInternalBias
+ */
+__STATIC_INLINE void DL_LCD_setBiasVoltageSource(
+    LCD_Regs *lcd, DL_LCD_BIAS_VOLTAGE_SOURCE biasVoltageSource)
+{
+    DL_Common_updateReg(&lcd->LCDVCTL, (uint32_t) biasVoltageSource,
+        LCD_LCDVCTL_VLCDSEL_VDD_R33_MASK);
+}
+
+/**
+ *  @brief Get bias voltage source
+ *
+ *  @param[in]  lcd Pointer to the register overlay for the peripheral
+ *
+ *  @return     The bias voltage source
+ *
+ *  @retval     One of @ref DL_LCD_BIAS_VOLTAGE_SOURCE
+ */
+__STATIC_INLINE DL_LCD_BIAS_VOLTAGE_SOURCE DL_LCD_getBiasVoltageSource(
+    LCD_Regs *lcd)
+{
+    uint32_t biasVoltageSource = (
+        lcd->LCDVCTL & LCD_LCDVCTL_VLCDSEL_VDD_R33_MASK);
+
+    return (DL_LCD_BIAS_VOLTAGE_SOURCE)(biasVoltageSource);
+}
+
+/**
+ * @brief Enables internal bias voltage resistor divider
+ *
+ * @param lcd   Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_LCD_enableInternalBias(LCD_Regs *lcd)
+{
+    lcd->LCDVCTL |= LCD_LCDVCTL_LCDINTBIASEN_INT_BIAS_ENABLE;
+}
+
+/**
+ * @brief Disables internal bias voltage resistor divider
+ *
+ * @param lcd   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LCD_disableInternalBias(LCD_Regs *lcd)
+{
+    lcd->LCDVCTL &= ~(LCD_LCDVCTL_LCDINTBIASEN_MASK);
+}
+
+/**
+ *  @brief Select LCD bias
+ *
+ *  @param[in]  lcd     Pointer to the register overlay for the peripheral
+ *  @param[in]  biasSel The bias. One of @ref DL_LCD_BIAS
+ *
+ *  @note       This bit (LCDBIASSEL) is ignored in static mode and for 2-mux,
+ *              3-mux, and 4-mux LCD modes
+ */
+__STATIC_INLINE void DL_LCD_setBias(
+    LCD_Regs *lcd, DL_LCD_BIAS biasSel)
+{
+    DL_Common_updateReg(
+        &lcd->LCDVCTL, (uint32_t) biasSel, LCD_LCDVCTL_LCDBIASSEL_MASK);
+}
+
+/**
+ *  @brief Get bias for LCD
+ *
+ *  @param[in]  lcd Pointer to the register overlay for the peripheral
+ *
+ *  @return     The bias for the LCD
+ *
+ *  @retval     One of @ref DL_LCD_BIAS
+ */
+__STATIC_INLINE DL_LCD_BIAS DL_LCD_getBias(LCD_Regs *lcd)
+{
+    uint32_t biasSel = (lcd->LCDVCTL & LCD_LCDVCTL_LCDBIASSEL_MASK);
+
+    return (DL_LCD_BIAS)(biasSel);
+}
+
+/**
+ *  @brief Set reference mode for R13 voltage
+ *
+ *  @param[in] lcd      Pointer to the register overlay for the peripheral
+ *  @param[in] refMode  Ref mode. One of @ref DL_LCD_REFERENCE_MODE
+ *
+ */
+__STATIC_INLINE void DL_LCD_setRefMode(
+    LCD_Regs *lcd, DL_LCD_REFERENCE_MODE refMode)
+{
+    DL_Common_updateReg(
+        &lcd->LCDVCTL, (uint32_t) refMode, LCD_LCDVCTL_LCDREFMODE_MASK);
+}
+
+/**
+ *  @brief Get reference mode for R13 voltage
+ *
+ *  @param[in]  lcd Pointer to the register overlay for the peripheral
+ *
+ *  @return     Voltage reference mode
+ *
+ *  @retval     One of @ref DL_LCD_REFERENCE_MODE
+ */
+__STATIC_INLINE DL_LCD_REFERENCE_MODE DL_LCD_getRefMode(LCD_Regs *lcd)
+{
+    uint32_t refMode = (lcd->LCDVCTL & LCD_LCDVCTL_LCDREFMODE_MASK);
+
+    return (DL_LCD_REFERENCE_MODE)(refMode);
+}
+
+/**
+ *  @brief Write to bits in LCD memory index register
+ *
+ *  @param[in]  lcd         Pointer to the register overlay for the peripheral
+ *  @param[in]  memIndex    Index of LCDMx register to write to.
+ *                          One of @ref DL_LCD_MEMORY.
+ *  @param[in]  mask        Registers to set in LCDMx register.
+ *                          Bitwise OR of @ref DL_LCD_MEMORY_BIT.
+ */
+__STATIC_INLINE void DL_LCD_writeMemory(
+    LCD_Regs *lcd, DL_LCD_MEMORY memIndex, uint32_t mask)
+{
+    lcd -> LCDM[(uint32_t) memIndex] = mask;
+}
+
+/**
+ *  @brief Set bits in LCD memory index register
+ *
+ *  @param[in]  lcd         Pointer to the register overlay for the peripheral
+ *  @param[in]  memIndex    Index of LCDMx register to write to.
+ *                          One of @ref DL_LCD_MEMORY.
+ *  @param[in]  mask        Registers to set in LCDMx register.
+ *                          Bitwise OR of @ref DL_LCD_MEMORY_BIT.
+ */
+__STATIC_INLINE void DL_LCD_setMemory(
+    LCD_Regs *lcd, DL_LCD_MEMORY memIndex, uint32_t mask)
+{
+    lcd -> LCDM[(uint32_t) memIndex] |= mask;
+}
+
+/**
+ *  @brief Toggle bits in LCD memory index register
+ *
+ *  @param[in]  lcd         Pointer to the register overlay for the peripheral
+ *  @param[in]  memIndex    Index of LCDMx register to write to.
+ *                          One of @ref DL_LCD_MEMORY.
+ *  @param[in]  mask        Registers to set in LCDMx register.
+ *                          Bitwise OR of @ref DL_LCD_MEMORY_BIT.
+ */
+__STATIC_INLINE void DL_LCD_toggleMemory(
+    LCD_Regs *lcd, DL_LCD_MEMORY memIndex, uint32_t mask)
+{
+    lcd -> LCDM[(uint32_t) memIndex] ^= mask;
+}
+
+/**
+ *  @brief Clear bits in LCD memory index register
+ *
+ *  @param[in]  lcd         Pointer to the register overlay for the peripheral
+ *  @param[in]  memIndex    Index of LCDMx register to write to.
+ *                          One of @ref DL_LCD_MEMORY.
+ *  @param[in]  mask        Registers to set in LCDMx register.
+ *                          Bitwise OR of @ref DL_LCD_MEMORY_BIT.
+ */
+__STATIC_INLINE void DL_LCD_clearMemory(
+    LCD_Regs *lcd, DL_LCD_MEMORY memIndex, uint32_t mask)
+{
+    lcd -> LCDM[(uint32_t) memIndex] &= ~(mask);
+}
+
+/**
+ *  @brief Get bits in LCD memory index register
+ *
+ *  @param[in]  lcd         Pointer to the register overlay for the peripheral
+ *  @param[in]  memIndex    Index of LCDMx register to read from.
+ *
+ *  @retval     32 bit value of register
+ *
+ *  @sa         DL_LCD_MEMORY_BIT
+ */
+__STATIC_INLINE uint32_t DL_LCD_getMemory(
+    LCD_Regs *lcd, DL_LCD_MEMORY memIndex)
+{
+    return lcd -> LCDM[(uint32_t) memIndex];
+}
+
+/**
+ *  @brief Write to bits in LCD blinking memory index register
+ *
+ *  @param[in]  lcd         Pointer to the register overlay for the peripheral
+ *  @param[in]  memIndex    Index of LCDMx register to write to.
+ *                          One of @ref DL_LCD_BLINKING_MEMORY.
+ *  @param[in]  mask        Registers to set in LCDBMx register.
+ *                          Bitwise OR of @ref DL_LCD_BLINK_MEMORY_BIT.
+ */
+__STATIC_INLINE void DL_LCD_writeBlinkingMemory(
+    LCD_Regs *lcd, DL_LCD_BLINKING_MEMORY memIndex, uint32_t mask)
+{
+    lcd -> LCDBM[(uint32_t) memIndex] = mask;
+}
+
+/**
+ *  @brief Set bits in LCD blinking memory index register
+ *
+ *  @param[in]  lcd         Pointer to the register overlay for the peripheral
+ *  @param[in]  memIndex    Index of LCDMx register to write to.
+ *                          One of @ref DL_LCD_BLINKING_MEMORY.
+ *  @param[in]  mask        Registers to set in LCDBMx register.
+ *                          Bitwise OR of @ref DL_LCD_BLINK_MEMORY_BIT.
+ */
+__STATIC_INLINE void DL_LCD_setBlinkingMemory(
+    LCD_Regs *lcd, DL_LCD_BLINKING_MEMORY memIndex, uint32_t mask)
+{
+    lcd -> LCDBM[(uint32_t) memIndex] |= mask;
+}
+
+/**
+ *  @brief Toggle bits in LCD blinking memory index register
+ *
+ *  @param[in]  lcd         Pointer to the register overlay for the peripheral
+ *  @param[in]  memIndex    Index of LCDMx register to write to.
+ *                          One of @ref DL_LCD_BLINKING_MEMORY.
+ *  @param[in]  mask        Registers to set in LCDBMx register.
+ *                          Bitwise OR of @ref DL_LCD_BLINK_MEMORY_BIT.
+ */
+__STATIC_INLINE void DL_LCD_toggleBlinkingMemory(
+    LCD_Regs *lcd, DL_LCD_BLINKING_MEMORY memIndex, uint32_t mask)
+{
+    lcd -> LCDBM[(uint32_t) memIndex] ^= mask;
+}
+
+/**
+ *  @brief Clear bits in LCD blinking memory index register
+ *
+ *  @param[in]  lcd         Pointer to the register overlay for the peripheral
+ *  @param[in]  memIndex    Index of LCDMx register to write to.
+ *                          One of @ref DL_LCD_BLINKING_MEMORY.
+ *  @param[in]  mask        Registers to set in LCDBMx register.
+ *                          Bitwise OR of @ref DL_LCD_BLINK_MEMORY_BIT.
+ */
+__STATIC_INLINE void DL_LCD_clearBlinkingMemory(
+    LCD_Regs *lcd, DL_LCD_BLINKING_MEMORY memIndex, uint32_t mask)
+{
+    lcd -> LCDBM[(uint32_t) memIndex] &= ~(mask);
+}
+
+/**
+ *  @brief Get bits in LCD blinking memory index register
+ *
+ *  @param[in]  lcd         Pointer to the register overlay for the peripheral
+ *  @param[in]  memIndex    Index of LCDMx register to read from.
+ *
+ *  @retval     32 bit value of register
+ *
+ *  @sa         DL_LCD_BLINK_MEMORY_BIT
+ */
+__STATIC_INLINE uint32_t DL_LCD_getBlinkingMemory(
+    LCD_Regs *lcd, DL_LCD_BLINKING_MEMORY memIndex)
+{
+    return lcd -> LCDBM[(uint32_t) memIndex];
+}
+
+/**
+ *  @brief Set number of cycles to enable voltage generation circuitry
+ *
+ *  @param[in] lcd      Pointer to the register overlay for the peripheral
+ *  @param[in] cycles   The number of cycles to enable voltage generation circuitry.
+ *                      One of @ref DL_LCD_VREFGEN_CYCLES.
+ */
+__STATIC_INLINE void DL_LCD_setVrefOnTimeCycles(
+    LCD_Regs *lcd, DL_LCD_VREFGEN_CYCLES cycles)
+{
+    DL_Common_updateReg(&lcd->LCDVREFCFG, (uint32_t) cycles,
+        LCD_LCDVREFCFG_ONTIME_MASK);
+}
+
+/**
+ *  @brief Get the number of cycles set to enable voltage generation circuitry
+ *
+ *  @param[in]  lcd  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The number of cycles
+ *
+ *  @retval     One of @ref DL_LCD_VREFGEN_CYCLES
+ */
+__STATIC_INLINE DL_LCD_VREFGEN_CYCLES DL_LCD_getVrefOnTimeCycles(LCD_Regs *lcd)
+{
+    uint32_t cycles = (lcd->LCDVREFCFG & LCD_LCDVREFCFG_ONTIME_MASK);
+
+    return (DL_LCD_VREFGEN_CYCLES)(cycles);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_LCD__ */
+
+#endif /* ti_dl_dl_lcd__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_lfss.c
+++ b/mspm0/source/ti/driverlib/dl_lfss.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_lfss.h>
+
+#ifdef __MSPM0_HAS_LFSS__
+#endif /* __MSPM0_HAS_LFSS__ */

--- a/mspm0/source/ti/driverlib/dl_lfss.h
+++ b/mspm0/source/ti/driverlib/dl_lfss.h
@@ -1,0 +1,1890 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_lfss.h
+ *  @brief      LFSS(Low Frequency Sub-System) Peripheral Interface
+ *  @defgroup   LFSS Low Frequeuncy Sub-System (LFSS)
+ *
+ *  @anchor ti_devices_msp_dl_lfss_Overview
+ *  # Overview
+ *  The Low Frequency Sub-System (LFSS) Driver Library allows full configuration
+ *  of the MSPM0 LFSS module.
+ *  The LFSS IP enables a separate, dedicated battery supply used for
+ *  maintaining continuous operation of real time clock (RTC), tamper detection
+ *  input / output (TIO) module, an independent asynchronous watchdog timer
+ *  (IWDT) and a small scratchpad memory storage (SPM).
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup LFSS
+ * @{
+ */
+#ifndef ti_dl_dl_lfss__include
+#define ti_dl_dl_lfss__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#if defined(__MSPM0_HAS_LFSS__) || defined(DOXYGEN__INCLUDE)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+
+/** @addtogroup DL_LFSS_TAMPERIO_INTERRUPT
+ *  @{
+ */
+
+/**
+ * @brief LFSS Tamper IO 0 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_0                   (LFSS_CPU_INT_IMASK_TIO0_SET)
+
+/**
+ * @brief LFSS Tamper IO 1 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_1                   (LFSS_CPU_INT_IMASK_TIO1_SET)
+
+/**
+ * @brief LFSS Tamper IO 2 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_2                   (LFSS_CPU_INT_IMASK_TIO2_SET)
+
+/**
+ * @brief LFSS Tamper IO 3 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_3                   (LFSS_CPU_INT_IMASK_TIO3_SET)
+
+/**
+ * @brief LFSS Tamper IO 4 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_4                   (LFSS_CPU_INT_IMASK_TIO4_SET)
+
+/**
+ * @brief LFSS Tamper IO 5 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_5                   (LFSS_CPU_INT_IMASK_TIO6_SET)
+
+/**
+ * @brief LFSS Tamper IO 6 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_6                   (LFSS_CPU_INT_IMASK_TIO6_SET)
+
+/**
+ * @brief LFSS Tamper IO 7 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_7                   (LFSS_CPU_INT_IMASK_TIO7_SET)
+
+/**
+ * @brief LFSS Tamper IO 8 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_8                   (LFSS_CPU_INT_IMASK_TIO8_SET)
+
+/**
+ * @brief LFSS Tamper IO 9 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_9                   (LFSS_CPU_INT_IMASK_TIO9_SET)
+
+/**
+ * @brief LFSS Tamper IO 10 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_10                   (LFSS_CPU_INT_IMASK_TIO10_SET)
+
+/**
+ * @brief LFSS Tamper IO 11 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_11                   (LFSS_CPU_INT_IMASK_TIO11_SET)
+
+/**
+ * @brief LFSS Tamper IO 12 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_12                   (LFSS_CPU_INT_IMASK_TIO12_SET)
+
+/**
+ * @brief LFSS Tamper IO 13 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_13                   (LFSS_CPU_INT_IMASK_TIO13_SET)
+
+/**
+ * @brief LFSS Tamper IO 14 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_14                   (LFSS_CPU_INT_IMASK_TIO14_SET)
+
+/**
+ * @brief LFSS Tamper IO 15 interrupt
+ */
+#define DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_15                   (LFSS_CPU_INT_IMASK_TIO15_SET)
+
+/** @}*/
+
+/** @addtogroup DL_LFSS_TAMPERIO_EVENT
+ *  @{
+ */
+/**
+ * @brief LFSS Tamper IO 0 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_0                   (LFSS_GEN_EVENT_IMASK_TIO0_SET)
+
+/**
+ * @brief LFSS Tamper IO 1 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_1                   (LFSS_GEN_EVENT_IMASK_TIO1_SET)
+
+/**
+ * @brief LFSS Tamper IO 2 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_2                   (LFSS_GEN_EVENT_IMASK_TIO2_SET)
+
+/**
+ * @brief LFSS Tamper IO 3 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_3                   (LFSS_GEN_EVENT_IMASK_TIO3_SET)
+
+/**
+ * @brief LFSS Tamper IO 4 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_4                   (LFSS_GEN_EVENT_IMASK_TIO4_SET)
+
+/**
+ * @brief LFSS Tamper IO 5 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_5                   (LFSS_GEN_EVENT_IMASK_TIO5_SET)
+
+/**
+ * @brief LFSS Tamper IO 6 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_6                   (LFSS_GEN_EVENT_IMASK_TIO6_SET)
+
+/**
+ * @brief LFSS Tamper IO 7 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_7                   (LFSS_GEN_EVENT_IMASK_TIO7_SET)
+
+/**
+ * @brief LFSS Tamper IO 8 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_8                   (LFSS_GEN_EVENT_IMASK_TIO8_SET)
+
+/**
+ * @brief LFSS Tamper IO 9 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_9                   (LFSS_GEN_EVENT_IMASK_TIO9_SET)
+
+/**
+ * @brief LFSS Tamper IO 10 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_10                   (LFSS_GEN_EVENT_IMASK_TIO10_SET)
+
+/**
+ * @brief LFSS Tamper IO 11 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_11                   (LFSS_GEN_EVENT_IMASK_TIO11_SET)
+
+/**
+ * @brief LFSS Tamper IO 12 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_12                   (LFSS_GEN_EVENT_IMASK_TIO12_SET)
+
+/**
+ * @brief LFSS Tamper IO 13 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_13                   (LFSS_GEN_EVENT_IMASK_TIO13_SET)
+
+/**
+ * @brief LFSS Tamper IO 14 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_14                   (LFSS_GEN_EVENT_IMASK_TIO14_SET)
+
+/**
+ * @brief LFSS Tamper IO 15 event
+ */
+#define DL_LFSS_TAMPERIO_EVENT_TAMPERIO_15                   (LFSS_GEN_EVENT_IMASK_TIO15_SET)
+
+/** @}*/
+
+/**
+ * @brief Individual Tamper IO pin enable
+ */
+#define LFSS_TAMPER_IO_PIN_ENABLE 0x1
+
+/**
+ * @brief Individual Tamper IO pin mask
+ */
+#define LFSS_TAMPER_IO_PIN_MASK 0x1
+
+/*! @enum DL_LFSS_TAMPERIO */
+typedef enum {
+    /*! LFSS Tamper IO 0 */
+    DL_LFSS_TAMPERIO_0 = 0x0000,
+    /*! LFSS Tamper IO 1 */
+    DL_LFSS_TAMPERIO_1 = 0x0001,
+    /*! LFSS Tamper IO 2 */
+    DL_LFSS_TAMPERIO_2 = 0x0002,
+    /*! LFSS Tamper IO 3 */
+    DL_LFSS_TAMPERIO_3 = 0x0003,
+    /*! LFSS Tamper IO 4 */
+    DL_LFSS_TAMPERIO_4 = 0x0004,
+    /*! LFSS Tamper IO 5 */
+    DL_LFSS_TAMPERIO_5 = 0x0005,
+    /*! LFSS Tamper IO 6 */
+    DL_LFSS_TAMPERIO_6 = 0x0006,
+    /*! LFSS Tamper IO 7 */
+    DL_LFSS_TAMPERIO_7 = 0x0007,
+    /*! LFSS Tamper IO 8 */
+    DL_LFSS_TAMPERIO_8 = 0x0008,
+    /*! LFSS Tamper IO 9 */
+    DL_LFSS_TAMPERIO_9 = 0x0009,
+    /*! LFSS Tamper IO 10 */
+    DL_LFSS_TAMPERIO_10 = 0x000A,
+    /*! LFSS Tamper IO 11 */
+    DL_LFSS_TAMPERIO_11 = 0x000B,
+    /*! LFSS Tamper IO 12 */
+    DL_LFSS_TAMPERIO_12 = 0x000C,
+    /*! LFSS Tamper IO 13 */
+    DL_LFSS_TAMPERIO_13 = 0x000D,
+    /*! LFSS Tamper IO 14 */
+    DL_LFSS_TAMPERIO_14 = 0x000E,
+    /*! LFSS Tamper IO 15 */
+    DL_LFSS_TAMPERIO_15 = 0x000F,
+} DL_LFSS_TAMPERIO;
+
+/*! @enum DL_LFSS_TAMPERIO_VALUE */
+typedef enum {
+    /*! LFSS Tamper IO Value is 0 */
+    DL_LFSS_TAMPERIO_VALUE_0 = 0x00000,
+    /*! LFSS Tamper IO Value is 1 */
+    DL_LFSS_TAMPERIO_VALUE_1 = 0x0001,
+} DL_LFSS_TAMPERIO_VALUE;
+
+/*! @enum DL_LFSS_TAMPERIO_OUTPUT_SOURCE */
+typedef enum {
+    /*! The TOUT register is the source for the tamper output (TOUT) control */
+    DL_LFSS_TAMPERIO_OUTPUT_SOURCE_TOUT = LFSS_TIOCTL_TOUTSEL_TOUT,
+    /*! LFCLK is the source for the tamper output (TOUT) control */
+    DL_LFSS_TAMPERIO_OUTPUT_SOURCE_LFCLK = LFSS_TIOCTL_TOUTSEL_LFCLKEXT,
+    /*! The heart beat generator is the source for the tamper output (TOUT)
+     *  control */
+    DL_LFSS_TAMPERIO_OUTPUT_SOURCE_HEARTBEAT = LFSS_TIOCTL_TOUTSEL_HEARTBEAT,
+    /*! The time stamp event is the source for the tamper output (TOUT)
+     *  control */
+    DL_LFSS_TAMPERIO_OUTPUT_SOURCE_TIME_STAMP_EVENT = LFSS_TIOCTL_TOUTSEL_TSEVTSTAT,
+} DL_LFSS_TAMPERIO_OUTPUT_SOURCE;
+
+/*! @enum DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH */
+typedef enum {
+    /*! No filtering on the Tamper IO beyond CDS synchronization sample */
+    DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH_NONE = LFSS_TIOCTL_FILTEREN_NO_FLT,
+    /*! Pulses on the Tamper IO less than 30us are filtered */
+    DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH_30_USEC = LFSS_TIOCTL_FILTEREN_FLT_1,
+    /*! Pulses on the Tamper IO less than 100us are filtered */
+    DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH_100_USEC = LFSS_TIOCTL_FILTEREN_FLT_2,
+    /*! Pulses on the Tamper IO less than 200us are filtered */
+    DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH_200_USEC = LFSS_TIOCTL_FILTEREN_FLT_3,
+} DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH;
+
+/*! @enum DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY */
+typedef enum {
+    /*! Edge detection polarity is disabled */
+    DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY_DISABLE = LFSS_TIOCTL_POLARITY_DISABLE,
+    /*! Enables rising edge detection of input event */
+    DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY_RISE = LFSS_TIOCTL_POLARITY_RISE,
+    /*! Enables falling edge detection of input event */
+    DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY_FALL = LFSS_TIOCTL_POLARITY_FALL,
+    /*! Enables both rising and falling edge detection of input event */
+    DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY_BOTH = LFSS_TIOCTL_POLARITY_BOTH,
+
+} DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY;
+
+/*! @enum DL_LFSS_TAMPERIO_MODE */
+typedef enum {
+    /*! The Tamper IO is set to tamper mode */
+    DL_LFSS_TAMPERIO_MODE_TAMPER = LFSS_TIOCTL_IOMUX_TAMPER,
+    /*! The Tamper IO is set to IOMUX mode */
+    DL_LFSS_TAMPERIO_MODE_IOMUX = LFSS_TIOCTL_IOMUX_IOMUX
+} DL_LFSS_TAMPERIO_MODE;
+
+/*! @enum DL_LFSS_HEARTBEAT_INTERVAL */
+typedef enum {
+    /*! Heart beat generator interval is 0.125 sec */
+    DL_LFSS_HEARTBEAT_INTERVAL_0_125_SEC = LFSS_HEARTBEAT_HBINTERVAL_HBINT0P125,
+    /*! Heart beat generator interval is 0.25 sec */
+    DL_LFSS_HEARTBEAT_INTERVAL_0_25_SEC = LFSS_HEARTBEAT_HBINTERVAL_HBINT0P25,
+    /*! Heart beat generator interval is 0.5 sec */
+    DL_LFSS_HEARTBEAT_INTERVAL_05_SEC = LFSS_HEARTBEAT_HBINTERVAL_HBINT0P5,
+    /*! Heart beat generator interval is 1 sec */
+    DL_LFSS_HEARTBEAT_INTERVAL_1_SEC = LFSS_HEARTBEAT_HBINTERVAL_HBINT1,
+    /*! Heart beat generator interval is 2 sec */
+    DL_LFSS_HEARTBEAT_INTERVAL_2_SEC = LFSS_HEARTBEAT_HBINTERVAL_HBINT2,
+    /*! Heart beat generator interval is 4 sec */
+    DL_LFSS_HEARTBEAT_INTERVAL_4_SEC = LFSS_HEARTBEAT_HBINTERVAL_HBINT4,
+    /*! Heart beat generator interval is 8 sec */
+    DL_LFSS_HEARTBEAT_INTERVAL_8_SEC = LFSS_HEARTBEAT_HBINTERVAL_HBINT8,
+    /*! Heart beat generator interval is 16 sec */
+    DL_LFSS_HEARTBEAT_INTERVAL_16_SEC = LFSS_HEARTBEAT_HBINTERVAL_HBINT16,
+} DL_LFSS_HEARTBEAT_INTERVAL;
+
+/*! @enum DL_LFSS_HEARTBEAT_PULSE_WIDTH */
+typedef enum {
+    /*! Heart beat generator pulse width is 1 msec */
+    DL_LFSS_HEARTBEAT_PULSE_WIDTH_1_MSEC = LFSS_HEARTBEAT_HBWIDTH_HBPWDTH1,
+    /*! Heart beat generator pulse width is 2 msec */
+    DL_LFSS_HEARTBEAT_PULSE_WIDTH_2_MSEC = LFSS_HEARTBEAT_HBWIDTH_HBPWDTH2,
+    /*! Heart beat generator pulse width is 4 msec */
+    DL_LFSS_HEARTBEAT_PULSE_WIDTH_4_MSEC = LFSS_HEARTBEAT_HBWIDTH_HBPWDTH4,
+    /*! Heart beat generator pulse width is 8 msec */
+    DL_LFSS_HEARTBEAT_PULSE_WIDTH_8_MSEC = LFSS_HEARTBEAT_HBWIDTH_HBPWDTH8,
+    /*! Heart beat generator pulse width is 16 msec */
+    DL_LFSS_HEARTBEAT_PULSE_WIDTH_16_MSEC = LFSS_HEARTBEAT_HBWIDTH_HBPWDTH16,
+    /*! Heart beat generator pulse width is 32 msec */
+    DL_LFSS_HEARTBEAT_PULSE_WIDTH_32_MSEC = LFSS_HEARTBEAT_HBWIDTH_HBPWDTH32,
+    /*! Heart beat generator pulse width is 64 msec */
+    DL_LFSS_HEARTBEAT_PULSE_WIDTH_64_MSEC = LFSS_HEARTBEAT_HBWIDTH_HBPWDTH64,
+    /*! Heart beat generator pulse width is 128 msec */
+    DL_LFSS_HEARTBEAT_PULSE_WIDTH_128_MSEC = LFSS_HEARTBEAT_HBWIDTH_HBPWDTH128,
+} DL_LFSS_HEARTBEAT_PULSE_WIDTH;
+
+/*! @enum DL_LFSS_HEARTBEAT_MODE */
+typedef enum {
+    /*! Heart beat generator mode is disabled */
+    DL_LFSS_HEARTBEAT_MODE_DISABLED = LFSS_HEARTBEAT_HBMODE_HB_DIS,
+    /*! Heart beat generator mode is always enabled */
+    DL_LFSS_HEARTBEAT_MODE_ALWAYS_ON = LFSS_HEARTBEAT_HBMODE_HB_ALLWAYS,
+    /*! Heart beat generator mode is enabled when time stamp event is detected */
+    DL_LFSS_HEARTBEAT_MODE_TIME_STAMP = LFSS_HEARTBEAT_HBMODE_HB_TS,
+    /*! Heart beat generator mode is enabled when the main power supply fails */
+    DL_LFSS_HEARTBEAT_MODE_POWER_FAIL = LFSS_HEARTBEAT_HBMODE_HB_VDDFAIL,
+} DL_LFSS_HEARTBEAT_MODE;
+
+/*! @enum DL_LFSS_TAMPERIO_IIDX */
+typedef enum {
+    /*! LFSS Tamper interrupt index for Tamper IO 0 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_0 = LFSS_CPU_INT_IIDX_STAT_TIO0,
+    /*! LFSS Tamper interrupt index for Tamper IO 1 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_1 = LFSS_CPU_INT_IIDX_STAT_TIO1,
+    /*! LFSS Tamper interrupt index for Tamper IO 2 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_2 = LFSS_CPU_INT_IIDX_STAT_TIO2,
+    /*! LFSS Tamper interrupt index for Tamper IO 3 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_3 = LFSS_CPU_INT_IIDX_STAT_TIO3,
+    /*! LFSS Tamper interrupt index for Tamper IO 4 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_4 = LFSS_CPU_INT_IIDX_STAT_TIO4,
+    /*! LFSS Tamper interrupt index for Tamper IO 5 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_5 = LFSS_CPU_INT_IIDX_STAT_TIO5,
+    /*! LFSS Tamper interrupt index for Tamper IO 6 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_6 = LFSS_CPU_INT_IIDX_STAT_TIO6,
+    /*! LFSS Tamper interrupt index for Tamper IO 7 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_7 = LFSS_CPU_INT_IIDX_STAT_TIO7,
+    /*! LFSS Tamper interrupt index for Tamper IO 8 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_8 = LFSS_CPU_INT_IIDX_STAT_TIO8,
+    /*! LFSS Tamper interrupt index for Tamper IO 9 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_9 = LFSS_CPU_INT_IIDX_STAT_TIO9,
+    /*! LFSS Tamper interrupt index for Tamper IO 10 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_10 = LFSS_CPU_INT_IIDX_STAT_TIO10,
+    /*! LFSS Tamper interrupt index for Tamper IO 11 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_11 = LFSS_CPU_INT_IIDX_STAT_TIO11,
+    /*! LFSS Tamper interrupt index for Tamper IO 12 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_12 = LFSS_CPU_INT_IIDX_STAT_TIO12,
+    /*! LFSS Tamper interrupt index for Tamper IO 13 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_13 = LFSS_CPU_INT_IIDX_STAT_TIO13,
+    /*! LFSS Tamper interrupt index for Tamper IO 14 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_14 = LFSS_CPU_INT_IIDX_STAT_TIO14,
+    /*! LFSS Tamper interrupt index for Tamper IO 15 */
+    DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_15 = LFSS_CPU_INT_IIDX_STAT_TIO15,
+} DL_LFSS_TAMPERIO_IIDX;
+
+/*! @enum DL_LFSS_SCRATCHPAD_MEM_WORD */
+typedef enum {
+    /*! LFSS Scratch Pad memory word 0 */
+    DL_LFSS_SCRATCHPAD_MEM_WORD_0 = 0x0000,
+    /*! LFSS Scratch Pad memory word 1 */
+    DL_LFSS_SCRATCHPAD_MEM_WORD_1 = 0x0001,
+    /*! LFSS Scratch Pad memory word 2 */
+    DL_LFSS_SCRATCHPAD_MEM_WORD_2 = 0x0002,
+    /*! LFSS Scratch Pad memory word 3 */
+    DL_LFSS_SCRATCHPAD_MEM_WORD_3 = 0x0003,
+    /*! LFSS Scratch Pad memory word 4 */
+    DL_LFSS_SCRATCHPAD_MEM_WORD_4 = 0x0004,
+    /*! LFSS Scratch Pad memory word 5 */
+    DL_LFSS_SCRATCHPAD_MEM_WORD_5 = 0x0005,
+    /*! LFSS Scratch Pad memory word 6 */
+    DL_LFSS_SCRATCHPAD_MEM_WORD_6 = 0x0006,
+    /*! LFSS Scratch Pad memory word 7 */
+    DL_LFSS_SCRATCHPAD_MEM_WORD_7 = 0x0007,
+} DL_LFSS_SCRATCHPAD_MEM_WORD;
+
+/*! @enum DL_LFSS_SCRATCHPAD_MEM_BYTE */
+typedef enum {
+    /*! LFSS Scratch Pad memory byte 0 of the given Scratch Pad memory word */
+    DL_LFSS_SCRATCHPAD_MEM_BYTE_0 = 0x0000,
+    /*! LFSS Scratch Pad memory byte 1 of the given Scratch Pad memory word */
+    DL_LFSS_SCRATCHPAD_MEM_BYTE_1 = 0x0001,
+    /*! LFSS Scratch Pad memory byte 2 of the given Scratch Pad memory word */
+    DL_LFSS_SCRATCHPAD_MEM_BYTE_2 = 0x0002,
+    /*! LFSS Scratch Pad memory byte 3 of the given Scratch Pad memory word */
+    DL_LFSS_SCRATCHPAD_MEM_BYTE_3 = 0x0003,
+} DL_LFSS_SCRATCHPAD_MEM_BYTE;
+
+/*! @enum DL_LFSS_IWDT_CLOCK_DIVIDE */
+typedef enum {
+    /*! WDT Clock divide by 1 */
+    DL_LFSS_IWDT_CLOCK_DIVIDE_1 = 0x00000000,
+    /*! WDT Clock divide by 2 */
+    DL_LFSS_IWDT_CLOCK_DIVIDE_2 = 0x00000001,
+    /*! WDT Clock divide by 3 */
+    DL_LFSS_IWDT_CLOCK_DIVIDE_3 = 0x00000002,
+    /*! WDT Clock divide by 4 */
+    DL_LFSS_IWDT_CLOCK_DIVIDE_4 = 0x00000003,
+    /*! WDT Clock divide by 5 */
+    DL_LFSS_IWDT_CLOCK_DIVIDE_5 = 0x00000004,
+    /*! WDT Clock divide by 6 */
+    DL_LFSS_IWDT_CLOCK_DIVIDE_6 = 0x00000005,
+    /*! WDT Clock divide by 7 */
+    DL_LFSS_IWDT_CLOCK_DIVIDE_7 = 0x00000006,
+    /*! WDT Clock divide by 8 */
+    DL_LFSS_IWDT_CLOCK_DIVIDE_8 = 0x00000007
+} DL_LFSS_IWDT_CLOCK_DIVIDE;
+
+/*! @enum DL_LFSS_IWDT_TIMER_PERIOD */
+typedef enum {
+    /*! WDT 2^6 timer period count */
+    DL_LFSS_IWDT_TIMER_PERIOD_6_BITS = LFSS_WDTCTL_PER_PER_EN_6,
+    /*! WDT 2^8 timer period count */
+    DL_LFSS_IWDT_TIMER_PERIOD_8_BITS = LFSS_WDTCTL_PER_PER_EN_8,
+    /*! WDT 2^10 timer period count */
+    DL_LFSS_IWDT_TIMER_PERIOD_10_BITS = LFSS_WDTCTL_PER_PER_EN_10,
+    /*! WDT 2^12 timer period count */
+    DL_LFSS_IWDT_TIMER_PERIOD_12_BITS = LFSS_WDTCTL_PER_PER_EN_12,
+    /*! WDT 2^15 timer period count */
+    DL_LFSS_IWDT_TIMER_PERIOD_15_BITS = LFSS_WDTCTL_PER_PER_EN_15,
+    /*! WDT 2^18 timer period count */
+    DL_LFSS_IWDT_TIMER_PERIOD_18_BITS = LFSS_WDTCTL_PER_PER_EN_18,
+    /*! WDT 2^21 timer period count */
+    DL_LFSS_IWDT_TIMER_PERIOD_21_BITS = LFSS_WDTCTL_PER_PER_EN_21,
+    /*! WDT 2^25 timer period count */
+    DL_LFSS_IWDT_TIMER_PERIOD_25_BITS = LFSS_WDTCTL_PER_PER_EN_25
+} DL_LFSS_IWDT_TIMER_PERIOD;
+
+/* clang-format on */
+
+/**
+ *  @brief      Enable output inversion for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_enableOutputInversion(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] |=
+        LFSS_TIOCTL_OUTINV_ENABLE;
+}
+
+/**
+ *  @brief      Checks if output inversion is enabled for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *
+ *  @return     Returns if output inversion is enabled
+ *
+ *  @retval     true  Output inversion for the Tamper I/O is enabled
+ *  @retval     false Output inversion for the Tamper I/O is disabled
+ */
+__STATIC_INLINE bool DL_LFSS_TamperIO_isOutputInversionEnabled(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    return ((lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] &
+                LFSS_TIOCTL_OUTINV_MASK) == LFSS_TIOCTL_OUTINV_ENABLE);
+}
+
+/**
+ *  @brief      Disable output inversion for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_disableOutputInversion(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] &=
+        ~(LFSS_TIOCTL_OUTINV_MASK);
+}
+
+/**
+ *  @brief      Selects the source for the tamper output (TOUT) control for
+ *              the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *  @param[in]  source    The source for the tamper output control.
+ *                        One of @ref DL_LFSS_TAMPERIO_OUTPUT_SOURCE.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_setOutputSource(LFSS_Regs *lfss,
+    DL_LFSS_TAMPERIO tamperIO, DL_LFSS_TAMPERIO_OUTPUT_SOURCE source)
+{
+    DL_Common_updateReg(&lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO],
+        (uint32_t) source, LFSS_TIOCTL_TOUTSEL_MASK);
+}
+
+/**
+ *  @brief      Gets the source for the tamper output (TOUT) control for
+ *              the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *
+ *  @return     The output source of the tamper IO
+ *
+ *  @retval     One of @ref DL_LFSS_TAMPERIO_OUTPUT_SOURCE
+ */
+__STATIC_INLINE DL_LFSS_TAMPERIO_OUTPUT_SOURCE
+DL_LFSS_TamperIO_getOutputSource(LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    return ((DL_LFSS_TAMPERIO_OUTPUT_SOURCE)(
+        lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] &
+        LFSS_TIOCTL_TOUTSEL_MASK));
+}
+
+/**
+ *  @brief      Selects the filter width for the digital glitch filter for
+ *              the specified Tamper IO
+ *
+ *  The tamper event detection allows to configure one or more tamper IO’s to
+ *  trigger a timestamp event and to generate an interrupt to the CPU. To
+ *  minimize false triggers, a digital filter circuit is inserted into the IO
+ *  path. Only pulses that are longer than the configured filter width will be
+ *  registered as a tamper event.
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *  @param[in]  width     The width of the digital glitch filter. Pulses
+ *                        smaller than this width will be filtered.
+ *                        One of @ref DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_setGlitchFilterWidth(LFSS_Regs *lfss,
+    DL_LFSS_TAMPERIO tamperIO, DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH width)
+{
+    DL_Common_updateReg(&lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO],
+        (uint32_t) width, LFSS_TIOCTL_FILTEREN_MASK);
+}
+
+/**
+ *  @brief      Gets the filter width for the digital glitch filter for
+ *              the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *
+ *  @return     The digital glitch filter width
+ *
+ *  @retval     One of @ref DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH
+ */
+__STATIC_INLINE DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH
+DL_LFSS_TamperIO_getGlitchFilterWidth(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    return ((DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH)(
+        lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] &
+        LFSS_TIOCTL_FILTEREN_MASK));
+}
+
+/**
+ *  @brief      Selects the edge detection polarity for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *  @param[in]  polarity  The edge detection polarity.
+ *                        One of @ref DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_setEdgeDetectionPolarity(LFSS_Regs *lfss,
+    DL_LFSS_TAMPERIO tamperIO,
+    DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY polarity)
+{
+    DL_Common_updateReg(&lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO],
+        (uint32_t) polarity, LFSS_TIOCTL_POLARITY_MASK);
+}
+
+/**
+ *  @brief      Gets the edge detection polarity for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *
+ *  @return     The edge detection polarity for the specified Tamper IO
+ *
+ *  @retval     One of @ref DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY
+ */
+__STATIC_INLINE DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY
+DL_LFSS_TamperIO_getEdgeDetectionPolarity(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    return ((DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY)(
+        lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] &
+        LFSS_TIOCTL_POLARITY_MASK));
+}
+
+/**
+ *  @brief      Enable internal pull-up resistor for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_enableInternalPullUp(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] |=
+        LFSS_TIOCTL_PIPU_ENABLE;
+}
+
+/**
+ *  @brief      Checks if internal pull-up resistor is enabled for the specified
+ *              Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *
+ *  @return     Returns the internal pull-up resistor enabled status
+ *
+ *  @retval     true  Internal pull-up resistor for the Tamper I/O is enabled
+ *  @retval     false Internal pull-up resistor for the Tamper I/O is disabled
+ */
+__STATIC_INLINE bool DL_LFSS_TamperIO_isInternalPullUpEnabled(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    return ((lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] &
+                LFSS_TIOCTL_PIPU_MASK) == LFSS_TIOCTL_PIPU_ENABLE);
+}
+
+/**
+ *  @brief      Disable internal pull-up resistor for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_disableInternalPullUp(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] &=
+        ~(LFSS_TIOCTL_PIPU_MASK);
+}
+
+/**
+ *  @brief      Enable internal pull-down resistor for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_enableInternalPullDown(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] |=
+        LFSS_TIOCTL_PIPD_ENABLE;
+}
+
+/**
+ *  @brief      Checks if internal pull-down resistor is enabled for the specified
+ *              Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *
+ *  @return     Returns the internal pull-down resistor enabled status
+ *
+ *  @retval     true  Internal pull-down resistor for the Tamper I/O is enabled
+ *  @retval     false Internal pull-down resistor for the Tamper I/O is disabled
+ */
+__STATIC_INLINE bool DL_LFSS_TamperIO_isInternalPullDownEnabled(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    return ((lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] &
+                LFSS_TIOCTL_PIPD_MASK) == LFSS_TIOCTL_PIPD_ENABLE);
+}
+
+/**
+ *  @brief      Disable internal pull-down resistor for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_disableInternalPullDown(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] &=
+        ~(LFSS_TIOCTL_PIPD_MASK);
+}
+
+/**
+ *  @brief      Enable input path for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_enableInput(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] |=
+        LFSS_TIOCTL_INENA_ENABLE;
+}
+
+/**
+ *  @brief      Checks if input is enabled for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *
+ *  @return     Returns the input enabled status
+ *
+ *  @retval     true  Input for the Tamper I/O is enabled
+ *  @retval     false Input for the Tamper I/O is disabled
+ */
+__STATIC_INLINE bool DL_LFSS_TamperIO_isInputEnabled(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    return ((lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] &
+                LFSS_TIOCTL_INENA_MASK) == LFSS_TIOCTL_INENA_ENABLE);
+}
+
+/**
+ *  @brief      Disable input path for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_disableInput(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] &=
+        ~(LFSS_TIOCTL_INENA_MASK);
+}
+
+/**
+ *  @brief      Selects the mode for the specified Tamper IO
+ *
+ * The tamper IOs have two modes of operation:
+ *     - In IOMUX mode (@ref DL_LFSS_TAMPERIO_MODE_IOMUX), the tamper IO input
+ *         and output path are connected to the SoC IOMUX module and the IO can
+ *         be used as a second function.
+ *     - In tamper mode (@ref DL_LFSS_TAMPERIO_MODE_TAMPER), the tamper IO is
+ *         completely controlled by the VBAT IP and will remain functional
+ *         during the power loss of the main supply or during SHUTDOWN mode.
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO to configure.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *  @param[in]  mode      The mode for the specified tamper IO.
+ *                        One of @ref DL_LFSS_TAMPERIO_MODE.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_setMode(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO, DL_LFSS_TAMPERIO_MODE mode)
+{
+    DL_Common_updateReg(&lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO],
+        (uint32_t) mode, LFSS_TIOCTL_IOMUX_MASK);
+}
+
+/**
+ *  @brief      Gets the mode for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *
+ *  @return     The mode for the specified Tamper IO
+ *
+ *  @retval     One of @ref DL_LFSS_TAMPERIO_MODE
+ */
+__STATIC_INLINE DL_LFSS_TAMPERIO_MODE DL_LFSS_TamperIO_getMode(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    return ((DL_LFSS_TAMPERIO_MODE)(
+        lfss->IPSPECIFIC_TIO.TIOCTL[(uint32_t) tamperIO] &
+        LFSS_TIOCTL_IOMUX_MASK));
+}
+
+/**
+ *  @brief      Enable data output for the specified Tamper IO
+ *
+ *  @param[in]  lfss       Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO   Specifies the tamper IO to configure.
+ *                         One of @ref DL_LFSS_TAMPERIO.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_enableOutput(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    volatile uint32_t *pReg = &lfss->IPSPECIFIC_TIO.TOE3_0;
+
+    /* Point to correct TOE register */
+    pReg = (uint32_t *) ((uint8_t *) pReg + (uint8_t) tamperIO);
+
+    /* Set just the one bit for the specified tamper IO */
+    *pReg |= LFSS_TAMPER_IO_PIN_ENABLE;
+}
+
+/**
+ *  @brief      Disable data output for the specified Tamper IO
+ *
+ *  @param[in]  lfss       Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO   Specifies the tamper IO to configure.
+ *                         One of @ref DL_LFSS_TAMPERIO.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_disableOutput(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    volatile uint32_t *pReg = &lfss->IPSPECIFIC_TIO.TOE3_0;
+
+    /* Point to correct TOE register */
+    pReg = (uint32_t *) ((uint8_t *) pReg + (uint8_t) tamperIO);
+
+    /* Clear just the one bit for the specified tamper IO */
+    *pReg &= ~(LFSS_TAMPER_IO_PIN_ENABLE);
+}
+
+/**
+ *  @brief      Checks if data output for the specified Tamper IO is enabled
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *
+ *  @return     If data output for the specified Tamper IO is enabled
+ *
+ *  @retval     true   Data output for the tamper IO is enabled
+ *  @retval     false  Data output for the tamper IO is disabled
+ */
+__STATIC_INLINE uint32_t DL_LFSS_TamperIO_isOutputEnabled(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    volatile uint32_t *pReg = &lfss->IPSPECIFIC_TIO.TOE3_0;
+
+    /* Point to correct TIOCTLx register */
+    pReg = (uint32_t *) ((uint8_t *) pReg + (uint8_t) tamperIO);
+
+    /* Get just the one bit for the specified tamper IO */
+    return ((*pReg & LFSS_TAMPER_IO_PIN_MASK) == LFSS_TAMPER_IO_PIN_ENABLE);
+}
+
+/**
+ *  @brief      Enable data output value as zero for the specified Tamper IO
+ *
+ *  @param[in]  lfss       Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO   Specifies the tamper IO to configure.
+ *                         One of @ref DL_LFSS_TAMPERIO.
+ *  @param[in]  outVal     The data value to set the tamper IO output to.
+ *                         One of @ref DL_LFSS_TAMPERIO_VALUE.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_setOutputValue(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO, DL_LFSS_TAMPERIO_VALUE outVal)
+{
+    volatile uint32_t *pReg = &lfss->IPSPECIFIC_TIO.TOUT3_0;
+
+    /* Point to correct TOE register */
+    pReg = (uint32_t *) ((uint8_t *) pReg + (uint8_t) tamperIO);
+
+    DL_Common_updateReg(pReg, (uint32_t) outVal, LFSS_TAMPER_IO_PIN_MASK);
+}
+
+/**
+ *  @brief      Gets the output data value for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *
+ *  @return     The output data value for the specified tamper IO
+ *
+ *  @retval     One of @ref DL_LFSS_TAMPERIO_VALUE
+ */
+__STATIC_INLINE DL_LFSS_TAMPERIO_VALUE DL_LFSS_TamperIO_getOutputValue(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    volatile uint32_t *pReg = &lfss->IPSPECIFIC_TIO.TOUT3_0;
+
+    /* Point to correct TOE register */
+    pReg = (uint32_t *) ((uint8_t *) pReg + (uint8_t) tamperIO);
+
+    uint32_t outVal = *pReg & LFSS_TAMPER_IO_PIN_MASK;
+
+    return (DL_LFSS_TAMPERIO_VALUE)(outVal);
+}
+
+/**
+ *  @brief      Gets the input data value for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  tamperIO  Specifies the tamper IO.
+ *                        One of @ref DL_LFSS_TAMPERIO
+ *
+ *  @return     The input data value for the specified tamper IO
+ *
+ *  @retval     One of @ref DL_LFSS_TAMPERIO_VALUE
+ */
+__STATIC_INLINE DL_LFSS_TAMPERIO_VALUE DL_LFSS_TamperIO_getInputValue(
+    LFSS_Regs *lfss, DL_LFSS_TAMPERIO tamperIO)
+{
+    const volatile uint32_t *pReg = &lfss->IPSPECIFIC_TIO.TIN3_0;
+
+    /* Point to correct TOE register */
+    pReg = (uint32_t *) ((uint8_t *) pReg + (uint8_t) tamperIO);
+
+    uint32_t inputVal = *pReg & LFSS_TAMPER_IO_PIN_MASK;
+
+    return (DL_LFSS_TAMPERIO_VALUE)(inputVal);
+}
+
+/**
+ *  @brief      Sets the interval for the heart beat generator
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  interval  The interval of the heart beat generator.
+ *                        One of @ref DL_LFSS_HEARTBEAT_INTERVAL
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_setHeartBeatInterval(
+    LFSS_Regs *lfss, DL_LFSS_HEARTBEAT_INTERVAL interval)
+{
+    DL_Common_updateReg(&lfss->IPSPECIFIC_TIO.HEARTBEAT, (uint32_t) interval,
+        LFSS_HEARTBEAT_HBINTERVAL_MASK);
+}
+
+/**
+ *  @brief      Gets the interval for the heart beat generator
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *
+ *  @return     The interval for the heart beat generator.
+ *
+ *  @retval     One of @ref DL_LFSS_HEARTBEAT_INTERVAL
+ */
+__STATIC_INLINE DL_LFSS_HEARTBEAT_INTERVAL
+DL_LFSS_TamperIO_getHeartBeatInterval(LFSS_Regs *lfss)
+{
+    uint32_t interval =
+        lfss->IPSPECIFIC_TIO.HEARTBEAT & LFSS_HEARTBEAT_HBINTERVAL_MASK;
+
+    return (DL_LFSS_HEARTBEAT_INTERVAL)(interval);
+}
+
+/**
+ *  @brief      Sets the pulse width for the heart beat generator
+ *
+ *  @param[in]  lfss   Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  width  The pulse width of the heart beat generator.
+ *                     One of @ref DL_LFSS_HEARTBEAT_PULSE_WIDTH
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_setHeartBeatPulseWidth(
+    LFSS_Regs *lfss, DL_LFSS_HEARTBEAT_PULSE_WIDTH width)
+{
+    DL_Common_updateReg(&lfss->IPSPECIFIC_TIO.HEARTBEAT, (uint32_t) width,
+        LFSS_HEARTBEAT_HBWIDTH_MASK);
+}
+
+/**
+ *  @brief      Gets the pulse width for the heart beat generator
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *
+ *  @return     The pulse width for the heart beat generator.
+ *
+ *  @retval     One of @ref DL_LFSS_HEARTBEAT_PULSE_WIDTH
+ */
+__STATIC_INLINE DL_LFSS_HEARTBEAT_PULSE_WIDTH
+DL_LFSS_TamperIO_getHeartBeatPulseWidth(LFSS_Regs *lfss)
+{
+    uint32_t width =
+        (lfss->IPSPECIFIC_TIO.HEARTBEAT & LFSS_HEARTBEAT_HBWIDTH_MASK);
+
+    return (DL_LFSS_HEARTBEAT_PULSE_WIDTH)(width);
+}
+
+/**
+ *  @brief      Sets the mode for the heart beat generator
+ *
+ *  @param[in]  lfss  Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  mode  The mode of the heart beat generator.
+ *                    One of @ref DL_LFSS_HEARTBEAT_MODE
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_setHeartBeatMode(
+    LFSS_Regs *lfss, DL_LFSS_HEARTBEAT_MODE mode)
+{
+    DL_Common_updateReg(&lfss->IPSPECIFIC_TIO.HEARTBEAT, (uint32_t) mode,
+        LFSS_HEARTBEAT_HBMODE_MASK);
+}
+
+/**
+ *  @brief      Gets the pulse mode for the heart beat generator
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *
+ *  @return     The pulse mode for the heart beat generator.
+ *
+ *  @retval     One of @ref DL_LFSS_HEARTBEAT_MODE
+ */
+__STATIC_INLINE DL_LFSS_HEARTBEAT_MODE DL_LFSS_TamperIO_getHeartBeatMode(
+    LFSS_Regs *lfss)
+{
+    uint32_t mode =
+        (lfss->IPSPECIFIC_TIO.HEARTBEAT & LFSS_HEARTBEAT_HBMODE_MASK);
+
+    return (DL_LFSS_HEARTBEAT_MODE)(mode);
+}
+
+/**
+ *  @brief      Enable write protection lock of the TIOCTL and HEARTBEAT
+ *              registers from accidental updates
+ *
+ *  When enabled, the TIOCTL and HEARTBEAT registers will have read-only access.
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_enableWriteProtectLock(LFSS_Regs *lfss)
+{
+    lfss->IPSPECIFIC_TIO.TIOLOCK =
+        (LFSS_TIOLOCK_PROTECT_SET | LFSS_TIOLOCK_KEY_UNLOCK_W);
+}
+
+/**
+ *  @brief      Checks if write protection lock of the TIOCTL and HEARTBEAT
+ *              registers is enabled for the specified Tamper IO
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *
+ *  @return     Returns the enabled status of the write protection lock
+ *
+ *  @retval     true  Write protection lock is enabled
+ *  @retval     false Write protection lock is disabled
+ */
+__STATIC_INLINE bool DL_LFSS_TamperIO_isWriteProtectLockEnabled(
+    LFSS_Regs *lfss)
+{
+    return ((lfss->IPSPECIFIC_TIO.TIOLOCK & LFSS_TIOLOCK_PROTECT_MASK) ==
+            LFSS_TIOLOCK_PROTECT_SET);
+}
+
+/**
+ *  @brief      Disable write protection lock of the TIOCTL and HEARTBEAT
+ *              registers
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_disableWriteProtectLock(LFSS_Regs *lfss)
+{
+    lfss->IPSPECIFIC_TIO.TIOLOCK =
+        (LFSS_TIOLOCK_PROTECT_CLR | LFSS_TIOLOCK_KEY_UNLOCK_W);
+}
+
+/**
+ * @brief Enables the Watchdog module
+ *
+ * @param lfss        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LFSS_IWDT_enableModule(LFSS_Regs *lfss)
+{
+    lfss->IPSPECIFIC_WDT.WDTEN =
+        (LFSS_WDTEN_KEY_UNLOCK_W | LFSS_WDTEN_ENABLE_SET);
+}
+
+/**
+ * @brief Disables the Watchdog module
+ *
+ * @param lfss        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LFSS_IWDT_disableModule(LFSS_Regs *lfss)
+{
+    lfss->IPSPECIFIC_WDT.WDTEN =
+        (LFSS_WDTEN_KEY_UNLOCK_W | LFSS_WDTEN_ENABLE_CLR);
+}
+
+/**
+ * @brief Returns if Watchdog module is on
+ *
+ * @param lfss        Pointer to the register overlay for the peripheral
+ *
+ * @return true  Watchdog is enabled
+ * @return false Watchdog is disabled
+ */
+__STATIC_INLINE bool DL_LFSS_IWDT_isModuleEnabled(LFSS_Regs *lfss)
+{
+    return ((lfss->IPSPECIFIC_WDT.WDTEN & LFSS_WDTEN_ENABLE_MASK) ==
+            LFSS_WDTEN_ENABLE_SET);
+}
+
+/**
+ * @brief Enables the Watchdog free run control
+ *
+ *  When enabled, the Watchdog will continue to free run and ignores the state
+ *  of the CPU halted debug state
+ *
+ * @param lfss        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LFSS_IWDT_enableFreeRun(LFSS_Regs *lfss)
+{
+    lfss->IPSPECIFIC_WDT.WDTDBGCTL = LFSS_WDTDBGCTL_FREE_RUN;
+}
+
+/**
+ * @brief Disables the Watchdog free run control
+ *
+ * @param lfss        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_LFSS_IWDT_disableFreeRun(LFSS_Regs *lfss)
+{
+    lfss->IPSPECIFIC_WDT.WDTDBGCTL = LFSS_WDTDBGCTL_FREE_STOP;
+}
+
+/**
+ * @brief Returns if Watchdog free run control is enabled
+ *
+ * @param lfss        Pointer to the register overlay for the peripheral
+ *
+ * @return true  Watchdog free run control is enabled
+ * @return false Watchdog free run control is disabled
+ */
+__STATIC_INLINE bool DL_LFSS_IWDT_isFreeRunEnabled(LFSS_Regs *lfss)
+{
+    return ((lfss->IPSPECIFIC_WDT.WDTDBGCTL & LFSS_WDTDBGCTL_FREE_MASK) ==
+            LFSS_WDTDBGCTL_FREE_RUN);
+}
+
+/**
+ *  @brief      Sets the clock divider for the WDT module
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  divider   The WDT clock divider to set.
+ *                        One of @ref DL_LFSS_IWDT_CLOCK_DIVIDE.
+ */
+__STATIC_INLINE void DL_LFSS_IWDT_setClockDivider(
+    LFSS_Regs *lfss, DL_LFSS_IWDT_CLOCK_DIVIDE divider)
+{
+    DL_Common_updateReg(&lfss->IPSPECIFIC_WDT.WDTCTL,
+        ((uint32_t) divider | LFSS_WDTCTL_KEY_UNLOCK_W),
+        LFSS_WDTCTL_CLKDIV_MASK | LFSS_WDTCTL_KEY_MASK);
+}
+
+/**
+ *  @brief      Gets the clock divider for the WDT module
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *
+ *  @return     The clock divider for the WDT module
+ *
+ *  @retval     One of @ref DL_LFSS_IWDT_CLOCK_DIVIDE
+ */
+__STATIC_INLINE DL_LFSS_IWDT_CLOCK_DIVIDE DL_LFSS_IWDT_getClockDivider(
+    LFSS_Regs *lfss)
+{
+    uint32_t divider =
+        (lfss->IPSPECIFIC_WDT.WDTCTL & LFSS_WDTCTL_CLKDIV_MASK) + (uint32_t) 1;
+
+    return (DL_LFSS_IWDT_CLOCK_DIVIDE)(divider);
+}
+
+/**
+ *  @brief      Sets the timer period for the WDT module
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  period    The WDT timer period to set.
+ *                        One of @ref DL_LFSS_IWDT_TIMER_PERIOD.
+ */
+__STATIC_INLINE void DL_LFSS_IWDT_setTimerPeriod(
+    LFSS_Regs *lfss, DL_LFSS_IWDT_TIMER_PERIOD period)
+{
+    DL_Common_updateReg(&lfss->IPSPECIFIC_WDT.WDTCTL,
+        ((uint32_t) period | LFSS_WDTCTL_KEY_UNLOCK_W),
+        LFSS_WDTCTL_PER_MASK | LFSS_WDTCTL_KEY_MASK);
+}
+
+/*!
+ *  @brief      Get the timer period for the WDT module
+ *
+ *  @param[in]  lfss  Pointer to the register overlay for peripheral
+ *
+ *  @return     The current timer period for the WDT module
+ *
+ *  @retval     One of @ref DL_LFSS_IWDT_TIMER_PERIOD
+ */
+__STATIC_INLINE DL_LFSS_IWDT_TIMER_PERIOD DL_LFSS_IWDT_getTimerPeriod(
+    LFSS_Regs *lfss)
+{
+    uint32_t period = (lfss->IPSPECIFIC_WDT.WDTCTL & LFSS_WDTCTL_PER_MASK);
+
+    return (DL_LFSS_IWDT_TIMER_PERIOD)(period);
+}
+
+/*!
+ *  @brief      Restarts the Watchdog
+ *
+ *  @param[in]  lfss  Pointer to the register overlay for peripheral
+ */
+__STATIC_INLINE void DL_LFSS_IWDT_restart(LFSS_Regs *lfss)
+{
+    lfss->IPSPECIFIC_WDT.WDTCNTRST = LFSS_WDTCNTRST_RESTART_VALUE;
+}
+
+/**
+ * @brief Returns if Watchdog module is running
+ *
+ * @param lfss        Pointer to the register overlay for the peripheral
+ *
+ * @return true  Watchdog module is running
+ * @return false Watchdog counter has stopped
+ */
+__STATIC_INLINE bool DL_LFSS_IWDT_isWatchdogRunning(LFSS_Regs *lfss)
+{
+    return ((lfss->IPSPECIFIC_WDT.WDTSTAT & LFSS_WDTSTAT_RUN_MASK) ==
+            LFSS_WDTSTAT_RUN_RUN);
+}
+
+/**
+ *  @brief      Enable write protection lock of the WDTEN and WDTCTL
+ *              registers from accidental updates
+ *
+ *  When enabled, the WDTEN and WDTCTL registers will have read-only access.
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ */
+__STATIC_INLINE void DL_LFSS_IWDT_enableWriteProtect(LFSS_Regs *lfss)
+{
+    lfss->IPSPECIFIC_WDT.WDTLOCK =
+        (LFSS_WDTLOCK_PROTECT_SET | LFSS_WDTLOCK_KEY_UNLOCK_W);
+}
+
+/**
+ *  @brief      Checks if write protection lock of the WDTEN and WDTCTL
+ *              registers is enabled
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *
+ *  @return     Returns the enabled status of the write protection lock
+ *
+ *  @retval     true  Write protection lock is enabled
+ *  @retval     false Write protection lock is disabled
+ */
+__STATIC_INLINE bool DL_LFSS_IWDT_isWriteProtectEnabled(LFSS_Regs *lfss)
+{
+    return ((lfss->IPSPECIFIC_WDT.WDTLOCK & LFSS_WDTLOCK_PROTECT_MASK) ==
+            LFSS_WDTLOCK_PROTECT_SET);
+}
+
+/**
+ *  @brief      Disable write protection lock of the WDTEN and WDTCTL
+ *              registers
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ */
+__STATIC_INLINE void DL_LFSS_IWDT_disableWriteProtect(LFSS_Regs *lfss)
+{
+    lfss->IPSPECIFIC_WDT.WDTLOCK =
+        (LFSS_WDTLOCK_PROTECT_CLR | LFSS_WDTLOCK_KEY_UNLOCK_W);
+}
+
+/**
+ *  @brief      Write a word in scratch pad memory
+ *
+ *  The VBAT scratch pad memory is register based memory that will retain data
+ *  as long as VBAT is supplied. Refer to the device TRM for details on the
+ *  specific size and implementation of the scratch pad memory.
+ *
+ *  This API wil write 32-bit data to the selected word in the scratch pad
+ *  memory.
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  memIndex  The specified scratch pad memory word to write to.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_WORD
+ *  @param[in]  data      The 32-bit data to write to the specified scratch pad
+ *                        memory word. Value in range of [0x0, 0xFFFFFFF].
+ */
+__STATIC_INLINE void DL_LFSS_writeScratchPadData32(
+    LFSS_Regs *lfss, DL_LFSS_SCRATCHPAD_MEM_WORD memIndex, uint32_t data)
+{
+    lfss->IPSPECIFIC_MEM.SPMEM[(uint32_t) memIndex] = data;
+}
+
+/**
+ *  @brief      Write to a single byte in scratch pad memory
+ *
+ *  The VBAT scratch pad memory is register based memory that will retain data
+ *  as long as VBAT is supplied. Refer to the device TRM for details on the
+ *  specific size and implementation of the scratch pad memory.
+ *
+ *  This API will write 8-bit data to the selected byte in the scratch pad
+ *  memory. The byte to write to is given in context of the scratch pad memory
+ *  word that contains that byte.
+ *      For example, to write to BYTE5 of scratch pad memory, the user will call
+ *      this API with parameters @ref DL_LFSS_SCRATCHPAD_MEM_WORD_1 and
+ *      @ref DL_LFSS_SCRATCHPAD_MEM_BYTE_1.
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  memIndex  The specified scratch pad memory word to write to.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_WORD
+ *  @param[in]  byteIndex The specified scratch pad memory byte to write to.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_BYTE
+ *  @param[in]  data      The 8-bit data to write to the specified scratch pad
+ *                        memory byte. Value in range of [0x0, 0xFF].
+ */
+
+__STATIC_INLINE void DL_LFSS_writeScratchPadData8(LFSS_Regs *lfss,
+    DL_LFSS_SCRATCHPAD_MEM_WORD memIndex,
+    DL_LFSS_SCRATCHPAD_MEM_BYTE byteIndex, uint32_t data)
+{
+    /* Point to correct SPMEM word */
+    volatile uint32_t *pReg = &lfss->IPSPECIFIC_MEM.SPMEM[(uint32_t) memIndex];
+
+    /* Get the correct bit based on the byteIndex */
+    uint32_t offset = ((uint32_t) byteIndex * (uint32_t) 8);
+    data            = data << offset;
+    uint32_t mask   = ((uint32_t) 0x000000FFU) << offset;
+
+    DL_Common_updateReg(pReg, data, mask);
+}
+
+/**
+ *  @brief      Read the specified word in scratch pad memory
+ *
+ *  The VBAT scratch pad memory is register based memory that will retain data
+ *  as long as VBAT is supplied. Refer to the device TRM for details on the
+ *  specific size and implementation of the scratch pad memory.
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  memIndex  The specified scratch pad memory word to read.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_WORD
+ *
+ *  @return     The 32-bit data in the specified scratch pad memory word
+ */
+__STATIC_INLINE uint32_t DL_LFSS_readScratchPadDataWord(
+    LFSS_Regs *lfss, DL_LFSS_SCRATCHPAD_MEM_WORD memIndex)
+{
+    return (lfss->IPSPECIFIC_MEM.SPMEM[(uint32_t) memIndex]);
+}
+
+/**
+ *  @brief      Read the specified byte in scratch pad memory
+ *
+ *  The VBAT scratch pad memory is register based memory that will retain data
+ *  as long as VBAT is supplied. Refer to the device TRM for details on the
+ *  specific size and implementation of the scratch pad memory.
+ *
+ *  This API will read 8-bit data from the selected byte in the scratch pad
+ *  memory. The byte to read to is given in context of the scratch pad memory
+ *  word that contains that byte.
+ *      For example, to read BYTE5 of scratch pad memory, the user will call
+ *      this API with parameters @ref DL_LFSS_SCRATCHPAD_MEM_WORD_1 and
+ *      @ref DL_LFSS_SCRATCHPAD_MEM_BYTE_1.
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  memIndex  The specified scratch pad memory word to read.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_WORD
+ *  @param[in]  byteIndex The specified scratch pad memory byte to read.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_BYTE
+ *
+ *  @return     The 8-bit data in the specified scratch pad memory byte
+ */
+__STATIC_INLINE uint8_t DL_LFSS_readScratchPadDataByte(LFSS_Regs *lfss,
+    DL_LFSS_SCRATCHPAD_MEM_WORD memIndex,
+    DL_LFSS_SCRATCHPAD_MEM_BYTE byteIndex)
+{
+    /* Point to correct SPMEM word */
+    volatile uint32_t *pReg = &lfss->IPSPECIFIC_MEM.SPMEM[(uint32_t) memIndex];
+
+    /* Get the correct bit based on the byteIndex */
+    uint32_t offset = ((uint32_t) byteIndex * (uint32_t) 8);
+    uint32_t mask   = ((uint32_t) 0x000000FFU) << offset;
+
+    return (((*pReg & mask)) >> offset);
+}
+
+/**
+ *  @brief     Enable write protection lock of the specified byte in scratch pad
+ *             memory from accidental updates
+ *
+ *  When enabled, the specified byte in scratch pad memory will have read-only
+ *  access.
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  memIndex  The specified scratch pad memory word.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_WORD
+ *  @param[in]  byteIndex The specified byte in scratch pad memory word to
+ *                        enable write protection for
+ */
+__STATIC_INLINE void DL_LFSS_enableScratchPadWriteProtectByte(LFSS_Regs *lfss,
+    DL_LFSS_SCRATCHPAD_MEM_WORD memIndex,
+    DL_LFSS_SCRATCHPAD_MEM_BYTE byteIndex)
+{
+    /* Point to correct SPMWPROT register */
+    uint32_t regIndex       = (uint32_t) memIndex >> (uint32_t) 2;
+    volatile uint32_t *pReg = &lfss->IPSPECIFIC_MEM.SPMWPROT0 + regIndex;
+
+    /* Get the correct bit based on the byteIndex */
+    uint32_t mask = (uint32_t) 1 << ((((uint32_t) memIndex % (uint32_t) 4)
+                                         << (uint32_t) 2) +
+                                     (uint32_t) byteIndex);
+
+    *pReg |= (LFSS_SPMWPROT0_KEY_UNLOCK_W | mask);
+}
+
+/**
+ *  @brief      Checks if write protection is enabled for the specified byte in
+ *              scratch pad memory
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  memIndex  The specified scratch pad memory word.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_WORD
+ *  @param[in]  byteIndex The specified scratch pad memory byte.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_BYTE
+ *
+ *  @return     Returns if write protection is enabled for the specified byte
+ *
+ *  @retval     true  Write protection for the specified byte is enabled
+ *  @retval     false Write protection for the specified byte is disabled
+ */
+__STATIC_INLINE bool DL_LFSS_isScratchPadWriteProtectByteEnabled(
+    LFSS_Regs *lfss, DL_LFSS_SCRATCHPAD_MEM_WORD memIndex,
+    DL_LFSS_SCRATCHPAD_MEM_BYTE byteIndex)
+{
+    /* Point to correct SPMWPROT index */
+    uint32_t regIndex       = (uint32_t) memIndex >> (uint32_t) 2;
+    volatile uint32_t *pReg = &lfss->IPSPECIFIC_MEM.SPMWPROT0 + regIndex;
+
+    /* Get the correct bit based on the byteIndex */
+    uint32_t mask = (uint32_t) 1 << ((((uint32_t) memIndex % (uint32_t) 4)
+                                         << (uint32_t) 2) +
+                                     (uint32_t) byteIndex);
+
+    return ((*pReg & mask) == mask);
+}
+
+/**
+ *  @brief     Disable write protection lock of the specified byte in scratch
+ *             pad memory
+ *
+ *  When disables, the specified byte in scratch pad memory will have read-only
+ *  access.
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  memIndex  The specified scratch pad memory word.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_WORD
+ *  @param[in]  byteIndex The specified byte in scratch pad memory word to
+ *                        disable write protection for.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_BYTE
+ */
+__STATIC_INLINE void DL_LFSS_disableScratchPadWriteProtectByte(LFSS_Regs *lfss,
+    DL_LFSS_SCRATCHPAD_MEM_WORD memIndex,
+    DL_LFSS_SCRATCHPAD_MEM_BYTE byteIndex)
+{
+    /* Point to correct SPMWPROT index */
+    uint32_t regIndex       = (uint32_t) memIndex >> (uint32_t) 2;
+    volatile uint32_t *pReg = &lfss->IPSPECIFIC_MEM.SPMWPROT0 + regIndex;
+
+    /* Get the correct bit based on the byteIndex */
+    uint32_t mask = (uint32_t) 1 << ((((uint32_t) memIndex % (uint32_t) 4)
+                                         << (uint32_t) 2) +
+                                     (uint32_t) byteIndex);
+
+    *pReg = ((*pReg & (~mask)) | LFSS_SPMWPROT1_KEY_UNLOCK_W);
+}
+
+/**
+ *  @brief     Enable tamper erase of the specified byte in scratch pad
+ *             memory
+ *
+ *  When enabled, the specified byte in scratch pad memory will be erased in the
+ *  event of a tamper detect.
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  memIndex  The specified scratch pad memory word.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_WORD
+ *  @param[in]  byteIndex The specified byte in scratch pad memory word to
+ *                        enable tamper erase for.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_BYTE
+ */
+__STATIC_INLINE void DL_LFSS_enableScratchPadTamperEraseByte(LFSS_Regs *lfss,
+    DL_LFSS_SCRATCHPAD_MEM_WORD memIndex,
+    DL_LFSS_SCRATCHPAD_MEM_BYTE byteIndex)
+{
+    /* Point to correct SPMTERASE index */
+    uint32_t regIndex       = (uint32_t) memIndex >> (uint32_t) 2;
+    volatile uint32_t *pReg = &lfss->IPSPECIFIC_MEM.SPMTERASE0 + regIndex;
+
+    /* Get the correct bit based on the byteIndex */
+    uint32_t mask = (uint32_t) 1 << ((((uint32_t) memIndex % (uint32_t) 4)
+                                         << (uint32_t) 2) +
+                                     (uint32_t) byteIndex);
+
+    *pReg |= (LFSS_SPMTERASE0_KEY_UNLOCK_W | mask);
+}
+
+/**
+ *  @brief      Checks if tamper erase is enabled for the specified byte in
+ *              scratch pad memory
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  memIndex  The specified scratch pad memory word.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_WORD
+ *  @param[in]  byteIndex The specified byte in scratch pad memory byte.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_BYTE
+ *
+ *  @return     Returns if tamper erase is enabled for the specified byte
+ *
+ *  @retval     true  Tamper erase for the specified byte is enabled
+ *  @retval     false tamper erase for the specified byte is disabled
+ */
+__STATIC_INLINE bool DL_LFSS_isScratchPadTamperEraseByteEnabled(
+    LFSS_Regs *lfss, DL_LFSS_SCRATCHPAD_MEM_WORD memIndex,
+    DL_LFSS_SCRATCHPAD_MEM_BYTE byteIndex)
+{
+    /* Point to correct SPMTERASE index */
+    uint32_t regIndex       = (uint32_t) memIndex >> (uint32_t) 2;
+    volatile uint32_t *pReg = &lfss->IPSPECIFIC_MEM.SPMTERASE0 + regIndex;
+
+    /* Get the correct bit based on the byteIndex */
+    uint32_t mask = (uint32_t) 1 << ((((uint32_t) memIndex % (uint32_t) 4)
+                                         << (uint32_t) 2) +
+                                     (uint32_t) byteIndex);
+
+    return ((*pReg & mask) == mask);
+}
+
+/**
+ *  @brief     Disable tamper erase of the specified byte in scratch pad memory
+ *
+ *  The specified byte in scratch pad memory will not be erased in the event of
+ *  a tamper detect.
+ *
+ *  @param[in]  lfss      Pointer to the register overlay for the LFSS peripheral
+ *  @param[in]  memIndex  The specified scratch pad memory word to write to.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_WORD
+ *  @param[in]  byteIndex The specified byte in scratch pad memory word to
+ *                        disable tamper erase for.
+ *                        One of @ref DL_LFSS_SCRATCHPAD_MEM_BYTE
+ */
+__STATIC_INLINE void DL_LFSS_disableScratchPadTamperEraseByte(LFSS_Regs *lfss,
+    DL_LFSS_SCRATCHPAD_MEM_WORD memIndex,
+    DL_LFSS_SCRATCHPAD_MEM_BYTE byteIndex)
+{
+    /* Point to correct SPMTERASE index */
+    uint32_t regIndex       = (uint32_t) memIndex >> (uint32_t) 2;
+    volatile uint32_t *pReg = &lfss->IPSPECIFIC_MEM.SPMTERASE0 + regIndex;
+
+    /* Get the correct bit based on the byteIndex */
+    uint32_t mask = (uint32_t) 1 << ((((uint32_t) memIndex % (uint32_t) 4)
+                                         << (uint32_t) 2) +
+                                     (uint32_t) byteIndex);
+
+    *pReg = ((*pReg & (~mask)) | LFSS_SPMWPROT2_KEY_UNLOCK_W);
+}
+
+/**
+ *  @brief      Enable LFSS Tamper Interrupts
+ *
+ *  @param[in]  lfss  Pointer to the register overlay for the LFSS Tamper peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Logical OR of
+ *                             @ref DL_LFSS_TAMPERIO_INTERRUPT.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_enableInterrupt(
+    LFSS_Regs *lfss, uint32_t interruptMask)
+{
+    lfss->CPU_INT.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disable LFSS Tamper interrupts
+ *
+ *  @param[in]  lfss  Pointer to the register overlay for the LFSS Tamper peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Logical OR of
+ *                             @ref DL_LFSS_TAMPERIO_INTERRUPT
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_disableInterrupt(
+    LFSS_Regs *lfss, uint32_t interruptMask)
+{
+    lfss->CPU_INT.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief      Check which LFSS Tamper interrupts are enabled
+ *
+ *  @param[in]  lfss  Pointer to the register overlay for the LFSS Tamper peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Logical OR of
+ *                             @ref DL_LFSS_TAMPERIO_INTERRUPT
+ *
+ *  @return     Which of the requested LFSS interrupts are enabled
+ *
+ *  @retval     Logical OR of @ref DL_LFSS_TAMPERIO_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_LFSS_TamperIO_getEnabledInterrupts(
+    LFSS_Regs *lfss, uint32_t interruptMask)
+{
+    return (lfss->CPU_INT.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled LFSS Tamper interrupts
+ *
+ *  Checks if any of the LFSS Tamper interrupts that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  lfss  Pointer to the register overlay for the LFSS Tamper peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Logical OR of
+ *                             @ref DL_LFSS_TAMPERIO_INTERRUPT
+ *
+ *  @return     Which of the requested LFSS Tamper interrupts are pending
+ *
+ *  @retval     Logical OR of @ref DL_LFSS_TAMPERIO_INTERRUPT values
+ *
+ *  @sa         DL_LFSS_TAMPERIO_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_LFSS_TamperIO_getEnabledInterruptStatus(
+    LFSS_Regs *lfss, uint32_t interruptMask)
+{
+    return (lfss->CPU_INT.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any LFSS Tamper interrupt
+ *
+ *  Checks if any of the LFSS Tamper interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  lfss  Pointer to the register overlay for the LFSS Tamper peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Logical OR of
+ *                             @ref DL_LFSS_TAMPERIO_INTERRUPT
+ *
+ *  @return     Which of the requested LFSS Tamper interrupts are pending
+ *
+ *  @retval     Logical OR of @ref DL_LFSS_TAMPERIO_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_LFSS_TamperIO_getRawInterruptStatus(
+    LFSS_Regs *lfss, uint32_t interruptMask)
+{
+    return (lfss->CPU_INT.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending LFSS interrupt
+ *
+ *  Checks if any of the LFSS interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  lfss  Pointer to the register overlay for the LFSS Tamper peripheral
+ *
+ *  @return     The highest priority pending LFSS Tamper interrupt
+ *
+ *  @retval     One of @ref DL_LFSS_TAMPERIO_IIDX
+ */
+__STATIC_INLINE DL_LFSS_TAMPERIO_IIDX DL_LFSS_TamperIO_getPendingInterrupt(
+    LFSS_Regs *lfss)
+{
+    return (DL_LFSS_TAMPERIO_IIDX)(lfss->CPU_INT.IIDX);
+}
+
+/**
+ *  @brief      Clear pending LFSS Tamper interrupts
+ *
+ *  @param[in]  lfss  Pointer to the register overlay for the LFSS Tamper peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Logical OR of
+ *                             @ref DL_LFSS_TAMPERIO_INTERRUPT
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_clearInterruptStatus(
+    LFSS_Regs *lfss, uint32_t interruptMask)
+{
+    lfss->CPU_INT.ICLR = interruptMask;
+}
+
+/**
+ *  @brief      Enable LFSS Tamper event
+ *
+ *  @param[in]  lfss       Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask   Bit mask of interrupts to enable. Bitwise OR of
+ *                          @ref DL_LFSS_TAMPERIO_EVENT.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_enableEvent(
+    LFSS_Regs *lfss, uint32_t eventMask)
+{
+    lfss->GEN_EVENT.IMASK |= (eventMask);
+}
+
+/**
+ *  @brief      Disable LFSS Tamper event
+ *
+ *  @param[in]  lfss       Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask   Bit mask of interrupts to enable. Bitwise OR of
+ *                          @ref DL_LFSS_TAMPERIO_EVENT.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_disableEvent(
+    LFSS_Regs *lfss, uint32_t eventMask)
+{
+    lfss->GEN_EVENT.IMASK &= ~(eventMask);
+}
+
+/**
+ *  @brief      Check which LFSS Tamper events are enabled
+ *
+ *  @param[in]  lfss       Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask   Bit mask of interrupts to check. Bitwise OR of
+ *                          @ref DL_LFSS_TAMPERIO_EVENT.
+ *
+ *  @return     Which of the requested LFSS Tamper interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_LFSS_TAMPERIO_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_LFSS_TamperIO_getEnabledEvents(
+    LFSS_Regs *lfss, uint32_t eventMask)
+{
+    return ((lfss->GEN_EVENT.IMASK) & (eventMask));
+}
+
+/**
+ *  @brief      Check event flag of enabled LFSS Tamper event
+ *
+ *  Checks if any of the LFSS Tamper events that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  lfss       Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask   Bit mask of interrupts to check. Bitwise OR of
+ *                          @ref DL_LFSS_TAMPERIO_EVENT.
+ *
+ *  @return     Which of the requested LFSS Tamper interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_LFSS_TAMPERIO_EVENT values
+ *
+ *  @sa         DL_LFSS_TamperIO_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_LFSS_TamperIO_getEnabledEventStatus(
+    LFSS_Regs *lfss, uint32_t eventMask)
+{
+    return ((lfss->GEN_EVENT.MIS) & eventMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any LFSS Tamper event
+ *
+ *  Checks if any events are pending. Events do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  lfss       Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask   Bit mask of interrupts to check. Bitwise OR of
+ *                          @ref DL_LFSS_TAMPERIO_EVENT.
+ *
+ *  @return     Which of the requested LFSS Tamper interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_LFSS_TAMPERIO_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_LFSS_TamperIO_getRawEventsStatus(
+    LFSS_Regs *lfss, uint32_t eventMask)
+{
+    return ((lfss->GEN_EVENT.RIS) & eventMask);
+}
+
+/**
+ *  @brief      Clear pending LFSS Tamper events
+ *
+ *  @param[in]  lfss       Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask   Bit mask of interrupts to clear. Bitwise OR of
+ *                          @ref DL_LFSS_TAMPERIO_EVENT.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_clearEventsStatus(
+    LFSS_Regs *lfss, uint32_t eventMask)
+{
+    lfss->GEN_EVENT.ICLR |= (eventMask);
+}
+
+/**
+ *  @brief Sets the LFSS Tamper event publisher channel ID
+ *
+ *  @param[in]  lfss       Pointer to the register overlay for the peripheral
+ *  @param[in]  chanID  Channel ID number. Valid range 0-15. If ChanID == 0
+ *                      publisher is disconnected.
+ */
+__STATIC_INLINE void DL_LFSS_TamperIO_setPublisherChanID(
+    LFSS_Regs *lfss, uint8_t chanID)
+{
+    lfss->FPUB_0 = (chanID & LFSS_FPUB_0_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event publisher channel ID
+ *
+ *  @param[in]  lfss       Pointer to the register overlay for the peripheral
+ *
+ *  @return     Event publisher channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_LFSS_TamperIO_getPublisherChanID(LFSS_Regs *lfss)
+{
+    return (uint8_t)(lfss->FPUB_0 & LFSS_FPUB_0_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Requests a reset to the LFSS module
+ *
+ *  @param[in]  lfss       Pointer to the register overlay for the peripheral
+ *
+ *
+ */
+__STATIC_INLINE void DL_LFSS_reset(LFSS_Regs *lfss)
+{
+    lfss->IPSPECIFIC_RTC.LFSSRST =
+        (LFSS_LFSSRST_KEY_UNLOCK_W | LFSS_LFSSRST_VBATPOR_SET);
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __MSPM0_HAS_LFSS__ */
+#endif /* ti_dl_dl_lfss__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_mathacl.c
+++ b/mspm0/source/ti/driverlib/dl_mathacl.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_mathacl.h>
+
+#ifdef __MSPM0_HAS_MATHACL__
+
+void DL_MathACL_configOperation(MATHACL_Regs *mathacl,
+    const DL_MathACL_operationConfig *opConfig, uint32_t op1, uint32_t op2)
+{
+    mathacl->CTL =
+        (uint32_t) opConfig->opType | (uint32_t) opConfig->opSign |
+        (uint32_t) opConfig->qType |
+        ((uint32_t) opConfig->iterations << MATHACL_CTL_NUMITER_OFS) |
+        ((uint32_t) opConfig->scaleFactor << MATHACL_CTL_SFACTOR_OFS);
+
+    DL_MathACL_setOperandTwo(mathacl, op2);
+    DL_MathACL_setOperandOne(mathacl, op1);
+}
+
+#endif /* __MSPM0_HAS_MATHACL__ */

--- a/mspm0/source/ti/driverlib/dl_mathacl.h
+++ b/mspm0/source/ti/driverlib/dl_mathacl.h
@@ -1,0 +1,543 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_mathacl.h
+ *  @brief      Math Accelerator Driver Library
+ *  @defgroup   MATHACL Math Accelerator (MATHACL)
+ *
+ *  @anchor ti_dl_dl_m0p_mathacl_Overview
+ *  # Overview
+ *
+ *  The Math Accelerator Driver Library provides software to control the
+ *  onboard Math Accelerator hardware.
+ *
+ ******************************************************************************
+ */
+/** @addtogroup MATHACL
+ * @{
+ */
+#ifndef ti_dl_dl_mathacl__include
+#define ti_dl_dl_mathacl__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_MATHACL__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_MATHACL_STATUS
+ *  @{
+ */
+
+/*!
+ * @brief MATHACL operation underflow status
+ */
+#define DL_MATHACL_STATUS_UNDERFLOW               (MATHACL_STATUS_UF_UNDERFLOW)
+
+/*!
+ * @brief MATHACL generic underflow bitmask for MATHACL Status register comparison
+ */
+#define DL_MATHACL_STATUS_UF_MASK                      (MATHACL_STATUS_UF_MASK)
+
+/*!
+ * @brief MATHACL operation overflow status
+ */
+#define DL_MATHACL_STATUS_OVERFLOW                (MATHACL_STATUS_OVF_OVERFLOW)
+
+/*!
+ * @brief MATHACL generic overflow bitmask for MATHACL Status register comparison
+ */
+#define DL_MATHACL_STATUS_OVF_MASK                    (MATHACL_STATUS_OVF_MASK)
+
+/*!
+ * @brief MATHACL divide by error status
+ */
+#define DL_MATHACL_STATUS_ERR_DIVBY0                (MATHACL_STATUS_ERR_DIVBY0)
+
+/*!
+ * @brief MATHACL generic error bits mask
+ */
+#define DL_MATHACL_STATUS_ERR_MASK                    (MATHACL_STATUS_ERR_MASK)
+
+/*!
+ * @brief Alias for one-shot sin/cos operation
+ */
+#define DL_MathACL_startSinCosOperation(MATHACL, config, op)    DL_MathACL_configOperation(MATHACL, config, op, 0)
+
+/*!
+ * @brief Alias for one-shot inverse 4-quadrant arctan operation
+ */
+#define DL_MathACL_startArcTan2Operation(MATHACL, config, x, y)    DL_MathACL_configOperation(MATHACL, config, x, y)
+
+/*!
+ * @brief Alias for one-shot arctan operation
+ */
+#define DL_MathACL_startArcTanOperation(MATHACL, config, x)    DL_MathACL_configOperation(MATHACL, config, x, 0)
+
+/*!
+ * @brief Alias for one-shot divide
+ */
+#define DL_MathACL_startDivOperation(MATHACL, config, num, den)    DL_MathACL_configOperation(MATHACL, config, num, den)
+
+/*!
+ * @brief Alias for one-shot square root operation
+ */
+#define DL_MathACL_startSqrtOperation(MATHACL, config, sqrt)    DL_MathACL_configOperation(MATHACL, config, sqrt, 0)
+
+/*!
+ * @brief Alias for one-shot multiply operation
+ */
+#define DL_MathACL_startMpyOperation(MATHACL, config, multicand, multiplier)    DL_MathACL_configOperation(MATHACL, config, multicand, multiplier)
+
+/** @}*/
+
+/* clang-format on */
+
+/*! @enum DL_MATHACL_OP_TYPE */
+typedef enum {
+    /*! Sin or cosine operation */
+    DL_MATHACL_OP_TYPE_SINCOS = MATHACL_CTL_FUNC_SINCOS,
+    /*! Arc tangent 2 operation -- takes in X, Y values */
+    DL_MATHACL_OP_TYPE_ARCTAN2 = MATHACL_CTL_FUNC_ATAN2,
+    /*! Divide operation -- takes in numerator, denominator, division type */
+    DL_MATHACL_OP_TYPE_DIV = MATHACL_CTL_FUNC_DIV,
+    /*! Square root operation -- requires that a scaling factor be provided as well  */
+    DL_MATHACL_OP_TYPE_SQRT = MATHACL_CTL_FUNC_SQRT,
+    /*! Multiply operation returns 32-bit result -- takes in two operands */
+    DL_MATHACL_OP_TYPE_MPY_32 = MATHACL_CTL_FUNC_MPY32,
+    /*! Square operation returns 32-bit result -- takes in one operand. Supports
+     * Q and int data formats. Enable saturation with @ref
+     * DL_MathACL_enableSaturation and check @ref DL_MATHACL_STATUS_OVERFLOW
+     * for overflow. */
+    DL_MATHACL_OP_TYPE_SQUARE_32 = MATHACL_CTL_FUNC_SQUARE32,
+    /*! Multiply operation returns 64-bit result -- takes in two operands */
+    DL_MATHACL_OP_TYPE_MPY_64 = MATHACL_CTL_FUNC_MPY64,
+    /*! Square operation returns 64-bit result -- takes in one operand */
+    DL_MATHACL_OP_TYPE_SQUARE_64 = MATHACL_CTL_FUNC_SQUARE64,
+    /*! Multiply and Accumulate operation -- takes in two operands. Supports Q
+     * and int data formats. Enable saturation with @ref
+     * DL_MathACL_enableSaturation and check @ref DL_MATHACL_STATUS_OVERFLOW
+     * for overflow. */
+    DL_MATHACL_OP_TYPE_MAC = MATHACL_CTL_FUNC_MAC,
+    /*! Square and Accumulate operation -- takes in one operand. Supports Q and
+     * int data formats. Enable saturation with @ref
+     * DL_MathACL_enableSaturation and check @ref DL_MATHACL_STATUS_OVERFLOW
+     * for overflow. */
+    DL_MATHACL_OP_TYPE_SAC = MATHACL_CTL_FUNC_SAC,
+} DL_MATHACL_OP_TYPE;
+
+/*! @enum DL_MATHACL_Q_TYPE */
+typedef enum {
+    /*! Q0 Operand Type */
+    DL_MATHACL_Q_TYPE_Q0 = MATHACL_CTL_QVAL_Q0,
+    /*! Q1 Operand Type */
+    DL_MATHACL_Q_TYPE_Q1 = MATHACL_CTL_QVAL_Q1,
+    /*! Q2 Operand Type */
+    DL_MATHACL_Q_TYPE_Q2 = MATHACL_CTL_QVAL_Q2,
+    /*! Q3 Operand Type */
+    DL_MATHACL_Q_TYPE_Q3 = MATHACL_CTL_QVAL_Q3,
+    /*! Q4 Operand Type */
+    DL_MATHACL_Q_TYPE_Q4 = MATHACL_CTL_QVAL_Q4,
+    /*! Q5 Operand Type */
+    DL_MATHACL_Q_TYPE_Q5 = MATHACL_CTL_QVAL_Q5,
+    /*! Q6 Operand Type */
+    DL_MATHACL_Q_TYPE_Q6 = MATHACL_CTL_QVAL_Q6,
+    /*! Q7 Operand Type */
+    DL_MATHACL_Q_TYPE_Q7 = MATHACL_CTL_QVAL_Q7,
+    /*! Q8 Operand Type */
+    DL_MATHACL_Q_TYPE_Q8 = MATHACL_CTL_QVAL_Q8,
+    /*! Q9 Operand Type */
+    DL_MATHACL_Q_TYPE_Q9 = MATHACL_CTL_QVAL_Q9,
+    /*! Q10 Operand Type */
+    DL_MATHACL_Q_TYPE_Q10 = MATHACL_CTL_QVAL_Q10,
+    /*! Q11 Operand Type */
+    DL_MATHACL_Q_TYPE_Q11 = MATHACL_CTL_QVAL_Q11,
+    /*! Q12 Operand Type */
+    DL_MATHACL_Q_TYPE_Q12 = MATHACL_CTL_QVAL_Q12,
+    /*! Q13 Operand Type */
+    DL_MATHACL_Q_TYPE_Q13 = MATHACL_CTL_QVAL_Q13,
+    /*! Q14 Operand Type */
+    DL_MATHACL_Q_TYPE_Q14 = MATHACL_CTL_QVAL_Q14,
+    /*! Q15 Operand Type */
+    DL_MATHACL_Q_TYPE_Q15 = MATHACL_CTL_QVAL_Q15,
+    /*! Q16 Operand Type */
+    DL_MATHACL_Q_TYPE_Q16 = MATHACL_CTL_QVAL_Q16,
+    /*! Q17 Operand Type */
+    DL_MATHACL_Q_TYPE_Q17 = MATHACL_CTL_QVAL_Q17,
+    /*! Q18 Operand Type */
+    DL_MATHACL_Q_TYPE_Q18 = MATHACL_CTL_QVAL_Q18,
+    /*! Q19 Operand Type */
+    DL_MATHACL_Q_TYPE_Q19 = MATHACL_CTL_QVAL_Q19,
+    /*! Q20 Operand Type */
+    DL_MATHACL_Q_TYPE_Q20 = MATHACL_CTL_QVAL_Q20,
+    /*! Q21 Operand Type */
+    DL_MATHACL_Q_TYPE_Q21 = MATHACL_CTL_QVAL_Q21,
+    /*! Q22 Operand Type */
+    DL_MATHACL_Q_TYPE_Q22 = MATHACL_CTL_QVAL_Q22,
+    /*! Q23 Operand Type */
+    DL_MATHACL_Q_TYPE_Q23 = MATHACL_CTL_QVAL_Q23,
+    /*! Q24 Operand Type */
+    DL_MATHACL_Q_TYPE_Q24 = MATHACL_CTL_QVAL_Q24,
+    /*! Q25 Operand Type */
+    DL_MATHACL_Q_TYPE_Q25 = MATHACL_CTL_QVAL_Q25,
+    /*! Q26 Operand Type */
+    DL_MATHACL_Q_TYPE_Q26 = MATHACL_CTL_QVAL_Q26,
+    /*! Q27 Operand Type */
+    DL_MATHACL_Q_TYPE_Q27 = MATHACL_CTL_QVAL_Q27,
+    /*! Q28 Operand Type */
+    DL_MATHACL_Q_TYPE_Q28 = MATHACL_CTL_QVAL_Q28,
+    /*! Q29 Operand Type */
+    DL_MATHACL_Q_TYPE_Q29 = MATHACL_CTL_QVAL_Q29,
+    /*! Q30 Operand Type */
+    DL_MATHACL_Q_TYPE_Q30 = MATHACL_CTL_QVAL_Q30,
+    /*! Q31 Operand Type */
+    DL_MATHACL_Q_TYPE_Q31 = MATHACL_CTL_QVAL_Q31,
+} DL_MATHACL_Q_TYPE;
+
+/*! @enum DL_MATHACL_OPSIGN */
+typedef enum {
+    /*! Unsigned operation type */
+    DL_MATHACL_OPSIGN_UNSIGNED = MATHACL_CTL_OPTYPE_UNSIGNED,
+    /*! Signed operation type */
+    DL_MATHACL_OPSIGN_SIGNED = MATHACL_CTL_OPTYPE_SIGNED,
+} DL_MATHACL_OPSIGN;
+
+/**
+ * @brief Configuration struct for @ref DL_MathACL_configOperation.
+ */
+typedef struct {
+    /*! Operation type. Set to one of @ref DL_MATHACL_OP_TYPE */
+    DL_MATHACL_OP_TYPE opType;
+    /*! Operation sign type. One of @ref DL_MATHACL_OPSIGN */
+    DL_MATHACL_OPSIGN opSign;
+    /*! Number of iterations, for applicable operation types. Supported types
+        include trigonometric operations and square root. */
+    uint32_t iterations;
+    /*! Scaling factor on the input in division operations. Leave as 0
+        for non-division operations. */
+    uint32_t scaleFactor;
+    /*! Q value for the operand inputs for the operation */
+    DL_MATHACL_Q_TYPE qType;
+} DL_MathACL_operationConfig;
+
+/**
+ * @brief Enables power on MATHACL module
+ *
+ * @param mathacl       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_MathACL_enablePower(MATHACL_Regs *mathacl)
+{
+    mathacl->GPRCM.PWREN =
+        MATHACL_PWREN_KEY_UNLOCK_W | MATHACL_PWREN_ENABLE_ENABLE;
+}
+
+/**
+ * @brief Disable power on MATHACL module
+ *
+ * @param mathacl       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_MathACL_disablePower(MATHACL_Regs *mathacl)
+{
+    mathacl->GPRCM.PWREN =
+        MATHACL_PWREN_KEY_UNLOCK_W | MATHACL_PWREN_ENABLE_DISABLE;
+}
+/**
+ * @brief Resets the MATHACL module
+ *
+ * @param mathacl       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_MathACL_reset(MATHACL_Regs *mathacl)
+{
+    mathacl->GPRCM.RSTCTL =
+        MATHACL_RSTCTL_RESETASSERT_ASSERT | MATHACL_RSTCTL_KEY_UNLOCK_W;
+}
+
+/**
+ * @brief Returns if MATHACL peripheral was reset
+ *
+ * @param mathacl        Pointer to the register overlay for the MATHACL peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_MathACL_isReset(MATHACL_Regs *mathacl)
+{
+    return (mathacl->GPRCM.STAT & MATHACL_STAT_RESETSTKY_MASK) ==
+           MATHACL_STAT_RESETSTKY_RESET;
+}
+
+/**
+ * @brief Enable saturation
+ *
+ * This bit is shared among @ref DL_MATHACL_OP_TYPE_DIV, @ref
+ * DL_MATHACL_OP_TYPE_SQUARE_32, @ref DL_MATHACL_OP_TYPE_MPY_32, @ref
+ * DL_MATHACL_OP_TYPE_MAC, and @ref DL_MATHACL_OP_TYPE_SAC operations.
+ * When saturation is enabled, if there is an overflow event during an
+ * operation, then the result will saturate to the maximum value.
+ *
+ * @param mathacl       Pointer to the register overlay for the peripheral
+ *
+ * @sa    DL_MATHACL_STATUS_OVERFLOW
+ */
+__STATIC_INLINE void DL_MathACL_enableSaturation(MATHACL_Regs *mathacl)
+{
+    mathacl->CTL |= MATHACL_CTL_SATEN_ENABLE;
+}
+
+/**
+ * @brief Disable saturation
+ *
+ * When saturation is disabled, if there is an overflow event during an
+ * operation, then the result will overflow to an unknown value.
+ *
+ * @param mathacl       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_MathACL_disableSaturation(MATHACL_Regs *mathacl)
+{
+    mathacl->CTL &= ~(MATHACL_CTL_SATEN_MASK);
+}
+
+/**
+ * @brief Returns if saturation is enabled
+ *
+ * @param mathacl     Pointer to the register overlay for the MATHACL peripheral
+ *
+ * @return true if saturation is enabled
+ * @return false if saturation is not enabled
+ *
+ */
+__STATIC_INLINE bool DL_MathACL_isSaturationEnabled(MATHACL_Regs *mathacl)
+{
+    return (
+        (mathacl->CTL & MATHACL_CTL_SATEN_MASK) == MATHACL_CTL_SATEN_ENABLE);
+}
+
+/**
+ *  @brief      Load Operand one into the math accelerator
+
+ *  @param[in]  mathacl Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  op      Operand one to load into the Math Accelerator
+ *
+ */
+__STATIC_INLINE void DL_MathACL_setOperandOne(
+    MATHACL_Regs *mathacl, uint32_t op)
+{
+    mathacl->OP1 = op;
+}
+
+/**
+ *  @brief      Load Operand two into the math accelerator
+ *
+ *  @param[in]  mathacl Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  op  Operand two to load into the Math Accelerator
+ *
+ */
+__STATIC_INLINE void DL_MathACL_setOperandTwo(
+    MATHACL_Regs *mathacl, uint32_t op)
+{
+    mathacl->OP2 = op;
+}
+
+/**
+ *  @param[in]  mathacl Pointer to the register overlay for the peripheral
+ *
+ *  @brief Returns MATHACL result one register
+ *
+ *  @return Value stored in MATHACUL Result 1 status
+ */
+__STATIC_INLINE uint32_t DL_MathACL_getResultOne(MATHACL_Regs *mathacl)
+{
+    return mathacl->RES1;
+}
+
+/**
+ *  @param[in]  mathacl Pointer to the register overlay for the peripheral
+ *
+ *  @brief Returns MATHACL result two register
+ *
+ *  @return Value stored in MATHACUL Result 2 status
+ *
+ */
+__STATIC_INLINE uint32_t DL_MathACL_getResultTwo(MATHACL_Regs *mathacl)
+{
+    return mathacl->RES2;
+}
+
+/**
+ *  @param[in]  mathacl Pointer to the register overlay for the peripheral
+ *
+ *  @brief Returns MATHACL operation status
+ *
+ *  @return One of @ref DL_MATHACL_STATUS
+ *
+ */
+__STATIC_INLINE uint32_t DL_MathACL_getStatus(MATHACL_Regs *mathacl)
+{
+    return mathacl->STATUS;
+}
+
+/**
+ *  @brief      Clear the overflow status bit
+ *
+ *  Calling this API clears @ref DL_MATHACL_STATUS_OVERFLOW
+ *
+ *  @param[in]  mathacl Pointer to the register overlay for the peripheral
+ *
+ *  @sa         DL_MATHACL_STATUS_OVERFLOW
+ */
+__STATIC_INLINE void DL_MathACL_clearOverflowStatus(MATHACL_Regs *mathacl)
+{
+    mathacl->STATUSCLR |= MATHACL_STATUSCLR_CLR_OVF_CLR;
+}
+
+/**
+ *  @brief      Clear the underflow status bit
+ *
+ *  Calling this API clears @ref DL_MATHACL_STATUS_UNDERFLOW
+ *
+ *  @param[in]  mathacl Pointer to the register overlay for the peripheral
+ *
+ *  @sa         DL_MATHACL_STATUS_UNDERFLOW
+ */
+__STATIC_INLINE void DL_MathACL_clearUnderflowStatus(MATHACL_Regs *mathacl)
+{
+    mathacl->STATUSCLR |= MATHACL_STATUSCLR_CLR_UF_CLR;
+}
+
+/**
+ *  @brief      Clear the error status bit
+ *
+ *  Calling this API clears @ref DL_MATHACL_STATUS_ERR_MASK
+ *
+ *  @param[in]  mathacl Pointer to the register overlay for the peripheral
+ *
+ *  @sa         DL_MATHACL_STATUS_ERR_MASK
+ */
+__STATIC_INLINE void DL_MathACL_clearErrorStatus(MATHACL_Regs *mathacl)
+{
+    mathacl->STATUSCLR |= MATHACL_STATUSCLR_CLR_ERR_CLR;
+}
+
+/**
+ *  @brief      Block until MATHACL_STATUS_BUSY_DONE is active in MATHACL
+ *
+ *  @param[in]  mathacl  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_MathACL_waitForOperation(MATHACL_Regs *mathacl)
+{
+    while ((mathacl->STATUS & MATHACL_STATUS_BUSY_MASK) ==
+           MATHACL_STATUS_BUSY_NOTDONE) {
+        ;
+    }
+}
+
+/**
+ *  @brief      Configure and execute a Math accelerator operation
+ *
+ *  @pre        Call @ref DL_MathACL_clearResults when configuring the MATHACL
+ *              for performing @ref DL_MATHACL_OP_TYPE_MAC and
+ *              @ref DL_MATHACL_OP_TYPE_SAC operations.
+ *
+ *  @param[in]  mathacl   Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  opConfig  Pointer to the configuration structure for the
+ *                        operation
+ *
+ *  @param[in]  op1       Operand one for the operation
+ *
+ *  @param[in]  op2       Operand two for the operation. May be left as 0
+ *                        if unused
+ *
+ */
+void DL_MathACL_configOperation(MATHACL_Regs *mathacl,
+    const DL_MathACL_operationConfig *opConfig, uint32_t op1, uint32_t op2);
+
+/**
+ *  @brief      Clears the RES1 register
+ *
+ *  Clears the Result 1 (RES1) register
+ *
+ *  @param[in]  mathacl Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_MathACL_clearResultOne(MATHACL_Regs *mathacl)
+{
+    mathacl->RES1 = 0;
+}
+
+/**
+ *  @brief      Clears the RES2 register
+ *
+ *  Clears the Result 2 (RES2) register
+ *
+ *  @param[in]  mathacl Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_MathACL_clearResultTwo(MATHACL_Regs *mathacl)
+{
+    mathacl->RES2 = 0;
+}
+
+/**
+ *  @brief      Clears the RES1 and RES2 registers
+ *
+ *  Clears the Result 1 (RES1) and Result 2 (RES2) registers
+ *
+ *  @param[in]  mathacl Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_MathACL_clearResults(MATHACL_Regs *mathacl)
+{
+    mathacl->RES1 = 0;
+    mathacl->RES2 = 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_MATHACL__ */
+
+#endif /* ti_dl_mathacl__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_mcan.c
+++ b/mspm0/source/ti/driverlib/dl_mcan.c
@@ -1,0 +1,1944 @@
+/*
+ * Copyright (c) 2021, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_mcan.h>
+
+#ifdef __MSPM0_HAS_MCAN__
+
+/* ========================================================================== */
+/*                           Macros & Typedefs                                */
+/* ========================================================================== */
+
+/**
+ * \brief  MCAN MSG RAM BANK number for ECC AGGR.
+ */
+#define MCANSS_MSG_RAM_NUM (0U)
+
+/**
+ * \brief  Maximum Number of Rx Buffers.
+ */
+#define MCANSS_RX_BUFFER_MAX (64U)
+
+/**
+ * \brief  Maximum Number of Tx Buffers.
+ */
+#define MCANSS_TX_BUFFER_MAX (32U)
+
+/**
+ * \brief  Macro for standard Message ID filter.
+ */
+#define MCANSS_STD_ID_FILTER_SIZE_WORDS (1U)
+
+/**
+ * \brief  Macro for extended Message ID filter.
+ */
+#define MCANSS_EXT_ID_FILTER_SIZE_WORDS (2U)
+
+/**
+ * \brief  Macro for Tx Event FIFO element size.
+ */
+#define MCANSS_TX_EVENT_FIFO_SIZE_WORDS (2U)
+
+/**
+ * \brief  Macro for Interrupt Line enable mask.
+ */
+#define MCANSS_INTR_LINE_EN_MASK ((MCAN_ILE_EINT0_MASK | MCAN_ILE_EINT1_MASK))
+
+/**
+ * \brief  Mask and shift for Tx Buffers elements.
+ */
+#define MCANSS_TX_BUFFER_ELEM_ID_SHIFT (0U)
+#define MCANSS_TX_BUFFER_ELEM_ID_MASK (0x1FFFFFFFU)
+#define MCANSS_TX_BUFFER_ELEM_RTR_SHIFT (29U)
+#define MCANSS_TX_BUFFER_ELEM_RTR_MASK (0x20000000U)
+#define MCANSS_TX_BUFFER_ELEM_XTD_SHIFT (30U)
+#define MCANSS_TX_BUFFER_ELEM_XTD_MASK (0x40000000U)
+#define MCANSS_TX_BUFFER_ELEM_ESI_SHIFT (31U)
+#define MCANSS_TX_BUFFER_ELEM_ESI_MASK (0x80000000U)
+#define MCANSS_TX_BUFFER_ELEM_DLC_SHIFT (16U)
+#define MCANSS_TX_BUFFER_ELEM_DLC_MASK (0x000F0000U)
+#define MCANSS_TX_BUFFER_ELEM_BRS_SHIFT (20U)
+#define MCANSS_TX_BUFFER_ELEM_BRS_MASK (0x00100000U)
+#define MCANSS_TX_BUFFER_ELEM_FDF_SHIFT (21U)
+#define MCANSS_TX_BUFFER_ELEM_FDF_MASK (0x00200000U)
+#define MCANSS_TX_BUFFER_ELEM_EFC_SHIFT (23U)
+#define MCANSS_TX_BUFFER_ELEM_EFC_MASK (0x00800000U)
+#define MCANSS_TX_BUFFER_ELEM_MM_SHIFT (24U)
+#define MCANSS_TX_BUFFER_ELEM_MM_MASK (0xFF000000U)
+
+/**
+ * \brief  Mask and shift for Rx Buffers elements.
+ */
+#define MCANSS_RX_BUFFER_ELEM_ID_SHIFT (0U)
+#define MCANSS_RX_BUFFER_ELEM_ID_MASK (0x1FFFFFFFU)
+#define MCANSS_RX_BUFFER_ELEM_RTR_SHIFT (29U)
+#define MCANSS_RX_BUFFER_ELEM_RTR_MASK (0x20000000U)
+#define MCANSS_RX_BUFFER_ELEM_XTD_SHIFT (30U)
+#define MCANSS_RX_BUFFER_ELEM_XTD_MASK (0x40000000U)
+#define MCANSS_RX_BUFFER_ELEM_ESI_SHIFT (31U)
+#define MCANSS_RX_BUFFER_ELEM_ESI_MASK (0x80000000U)
+#define MCANSS_RX_BUFFER_ELEM_RXTS_SHIFT (0U)
+#define MCANSS_RX_BUFFER_ELEM_RXTS_MASK (0x0000FFFFU)
+#define MCANSS_RX_BUFFER_ELEM_DLC_SHIFT (16U)
+#define MCANSS_RX_BUFFER_ELEM_DLC_MASK (0x000F0000U)
+#define MCANSS_RX_BUFFER_ELEM_BRS_SHIFT (20U)
+#define MCANSS_RX_BUFFER_ELEM_BRS_MASK (0x00100000U)
+#define MCANSS_RX_BUFFER_ELEM_FDF_SHIFT (21U)
+#define MCANSS_RX_BUFFER_ELEM_FDF_MASK (0x00200000U)
+#define MCANSS_RX_BUFFER_ELEM_FIDX_SHIFT (24U)
+#define MCANSS_RX_BUFFER_ELEM_FIDX_MASK (0x7F000000U)
+#define MCANSS_RX_BUFFER_ELEM_ANMF_SHIFT (31U)
+#define MCANSS_RX_BUFFER_ELEM_ANMF_MASK (0x80000000U)
+
+/**
+ * \brief  Mask and shift for Standard Message ID Filter Elements.
+ */
+#define MCANSS_STD_ID_FILTER_SFID2_SHIFT (0U)
+#define MCANSS_STD_ID_FILTER_SFID2_MASK (0x000003FFU)
+#define MCANSS_STD_ID_FILTER_SFID1_SHIFT (16U)
+#define MCANSS_STD_ID_FILTER_SFID1_MASK (0x03FF0000U)
+#define MCANSS_STD_ID_FILTER_SFEC_SHIFT (27U)
+#define MCANSS_STD_ID_FILTER_SFEC_MASK (0x38000000U)
+#define MCANSS_STD_ID_FILTER_SFT_SHIFT (30U)
+#define MCANSS_STD_ID_FILTER_SFT_MASK (0xC0000000U)
+
+/**
+ * \brief  Extended Message ID Filter Element.
+ */
+#define MCANSS_EXT_ID_FILTER_EFID2_SHIFT (0U)
+#define MCANSS_EXT_ID_FILTER_EFID2_MASK (0x1FFFFFFFU)
+#define MCANSS_EXT_ID_FILTER_EFID1_SHIFT (0U)
+#define MCANSS_EXT_ID_FILTER_EFID1_MASK (0x1FFFFFFFU)
+#define MCANSS_EXT_ID_FILTER_EFEC_SHIFT (29U)
+#define MCANSS_EXT_ID_FILTER_EFEC_MASK (0xE0000000U)
+#define MCANSS_EXT_ID_FILTER_EFT_SHIFT (30U)
+#define MCANSS_EXT_ID_FILTER_EFT_MASK (0xC0000000U)
+
+/**
+ * \brief  Mask and shift for Tx Event FIFO elements.
+ */
+#define MCANSS_TX_EVENT_FIFO_ELEM_ID_SHIFT (0U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_ID_MASK (0x1FFFFFFFU)
+#define MCANSS_TX_EVENT_FIFO_ELEM_RTR_SHIFT (29U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_RTR_MASK (0x20000000U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_XTD_SHIFT (30U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_XTD_MASK (0x40000000U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_ESI_SHIFT (31U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_ESI_MASK (0x80000000U)
+
+#define MCANSS_TX_EVENT_FIFO_ELEM_TXTS_SHIFT (0U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_TXTS_MASK (0x0000FFFFU)
+#define MCANSS_TX_EVENT_FIFO_ELEM_DLC_SHIFT (16U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_DLC_MASK (0x000F0000U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_BRS_SHIFT (20U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_BRS_MASK (0x00100000U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_FDF_SHIFT (21U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_FDF_MASK (0x00200000U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_ET_SHIFT (22U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_ET_MASK (0x00C00000U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_MM_SHIFT (24U)
+#define MCANSS_TX_EVENT_FIFO_ELEM_MM_MASK (0xFF000000U)
+
+#define HW_RD_REG32(addr) (uint32_t)(HW_RD_REG32_RAW((uint32_t)(addr)))
+
+#define HW_WR_REG32(addr, value) \
+    (HW_WR_REG32_RAW((uint32_t)(addr), (uint32_t)(value)))
+
+#define HW_GET_FIELD(regVal, REG_FIELD) \
+    (((regVal) & (uint32_t) REG_FIELD##_MASK) >> (uint32_t) REG_FIELD##_OFS)
+
+#define HW_SET_FIELD32(regVal, REG_FIELD, fieldVal)                       \
+    ((regVal) = ((regVal) & (uint32_t)(~(uint32_t) REG_FIELD##_MASK)) |   \
+                ((((uint32_t)(fieldVal)) << (uint32_t) REG_FIELD##_OFS) & \
+                    (uint32_t) REG_FIELD##_MASK))
+
+#define HW_WR_FIELD32(regAddr, REG_FIELD, fieldVal)                      \
+    (HW_WR_FIELD32_RAW((uint32_t)(regAddr), (uint32_t) REG_FIELD##_MASK, \
+        (uint32_t) REG_FIELD##_OFS, (uint32_t)(fieldVal)))
+
+#define HW_RD_FIELD32(regAddr, REG_FIELD)                                \
+    (HW_RD_FIELD32_RAW((uint32_t)(regAddr), (uint32_t) REG_FIELD##_MASK, \
+        (uint32_t) REG_FIELD##_OFS))
+
+#define STW_SOK ((int32_t) 0)
+#define STW_EFAIL (-((int32_t) 1))
+#define STW_EBADARGS (-((int32_t) 2))
+#define STW_EINVALID_PARAMS (-((int32_t) 3))
+#define STW_ETIMEOUT (-((int32_t) 4))
+#define STW_EOUT_OF_RANGE (-((int32_t) 5))
+#define STW_EUNSUPPORTED_CMD (-((int32_t) 6))
+#define STW_EUNSUPPORTED_OPS (-((int32_t) 7))
+
+#define MCAN_MCAN_MSG_MEM (0x0U)
+
+/* To fix Misra-C errors */
+#ifndef TRUE
+#define TRUE ((Bool) 1)
+#endif
+#ifndef FALSE
+#define FALSE ((Bool) 0)
+#endif
+
+/* ========================================================================== */
+/*                         Structures and Enums                               */
+/* ========================================================================== */
+
+/* None */
+
+/* ========================================================================== */
+/*                 Internal Function Declarations                             */
+/* ========================================================================== */
+
+/**
+ * \brief   This API will unblock write access to write protected registers.
+ *
+ * \param   mcan        Base Address of the MCAN Registers.
+ *
+ * \return  None.
+ */
+static void DL_MCAN_writeProtectedRegAccessUnlock(MCAN_Regs *mcan);
+
+/**
+ * \brief   This API will block write access to write protected registers.
+ *
+ * \param   mcan        Base Address of the MCAN Registers.
+ *
+ * \return  None.
+ */
+static void DL_MCAN_writeProtectedRegAccessLock(MCAN_Regs *mcan);
+
+/**
+ * \brief   This API will load the register from ECC memory bank.
+ *
+ * \param   mcan        Base Address of the MCAN Registers.
+ * \param   regOffset       Offset of the register to read.
+ *
+ * \return  None.
+ */
+static void DL_MCAN_eccLoadRegister(MCAN_Regs *mcan, uint32_t regOffset);
+
+/**
+ * \brief   This API will read the message object from Message RAM.
+ *
+ * \param   mcan        Base Address of the MCAN Registers.
+ * \param   elemAddr        Address of the message object.
+ * \param   elem            Message Object.
+ *                          Refer struct #DL_MCAN_RxBufElement.
+ *
+ * \return  None.
+ */
+static void DL_MCAN_readMsg(
+    uint32_t mcan, uint32_t elemAddr, DL_MCAN_RxBufElement *elem);
+
+/**
+ * \brief   This API will write the message object to Message RAM.
+ *
+ * \param   mcan        Base Address of the MCAN Registers.
+ * \param   elemAddr        Address of the message object.
+ * \param   elem            Message Object.
+ *                          Refer struct #MCAN_TXBufElement.
+ *
+ * \return  None.
+ */
+static void DL_MCAN_writeMsg(
+    uint32_t mcan, uint32_t elemAddr, const DL_MCAN_TxBufElement *elem);
+
+/**
+ * \brief   This API will return payload depending on 'dlc'  field.
+ *
+ * \param   dlc             Data Length Code.
+ *
+ * \return  data size       Size of the payload.
+ */
+static uint32_t DL_MCAN_getDataSize(uint32_t dlc);
+
+/**
+ * \brief   This API will return message object size.
+ *
+ * \param   elemSize        Element Size.
+ *
+ * \return  message object size
+ *                          Size of the message object stored in Message RAM.
+ */
+static uint32_t DL_MCAN_getMsgObjSize(uint32_t elemSize);
+
+/**
+ *  \brief   This function reads a 32-bit value from a hardware register
+ *           and returns the value.
+ *
+ *  \param   addr    Address of the memory mapped hardware register.
+ *
+ *  \return  Unsigned 32-bit value read from a register.
+ */
+__STATIC_INLINE uint32_t HW_RD_REG32_RAW(uint32_t addr);
+
+/**
+ *  \brief   This function writes a 32-bit value to a hardware register.
+ *
+ *  \param   addr    Address of the memory mapped hardware register.
+ *  \param   value   unsigned 32-bit value which has to be written to the
+ *                   register.
+ */
+__STATIC_INLINE void HW_WR_REG32_RAW(uint32_t addr, uint32_t value);
+
+/**
+ *  \brief   This function reads a 32 bit register, modifies specific set of
+ *           bits and writes back to the register.
+ *
+ *  \param   addr    Address of the memory mapped hardware register.
+ *  \param   mask    Mask for the bit field.
+ *  \param   shift   Bit field shift from LSB.
+ *  \param   value   Value to be written to bit-field.
+ */
+__STATIC_INLINE void HW_WR_FIELD32_RAW(
+    uint32_t addr, uint32_t mask, uint32_t shift, uint32_t value);
+
+/**
+ *  \brief   This function reads a 32 bit register, masks specific set of bits
+ *           and the left shifted value.
+ *
+ *  \param   addr    Address of the memory mapped hardware register.
+ *  \param   mask    Mask for the bit field.
+ *  \param   shift   Bit field shift from LSB.
+ *
+ *  \return  Bit-field value (absolute value - shifted to LSB position)
+ */
+__STATIC_INLINE uint32_t HW_RD_FIELD32_RAW(
+    uint32_t addr, uint32_t mask, uint32_t shift);
+
+/* ========================================================================== */
+/*                            Global Variables                                */
+/* ========================================================================== */
+
+/* None */
+
+/* ========================================================================== */
+/*                          Function Definitions                              */
+/* ========================================================================== */
+
+bool DL_MCAN_isReady(DL_MCAN_INSTANCE instance)
+{
+    return ((SYSCTL->SOCLOCK.SYSSTATUS & (uint32_t) instance) ==
+            (uint32_t) instance);
+}
+
+void DL_MCAN_setClockConfig(MCAN_Regs *mcan, DL_MCAN_ClockConfig *config)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.GENCLKCFG,
+        (uint32_t) config->clockSel, SYSCTL_GENCLKCFG_CANCLKSRC_MASK);
+
+    mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKDIV = (uint32_t) config->divider;
+}
+
+void DL_MCAN_getClockConfig(MCAN_Regs *mcan, DL_MCAN_ClockConfig *config)
+{
+    uint32_t clockSource =
+        (SYSCTL->SOCLOCK.GENCLKCFG & SYSCTL_GENCLKCFG_CANCLKSRC_MASK);
+
+    config->clockSel = (DL_MCAN_FCLK)(clockSource);
+}
+
+bool DL_MCAN_isInReset(MCAN_Regs *mcan)
+{
+    uint32_t reset;
+    bool state;
+
+    reset = HW_RD_FIELD32(
+        &mcan->MCANSS.STAT, MCAN_TI_WRAPPER_PROCESSORS_REGS_STAT_RESET);
+    if (1U == reset) {
+        state = true;
+    } else {
+        state = false;
+    }
+    return state;
+}
+
+bool DL_MCAN_isFDOpEnable(MCAN_Regs *mcan)
+{
+    uint32_t fdoe;
+    bool state;
+
+    fdoe = HW_RD_FIELD32(
+        &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_STAT,
+        MCAN_TI_WRAPPER_PROCESSORS_REGS_STAT_ENABLE_FDOE);
+    if (1U == fdoe) {
+        state = true;
+    } else {
+        state = false;
+    }
+    return state;
+}
+
+bool DL_MCAN_isMemInitDone(MCAN_Regs *mcan)
+{
+    uint32_t memInit;
+    bool state;
+
+    memInit = HW_RD_FIELD32(
+        &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_STAT,
+        MCAN_TI_WRAPPER_PROCESSORS_REGS_STAT_MEM_INIT_DONE);
+    if (1U == memInit) {
+        state = true;
+    } else {
+        state = false;
+    }
+    return state;
+}
+
+void DL_MCAN_setOpMode(MCAN_Regs *mcan, uint32_t mode)
+{
+    HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_INIT, mode);
+}
+
+uint32_t DL_MCAN_getOpMode(MCAN_Regs *mcan)
+{
+    return (HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_INIT));
+}
+
+int32_t DL_MCAN_init(MCAN_Regs *mcan, const DL_MCAN_InitParams *initParams)
+{
+    int32_t status;
+    uint32_t regVal;
+
+    /* Configure MCAN wakeup and clock stop controls */
+    regVal = HW_RD_REG32(
+        &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_CTRL);
+    HW_SET_FIELD32(regVal, MCAN_TI_WRAPPER_REGS_CTRL_WAKEUPREQEN,
+        initParams->wkupReqEnable);
+    HW_SET_FIELD32(regVal, MCAN_TI_WRAPPER_REGS_CTRL_AUTOWAKEUP,
+        initParams->autoWkupEnable);
+    HW_SET_FIELD32(regVal, MCAN_TI_WRAPPER_REGS_CTRL_DBGSUSP_FREE,
+        initParams->emulationEnable);
+
+    HW_WR_REG32(
+        &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_CTRL, regVal);
+
+    DL_MCAN_writeProtectedRegAccessUnlock(mcan);
+
+    /* Configure MCAN mode(FD vs Classic CAN operation) and controls */
+    regVal = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_CCCR);
+    HW_SET_FIELD32(regVal, MCAN_CCCR_FDOE, initParams->fdMode);
+    HW_SET_FIELD32(regVal, MCAN_CCCR_BRSE, initParams->brsEnable);
+    HW_SET_FIELD32(regVal, MCAN_CCCR_TXP, initParams->txpEnable);
+    HW_SET_FIELD32(regVal, MCAN_CCCR_EFBI, initParams->efbi);
+    HW_SET_FIELD32(regVal, MCAN_CCCR_PXHD, initParams->pxhddisable);
+    HW_SET_FIELD32(regVal, MCAN_CCCR_DAR, initParams->darEnable);
+    HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_CCCR, regVal);
+
+    if ((DL_MCAN_TDCR_TDCF_MAX >= initParams->tdcConfig.tdcf) &&
+        (DL_MCAN_TDCR_TDCO_MAX >= initParams->tdcConfig.tdco) &&
+        (DL_MCAN_RWD_WDC_MAX >= initParams->wdcPreload)) {
+        /* Configure Transceiver Delay Compensation */
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TDCR, MCAN_TDCR_TDCF,
+            initParams->tdcConfig.tdcf);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TDCR, MCAN_TDCR_TDCO,
+            initParams->tdcConfig.tdco);
+        /* Configure MSG RAM watchdog counter preload value */
+        HW_WR_FIELD32(
+            &mcan->MCANSS.MCAN.MCAN_RWD, MCAN_RWD_WDC, initParams->wdcPreload);
+        /* Enable/Disable Transceiver Delay Compensation */
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_DBTP, MCAN_DBTP_TDC,
+            initParams->tdcEnable);
+        status = STW_SOK;
+    } else {
+        status = STW_EFAIL;
+    }
+
+    DL_MCAN_writeProtectedRegAccessLock(mcan);
+
+    return status;
+}
+
+int32_t DL_MCAN_config(
+    MCAN_Regs *mcan, const DL_MCAN_ConfigParams *configParams)
+{
+    int32_t status;
+
+    DL_MCAN_writeProtectedRegAccessUnlock(mcan);
+
+    /* Configure MCAN control registers */
+    HW_WR_FIELD32(
+        &mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_MON, configParams->monEnable);
+    HW_WR_FIELD32(
+        &mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_ASM, configParams->asmEnable);
+    /* Configure Global Filter */
+    HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_GFC, MCAN_GFC_RRFE,
+        configParams->filterConfig.rrfe);
+    HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_GFC, MCAN_GFC_RRFS,
+        configParams->filterConfig.rrfs);
+    HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_GFC, MCAN_GFC_ANFE,
+        configParams->filterConfig.anfe);
+    HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_GFC, MCAN_GFC_ANFS,
+        configParams->filterConfig.anfs);
+
+    if ((DL_MCAN_TSCC_TCP_MAX >= configParams->tsPrescalar) &&
+        (DL_MCAN_TOCC_TOP_MAX >= configParams->timeoutPreload)) {
+        /* Configure Time-stamp counter */
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TSCC, MCAN_TSCC_TSS,
+            configParams->tsSelect);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TSCC, MCAN_TSCC_TCP,
+            (configParams->tsPrescalar - 1U));
+        /* Configure Time-out counter */
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TOCC, MCAN_TOCC_TOS,
+            configParams->timeoutSelect);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TOCC, MCAN_TOCC_TOP,
+            configParams->timeoutPreload);
+        /* Enable Time-out counter */
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TOCC, MCAN_TOCC_ETOC,
+            configParams->timeoutCntEnable);
+        status = STW_SOK;
+    } else {
+        status = STW_EFAIL;
+    }
+
+    DL_MCAN_writeProtectedRegAccessLock(mcan);
+
+    return status;
+}
+
+void DL_MCAN_eccConfig(
+    MCAN_Regs *mcan, const DL_MCAN_ECCConfigParams *configParams)
+{
+    DL_MCAN_eccLoadRegister(mcan, (uint32_t) &mcan->MCANSS.TI_WRAPPER
+                                      .PROCESSORS.MCAN_ECC_REGS.MCANERR_CTRL);
+    HW_WR_FIELD32(
+        &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_CTRL,
+        MCAN_TI_WRAPPER_ECC_REGS_CTRL_ECC_CHECK, configParams->enableChk);
+    DL_MCAN_eccLoadRegister(mcan, (uint32_t) &mcan->MCANSS.TI_WRAPPER
+                                      .PROCESSORS.MCAN_ECC_REGS.MCANERR_CTRL);
+    HW_WR_FIELD32(
+        &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_CTRL,
+        MCAN_TI_WRAPPER_ECC_REGS_CTRL_ECC_ENABLE, configParams->enable);
+    DL_MCAN_eccLoadRegister(mcan, (uint32_t) &mcan->MCANSS.TI_WRAPPER
+                                      .PROCESSORS.MCAN_ECC_REGS.MCANERR_CTRL);
+    HW_WR_FIELD32(
+        &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_CTRL,
+        MCAN_TI_WRAPPER_ECC_REGS_CTRL_ENABLE_RMW, configParams->enableRdModWr);
+    DL_MCAN_eccLoadRegister(mcan, (uint32_t) &mcan->MCANSS.TI_WRAPPER
+                                      .PROCESSORS.MCAN_ECC_REGS.MCANERR_CTRL);
+}
+
+int32_t DL_MCAN_setBitTime(
+    MCAN_Regs *mcan, const DL_MCAN_BitTimingParams *configParams)
+{
+    int32_t status;
+
+    DL_MCAN_writeProtectedRegAccessUnlock(mcan);
+
+    if ((DL_MCAN_NBTP_NSJW_MAX >= configParams->nomSynchJumpWidth) &&
+        (DL_MCAN_NBTP_NTSEG2_MAX >= configParams->nomTimeSeg2) &&
+        (DL_MCAN_NBTP_NTSEG1_MAX >= configParams->nomTimeSeg1) &&
+        (DL_MCAN_NBTP_NBRP_MAX >= configParams->nomRatePrescalar)) {
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_NBTP, MCAN_NBTP_NSJW,
+            configParams->nomSynchJumpWidth);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_NBTP, MCAN_NBTP_NTSEG2,
+            configParams->nomTimeSeg2);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_NBTP, MCAN_NBTP_NTSEG1,
+            configParams->nomTimeSeg1);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_NBTP, MCAN_NBTP_NBRP,
+            configParams->nomRatePrescalar);
+        status = STW_SOK;
+    } else {
+        status = STW_EFAIL;
+    }
+    if (STW_SOK == status) {
+        if ((DL_MCAN_DBTP_DSJW_MAX >= configParams->dataSynchJumpWidth) &&
+            (DL_MCAN_DBTP_DTSEG2_MAX >= configParams->dataTimeSeg2) &&
+            (DL_MCAN_DBTP_DTSEG1_MAX >= configParams->dataTimeSeg1) &&
+            (DL_MCAN_DBTP_DBRP_MAX >= configParams->dataRatePrescalar)) {
+            HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_DBTP, MCAN_DBTP_DSJW,
+                configParams->dataSynchJumpWidth);
+            HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_DBTP, MCAN_DBTP_DTSEG2,
+                configParams->dataTimeSeg2);
+            HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_DBTP, MCAN_DBTP_DTSEG1,
+                configParams->dataTimeSeg1);
+            HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_DBTP, MCAN_DBTP_DBRP,
+                configParams->dataRatePrescalar);
+            status = STW_SOK;
+        } else {
+            status = STW_EFAIL;
+        }
+    }
+
+    DL_MCAN_writeProtectedRegAccessLock(mcan);
+    return status;
+}
+
+int32_t DL_MCAN_msgRAMConfig(
+    MCAN_Regs *mcan, const DL_MCAN_MsgRAMConfigParams *msgRAMConfigParams)
+{
+    int32_t status;
+    uint32_t elemNum = 0U;
+
+    DL_MCAN_writeProtectedRegAccessUnlock(mcan);
+
+    /* Configure Message Filters section */
+    if (0U != msgRAMConfigParams->lss) {
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_SIDFC, MCAN_SIDFC_FLSSA,
+            (msgRAMConfigParams->flssa >> 2U));
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_SIDFC, MCAN_SIDFC_LSS,
+            msgRAMConfigParams->lss);
+    }
+    if (0U != msgRAMConfigParams->lse) {
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_XIDFC, MCAN_XIDFC_FLESA,
+            (msgRAMConfigParams->flesa >> 2U));
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_XIDFC, MCAN_XIDFC_LSE,
+            msgRAMConfigParams->lse);
+    }
+    /* Configure Rx FIFO 0 section */
+    if (0U != msgRAMConfigParams->rxFIFO0size) {
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXF0C, MCAN_RXF0C_F0SA,
+            (msgRAMConfigParams->rxFIFO0startAddr >> 2U));
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXF0C, MCAN_RXF0C_F0S,
+            msgRAMConfigParams->rxFIFO0size);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXF0C, MCAN_RXF0C_F0WM,
+            msgRAMConfigParams->rxFIFO0waterMark);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXF0C, MCAN_RXF0C_F0OM,
+            msgRAMConfigParams->rxFIFO0OpMode);
+        /* Configure Rx FIFO0 elements size */
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXESC, MCAN_RXESC_F0DS,
+            msgRAMConfigParams->rxFIFO0ElemSize);
+    }
+    /* Configure Rx FIFO 1 section */
+    if (0U != msgRAMConfigParams->rxFIFO1size) {
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXF1C, MCAN_RXF1C_F1SA,
+            (msgRAMConfigParams->rxFIFO1startAddr >> 2U));
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXF1C, MCAN_RXF1C_F1S,
+            msgRAMConfigParams->rxFIFO1size);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXF1C, MCAN_RXF1C_F1WM,
+            msgRAMConfigParams->rxFIFO1waterMark);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXF1C, MCAN_RXF1C_F1OM,
+            msgRAMConfigParams->rxFIFO1OpMode);
+        /* Configure Rx FIFO1 elements size */
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXESC, MCAN_RXESC_F1DS,
+            msgRAMConfigParams->rxFIFO1ElemSize);
+    }
+    /* Configure Rx Buffer Start Address */
+    HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXBC, MCAN_RXBC_RBSA,
+        (msgRAMConfigParams->rxBufStartAddr >> 2U));
+    /* Configure Rx Buffer elements size */
+    HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXESC, MCAN_RXESC_RBDS,
+        msgRAMConfigParams->rxBufElemSize);
+    /* Configure Tx Event FIFO section */
+    if (0U != msgRAMConfigParams->txEventFIFOSize) {
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXEFC, MCAN_TXEFC_EFSA,
+            (msgRAMConfigParams->txEventFIFOStartAddr >> 2U));
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXEFC, MCAN_TXEFC_EFS,
+            msgRAMConfigParams->txEventFIFOSize);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXEFC, MCAN_TXEFC_EFWM,
+            msgRAMConfigParams->txEventFIFOWaterMark);
+    }
+    /* Configure Tx Buffer and FIFO/Q section */
+    elemNum = msgRAMConfigParams->txBufNum + msgRAMConfigParams->txFIFOSize;
+    if ((MCANSS_TX_BUFFER_MAX >= elemNum) &&
+        ((0U != msgRAMConfigParams->txBufNum) ||
+            (0U != msgRAMConfigParams->txFIFOSize))) {
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXBC, MCAN_TXBC_TBSA,
+            (msgRAMConfigParams->txStartAddr >> 2U));
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXBC, MCAN_TXBC_NDTB,
+            msgRAMConfigParams->txBufNum);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXBC, MCAN_TXBC_TFQS,
+            msgRAMConfigParams->txFIFOSize);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXBC, MCAN_TXBC_TFQM,
+            msgRAMConfigParams->txBufMode);
+        /* Configure Tx Buffer/FIFO0/FIFO1 elements size */
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXESC, MCAN_TXESC_TBDS,
+            msgRAMConfigParams->txBufElemSize);
+        status = STW_SOK;
+    } else {
+        status = STW_EFAIL;
+    }
+
+    DL_MCAN_writeProtectedRegAccessLock(mcan);
+
+    return status;
+}
+
+int32_t DL_MCAN_setExtIDAndMask(MCAN_Regs *mcan, uint32_t idMask)
+{
+    int32_t status;
+
+    if (DL_MCAN_XIDAM_EIDM_MAX >= idMask) {
+        DL_MCAN_writeProtectedRegAccessUnlock(mcan);
+
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_XIDAM, MCAN_XIDAM_EIDM, idMask);
+
+        DL_MCAN_writeProtectedRegAccessLock(mcan);
+        status = STW_SOK;
+    } else {
+        status = STW_EFAIL;
+    }
+    return status;
+}
+
+void DL_MCAN_writeMsgRam(MCAN_Regs *mcan, uint32_t memType, uint32_t bufNum,
+    const DL_MCAN_TxBufElement *elem)
+{
+    uint32_t startAddr = 0U, elemSize = 0U, elemAddr = 0U;
+    uint32_t idx = 0U, enableMod = 0U;
+
+    if (((uint32_t) DL_MCAN_MEM_TYPE_BUF) == memType) {
+        idx       = bufNum;
+        enableMod = 1U;
+    }
+    if (((uint32_t) DL_MCAN_MEM_TYPE_FIFO) == memType) {
+        idx = HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXFQS, MCAN_TXFQS_TFQP);
+        enableMod = 1U;
+    }
+    if (1U == enableMod) {
+        startAddr =
+            HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXBC, MCAN_TXBC_TBSA);
+        elemSize =
+            HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXESC, MCAN_TXESC_TBDS);
+        startAddr = (uint32_t)(startAddr << 2U);
+        elemSize  = DL_MCAN_getMsgObjSize(elemSize);
+        elemSize *= 4U;
+        elemAddr = startAddr + (elemSize * idx);
+        elemAddr += MCAN_MCAN_MSG_MEM;
+        DL_MCAN_writeMsg((uint32_t) mcan, elemAddr, elem);
+    }
+}
+
+int32_t DL_MCAN_TXBufAddReq(MCAN_Regs *mcan, uint32_t bufNum)
+{
+    int32_t status;
+    uint32_t regVal;
+
+    if (MCANSS_TX_BUFFER_MAX > bufNum) {
+        regVal = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_TXBAR);
+        regVal |= ((uint32_t) 1U << bufNum);
+
+        /*
+         * For writing to TXBAR CCE bit should be '0'. This need not be
+         * reverted because for other qualified writes this is locked state
+         * and can't be written.
+         */
+        DL_MCAN_writeProtectedRegAccessLock(mcan);
+        HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_TXBAR, regVal);
+
+        status = STW_SOK;
+    } else {
+        status = STW_EFAIL;
+    }
+    return status;
+}
+
+void DL_MCAN_getNewDataStatus(
+    MCAN_Regs *mcan, DL_MCAN_RxNewDataStatus *newDataStatus)
+{
+    newDataStatus->statusLow  = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_NDAT1);
+    newDataStatus->statusHigh = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_NDAT2);
+}
+
+void DL_MCAN_clearNewDataStatus(
+    MCAN_Regs *mcan, const DL_MCAN_RxNewDataStatus *newDataStatus)
+{
+    HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_NDAT1, newDataStatus->statusLow);
+    HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_NDAT2, newDataStatus->statusHigh);
+}
+
+void DL_MCAN_readMsgRam(MCAN_Regs *mcan, uint32_t memType, uint32_t bufNum,
+    uint32_t fifoNum, DL_MCAN_RxBufElement *elem)
+{
+    uint32_t startAddr = 0U, elemSize = 0U, elemAddr = 0U;
+    uint32_t enableMod = 0U, idx = 0U;
+
+    if (((uint32_t) DL_MCAN_MEM_TYPE_BUF) == memType) {
+        startAddr =
+            HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXBC, MCAN_RXBC_RBSA);
+        elemSize =
+            HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXESC, MCAN_RXESC_RBDS);
+        idx       = bufNum;
+        enableMod = 1U;
+    }
+    if (((uint32_t) DL_MCAN_MEM_TYPE_FIFO) == memType) {
+        switch (fifoNum) {
+            case ((uint32_t) DL_MCAN_RX_FIFO_NUM_0):
+                startAddr = HW_RD_FIELD32(
+                    &mcan->MCANSS.MCAN.MCAN_RXF0C, MCAN_RXF0C_F0SA);
+                elemSize = HW_RD_FIELD32(
+                    &mcan->MCANSS.MCAN.MCAN_RXESC, MCAN_RXESC_F0DS);
+                idx = HW_RD_FIELD32(
+                    &mcan->MCANSS.MCAN.MCAN_RXF0S, MCAN_RXF0S_F0GI);
+                enableMod = 1U;
+                break;
+            case ((uint32_t) DL_MCAN_RX_FIFO_NUM_1):
+                startAddr = HW_RD_FIELD32(
+                    &mcan->MCANSS.MCAN.MCAN_RXF1C, MCAN_RXF1C_F1SA);
+                elemSize = HW_RD_FIELD32(
+                    &mcan->MCANSS.MCAN.MCAN_RXESC, MCAN_RXESC_F1DS);
+                idx = HW_RD_FIELD32(
+                    &mcan->MCANSS.MCAN.MCAN_RXF1S, MCAN_RXF1S_F1GI);
+                enableMod = 1U;
+                break;
+            default:
+                /* Invalid option */
+                break;
+        }
+    }
+    if (1U == enableMod) {
+        startAddr = (uint32_t)(startAddr << 2U);
+        elemSize  = DL_MCAN_getMsgObjSize(elemSize);
+        elemSize *= 4U;
+        elemAddr = startAddr + (elemSize * idx);
+        elemAddr += MCAN_MCAN_MSG_MEM;
+        DL_MCAN_readMsg((uint32_t) mcan, elemAddr, elem);
+    }
+}
+
+void DL_MCAN_readTxEventFIFO(
+    MCAN_Regs *mcan, DL_MCAN_TxEventFIFOElement *txEventElem)
+{
+    uint32_t startAddr = 0U, elemSize = 0U, elemAddr = 0U;
+    uint32_t idx = 0U, regVal;
+
+    startAddr = HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXEFC, MCAN_TXEFC_EFSA);
+    elemSize  = MCANSS_TX_EVENT_FIFO_SIZE_WORDS;
+    idx       = HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXEFS, MCAN_TXEFS_EFGI);
+
+    startAddr = (uint32_t)(startAddr << 2U);
+    elemSize *= 4U;
+    elemAddr = startAddr + (elemSize * idx);
+    elemAddr += MCAN_MCAN_MSG_MEM;
+
+    regVal = HW_RD_REG32(((uint32_t) mcan + (uint32_t) elemAddr));
+    txEventElem->id =
+        (uint32_t)((regVal & MCANSS_TX_EVENT_FIFO_ELEM_ID_MASK) >>
+                   MCANSS_TX_EVENT_FIFO_ELEM_ID_SHIFT);
+    txEventElem->rtr =
+        (uint32_t)((regVal & MCANSS_TX_EVENT_FIFO_ELEM_RTR_MASK) >>
+                   MCANSS_TX_EVENT_FIFO_ELEM_RTR_SHIFT);
+    txEventElem->xtd =
+        (uint32_t)((regVal & MCANSS_TX_EVENT_FIFO_ELEM_XTD_MASK) >>
+                   MCANSS_TX_EVENT_FIFO_ELEM_XTD_SHIFT);
+    txEventElem->esi =
+        (uint32_t)((regVal & MCANSS_TX_EVENT_FIFO_ELEM_ESI_MASK) >>
+                   MCANSS_TX_EVENT_FIFO_ELEM_ESI_SHIFT);
+    elemAddr += 4U;
+
+    regVal = HW_RD_REG32(((uint32_t) mcan + (uint32_t) elemAddr));
+
+    txEventElem->txts =
+        (uint32_t)((regVal & MCANSS_TX_EVENT_FIFO_ELEM_TXTS_MASK) >>
+                   MCANSS_TX_EVENT_FIFO_ELEM_TXTS_SHIFT);
+    txEventElem->dlc =
+        (uint32_t)((regVal & MCANSS_TX_EVENT_FIFO_ELEM_DLC_MASK) >>
+                   MCANSS_TX_EVENT_FIFO_ELEM_DLC_SHIFT);
+    txEventElem->brs =
+        (uint32_t)((regVal & MCANSS_TX_EVENT_FIFO_ELEM_BRS_MASK) >>
+                   MCANSS_TX_EVENT_FIFO_ELEM_BRS_SHIFT);
+    txEventElem->fdf =
+        (uint32_t)((regVal & MCANSS_TX_EVENT_FIFO_ELEM_FDF_MASK) >>
+                   MCANSS_TX_EVENT_FIFO_ELEM_FDF_SHIFT);
+    txEventElem->et =
+        (uint32_t)((regVal & MCANSS_TX_EVENT_FIFO_ELEM_ET_MASK) >>
+                   MCANSS_TX_EVENT_FIFO_ELEM_ET_SHIFT);
+    txEventElem->mm =
+        (uint32_t)((regVal & MCANSS_TX_EVENT_FIFO_ELEM_MM_MASK) >>
+                   MCANSS_TX_EVENT_FIFO_ELEM_MM_SHIFT);
+}
+
+void DL_MCAN_addStdMsgIDFilter(MCAN_Regs *mcan, uint32_t filtNum,
+    const DL_MCAN_StdMsgIDFilterElement *elem)
+{
+    uint32_t startAddr, elemAddr, regVal;
+
+    startAddr = HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_SIDFC, MCAN_SIDFC_FLSSA);
+    startAddr = (uint32_t)(startAddr << 2U);
+    elemAddr  = startAddr + (filtNum * MCANSS_STD_ID_FILTER_SIZE_WORDS * 4U);
+    elemAddr += MCAN_MCAN_MSG_MEM;
+
+    regVal = 0U;
+    regVal |= (uint32_t)(elem->sfid2 << MCANSS_STD_ID_FILTER_SFID2_SHIFT);
+    regVal |= (uint32_t)(elem->sfid1 << MCANSS_STD_ID_FILTER_SFID1_SHIFT);
+    regVal |= (uint32_t)(elem->sfec << MCANSS_STD_ID_FILTER_SFEC_SHIFT);
+    regVal |= (uint32_t)(elem->sft << MCANSS_STD_ID_FILTER_SFT_SHIFT);
+    HW_WR_REG32(((uint32_t) mcan + (uint32_t) elemAddr), regVal);
+}
+
+void DL_MCAN_addExtMsgIDFilter(MCAN_Regs *mcan, uint32_t filtNum,
+    const DL_MCAN_ExtMsgIDFilterElement *elem)
+{
+    uint32_t startAddr, elemAddr, regVal;
+
+    startAddr = HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_XIDFC, MCAN_XIDFC_FLESA);
+    startAddr = (uint32_t)(startAddr << 2U);
+    elemAddr  = startAddr + (filtNum * MCANSS_EXT_ID_FILTER_SIZE_WORDS * 4U);
+    elemAddr += MCAN_MCAN_MSG_MEM;
+
+    regVal = 0U;
+    regVal |= (uint32_t)(elem->efid1 << MCANSS_EXT_ID_FILTER_EFID1_SHIFT);
+    regVal |= (uint32_t)(elem->efec << MCANSS_EXT_ID_FILTER_EFEC_SHIFT);
+    HW_WR_REG32(((uint32_t) mcan + (uint32_t) elemAddr), regVal);
+
+    elemAddr += 4U;
+    regVal = 0U;
+    regVal |= (uint32_t)(elem->efid2 << MCANSS_EXT_ID_FILTER_EFID2_SHIFT);
+    regVal |= (uint32_t)(elem->eft << MCANSS_EXT_ID_FILTER_EFT_SHIFT);
+    HW_WR_REG32(((uint32_t) mcan + (uint32_t) elemAddr), regVal);
+}
+
+void DL_MCAN_lpbkModeEnable(MCAN_Regs *mcan, uint32_t lpbkMode, bool enable)
+{
+    DL_MCAN_writeProtectedRegAccessUnlock(mcan);
+
+    if (true == enable) {
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_TEST, 0x1U);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TEST, MCAN_TEST_LBCK, enable);
+        if (((uint32_t) DL_MCAN_LPBK_MODE_INTERNAL) == lpbkMode) {
+            HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_MON, 0x1U);
+        }
+    } else {
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TEST, MCAN_TEST_LBCK, enable);
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_TEST, 0x0U);
+        if (((uint32_t) DL_MCAN_LPBK_MODE_INTERNAL) == lpbkMode) {
+            HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_MON, 0x0U);
+        }
+    }
+    DL_MCAN_writeProtectedRegAccessLock(mcan);
+}
+
+void DL_MCAN_getErrCounters(MCAN_Regs *mcan, DL_MCAN_ErrCntStatus *errCounter)
+{
+    errCounter->canErrLogCnt =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_ECR, MCAN_ECR_CEL);
+    errCounter->transErrLogCnt =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_ECR, MCAN_ECR_TEC);
+    errCounter->recErrCnt =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_ECR, MCAN_ECR_REC);
+    errCounter->rpStatus =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_ECR, MCAN_ECR_RP);
+}
+
+void DL_MCAN_getProtocolStatus(
+    MCAN_Regs *mcan, DL_MCAN_ProtocolStatus *protStatus)
+{
+    uint32_t regVal;
+
+    regVal                    = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_PSR);
+    protStatus->lastErrCode   = HW_GET_FIELD(regVal, MCAN_PSR_LEC);
+    protStatus->act           = HW_GET_FIELD(regVal, MCAN_PSR_ACT);
+    protStatus->errPassive    = HW_GET_FIELD(regVal, MCAN_PSR_EP);
+    protStatus->warningStatus = HW_GET_FIELD(regVal, MCAN_PSR_EW);
+    protStatus->busOffStatus  = HW_GET_FIELD(regVal, MCAN_PSR_BO);
+    protStatus->dlec          = HW_GET_FIELD(regVal, MCAN_PSR_DLEC);
+    protStatus->resi          = HW_GET_FIELD(regVal, MCAN_PSR_RESI);
+    protStatus->rbrs          = HW_GET_FIELD(regVal, MCAN_PSR_RBRS);
+    protStatus->rfdf          = HW_GET_FIELD(regVal, MCAN_PSR_RFDF);
+    protStatus->pxe           = HW_GET_FIELD(regVal, MCAN_PSR_PXE);
+    protStatus->tdcv          = HW_GET_FIELD(regVal, MCAN_PSR_TDCV);
+}
+
+void DL_MCAN_enableIntr(MCAN_Regs *mcan, uint32_t intrMask, bool enable)
+{
+    uint32_t regVal;
+
+    if (true == enable) {
+        regVal = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_IE);
+        regVal |= intrMask;
+        HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_IE, regVal);
+    } else {
+        regVal = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_IE);
+        regVal &= ~intrMask;
+        HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_IE, regVal);
+    }
+}
+
+void DL_MCAN_selectIntrLine(
+    MCAN_Regs *mcan, uint32_t intrMask, uint32_t lineNum)
+{
+    uint32_t regVal;
+
+    if (((uint32_t) DL_MCAN_INTR_LINE_NUM_0) == lineNum) {
+        regVal = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_ILS);
+        regVal &= ~intrMask;
+        HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_ILS, regVal);
+    } else {
+        regVal = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_ILS);
+        regVal |= intrMask;
+        HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_ILS, regVal);
+    }
+}
+
+uint32_t DL_MCAN_getIntrLineSelectStatus(MCAN_Regs *mcan)
+{
+    return (HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_ILS));
+}
+
+void DL_MCAN_enableIntrLine(MCAN_Regs *mcan, uint32_t lineNum, bool enable)
+{
+    uint32_t regVal;
+
+    lineNum &= MCANSS_INTR_LINE_EN_MASK;
+    regVal = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_ILE);
+    regVal &= ~((uint32_t) 0x1U << lineNum);
+    regVal |= ((uint32_t) enable << lineNum);
+    HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_ILE, regVal);
+}
+
+uint32_t DL_MCAN_getIntrStatus(MCAN_Regs *mcan)
+{
+    return (HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_IR));
+}
+
+void DL_MCAN_clearIntrStatus(
+    MCAN_Regs *mcan, uint32_t intrMask, DL_MCAN_INTR_SRC_MCAN eoi)
+{
+    HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_IR, intrMask);
+    HW_WR_REG32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_EOI,
+        (uint32_t) eoi);
+}
+
+void DL_MCAN_getHighPriorityMsgStatus(
+    MCAN_Regs *mcan, DL_MCAN_HighPriorityMsgInfo *hpm)
+{
+    hpm->bufIdx = HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_HPMS, MCAN_HPMS_BIDX);
+    hpm->msi    = HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_HPMS, MCAN_HPMS_MSI);
+    hpm->filterIdx =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_HPMS, MCAN_HPMS_FIDX);
+    hpm->filterList =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_HPMS, MCAN_HPMS_FLST);
+}
+
+void DL_MCAN_getRxFIFOStatus(MCAN_Regs *mcan, DL_MCAN_RxFIFOStatus *fifoStatus)
+{
+    uint32_t regVal;
+
+    switch (fifoStatus->num) {
+        case ((uint32_t) DL_MCAN_RX_FIFO_NUM_0):
+            regVal               = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_RXF0S);
+            fifoStatus->fillLvl  = HW_GET_FIELD(regVal, MCAN_RXF0S_F0FL);
+            fifoStatus->getIdx   = HW_GET_FIELD(regVal, MCAN_RXF0S_F0GI);
+            fifoStatus->putIdx   = HW_GET_FIELD(regVal, MCAN_RXF0S_F0PI);
+            fifoStatus->fifoFull = HW_GET_FIELD(regVal, MCAN_RXF0S_F0F);
+            fifoStatus->msgLost  = HW_GET_FIELD(regVal, MCAN_RXF0S_RF0L);
+            break;
+        case ((uint32_t) DL_MCAN_RX_FIFO_NUM_1):
+            regVal               = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_RXF1S);
+            fifoStatus->fillLvl  = HW_GET_FIELD(regVal, MCAN_RXF1S_F1FL);
+            fifoStatus->getIdx   = HW_GET_FIELD(regVal, MCAN_RXF1S_F1GI);
+            fifoStatus->putIdx   = HW_GET_FIELD(regVal, MCAN_RXF1S_F1PI);
+            fifoStatus->fifoFull = HW_GET_FIELD(regVal, MCAN_RXF1S_F1F);
+            fifoStatus->msgLost  = HW_GET_FIELD(regVal, MCAN_RXF1S_RF1L);
+            break;
+        default:
+            /* Invalid option */
+            break;
+    }
+}
+
+int32_t DL_MCAN_writeRxFIFOAck(MCAN_Regs *mcan, uint32_t fifoNum, uint32_t idx)
+{
+    int32_t status;
+    uint32_t size;
+
+    switch (fifoNum) {
+        case ((uint32_t) DL_MCAN_RX_FIFO_NUM_0):
+            size =
+                HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXF0C, MCAN_RXF0C_F0S);
+            if (size >= idx) {
+                HW_WR_FIELD32(
+                    &mcan->MCANSS.MCAN.MCAN_RXF0A, MCAN_RXF0A_F0AI, idx);
+                status = STW_SOK;
+            } else {
+                status = STW_EFAIL;
+            }
+            break;
+        case ((uint32_t) DL_MCAN_RX_FIFO_NUM_1):
+            size =
+                HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_RXF1C, MCAN_RXF1C_F1S);
+            if (size >= idx) {
+                HW_WR_FIELD32(
+                    &mcan->MCANSS.MCAN.MCAN_RXF1A, MCAN_RXF1A_F1AI, idx);
+                status = STW_SOK;
+            } else {
+                status = STW_EFAIL;
+            }
+            break;
+        default:
+            status = STW_EFAIL;
+            break;
+    }
+
+    return status;
+}
+
+void DL_MCAN_getTxFIFOQueStatus(
+    MCAN_Regs *mcan, DL_MCAN_TxFIFOStatus *fifoStatus)
+{
+    uint32_t regVal;
+
+    regVal               = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_TXFQS);
+    fifoStatus->freeLvl  = HW_GET_FIELD(regVal, MCAN_TXFQS_TFFL);
+    fifoStatus->getIdx   = HW_GET_FIELD(regVal, MCAN_TXFQS_TFGI);
+    fifoStatus->putIdx   = HW_GET_FIELD(regVal, MCAN_TXFQS_TFQP);
+    fifoStatus->fifoFull = HW_GET_FIELD(regVal, MCAN_TXFQS_TFQF);
+}
+
+uint32_t DL_MCAN_getTxBufReqPend(MCAN_Regs *mcan)
+{
+    return (HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_TXBRP));
+}
+
+int32_t DL_MCAN_txBufCancellationReq(MCAN_Regs *mcan, uint32_t buffNum)
+{
+    int32_t status;
+    uint32_t regVal;
+
+    if (MCANSS_TX_BUFFER_MAX > buffNum) {
+        regVal = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_TXBCR);
+        regVal |= ((uint32_t) 1U << buffNum);
+
+        /*
+         * For writing to TXBCR CCE bit should be '0'. This need not be
+         * reverted because for other qualified writes this is locked state
+         * and can't be written.
+         */
+        DL_MCAN_writeProtectedRegAccessLock(mcan);
+        HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_TXBCR, regVal);
+
+        status = STW_SOK;
+    } else {
+        status = STW_EFAIL;
+    }
+    return status;
+}
+
+uint32_t DL_MCAN_getTxBufTransmissionStatus(MCAN_Regs *mcan)
+{
+    return (HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_TXBTO));
+}
+
+uint32_t DL_MCAN_txBufCancellationStatus(MCAN_Regs *mcan)
+{
+    return (HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_TXBCF));
+}
+
+int32_t DL_MCAN_TXBufTransIntrEnable(
+    MCAN_Regs *mcan, uint32_t bufNum, bool enable)
+{
+    int32_t status;
+    uint32_t regVal;
+
+    if (MCANSS_TX_BUFFER_MAX > bufNum) {
+        if (true == enable) {
+            regVal = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_TXBTIE);
+            regVal |= ((uint32_t) 1U << bufNum);
+            HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_TXBTIE, regVal);
+        } else {
+            regVal = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_TXBTIE);
+            regVal &= ~((uint32_t) 0x1U << bufNum);
+            HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_TXBTIE, regVal);
+        }
+        status = STW_SOK;
+    } else {
+        status = STW_EFAIL;
+    }
+    return status;
+}
+
+int32_t DL_MCAN_getTxBufCancellationIntrEnable(
+    MCAN_Regs *mcan, uint32_t bufNum, bool enable)
+{
+    int32_t status;
+    uint32_t regVal;
+
+    if (MCANSS_TX_BUFFER_MAX > bufNum) {
+        if (true == enable) {
+            regVal = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_TXBCIE);
+            regVal |= ((uint32_t) 0x1U << bufNum);
+            HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_TXBCIE, regVal);
+        } else {
+            regVal = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_TXBCIE);
+            regVal &= ~((uint32_t) 0x1U << bufNum);
+            HW_WR_REG32(&mcan->MCANSS.MCAN.MCAN_TXBCIE, regVal);
+        }
+        status = STW_SOK;
+    } else {
+        status = STW_EFAIL;
+    }
+    return status;
+}
+
+void DL_MCAN_getTxEventFIFOStatus(
+    MCAN_Regs *mcan, DL_MCAN_TxEventFIFOStatus *fifoStatus)
+{
+    uint32_t regVal;
+
+    regVal               = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_TXEFS);
+    fifoStatus->fillLvl  = HW_GET_FIELD(regVal, MCAN_TXEFS_EFFL);
+    fifoStatus->getIdx   = HW_GET_FIELD(regVal, MCAN_TXEFS_EFGI);
+    fifoStatus->putIdx   = HW_GET_FIELD(regVal, MCAN_TXEFS_EFPI);
+    fifoStatus->fifoFull = HW_GET_FIELD(regVal, MCAN_TXEFS_EFF);
+    fifoStatus->eleLost  = HW_GET_FIELD(regVal, MCAN_TXEFS_TEFL);
+}
+
+void DL_MCAN_addClockStopRequest(MCAN_Regs *mcan, bool enable)
+{
+    if (true == enable) {
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_CSR, 0x1U);
+    } else {
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_CSR, 0x0U);
+    }
+}
+
+int32_t DL_MCAN_writeTxEventFIFOAck(MCAN_Regs *mcan, uint32_t idx)
+{
+    int32_t status;
+    uint32_t size;
+
+    size = HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXEFC, MCAN_TXEFC_EFS);
+
+    if (size >= idx) {
+        HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TXEFA, MCAN_TXEFA_EFAI, idx);
+        status = STW_SOK;
+    } else {
+        status = STW_EFAIL;
+    }
+
+    return status;
+}
+
+void DL_MCAN_eccForceError(
+    MCAN_Regs *mcan, const DL_MCAN_ECCErrForceParams *eccErr)
+{
+    uint32_t regVal;
+
+    if ((eccErr->errType == ((uint32_t) DL_MCAN_ECC_ERR_TYPE_SEC)) ||
+        (eccErr->errType == ((uint32_t) DL_MCAN_ECC_ERR_TYPE_DED))) {
+        DL_MCAN_eccLoadRegister(
+            mcan, (uint32_t) &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                      .MCANERR_ERR_CTRL1);
+        regVal = HW_RD_REG32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                                  .MCANERR_ERR_CTRL1);
+        HW_SET_FIELD32(regVal, MCAN_ERR_CTRL1_ECC_ROW, eccErr->rowNum);
+        HW_WR_REG32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                         .MCANERR_ERR_CTRL1,
+            regVal);
+        DL_MCAN_eccLoadRegister(
+            mcan, (uint32_t) &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                      .MCANERR_ERR_CTRL2);
+        regVal = HW_RD_REG32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                                  .MCANERR_ERR_CTRL2);
+        HW_SET_FIELD32(regVal, MCAN_ERR_CTRL2_ECC_BIT1, eccErr->bit1);
+        HW_SET_FIELD32(regVal, MCAN_ERR_CTRL2_ECC_BIT2, eccErr->bit2);
+        HW_WR_REG32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                         .MCANERR_ERR_CTRL2,
+            regVal);
+        DL_MCAN_eccLoadRegister(
+            mcan, (uint32_t) &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                      .MCANERR_CTRL);
+        regVal = HW_RD_REG32(
+            &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_CTRL);
+        HW_SET_FIELD32(regVal, MCAN_TI_WRAPPER_ECC_REGS_CTRL_FORCE_N_ROW,
+            eccErr->errForce);
+        HW_SET_FIELD32(
+            regVal, MCAN_TI_WRAPPER_ECC_REGS_CTRL_ERROR_ONCE, eccErr->errOnce);
+        if (eccErr->errType == ((uint32_t) DL_MCAN_ECC_ERR_TYPE_SEC)) {
+            HW_SET_FIELD32(
+                regVal, MCAN_TI_WRAPPER_ECC_REGS_CTRL_FORCE_SEC, 0x1U);
+        } else {
+            /* eccErr->errType == ((uint32_t) DL_MCAN_ECC_ERR_TYPE_DED) */
+            HW_SET_FIELD32(
+                regVal, MCAN_TI_WRAPPER_ECC_REGS_CTRL_FORCE_DED, 0x1U);
+        }
+        HW_WR_REG32(
+            &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_CTRL,
+            regVal);
+        DL_MCAN_eccLoadRegister(
+            mcan, (uint32_t) &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                      .MCANERR_CTRL);
+    }
+}
+
+void DL_MCAN_eccGetErrorStatus(MCAN_Regs *mcan, DL_MCAN_ECCErrStatus *eccErr)
+{
+    uint32_t regVal;
+
+    DL_MCAN_eccLoadRegister(
+        mcan, (uint32_t) &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                  .MCANERR_ERR_STAT1);
+    regVal = HW_RD_REG32(
+        &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_ERR_STAT1);
+    eccErr->secErr = HW_GET_FIELD(regVal, MCAN_ERR_STAT1_ECC_SEC);
+    eccErr->dedErr = HW_GET_FIELD(regVal, MCAN_ERR_STAT1_ECC_DED);
+    eccErr->bit1   = HW_GET_FIELD(regVal, MCAN_ERR_STAT1_ECC_BIT1);
+    DL_MCAN_eccLoadRegister(
+        mcan, (uint32_t) &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                  .MCANERR_ERR_STAT2);
+    regVal = HW_RD_REG32(
+        &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_ERR_STAT2);
+    eccErr->row = HW_GET_FIELD(regVal, MCAN_ERR_STAT2_ECC_ROW);
+}
+
+void DL_MCAN_eccClearErrorStatus(MCAN_Regs *mcan, uint32_t errType)
+{
+    DL_MCAN_eccLoadRegister(
+        mcan, (uint32_t) &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                  .MCANERR_ERR_STAT1);
+    switch (errType) {
+        case ((uint32_t) DL_MCAN_ECC_ERR_TYPE_SEC):
+            HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                               .MCANERR_ERR_STAT1,
+                MCAN_ERR_STAT1_ECC_SEC, 0x1U);
+            break;
+        case ((uint32_t) DL_MCAN_ECC_ERR_TYPE_DED):
+            HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                               .MCANERR_ERR_STAT1,
+                MCAN_ERR_STAT1_ECC_DED, 0x1U);
+            break;
+        default:
+            /* Invalid option */
+            break;
+    }
+    DL_MCAN_eccLoadRegister(
+        mcan, (uint32_t) &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                  .MCANERR_ERR_STAT1);
+}
+
+void DL_MCAN_eccWriteEOI(MCAN_Regs *mcan, uint32_t errType)
+{
+    switch (errType) {
+        case ((uint32_t) DL_MCAN_ECC_ERR_TYPE_SEC):
+            HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                               .MCANERR_SEC_EOI,
+                MCAN_SEC_EOI_EOI_WR, 0x1U);
+            break;
+        case ((uint32_t) DL_MCAN_ECC_ERR_TYPE_DED):
+            HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                               .MCANERR_DED_EOI,
+                MCAN_DED_EOI_EOI_WR, 0x1U);
+            break;
+        default:
+            /* Invalid option */
+            break;
+    }
+}
+
+void DL_MCAN_eccEnableIntr(MCAN_Regs *mcan, uint32_t errType, bool enable)
+{
+    if (true == enable) {
+        switch (errType) {
+            case ((uint32_t) DL_MCAN_ECC_ERR_TYPE_SEC):
+                HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                                   .MCANERR_SEC_ENABLE_SET,
+                    MCAN_SEC_ENABLE_SET_MSGMEM_ENABLE_SET, 0x1U);
+                break;
+            case ((uint32_t) DL_MCAN_ECC_ERR_TYPE_DED):
+                HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                                   .MCANERR_DED_ENABLE_SET,
+                    MCAN_DED_ENABLE_SET_MSGMEM_ENABLE_SET, 0x1U);
+                break;
+            default:
+                /* Invalid option */
+                break;
+        }
+    } else {
+        switch (errType) {
+            case ((uint32_t) DL_MCAN_ECC_ERR_TYPE_SEC):
+                HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                                   .MCANERR_SEC_ENABLE_CLR,
+                    MCAN_SEC_ENABLE_CLR_MSGMEM_ENABLE_CLR, 0x1U);
+                break;
+            case ((uint32_t) DL_MCAN_ECC_ERR_TYPE_DED):
+                HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                                   .MCANERR_DED_ENABLE_CLR,
+                    MCAN_DED_ENABLE_CLR_MSGMEM_ENABLE_CLR, 0x1U);
+                break;
+            default:
+                /* Invalid option */
+                break;
+        }
+    }
+}
+
+uint32_t DL_MCAN_eccGetIntrStatus(MCAN_Regs *mcan, uint32_t errType)
+{
+    uint32_t retVal = 0U;
+
+    switch (errType) {
+        case ((uint32_t) DL_MCAN_ECC_ERR_TYPE_SEC):
+            retVal = HW_RD_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS
+                                        .MCAN_ECC_REGS.MCANERR_SEC_STATUS,
+                MCAN_SEC_STATUS_MSGMEM_PEND);
+            break;
+        case ((uint32_t) DL_MCAN_ECC_ERR_TYPE_DED):
+            retVal = HW_RD_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS
+                                        .MCAN_ECC_REGS.MCANERR_DED_STATUS,
+                MCAN_DED_STATUS_MSGMEM_PEND);
+            break;
+        default:
+            retVal = 0U;
+            break;
+    }
+    return retVal;
+}
+
+void DL_MCAN_eccClearIntrStatus(MCAN_Regs *mcan, uint32_t errType)
+{
+    switch (errType) {
+        case ((uint32_t) DL_MCAN_ECC_ERR_TYPE_SEC):
+            HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                               .MCANERR_SEC_STATUS,
+                MCAN_SEC_STATUS_MSGMEM_PEND, 0x1U);
+            break;
+        case ((uint32_t) DL_MCAN_ECC_ERR_TYPE_DED):
+            HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                               .MCANERR_DED_STATUS,
+                MCAN_DED_STATUS_MSGMEM_PEND, 0x1U);
+            break;
+        default:
+            break;
+    }
+}
+
+void DL_MCAN_extTSCounterConfig(MCAN_Regs *mcan, uint32_t prescalar)
+{
+    HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS
+                       .MCANSS_EXT_TS_PRESCALER,
+        MCAN_EXT_TS_PRESCALER_PRESCALER, prescalar);
+}
+
+void DL_MCAN_extTSCounterEnable(MCAN_Regs *mcan, bool enable)
+{
+    HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_CTRL,
+        MCAN_TI_WRAPPER_REGS_CTRL_EXT_TS_CNTR_EN, enable);
+}
+
+void DL_MCAN_extTSEnableIntr(MCAN_Regs *mcan, bool enable)
+{
+    if (true == enable) {
+        HW_WR_FIELD32(
+            &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_IE,
+            MCAN_TI_WRAPPER_PROCESSORS_REGS_IE_EXT_TS_CNTR_OVFL, 1U);
+    } else {
+        HW_WR_FIELD32(
+            &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_IECS,
+            MCAN_IECS_EXT_TS_CNTR_OVFL, 1U);
+    }
+}
+
+void DL_MCAN_extTSWriteEOI(MCAN_Regs *mcan)
+{
+    HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_EOI,
+        MCAN_EOI_EOI, 0x1U);
+}
+
+uint32_t DL_MCAN_extTSGetUnservicedIntrCount(MCAN_Regs *mcan)
+{
+    return (HW_RD_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS
+                               .MCANSS_EXT_TS_UNSERVICED_INTR_CNTR,
+        MCAN_EXT_TS_UNSERVICED_INTR_CNTR_EXT_TS_INTR_CNTR));
+}
+
+/* ========================================================================== */
+/*                          Advance Functions                                 */
+/* ========================================================================== */
+
+void DL_MCAN_getRevisionId(MCAN_Regs *mcan, DL_MCAN_RevisionId *revId)
+{
+    uint32_t regVal;
+
+    regVal = HW_RD_REG32(
+        &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_PID);
+    revId->minor  = HW_GET_FIELD(regVal, MCAN_PID_MINOR);
+    revId->major  = HW_GET_FIELD(regVal, MCAN_PID_MAJOR);
+    revId->modId  = HW_GET_FIELD(regVal, MCAN_PID_MODULE_ID);
+    revId->scheme = HW_GET_FIELD(regVal, MCAN_PID_SCHEME);
+
+    regVal         = HW_RD_REG32(&mcan->MCANSS.MCAN.MCAN_CREL);
+    revId->day     = HW_GET_FIELD(regVal, MCAN_CREL_DAY);
+    revId->mon     = HW_GET_FIELD(regVal, MCAN_CREL_MON);
+    revId->year    = HW_GET_FIELD(regVal, MCAN_CREL_YEAR);
+    revId->subStep = HW_GET_FIELD(regVal, MCAN_CREL_SUBSTEP);
+    revId->step    = HW_GET_FIELD(regVal, MCAN_CREL_STEP);
+    revId->rel     = HW_GET_FIELD(regVal, MCAN_CREL_REL);
+}
+
+uint32_t DL_MCAN_getClockStopAck(MCAN_Regs *mcan)
+{
+    return (HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_CSR));
+}
+
+void DL_MCAN_extTSSetRawStatus(MCAN_Regs *mcan)
+{
+    HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_IRS,
+        MCAN_IRS_EXT_TS_CNTR_OVFL, 1U);
+}
+
+void DL_MCAN_extTSClearRawStatus(MCAN_Regs *mcan)
+{
+    HW_WR_FIELD32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_ICS,
+        MCAN_ICS_EXT_TS_CNTR_OVFL, 1U);
+}
+
+uint32_t DL_MCAN_getRxPinState(MCAN_Regs *mcan)
+{
+    return (HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_TEST, MCAN_TEST_RX));
+}
+
+void DL_MCAN_setTxPinState(MCAN_Regs *mcan, uint32_t state)
+{
+    DL_MCAN_writeProtectedRegAccessUnlock(mcan);
+
+    HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_TEST, 0x1U);
+    HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TEST, MCAN_TEST_TX, state);
+
+    DL_MCAN_writeProtectedRegAccessLock(mcan);
+}
+
+uint32_t DL_MCAN_getTxPinState(MCAN_Regs *mcan)
+{
+    return (HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_TEST, MCAN_TEST_TX));
+}
+
+uint32_t DL_MCAN_getTSCounterVal(MCAN_Regs *mcan)
+{
+    return (HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_TSCV, MCAN_TSCV_TSC));
+}
+
+uint32_t DL_MCAN_getClkStopAck(MCAN_Regs *mcan)
+{
+    return (HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_CSA));
+}
+
+void DL_MCAN_getBitTime(MCAN_Regs *mcan, DL_MCAN_BitTimingParams *configParams)
+{
+    configParams->nomSynchJumpWidth =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_NBTP, MCAN_NBTP_NSJW);
+    configParams->nomTimeSeg2 =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_NBTP, MCAN_NBTP_NTSEG2);
+    configParams->nomTimeSeg1 =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_NBTP, MCAN_NBTP_NTSEG1);
+    configParams->nomRatePrescalar =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_NBTP, MCAN_NBTP_NBRP);
+
+    configParams->dataSynchJumpWidth =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_DBTP, MCAN_DBTP_DSJW);
+    configParams->dataTimeSeg2 =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_DBTP, MCAN_DBTP_DTSEG2);
+    configParams->dataTimeSeg1 =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_DBTP, MCAN_DBTP_DTSEG1);
+    configParams->dataRatePrescalar =
+        HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_DBTP, MCAN_DBTP_DBRP);
+}
+
+void DL_MCAN_resetTSCounter(MCAN_Regs *mcan)
+{
+    HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_TSCV, MCAN_TSCV_TSC, 0x0U);
+}
+
+uint32_t DL_MCAN_getTOCounterVal(MCAN_Regs *mcan)
+{
+    return (HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_TOCV, MCAN_TOCV_TOC));
+}
+
+void DL_MCAN_eccAggrGetRevisionId(
+    MCAN_Regs *mcan, DL_MCAN_ECCAggrRevisionId *revId)
+{
+    uint32_t regVal;
+
+    regVal = HW_RD_REG32(
+        &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_REV);
+    revId->minor  = HW_GET_FIELD(regVal, MCAN_REV_REVMIN);
+    revId->major  = HW_GET_FIELD(regVal, MCAN_REV_REVMAJ);
+    revId->modId  = HW_GET_FIELD(regVal, MCAN_REV_MODULE_ID);
+    revId->scheme = HW_GET_FIELD(regVal, MCAN_REV_SCHEME);
+}
+
+void DL_MCAN_eccWrapGetRevisionId(
+    MCAN_Regs *mcan, DL_MCAN_ECCWrapRevisionId *revId)
+{
+    uint32_t regVal;
+
+    DL_MCAN_eccLoadRegister(
+        mcan, (uint32_t) &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                  .MCANERR_WRAP_REV);
+    regVal = HW_RD_REG32(
+        &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_WRAP_REV);
+    revId->minor  = HW_GET_FIELD(regVal, MCAN_WRAP_REV_REVMIN);
+    revId->major  = HW_GET_FIELD(regVal, MCAN_WRAP_REV_REVMAJ);
+    revId->modId  = HW_GET_FIELD(regVal, MCAN_WRAP_REV_MODULE_ID);
+    revId->scheme = HW_GET_FIELD(regVal, MCAN_WRAP_REV_SCHEME);
+}
+
+bool DL_MCAN_extTSIsIntrEnable(MCAN_Regs *mcan)
+{
+    bool status;
+
+    if (1U == HW_RD_FIELD32(
+                  &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_IES,
+                  MCAN_IES_EXT_TS_CNTR_OVFL)) {
+        status = true;
+    } else {
+        status = false;
+    }
+
+    return status;
+}
+
+uint32_t DL_MCAN_getEndianVal(MCAN_Regs *mcan)
+{
+    return (HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_ENDN, MCAN_ENDN_ETV));
+}
+
+uint32_t DL_MCAN_getExtIDANDMask(MCAN_Regs *mcan)
+{
+    return (HW_RD_FIELD32(&mcan->MCANSS.MCAN.MCAN_XIDAM, MCAN_XIDAM_EIDM));
+}
+
+/* ========================================================================== */
+/*                          Internal Functions                                */
+/* ========================================================================== */
+
+static void DL_MCAN_writeProtectedRegAccessUnlock(MCAN_Regs *mcan)
+{
+    HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_CCE, 0x1U);
+}
+
+static void DL_MCAN_writeProtectedRegAccessLock(MCAN_Regs *mcan)
+{
+    HW_WR_FIELD32(&mcan->MCANSS.MCAN.MCAN_CCCR, MCAN_CCCR_CCE, 0x0U);
+}
+
+static void DL_MCAN_eccLoadRegister(MCAN_Regs *mcan, uint32_t regOffset)
+{
+    uint32_t regVal = 0U, offset;
+
+    offset = regOffset & 0xFFU;
+    regVal |= ((uint32_t) MCANSS_MSG_RAM_NUM << MCAN_VECTOR_ECC_VECTOR_OFS);
+    regVal |= (offset << MCAN_VECTOR_RD_SVBUS_ADDRESS_OFS);
+    regVal |= ((uint32_t) 1U << MCAN_VECTOR_RD_SVBUS_OFS);
+    HW_WR_REG32(
+        &mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_VECTOR,
+        regVal);
+    while (MCAN_VECTOR_RD_SVBUS_DONE_MASK !=
+           (HW_RD_REG32(&mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS
+                             .MCANERR_VECTOR) &
+               MCAN_VECTOR_RD_SVBUS_DONE_MASK)) {
+    }
+}
+
+static void DL_MCAN_readMsg(
+    uint32_t mcan, uint32_t elemAddr, DL_MCAN_RxBufElement *elem)
+{
+    uint32_t regVal = 0U, loopCnt = 0U;
+
+    regVal    = HW_RD_REG32(((uint32_t) mcan + (uint32_t) elemAddr));
+    elem->id  = (uint32_t)((regVal & MCANSS_RX_BUFFER_ELEM_ID_MASK) >>
+                          MCANSS_RX_BUFFER_ELEM_ID_SHIFT);
+    elem->rtr = (uint32_t)((regVal & MCANSS_RX_BUFFER_ELEM_RTR_MASK) >>
+                           MCANSS_RX_BUFFER_ELEM_RTR_SHIFT);
+    elem->xtd = (uint32_t)((regVal & MCANSS_RX_BUFFER_ELEM_XTD_MASK) >>
+                           MCANSS_RX_BUFFER_ELEM_XTD_SHIFT);
+    elem->esi = (uint32_t)((regVal & MCANSS_RX_BUFFER_ELEM_ESI_MASK) >>
+                           MCANSS_RX_BUFFER_ELEM_ESI_SHIFT);
+
+    elemAddr += 4U;
+    regVal     = HW_RD_REG32(((uint32_t) mcan + (uint32_t) elemAddr));
+    elem->rxts = (uint32_t)((regVal & MCANSS_RX_BUFFER_ELEM_RXTS_MASK) >>
+                            MCANSS_RX_BUFFER_ELEM_RXTS_SHIFT);
+    elem->dlc  = (uint32_t)((regVal & MCANSS_RX_BUFFER_ELEM_DLC_MASK) >>
+                           MCANSS_RX_BUFFER_ELEM_DLC_SHIFT);
+    elem->brs  = (uint32_t)((regVal & MCANSS_RX_BUFFER_ELEM_BRS_MASK) >>
+                           MCANSS_RX_BUFFER_ELEM_BRS_SHIFT);
+    elem->fdf  = (uint32_t)((regVal & MCANSS_RX_BUFFER_ELEM_FDF_MASK) >>
+                           MCANSS_RX_BUFFER_ELEM_FDF_SHIFT);
+    elem->fidx = (uint32_t)((regVal & MCANSS_RX_BUFFER_ELEM_FIDX_MASK) >>
+                            MCANSS_RX_BUFFER_ELEM_FIDX_SHIFT);
+    elem->anmf = (uint32_t)((regVal & MCANSS_RX_BUFFER_ELEM_ANMF_MASK) >>
+                            MCANSS_RX_BUFFER_ELEM_ANMF_SHIFT);
+    elemAddr += 4U;
+
+    loopCnt = 0U;
+    /* Reading words from message RAM and forming payload bytes out of it */
+    while ((4U <= (DL_MCAN_getDataSize(elem->dlc) - loopCnt)) &&
+           (0U != (DL_MCAN_getDataSize(elem->dlc) - loopCnt))) {
+        regVal = HW_RD_REG32(((uint32_t) mcan + (uint32_t) elemAddr));
+        elem->data[loopCnt]        = (uint16_t)(regVal & 0x000000FFU);
+        elem->data[(loopCnt + 1U)] = (uint16_t)((regVal & 0x0000FF00U) >> 8U);
+        elem->data[(loopCnt + 2U)] = (uint16_t)((regVal & 0x00FF0000U) >> 16U);
+        elem->data[(loopCnt + 3U)] = (uint16_t)((regVal & 0xFF000000U) >> 24U);
+        elemAddr += 4U;
+        loopCnt += 4U;
+    }
+    /* Reading remaining bytes from message RAM */
+    if (0U < (DL_MCAN_getDataSize(elem->dlc) - loopCnt)) {
+        regVal = HW_RD_REG32(((uint32_t) mcan + (uint32_t) elemAddr));
+        elem->data[loopCnt]        = (uint16_t)(regVal & 0x000000FFU);
+        elem->data[(loopCnt + 1U)] = (uint16_t)((regVal & 0x0000FF00U) >> 8U);
+        elem->data[(loopCnt + 2U)] = (uint16_t)((regVal & 0x00FF0000U) >> 16U);
+    }
+}
+
+static void DL_MCAN_writeMsg(
+    uint32_t mcan, uint32_t elemAddr, const DL_MCAN_TxBufElement *elem)
+{
+    uint32_t regVal = 0, loopCnt = 0U;
+
+    regVal = 0U;
+    regVal |= (((uint32_t)(elem->id << MCANSS_TX_BUFFER_ELEM_ID_SHIFT)) |
+               ((uint32_t)(elem->rtr << MCANSS_TX_BUFFER_ELEM_RTR_SHIFT)) |
+               ((uint32_t)(elem->xtd << MCANSS_TX_BUFFER_ELEM_XTD_SHIFT)) |
+               ((uint32_t)(elem->esi << MCANSS_TX_BUFFER_ELEM_ESI_SHIFT)));
+    HW_WR_REG32(((uint32_t) mcan + (uint32_t) elemAddr), regVal);
+    elemAddr += 4U;
+
+    regVal = 0U;
+    regVal |= ((uint32_t)(elem->dlc << MCANSS_TX_BUFFER_ELEM_DLC_SHIFT)) |
+              ((uint32_t)(elem->brs << MCANSS_TX_BUFFER_ELEM_BRS_SHIFT)) |
+              ((uint32_t)(elem->fdf << MCANSS_TX_BUFFER_ELEM_FDF_SHIFT)) |
+              ((uint32_t)(elem->efc << MCANSS_TX_BUFFER_ELEM_EFC_SHIFT)) |
+              ((uint32_t)(elem->mm << MCANSS_TX_BUFFER_ELEM_MM_SHIFT));
+    HW_WR_REG32(((uint32_t) mcan + (uint32_t) elemAddr), regVal);
+    elemAddr += 4U;
+
+    loopCnt = 0U;
+    /* Framing words out of the payload bytes and writing it to message RAM */
+    while ((4U <= (DL_MCAN_getDataSize(elem->dlc) - loopCnt)) &&
+           (0U != (DL_MCAN_getDataSize(elem->dlc) - loopCnt))) {
+        regVal = 0U;
+        regVal |= ((uint32_t) elem->data[loopCnt] |
+                   ((uint32_t) elem->data[(loopCnt + 1U)] << 8U) |
+                   ((uint32_t) elem->data[(loopCnt + 2U)] << 16U) |
+                   ((uint32_t) elem->data[(loopCnt + 3U)] << 24U));
+        HW_WR_REG32(((uint32_t) mcan + (uint32_t) elemAddr), regVal);
+        elemAddr += 4U;
+        loopCnt += 4U;
+    }
+    /* Framing a word out of remaining payload bytes and writing it to
+     * message RAM */
+    if (0U < (DL_MCAN_getDataSize(elem->dlc) - loopCnt)) {
+        regVal = 0U;
+        regVal |= ((uint32_t) elem->data[loopCnt] |
+                   ((uint32_t) elem->data[(loopCnt + 1U)] << 8U) |
+                   ((uint32_t) elem->data[(loopCnt + 2U)] << 16U) |
+                   ((uint32_t) elem->data[(loopCnt + 3U)] << 24U));
+        HW_WR_REG32(((uint32_t) mcan + (uint32_t) elemAddr), regVal);
+    }
+}
+
+static uint32_t DL_MCAN_getDataSize(uint32_t dlc)
+{
+    uint32_t dataSize[16] = {
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64};
+    return (dataSize[dlc]);
+}
+
+static uint32_t DL_MCAN_getMsgObjSize(uint32_t elemSize)
+{
+    uint32_t objSize[8] = {4, 5, 6, 7, 8, 10, 14, 18};
+    return (objSize[elemSize]);
+}
+
+__STATIC_INLINE uint32_t HW_RD_REG32_RAW(uint32_t addr)
+{
+    uint32_t regVal = *(volatile uint32_t *) addr;
+    return (regVal);
+}
+
+__STATIC_INLINE void HW_WR_REG32_RAW(uint32_t addr, uint32_t value)
+{
+    *(volatile uint32_t *) addr = value;
+    return;
+}
+
+__STATIC_INLINE void HW_WR_FIELD32_RAW(
+    uint32_t addr, uint32_t mask, uint32_t shift, uint32_t value)
+{
+    uint32_t regVal = *(volatile uint32_t *) addr;
+    regVal &= (~mask);
+    regVal |= (value << shift) & mask;
+    *(volatile uint32_t *) addr = regVal;
+    return;
+}
+__STATIC_INLINE uint32_t HW_RD_FIELD32_RAW(
+    uint32_t addr, uint32_t mask, uint32_t shift)
+{
+    uint32_t regVal = *(volatile uint32_t *) addr;
+    regVal          = (regVal & mask) >> shift;
+    return (regVal);
+}
+
+bool DL_MCAN_saveConfiguration(MCAN_Regs *mcan, DL_MCAN_backupConfig *ptr)
+{
+    bool saveState = !ptr->backupRdy;
+    if (saveState) {
+        /* Clock configuration */
+        ptr->clkDivConf = mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKDIV;
+        ptr->clkConf    = mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKCTL;
+        ptr->clkEnConf  = mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKEN;
+
+        /* Interrupt Configuration */
+        ptr->txBuffTxIntConf   = mcan->MCANSS.MCAN.MCAN_TXBTIE;
+        ptr->txBuffCancIntConf = mcan->MCANSS.MCAN.MCAN_TXBCIE;
+        ptr->intLnSelConf      = mcan->MCANSS.MCAN.MCAN_ILS;
+        ptr->intLnEnableConf   = mcan->MCANSS.MCAN.MCAN_ILE;
+        ptr->ssIntEnConf =
+            mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_IE;
+        ptr->intEnConf    = mcan->MCANSS.MCAN.MCAN_IE;
+        ptr->intEvnt0Conf = mcan->MCANSS.TI_WRAPPER.MSP.CPU_INT.IMASK;
+
+        /* MCAN configuration */
+        ptr->ctrlConf        = mcan->MCANSS.MCAN.MCAN_CCCR;
+        ptr->nomBitTimeConf  = mcan->MCANSS.MCAN.MCAN_NBTP;
+        ptr->dataBitTimeConf = mcan->MCANSS.MCAN.MCAN_DBTP;
+        ptr->timeCntConf     = mcan->MCANSS.MCAN.MCAN_TSCC;
+        ptr->timeCntVal      = mcan->MCANSS.MCAN.MCAN_TSCV;
+        ptr->timeOutConf     = mcan->MCANSS.MCAN.MCAN_TOCC;
+        ptr->timeOutCntVal   = mcan->MCANSS.MCAN.MCAN_TOCV;
+        ptr->txDelCompConf   = mcan->MCANSS.MCAN.MCAN_TDCR;
+        ptr->globFiltIDConf  = mcan->MCANSS.MCAN.MCAN_GFC;
+        ptr->stdFiltIDConf   = mcan->MCANSS.MCAN.MCAN_SIDFC;
+        ptr->exFiltIDConf    = mcan->MCANSS.MCAN.MCAN_XIDFC;
+        ptr->exFiltIDMsk     = mcan->MCANSS.MCAN.MCAN_XIDAM;
+        ptr->rxFIFO0Conf     = mcan->MCANSS.MCAN.MCAN_RXF0C;
+        ptr->rxBuffConf      = mcan->MCANSS.MCAN.MCAN_RXBC;
+        ptr->rxFIFO1Conf     = mcan->MCANSS.MCAN.MCAN_RXF1C;
+        ptr->rxDataSize      = mcan->MCANSS.MCAN.MCAN_RXESC;
+        ptr->txBuffConf      = mcan->MCANSS.MCAN.MCAN_TXBC;
+        ptr->txDataSize      = mcan->MCANSS.MCAN.MCAN_TXESC;
+        ptr->txEvntFIFOConf  = mcan->MCANSS.MCAN.MCAN_TXEFC;
+        ptr->ssCtrlConf =
+            mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_CTRL;
+        ptr->preSclConf = mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS
+                              .MCANSS_EXT_TS_PRESCALER;
+        ptr->edcVecConf =
+            mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_VECTOR;
+        ptr->edcConf2 =
+            mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_CTRL;
+        ptr->edcConf1 =
+            mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_ERR_CTRL1;
+        ptr->edcConf0 =
+            mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_ERR_CTRL2;
+        ptr->ramWDConf = mcan->MCANSS.MCAN.MCAN_RWD;
+        ptr->testConf  = mcan->MCANSS.MCAN.MCAN_TEST;
+        ptr->backupRdy = true;
+    }
+    return saveState;
+}
+
+bool DL_MCAN_restoreConfiguration(MCAN_Regs *mcan, DL_MCAN_backupConfig *ptr)
+{
+    bool stateRestored = ptr->backupRdy;
+    bool cceState;
+    bool initState;
+    if (stateRestored) {
+        ptr->backupRdy = false;
+
+        /**
+         * Stores actual state of Configuration Change Enable. CCE will be set
+         * during restore operation and will configure CCE actual state at the
+         * end.
+         */
+        cceState =
+            ((ptr->ctrlConf & MCAN_CCCR_CCE_MASK) == MCAN_CCCR_CCE_MASK);
+        initState =
+            ((ptr->ctrlConf & MCAN_CCCR_INIT_MASK) == MCAN_CCCR_INIT_MASK);
+
+        /**
+         * MCAN configuration only overwrittring CCE configuration since INIT
+         * reset value is 0x1. CCE and INIT must be set to 0x1 to allow
+         * reconfiguration of MCAN.
+         */
+        mcan->MCANSS.MCAN.MCAN_CCCR  = (ptr->ctrlConf |= MCAN_CCCR_CCE_MASK);
+        mcan->MCANSS.MCAN.MCAN_NBTP  = ptr->nomBitTimeConf;
+        mcan->MCANSS.MCAN.MCAN_DBTP  = ptr->dataBitTimeConf;
+        mcan->MCANSS.MCAN.MCAN_TSCC  = ptr->timeCntConf;
+        mcan->MCANSS.MCAN.MCAN_TSCV  = ptr->timeCntVal;
+        mcan->MCANSS.MCAN.MCAN_TOCC  = ptr->timeOutConf;
+        mcan->MCANSS.MCAN.MCAN_TOCV  = ptr->timeOutCntVal;
+        mcan->MCANSS.MCAN.MCAN_TDCR  = ptr->txDelCompConf;
+        mcan->MCANSS.MCAN.MCAN_GFC   = ptr->globFiltIDConf;
+        mcan->MCANSS.MCAN.MCAN_SIDFC = ptr->stdFiltIDConf;
+        mcan->MCANSS.MCAN.MCAN_XIDFC = ptr->exFiltIDConf;
+        mcan->MCANSS.MCAN.MCAN_XIDAM = ptr->exFiltIDMsk;
+        mcan->MCANSS.MCAN.MCAN_RXF0C = ptr->rxFIFO0Conf;
+        mcan->MCANSS.MCAN.MCAN_RXBC  = ptr->rxBuffConf;
+        mcan->MCANSS.MCAN.MCAN_RXF1C = ptr->rxFIFO1Conf;
+        mcan->MCANSS.MCAN.MCAN_RXESC = ptr->rxDataSize;
+        mcan->MCANSS.MCAN.MCAN_TXBC  = ptr->txBuffConf;
+        mcan->MCANSS.MCAN.MCAN_TXESC = ptr->txDataSize;
+        mcan->MCANSS.MCAN.MCAN_TXEFC = ptr->txEvntFIFOConf;
+        mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_CTRL =
+            ptr->ssCtrlConf;
+        mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS
+            .MCANSS_EXT_TS_PRESCALER = ptr->preSclConf;
+        mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_VECTOR =
+            ptr->edcVecConf;
+        mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_CTRL =
+            ptr->edcConf2;
+        mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_ERR_CTRL1 =
+            ptr->edcConf1;
+        mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCAN_ECC_REGS.MCANERR_ERR_CTRL2 =
+            ptr->edcConf0;
+        mcan->MCANSS.MCAN.MCAN_RWD  = ptr->ramWDConf;
+        mcan->MCANSS.MCAN.MCAN_TEST = ptr->testConf;
+
+        /* Clock configuration */
+        mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKDIV = ptr->clkDivConf;
+        mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKCTL = ptr->clkConf;
+        mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKEN  = ptr->clkEnConf;
+
+        /* Interrupt Configuration */
+        mcan->MCANSS.MCAN.MCAN_TXBTIE = ptr->txBuffTxIntConf;
+        mcan->MCANSS.MCAN.MCAN_TXBCIE = ptr->txBuffCancIntConf;
+        mcan->MCANSS.MCAN.MCAN_ILS    = ptr->intLnSelConf;
+        mcan->MCANSS.MCAN.MCAN_ILE    = ptr->intLnEnableConf;
+        mcan->MCANSS.TI_WRAPPER.PROCESSORS.MCANSS_REGS.MCANSS_IE =
+            ptr->ssIntEnConf;
+        mcan->MCANSS.MCAN.MCAN_IE                 = ptr->intEnConf;
+        mcan->MCANSS.TI_WRAPPER.MSP.CPU_INT.IMASK = ptr->intEvnt0Conf;
+
+        /* Restores MCAN configuration change state */
+        if (false == cceState) {
+            DL_Common_updateReg(
+                &mcan->MCANSS.MCAN.MCAN_CCCR, 0, MCAN_CCCR_CCE_MASK);
+        } else {
+            DL_Common_updateReg(&mcan->MCANSS.MCAN.MCAN_CCCR,
+                MCAN_CCCR_CCE_MASK, MCAN_CCCR_CCE_MASK);
+        }
+
+        /* Restores MCAN intialization status */
+        if (false == initState) {
+            DL_Common_updateReg(
+                &mcan->MCANSS.MCAN.MCAN_CCCR, 0, MCAN_CCCR_INIT_MASK);
+        } else {
+            DL_Common_updateReg(&mcan->MCANSS.MCAN.MCAN_CCCR,
+                MCAN_CCCR_INIT_MASK, MCAN_CCCR_INIT_MASK);
+        }
+    }
+
+    return stateRestored;
+}
+
+#endif /* __MSPM0_HAS_MCAN__ */

--- a/mspm0/source/ti/driverlib/dl_mcan.h
+++ b/mspm0/source/ti/driverlib/dl_mcan.h
@@ -1,0 +1,3025 @@
+/*
+ * Copyright (c) 2021, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_mcan.h
+ *  @brief      Modular Controller Area Network (MCAN) Driver Library
+ *  @defgroup   MCAN Modular Controller Area Network (MCAN)
+ *
+ *  @anchor ti_dl_dl_mcan_Overview
+ *  # Overview
+ *
+ *  The MCAN Driver Library allows full configuration of the MSPM0 MCAN (CAN-FD)
+ *  module.
+ *  The Modular Controller Area Network (MCAN) peripheral supports both
+ *  communication through classic CAN and CAN-FD protocols.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup MCAN
+ * @{
+ */
+#ifndef ti_dl_dl_mcan__include
+#define ti_dl_dl_mcan__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_MCAN__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/**
+ *  @brief  Macro defines mask for all the interrupts status for MCAN.
+ */
+#define DL_MCAN_INTR_MASK_ALL (MCAN_IR_RF0N_MASK |                          \
+                               MCAN_IR_RF0W_MASK |                          \
+                               MCAN_IR_RF0F_MASK |                          \
+                               MCAN_IR_RF0L_MASK |                          \
+                               MCAN_IR_RF1N_MASK |                          \
+                               MCAN_IR_RF1W_MASK |                          \
+                               MCAN_IR_RF1F_MASK |                          \
+                               MCAN_IR_RF1L_MASK |                          \
+                               MCAN_IR_HPM_MASK  |                          \
+                               MCAN_IR_TC_MASK   |                          \
+                               MCAN_IR_TCF_MASK  |                          \
+                               MCAN_IR_TFE_MASK  |                          \
+                               MCAN_IR_TEFN_MASK |                          \
+                               MCAN_IR_TEFW_MASK |                          \
+                               MCAN_IR_TEFF_MASK |                          \
+                               MCAN_IR_TEFL_MASK |                          \
+                               MCAN_IR_TSW_MASK  |                          \
+                               MCAN_IR_MRAF_MASK |                          \
+                               MCAN_IR_TOO_MASK  |                          \
+                               MCAN_IR_DRX_MASK  |                          \
+                               MCAN_IR_BEU_MASK  |                          \
+                               MCAN_IR_ELO_MASK  |                          \
+                               MCAN_IR_EP_MASK   |                          \
+                               MCAN_IR_EW_MASK   |                          \
+                               MCAN_IR_BO_MASK   |                          \
+                               MCAN_IR_WDI_MASK  |                          \
+                               MCAN_IR_PEA_MASK  |                          \
+                               MCAN_IR_PED_MASK  |                          \
+                               MCAN_IR_ARA_MASK)
+
+/**
+ *  @brief  Maximum payload supported by CAn-FD protocol in bytes.
+ */
+#define DL_MCAN_MAX_PAYLOAD_BYTES                                          (64U)
+
+
+/** @addtogroup DL_MCAN_INTERRUPT
+ *  @{
+ */
+/*!
+ * @brief Access to Reserved Address interrupt
+ */
+#define DL_MCAN_INTERRUPT_ARA                                 (MCAN_IR_ARA_MASK)
+
+/*!
+ * @brief Protocol Error in Data Phase interrupt
+ */
+#define DL_MCAN_INTERRUPT_PED                                 (MCAN_IR_PED_MASK)
+
+/*!
+ * @brief Protocol Error in Arbitration Phase interrupt
+ */
+#define DL_MCAN_INTERRUPT_PEA                                 (MCAN_IR_PEA_MASK)
+
+/*!
+ * @brief Watchdog interrupt
+ */
+#define DL_MCAN_INTERRUPT_WDI                                 (MCAN_IR_WDI_MASK)
+
+/*!
+ * @brief Bus_Off Status interrupt
+ */
+#define DL_MCAN_INTERRUPT_BO                                   (MCAN_IR_BO_MASK)
+
+/*!
+ * @brief Warning Status interrupt
+ */
+#define DL_MCAN_INTERRUPT_EW                                 (MCAN_IR_EW_MASK)
+
+/*!
+ * @brief Error Passive interrupt
+ */
+#define DL_MCAN_INTERRUPT_EP                                 (MCAN_IR_EP_MASK)
+
+/*!
+ * @brief Error Logging Overflow interrupt
+ */
+#define DL_MCAN_INTERRUPT_ELO                                 (MCAN_IR_ELO_MASK)
+
+/*!
+ * @brief Bit Error Uncorrected. Message RAM bit error detected, uncorrected interrupt
+ */
+#define DL_MCAN_INTERRUPT_BEU                                 (MCAN_IR_BEU_MASK)
+
+/*!
+ * @brief Message Stored to Dedicated Rx Buffer interrupt
+ */
+#define DL_MCAN_INTERRUPT_DRX                                 (MCAN_IR_DRX_MASK)
+
+/*!
+ * @brief Timeout Occurred interrupt
+ */
+#define DL_MCAN_INTERRUPT_TOO                                 (MCAN_IR_TOO_MASK)
+
+/*!
+ * @brief Message RAM Access Failure interrupt
+ */
+#define DL_MCAN_INTERRUPT_MRAF                               (MCAN_IR_MRAF_MASK)
+
+/*!
+ * @brief Timestamp Wraparound interrupt
+ */
+#define DL_MCAN_INTERRUPT_TSW                                 (MCAN_IR_TSW_MASK)
+
+/*!
+ * @brief Tx Event FIFO Element Lost interrupt
+ */
+#define DL_MCAN_INTERRUPT_TEFL                               (MCAN_IR_TEFL_MASK)
+
+/*!
+ * @brief Tx Event FIFO Full interrupt
+ */
+#define DL_MCAN_INTERRUPT_TEFF                               (MCAN_IR_TEFF_MASK)
+
+/*!
+ * @brief Tx Event FIFO Watermark Reached interrupt
+ */
+#define DL_MCAN_INTERRUPT_TEFW                               (MCAN_IR_TEFW_MASK)
+
+/*!
+ * @brief Tx Event FIFO New Entry interrupt
+ */
+#define DL_MCAN_INTERRUPT_TEFN                               (MCAN_IR_TEFN_MASK)
+
+/*!
+ * @brief Tx FIFO Empty interrupt
+ */
+#define DL_MCAN_INTERRUPT_TFE                                 (MCAN_IR_TFE_MASK)
+
+/*!
+ * @brief Transmission Cancellation Finished interrupt
+ */
+#define DL_MCAN_INTERRUPT_TCF                                 (MCAN_IR_TCF_MASK)
+
+/*!
+ * @brief Transmission Completed interrupt
+ */
+#define DL_MCAN_INTERRUPT_TC                                   (MCAN_IR_TC_MASK)
+
+/*!
+ * @brief High Priority Message interrupt
+ */
+#define DL_MCAN_INTERRUPT_HPM                                 (MCAN_IR_HPM_MASK)
+
+/*!
+ * @brief Rx FIFO 1 Message Lost interrupt
+ */
+#define DL_MCAN_INTERRUPT_RF1L                               (MCAN_IR_RF1L_MASK)
+
+/*!
+ * @brief Rx FIFO 1 Full interrupt
+ */
+#define DL_MCAN_INTERRUPT_RF1F                               (MCAN_IR_RF1F_MASK)
+
+/*!
+ * @brief Rx FIFO 1 Watermark Reached interrupt
+ */
+#define DL_MCAN_INTERRUPT_RF1W                               (MCAN_IR_RF1W_MASK)
+
+/*!
+ * @brief Rx FIFO 1 New Message interrupt
+ */
+#define DL_MCAN_INTERRUPT_RF1N                               (MCAN_IR_RF1N_MASK)
+
+/*!
+ * @brief Rx FIFO 0 Message Lost interrupt
+ */
+#define DL_MCAN_INTERRUPT_RF0L                               (MCAN_IR_RF0L_MASK)
+
+/*!
+ * @brief Rx FIFO 0 Full interrupt
+ */
+#define DL_MCAN_INTERRUPT_RF0F                               (MCAN_IR_RF0F_MASK)
+
+/*!
+ * @brief Rx FIFO 0 Watermark interrupt
+ */
+#define DL_MCAN_INTERRUPT_RF0W                               (MCAN_IR_RF0W_MASK)
+
+/*!
+ * @brief Rx FIFO 0 New Message interrupt
+ */
+#define DL_MCAN_INTERRUPT_RF0N                               (MCAN_IR_RF0N_MASK)
+
+/** @}*/
+
+/** @addtogroup DL_MCAN_MSP_INTERRUPT
+ *  @{
+ */
+/*!
+ * @brief Clock Stop Wake Up interrupt
+ */
+#define DL_MCAN_MSP_INTERRUPT_WAKEUP                     (MCAN_IMASK_WAKEUP_SET)
+
+/*!
+ * @brief External Timestamp Counter Overflow interrupt
+ */
+#define DL_MCAN_MSP_INTERRUPT_TIMESTAMP_OVERFLOW (MCAN_IMASK_EXT_TS_CNTR_OVFL_SET)
+
+/*!
+ * @brief Message RAM Double Error Detection interrupt
+ */
+#define DL_MCAN_MSP_INTERRUPT_DOUBLE_ERROR_DETECTION        (MCAN_IMASK_DED_SET)
+
+/*!
+ * @brief Message RAM Single Error Correction interrupt
+ */
+#define DL_MCAN_MSP_INTERRUPT_SINGLE_ERROR_CORRECTION       (MCAN_IMASK_SEC_SET)
+
+/*!
+ * @brief MCAN Interrupt Line 1
+ */
+#define DL_MCAN_MSP_INTERRUPT_LINE1                       (MCAN_IMASK_INTL1_SET)
+
+/*!
+ * @brief MCAN Interrupt Line 0
+ */
+#define DL_MCAN_MSP_INTERRUPT_LINE0                       (MCAN_IMASK_INTL0_SET)
+
+/** @}*/
+
+/** @addtogroup DL_MCAN_INTR_SRC
+ *  @{
+ */
+/*!
+ * @brief Rx FIFO 0 New Message interrupt
+ */
+#define DL_MCAN_INTR_SRC_RX_FIFO0_NEW_MSG                    (MCAN_IR_RF0N_MASK)
+
+/*!
+ * @brief Rx FIFO 0 Watermark Reached interrupt
+ */
+#define DL_MCAN_INTR_SRC_RX_FIFO0_WATERMARK                  (MCAN_IR_RF0W_MASK)
+
+/*!
+ * @brief Rx FIFO 0 Full interrupt
+ */
+#define DL_MCAN_INTR_SRC_RX_FIFO0_FULL                       (MCAN_IR_RF0F_MASK)
+
+/*!
+ * @brief Rx FIFO 0 Message Lost interrupt
+ */
+#define DL_MCAN_INTR_SRC_RX_FIFO0_MSG_LOST                   (MCAN_IR_RF0L_MASK)
+
+/*!
+ * @brief Rx FIFO 1 New Message interrupt
+ */
+#define DL_MCAN_INTR_SRC_RX_FIFO1_NEW_MSG                    (MCAN_IR_RF1N_MASK)
+
+/*!
+ * @brief Rx FIFO 1 Watermark Reached interrupt
+ */
+#define DL_MCAN_INTR_SRC_RX_FIFO1_WATERMARK                  (MCAN_IR_RF1W_MASK)
+
+/*!
+ * @brief Rx FIFO 1 Full interrupt
+ */
+#define DL_MCAN_INTR_SRC_RX_FIFO1_FULL                       (MCAN_IR_RF1F_MASK)
+
+/*!
+ * @brief Rx FIFO 1 Message Lost interrupt
+ */
+#define DL_MCAN_INTR_SRC_RX_FIFO1_MSG_LOST                   (MCAN_IR_RF1L_MASK)
+
+/*!
+ * @brief High Priority Message interrupt
+ */
+#define DL_MCAN_INTR_SRC_HIGH_PRIO_MSG                        (MCAN_IR_HPM_MASK)
+
+/*!
+ * @brief Transmission Completed interrupt
+ */
+#define DL_MCAN_INTR_SRC_TRANS_COMPLETE                        (MCAN_IR_TC_MASK)
+
+/*!
+ * @brief Transmission Cancellation Finished interrupt
+ */
+#define DL_MCAN_INTR_SRC_TRANS_CANCEL_FINISH                  (MCAN_IR_TCF_MASK)
+
+/*!
+ * @brief Tx FIFO Empty interrupt
+ */
+#define DL_MCAN_INTR_SRC_TX_FIFO_EMPTY                        (MCAN_IR_TFE_MASK)
+
+/*!
+ * @brief Tx Event FIFO New Entry interrupt
+ */
+#define DL_MCAN_INTR_SRC_TX_EVT_FIFO_NEW_ENTRY               (MCAN_IR_TEFN_MASK)
+
+/*!
+ * @brief Tx Event FIFO Watermark Reached interrupt
+ */
+#define DL_MCAN_INTR_SRC_TX_EVT_FIFO_WATERMARK               (MCAN_IR_TEFW_MASK)
+
+/*!
+ * @brief Tx Event FIFO Full interrupt
+ */
+#define DL_MCAN_INTR_SRC_TX_EVT_FIFO_FULL                    (MCAN_IR_TEFF_MASK)
+
+/*!
+ * @brief Tx Event FIFO Element Lost interrupt
+ */
+#define DL_MCAN_INTR_SRC_TX_EVT_FIFO_ELEM_LOST               (MCAN_IR_TEFL_MASK)
+
+/*!
+ * @brief Timestamp Wraparound interrupt
+ */
+#define DL_MCAN_INTR_SRC_TIMESTAMP_WRAPAROUND                 (MCAN_IR_TSW_MASK)
+
+/*!
+ * @brief Message RAM Access Failure interrupt
+ */
+#define DL_MCAN_INTR_SRC_MSG_RAM_ACCESS_FAILURE              (MCAN_IR_MRAF_MASK)
+
+/*!
+ * @brief Timeout Occurred interrupt
+ */
+#define DL_MCAN_INTR_SRC_TIMEOUT                              (MCAN_IR_TOO_MASK)
+
+/*!
+ * @brief Message stored to Dedicated Rx Buffer interrupt
+ */
+#define DL_MCAN_INTR_SRC_DEDICATED_RX_BUFF_MSG                (MCAN_IR_DRX_MASK)
+
+/*!
+ * @brief Bit Error Uncorrected interrupt
+ */
+#define DL_MCAN_INTR_SRC_BIT_ERR_UNCORRECTED                  (MCAN_IR_BEU_MASK)
+
+/*!
+ * @brief Error Logging Overflow interrupt
+ */
+#define DL_MCAN_INTR_SRC_ERR_LOG_OVRFLW                       (MCAN_IR_ELO_MASK)
+
+/*!
+ * @brief Error Passive interrupt
+ */
+#define DL_MCAN_INTR_SRC_ERR_PASSIVE                           (MCAN_IR_EP_MASK)
+
+/*!
+ * @brief Warning Status interrupt
+ */
+#define DL_MCAN_INTR_SRC_WARNING_STATUS                        (MCAN_IR_EW_MASK)
+
+/*!
+ * @brief Bus_Off Status interrupt
+ */
+#define DL_MCAN_INTR_SRC_BUS_OFF_STATUS                        (MCAN_IR_BO_MASK)
+
+/*!
+ * @brief Watchdog Interrupt interrupt
+ */
+#define DL_MCAN_INTR_SRC_WATCHDOG                             (MCAN_IR_WDI_MASK)
+
+/*!
+ * @brief Protocol Error in Arbitration Phase interrupt
+ */
+#define DL_MCAN_INTR_SRC_PROTOCOL_ERR_ARB                     (MCAN_IR_PEA_MASK)
+
+/*!
+ * @brief Protocol Error in Data Phase interrupt
+ */
+#define DL_MCAN_INTR_SRC_PROTOCOL_ERR_DATA                    (MCAN_IR_PED_MASK)
+
+/*!
+ * @brief Access to Reserved Address interrupt
+ */
+#define DL_MCAN_INTR_SRC_RES_ADDR_ACCESS                      (MCAN_IR_ARA_MASK)
+
+/** @}*/
+
+/* User defined ranges */
+/*!
+ * @brief Maximum data synch jump width
+ */
+#define DL_MCAN_DBTP_DSJW_MAX                                             (0xFU)
+/*!
+ *  @brief Max data time segment 2
+ */
+#define DL_MCAN_DBTP_DTSEG2_MAX                                           (0xFU)
+/*!
+ *  @brief Max data time segment 1
+ */
+#define DL_MCAN_DBTP_DTSEG1_MAX                                          (0x1FU)
+/*!
+ *  @brief Max data date rate prescalar
+ */
+#define DL_MCAN_DBTP_DBRP_MAX                                            (0x1FU)
+/*!
+ *  @brief Max nom synch jump width
+ */
+#define DL_MCAN_NBTP_NSJW_MAX                                            (0x7FU)
+/*!
+ *  @brief Max nom synch time segment 2
+ */
+#define DL_MCAN_NBTP_NTSEG2_MAX                                          (0x7FU)
+/*!
+ *  @brief Max nom synch time segment 1
+ */
+#define DL_MCAN_NBTP_NTSEG1_MAX                                          (0xFFU)
+/*!
+ *  @brief Max nom data date rate prescalar
+ */
+#define DL_MCAN_NBTP_NBRP_MAX                                           (0x1FFU)
+/*!
+ *  @brief Max wdc preload
+ */
+#define DL_MCAN_RWD_WDC_MAX                                              (0xFFU)
+/*!
+ *  @brief Transmitter Delay Compensation Filter Window Length
+ */
+#define DL_MCAN_TDCR_TDCF_MAX                                            (0x7FU)
+/*!
+ *  @brief Transmitter Delay Compensation Offset
+ */
+#define DL_MCAN_TDCR_TDCO_MAX                                            (0x7FU)
+/*!
+ *  @brief Max MCAN extended id mask
+ */
+#define DL_MCAN_XIDAM_EIDM_MAX                                     (0x1FFFFFFFU)
+/*!
+ *  @brief Max timestamp counter prescaler
+ */
+#define DL_MCAN_TSCC_TCP_MAX                                              (0xFU)
+/*!
+ *  @brief Max timeout preload
+ */
+#define DL_MCAN_TOCC_TOP_MAX                                           (0xFFFFU)
+
+/* clang-format on */
+
+/**
+ *  @brief   Enum to select the MCAN instance
+ */
+typedef enum {
+    /*! Selects CANFD instance 0 of device */
+    DL_MCAN_INSTANCE_0 = SYSCTL_SYSSTATUS_MCAN0READY_MASK,
+} DL_MCAN_INSTANCE;
+
+/**
+ *  @brief   Enum to select source clock for CANCLK
+ */
+typedef enum {
+    /*! Selects SYSPLLCLK1 as the source clock for CANCLK */
+    DL_MCAN_FCLK_SYSPLLCLK1 = SYSCTL_GENCLKCFG_CANCLKSRC_SYSPLLOUT1,
+    /*! Selects HFCLK as the source clock for CANCLK */
+    DL_MCAN_FCLK_HFCLK = SYSCTL_GENCLKCFG_CANCLKSRC_HFCLK,
+} DL_MCAN_FCLK;
+
+/**
+ *  @brief   Enum to select CANCLK divider
+ */
+typedef enum {
+    /*! Clock divider 1 */
+    DL_MCAN_FCLK_DIV_1 = MCAN_CLKDIV_RATIO_DIV_BY_1_,
+    /*! Clock divider 2 */
+    DL_MCAN_FCLK_DIV_2 = MCAN_CLKDIV_RATIO_DIV_BY_2_,
+    /*! Clock divider 4 */
+    DL_MCAN_FCLK_DIV_4 = MCAN_CLKDIV_RATIO_DIV_BY_4_,
+} DL_MCAN_FCLK_DIV;
+
+/**
+ *  @brief   Enum to select the MCAN interrupt lines
+ */
+typedef enum {
+    /*! MCAN interrupt line 0 */
+    DL_MCAN_INTR_LINE_NUM_0 = 0U,
+    /*! MCAN interrupt line 1 */
+    DL_MCAN_INTR_LINE_NUM_1 = 1U
+
+} DL_MCAN_INTR_LINE_NUM;
+
+/**
+ *  @brief   Enum to represent the MCAN Identifier Type
+ */
+typedef enum {
+
+    /*! 11bit MCAN Identifier */
+    DL_MCAN_ID_TYPE_11_BIT = 0U,
+    /*! 29bit MCAN Identifier */
+    DL_MCAN_ID_TYPE_29_BIT = 1U
+
+} DL_MCAN_ID_TYPE;
+
+/**
+ *  @brief   Enum to represent the MCAN mode of operation
+ */
+typedef enum {
+    /*! MCAN normal mode */
+    DL_MCAN_OPERATION_MODE_NORMAL = 0U,
+    /*! MCAN SW initialization mode */
+    DL_MCAN_OPERATION_MODE_SW_INIT = 1U
+
+} DL_MCAN_OPERATION_MODE;
+
+/**
+ *  @brief   Enum to represent the MCAN Message RAM type.
+ */
+typedef enum {
+    /*! MCAN Msg RAM buffers */
+    DL_MCAN_MEM_TYPE_BUF = 0U,
+    /*! MCAN Msg RAM FIFO/Queue */
+    DL_MCAN_MEM_TYPE_FIFO = 1U
+
+} DL_MCAN_MEM_TYPE;
+
+/**
+ *  @brief   Enum to represent the MCAN Rx FIFO number
+ */
+typedef enum {
+    /*! MCAN Rx FIFO 0 */
+    DL_MCAN_RX_FIFO_NUM_0 = 0U,
+    /*! MCAN Rx FIFO 1 */
+    DL_MCAN_RX_FIFO_NUM_1 = 1U
+} DL_MCAN_RX_FIFO_NUM;
+
+/**
+ *  @brief   Enum to represent the MCAN pin type
+ */
+typedef enum {
+    /*! MCAN Rx Pin */
+    DL_MCAN_PIN_TYPE_RX = 0U,
+    /*! MCAN Tx Pin */
+    DL_MCAN_PIN_TYPE_TX = 1U
+} DL_MCAN_PIN_TYPE;
+
+/**
+ *  @brief   Enum to represent FIFO/Buffer element Size
+ */
+typedef enum {
+    /*! 8 byte data field */
+    DL_MCAN_ELEM_SIZE_8BYTES = 0U,
+    /*! 12 byte data field */
+    DL_MCAN_ELEM_SIZE_12BYTES = 1U,
+    /*! 16 byte data field */
+    DL_MCAN_ELEM_SIZE_16BYTES = 2U,
+    /*! 20 byte data field */
+    DL_MCAN_ELEM_SIZE_20BYTES = 3U,
+    /*! 24 byte data field */
+    DL_MCAN_ELEM_SIZE_24BYTES = 4U,
+    /*! 32 byte data field */
+    DL_MCAN_ELEM_SIZE_32BYTES = 5U,
+    /*! 48 byte data field */
+    DL_MCAN_ELEM_SIZE_48BYTES = 6U,
+    /*! 64 byte data field */
+    DL_MCAN_ELEM_SIZE_64BYTES = 7U
+} DL_MCAN_ELEM_SIZE;
+
+/**
+ *  @brief   Enum to represent the MCAN time-out counter configuration
+ */
+typedef enum {
+    /*! Continuous operation Mode */
+    DL_MCAN_TIMEOUT_SELECT_CONT = 0U,
+    /*! Timeout controlled by Tx Event FIFO */
+    DL_MCAN_TIMEOUT_SELECT_TX_EVENT_FIFO = 1U,
+    /*! Timeout controlled by Rx FIFO 0 */
+    DL_MCAN_TIMEOUT_SELECT_RX_FIFO0 = 2U,
+    /*! Timeout controlled by Rx FIFO 1 */
+    DL_MCAN_TIMEOUT_SELECT_RX_FIFO1 = 3U
+
+} DL_MCAN_TIMEOUT_SELECT;
+
+/**
+ *  @brief   Enum to select the MCAN instance
+ */
+typedef enum {
+    /*! MCAN interrupt source was triggered by external time stamp*/
+    DL_MCAN_INTR_SRC_MCAN_EXT_TS = 0x0,
+    /*! MCAN interrupt source was triggered by Line 0 */
+    DL_MCAN_INTR_SRC_MCAN_LINE_0 = 0x1,
+    /*! MCAN interrupt source was triggered by Line 1 */
+    DL_MCAN_INTR_SRC_MCAN_LINE_1 = 0x2,
+} DL_MCAN_INTR_SRC_MCAN;
+
+/**
+ *  @brief   Enum to represent the ECC Error Types
+ */
+typedef enum {
+    /*! ECC Single Error Correction */
+    DL_MCAN_ECC_ERR_TYPE_SEC = 0U,
+    /*! ECC Single Error Detection */
+    DL_MCAN_ECC_ERR_TYPE_DED = 1U
+
+} DL_MCAN_ECC_ERR_TYPE;
+
+/**
+ *  @brief   Enum to select the MCAN Loopback mode
+ */
+typedef enum {
+    /*! Internal Loop Back Mode
+     *   This mode can be used for hot self-test and this mode will not
+     *   affect bus state.
+     */
+    DL_MCAN_LPBK_MODE_INTERNAL = 0U,
+    /*! External Loop Back Mode
+    *   In this mode, MCAN the M_CAN treats its own
+    *   transmitted messages as
+    *   received messages and stores them (if they
+    *   pass acceptance filtering)
+    *   into an Rx Buffer or an Rx FIFO.
+    *   This mode will affect bus state
+    */
+    DL_MCAN_LPBK_MODE_EXTERNAL = 1U
+
+} DL_MCAN_LPBK_MODE;
+
+/**
+ *  @brief   Enum to represent MCAN's communication state
+ */
+typedef enum {
+    /*! MCAN is synchronizing on CAN communication */
+    DL_MCAN_COM_STATE_SYNCHRONIZING = 0U,
+    /*! MCAN is neither receiver nor transmitter */
+    DL_MCAN_COM_STATE_IDLE = 1U,
+    /*! MCAN is operating as receiver */
+    DL_MCAN_COM_STATE_RECEIVER = 2U,
+    /*! MCAN is operating as transmitter */
+    DL_MCAN_COM_STATE_TRANSMITTER = 3U
+} DL_MCAN_COM_STATE;
+
+/**
+ *  @brief   Enum to represent MCAN's Error Code
+ */
+typedef enum {
+    /*! No error occurred since LEC has been reset by
+     *   successful reception or transmission.
+     */
+    DL_MCAN_ERR_CODE_NO_ERROR = 0U,
+    /*! More than 5 equal bits in a sequence have occurred in a part of
+     *   a received message where this is not allowed.
+     */
+    DL_MCAN_ERR_CODE_STUFF_ERROR = 1U,
+    /*! A fixed format part of a received frame has the wrong format. */
+    DL_MCAN_ERR_CODE_FORM_ERROR = 2U,
+    /*! The message transmitted by the M_CAN was not acknowledged
+     *   by another node.
+     */
+    DL_MCAN_ERR_CODE_ACK_ERROR = 3U,
+    /*! During the transmission of a message (with the exception of
+     *   the arbitration field), the device wanted to send a
+     *   recessive level (bit of logical value 1),
+     *  but the monitored bus value was dominant.
+     */
+    DL_MCAN_ERR_CODE_BIT1_ERROR = 4U,
+    /*! During the transmission of a message (or acknowledge bit,
+     *   or active error flag, or overload flag), the device wanted to send
+     *   a dominant level (data or identifier bit logical value 0),
+     *   but the monitored bus value was recessive. During Bus_Off recovery
+     *   this status is set each time a sequence of 11 recessive bits has been
+     *   monitored. This enables the CPU to monitor the proceeding of
+     *   the Bus_Off recovery sequence (indicating the bus is not stuck at
+     *   dominant or continuously disturbed).
+     */
+    DL_MCAN_ERR_CODE_BIT0_ERROR = 5U,
+    /*! The CRC check sum of a received message was incorrect.
+     *   The CRC of an incoming message does not match with the
+     *   CRC calculated from the received data.
+     */
+    DL_MCAN_ERR_CODE_CRC_ERROR = 6U,
+    /*! Any read access to the Protocol Status Register re-initializes
+     * the LEC to 7. When the LEC shows the value 7,no CAN bus event was
+     * detected since the last CPU read access to the Protocol Status Register.
+     */
+    DL_MCAN_ERR_CODE_NO_CHANGE = 7U
+
+} DL_MCAN_ERR_CODE;
+
+/**
+ *  @brief  Structure for CANCLK configuration.
+ */
+typedef struct {
+    /*! Specifies the clock source for MCAN_FCLK (CANCLK). One of
+        @ref DL_MCAN_FCLK */
+    DL_MCAN_FCLK clockSel;
+    /*! Specifies clock divider for CANCLK. One of @ref DL_MCAN_FCLK_DIV */
+    DL_MCAN_FCLK_DIV divider;
+} DL_MCAN_ClockConfig;
+
+/**
+ *  @brief  Structure for bit timing calculation.
+ *         Bit timing related to data phase will be valid only in case where
+ *         MCAN is put in CAN-FD mode and will be '0' otherwise.
+ */
+typedef struct {
+    /*! Nominal Baud Rate Pre-scaler
+     *   Range:[0x0-0x1FF]
+     */
+    uint32_t nomRatePrescalar;
+    /*! Nominal Time segment before sample point
+     *   Range:[0x0-0xFF]
+     */
+    uint32_t nomTimeSeg1;
+    /*! Nominal Time segment after sample point
+     *   Range:[0x0-0x7F]
+     */
+    uint32_t nomTimeSeg2;
+    /*! Nominal (Re)Synchronization Jump Width
+     *   Range:[0x0-0x7F]
+     */
+    uint32_t nomSynchJumpWidth;
+    /*! Data Baud Rate Pre-scaler
+     *   Range:[0x0-0x1F]
+     */
+    uint32_t dataRatePrescalar;
+    /*! Data Time segment before sample point
+     *   Range:[0x0-0x1F]
+     */
+    uint32_t dataTimeSeg1;
+    /*! Data Time segment after sample point
+     *   Range:[0x0-0xF]
+     */
+    uint32_t dataTimeSeg2;
+    /*! Data (Re)Synchronization Jump Width
+     *   Range:[0x0-0xF]
+     */
+    uint32_t dataSynchJumpWidth;
+} DL_MCAN_BitTimingParams;
+
+/**
+ *  @brief  Structure for MCAN Transmitter Delay Compensation parameters.
+ */
+typedef struct {
+    /*! Transmitter Delay Compensation Filter Window Length
+     *   Range:[0x0-0x7F]
+     */
+    uint32_t tdcf;
+    /*! Transmitter Delay Compensation Offset
+     *   Range:[0x0-0x7F]
+     */
+    uint32_t tdco;
+} DL_MCAN_TDCConfig;
+
+/**
+ *  @brief  Structure for MCAN Global Filter Configuration parameters.
+ */
+typedef struct {
+    /*! Reject Remote Frames Extended
+     *   0 = Filter remote frames with 29-bit extended IDs
+     *   1 = Reject all remote frames with 29-bit extended IDs
+     */
+    uint32_t rrfe;
+    /*! Reject Remote Frames Standard
+     *   0 = Filter remote frames with 11-bit standard IDs
+     *   1 = Reject all remote frames with 11-bit standard IDs
+     */
+    uint32_t rrfs;
+    /*! Accept Non-matching Frames Extended
+     *   0 = Accept in Rx FIFO 0
+     *   1 = Accept in Rx FIFO 1
+     *   others = Reject
+     */
+    uint32_t anfe;
+    /*! Accept Non-matching Frames Standard
+     *   0 = Accept in Rx FIFO 0
+     *   1 = Accept in Rx FIFO 1
+     *   others = Reject
+     */
+    uint32_t anfs;
+} DL_MCAN_GlobalFiltConfig;
+
+/**
+ *  @brief  Structure for MCAN initialization parameters.
+ */
+typedef struct {
+    /*! CAN-FD Operation Enable
+     *   0 = FD operation disabled (Operates in CAN Classic mode)
+     *   1 = FD operation enabled
+     */
+    uint32_t fdMode;
+    /*! Bit Rate Switch Enable
+     *   This is valid only when CAN-FD operation is enabled (fdMode = 1).
+     *   0 = Bit rate switching for transmissions disabled
+     *   1 = Bit rate switching for transmissions enabled
+     */
+    uint32_t brsEnable;
+    /*! Transmit Pause. MCAN pauses for two CAN bit times before starting the
+     *  next transmission after itself has successfully transmitted a frame
+     *   0 = Transmit pause disabled
+     *   1 = Transmit pause enabled
+     */
+    uint32_t txpEnable;
+    /*! Edge Filtering during Bus Integration
+     *   0 = Edge filtering disabled
+     *   1 = Two consecutive dominant tq required to detect an edge for
+     *       hard synchronization
+     */
+    uint32_t efbi;
+    /*! Protocol Exception Handling. When protocol exception handling is
+     *  disabled, the MCAN will transmit an error frame when it detects a
+     *  protocol exception condition.
+     *   0 = Protocol exception handling enabled
+     *   1 = Protocol exception handling disabled
+     */
+    uint32_t pxhddisable;
+    /*! Disable Automatic Retransmission
+     *   0 = Automatic retransmission of messages not transmitted successfully
+     *       enabled
+     *   1 = Automatic retransmission disabled
+     */
+    uint32_t darEnable;
+    /*! Wakeup Request Enable
+     *   0 = Wakeup request is disabled
+     *   1 = Wakeup request is enabled
+     */
+    uint32_t wkupReqEnable;
+    /*! Auto-Wakeup Enable
+     *   0 = Auto-Wakeup is disabled
+     *   1 = Auto-Wakeup is enabled
+     */
+    uint32_t autoWkupEnable;
+    /*! Emulation/Debug Suspend Enable
+     *   0 = Emulation/Debug Suspend is disabled
+     *   1 = Emulation/Debug Suspend is enabled
+     */
+    uint32_t emulationEnable;
+    /*! Start value of the Message RAM Watchdog Counter
+     *   Range:[0x0-0xFF]
+     */
+    uint32_t wdcPreload;
+    /*! Transmitter Delay Compensation parameters.
+     *   @ref DL_MCAN_TDCConfig.
+     */
+    DL_MCAN_TDCConfig tdcConfig;
+    /*! Transmitter Delay Compensation Enable
+     *   0 = Transmitter Delay Compensation is disabled
+     *   1 = Transmitter Delay Compensation is enabled
+     */
+    uint32_t tdcEnable;
+} DL_MCAN_InitParams;
+
+/**
+ *  @brief  Structure for MCAN configuration parameters.
+ */
+typedef struct {
+    /*! Bus Monitoring Mode
+     *   0 = Bus Monitoring Mode is disabled
+     *   1 = Bus Monitoring Mode is enabled
+     */
+    uint32_t monEnable;
+    /*! Restricted Operation Mode
+     *   0 = Normal CAN operation
+     *   1 = Restricted Operation Mode active
+     *   This mode should not be combined with test modes.
+     */
+    uint32_t asmEnable;
+    /*! Timestamp Counter Prescaler.
+     *   Range:[0x0-0xF]
+     */
+    uint32_t tsPrescalar;
+    /*! Timestamp source selection.
+     *   00= Timestamp counter value always 0x0000
+     *   01= Timestamp counter value incremented according to tsPrescalar
+     *   10= External timestamp counter value used
+     *   11= Same as 0b00
+     */
+    uint32_t tsSelect;
+    /*! Time-out counter source select.
+     *   One of @ref DL_MCAN_TIMEOUT_SELECT.
+     */
+    uint32_t timeoutSelect;
+    /*! Start value of the Timeout Counter (down-counter).
+     *   The Timeout Counter is decremented in multiples of CAN bit times [1-16]
+     *   depending on the configuration of the tsPrescalar.
+     *   Range:[0x0-0xFFFF]
+     */
+    uint32_t timeoutPreload;
+    /*! Time-out Counter Enable
+     *   0 = Time-out Counter is disabled
+     *   1 = Time-out Counter is enabled
+     */
+    uint32_t timeoutCntEnable;
+    /*! Global Filter Configuration parameters.
+     *    @ref DL_MCAN_GlobalFiltConfig.
+     */
+    DL_MCAN_GlobalFiltConfig filterConfig;
+} DL_MCAN_ConfigParams;
+
+/**
+ *  @brief  Structure for MCAN error logging counters status.
+ */
+typedef struct {
+    /*! Transmit Error Counter */
+    uint32_t transErrLogCnt;
+    /*! Receive Error Counter */
+    uint32_t recErrCnt;
+    /*! Receive Error Passive
+     *   0 = The Receive Error Counter is below the error passive level(128)
+     *   1 = The Receive Error Counter has reached the error passive level(128)
+     */
+    uint32_t rpStatus;
+    /*! CAN Error Logging */
+    uint32_t canErrLogCnt;
+} DL_MCAN_ErrCntStatus;
+
+/**
+ *  @brief  Structure for MCAN protocol status.
+ */
+typedef struct {
+    /*! Last Error Code
+     *   One of @ref DL_MCAN_ERR_CODE
+     */
+    uint32_t lastErrCode;
+    /*! Activity - Monitors the module's CAN communication state.
+     *   One of @ref DL_MCAN_COM_STATE
+     */
+    uint32_t act;
+    /*! Error Passive
+     *   0 = The M_CAN is in the Error_Active state
+     *   1 = The M_CAN is in the Error_Passive state
+     */
+    uint32_t errPassive;
+    /*! Warning Status
+     *   0 = Both error counters are below the Error_Warning limit of 96
+     *   1 = At least one of error counter has reached the Error_Warning
+     *       limit of 96
+     */
+    uint32_t warningStatus;
+    /*! Bus_Off Status
+     *   0 = The M_CAN is not Bus_Off
+     *   1 = The M_CAN is in Bus_Off state
+     */
+    uint32_t busOffStatus;
+    /*! Data Phase Last Error Code
+     *   One of @ref DL_MCAN_ERR_CODE
+     */
+    uint32_t dlec;
+    /*! ESI flag of last received CAN FD Message
+     *   0 = Last received CAN FD message did not have its ESI flag set
+     *   1 = Last received CAN FD message had its ESI flag set
+     */
+    uint32_t resi;
+    /*! BRS flag of last received CAN FD Message
+     *   0 = Last received CAN FD message did not have its BRS flag set
+     *   1 = TLast received CAN FD message had its BRS flag set
+     */
+    uint32_t rbrs;
+    /*! Received a CAN FD Message
+     *   0 = Since this bit was reset by the CPU, no CAN FD message has been
+     *       received
+     *   1 = Message in CAN FD format with FDF flag set has been received
+     */
+    uint32_t rfdf;
+    /*! Protocol Exception Event
+     *   0 = No protocol exception event occurred since last read access
+     *   1 = Protocol exception event occurred
+     */
+    uint32_t pxe;
+    /*! Transmitter Delay Compensation Value */
+    uint32_t tdcv;
+} DL_MCAN_ProtocolStatus;
+
+/**
+ *  @brief  Structure for MCAN Message RAM Configuration Parameters.
+ *         Message RAM can contain following sections:
+ *         Standard ID filters, Extended ID filters, TX FIFO(or TX Q),
+ *         TX Buffers, TX EventFIFO, RX FIFO0, RX FIFO1, RX Buffer.
+ *         Note: If particular section in the RAM is not used then it's size
+ *         should be initialized to '0'
+ *         (Number of buffers in case of Tx/Rx buffer).
+ */
+typedef struct {
+    /*! Standard ID Filter List Start Address */
+    uint32_t flssa;
+    /*! List Size: Standard ID
+     *   0 = No standard Message ID filter
+     *   1-127 = Number of standard Message ID filter elements
+     *   others = Values greater than 128 are interpreted as 128
+     */
+    uint32_t lss;
+    /*! Extended ID Filter List Start Address */
+    uint32_t flesa;
+    /*! List Size: Extended ID
+     *   0 = No standard Message ID filter
+     *   1-64 = Number of standard Message ID filter elements
+     *   others = Values greater than 64 are interpreted as 64
+     */
+    uint32_t lse;
+    /*! Tx Buffers Start Address */
+    uint32_t txStartAddr;
+    /*! Number of Dedicated Transmit Buffers
+     *   0 = No Dedicated Tx Buffers
+     *   1-32 = Number of Dedicated Tx Buffers
+     *   others = Values greater than 32 are interpreted as 32
+     */
+    uint32_t txBufNum;
+    /*! Transmit FIFO/Queue Size
+     *   0 = No Tx FIFO/Queue
+     *   1-32 = Number of Tx Buffers used for Tx FIFO/Queue
+     *   others = Values greater than 32 are interpreted as 32
+     */
+    uint32_t txFIFOSize;
+    /*! Tx FIFO/Queue Mode
+     *   0 = Tx FIFO operation
+     *   1 = Tx Queue operation
+     */
+    uint32_t txBufMode;
+    /*! Tx Buffer Element Size */
+    uint32_t txBufElemSize;
+    /*! Tx Event FIFO Start Address */
+    uint32_t txEventFIFOStartAddr;
+    /*! Event FIFO Size
+     *   0 = Tx Event FIFO disabled
+     *   1-32 = Number of Tx Event FIFO elements
+     *   others = Values greater than 32 are interpreted as 32
+     */
+    uint32_t txEventFIFOSize;
+    /*! Tx Event FIFO Watermark
+     *   0 = Watermark interrupt disabled
+     *   1-32 = Level for Tx Event FIFO watermark interrupt
+     *   others = Watermark interrupt disabled
+     */
+    uint32_t txEventFIFOWaterMark;
+    /*! Rx FIFO0 Start Address */
+    uint32_t rxFIFO0startAddr;
+    /*! Rx FIFO0 Size
+     *   0 = No Rx FIFO
+     *   1-64 = Number of Rx FIFO elements
+     *   others = Values greater than 64 are interpreted as 64
+     */
+    uint32_t rxFIFO0size;
+    /*! Rx FIFO0 Watermark
+     *   0 = Watermark interrupt disabled
+     *   1-63 = Level for Rx FIFO 0 watermark interrupt
+     *   others = Watermark interrupt disabled
+     */
+    uint32_t rxFIFO0waterMark;
+    /*! Rx FIFO0 Operation Mode
+     *   0 = FIFO blocking mode
+     *   1 = FIFO overwrite mode
+     */
+    uint32_t rxFIFO0OpMode;
+    /*! Rx FIFO1 Start Address */
+    uint32_t rxFIFO1startAddr;
+    /*! Rx FIFO1 Size
+     *   0 = No Rx FIFO
+     *   1-64 = Number of Rx FIFO elements
+     *   others = Values greater than 64 are interpreted as 64
+     */
+    uint32_t rxFIFO1size;
+    /*! Rx FIFO1 Watermark
+     *   0 = Watermark interrupt disabled
+     *   1-63 = Level for Rx FIFO 1 watermark interrupt
+     *   others = Watermark interrupt disabled
+     */
+    uint32_t rxFIFO1waterMark;
+    /*! Rx FIFO1 Operation Mode
+     *   0 = FIFO blocking mode
+     *   1 = FIFO overwrite mode
+     */
+    uint32_t rxFIFO1OpMode;
+    /*! Rx Buffer Start Address */
+    uint32_t rxBufStartAddr;
+    /*! Rx Buffer Element Size */
+    uint32_t rxBufElemSize;
+    /*! Rx FIFO0 Element Size */
+    uint32_t rxFIFO0ElemSize;
+    /*! Rx FIFO1 Element Size */
+    uint32_t rxFIFO1ElemSize;
+} DL_MCAN_MsgRAMConfigParams;
+
+/**
+ *  @brief  Structure for MCAN High Priority Message.
+ */
+typedef struct {
+    /*! Buffer Index
+     *   Only valid when MSI[1] = 1.
+     */
+    uint32_t bufIdx;
+    /*! Message Storage Indicator
+     *   MSI[1:0]
+     *       00  = No FIFO selected
+     *       01  = FIFO message lost
+     *       10  = Message stored in FIFO 0
+     *       11  = Message stored in FIFO 1
+     */
+    uint32_t msi;
+    /*! Filter Index */
+    uint32_t filterIdx;
+    /*! Indicates the filter list of the matching filter element
+     *   0 = Standard Filter List
+     *   1 = Extended Filter List
+     */
+    uint32_t filterList;
+} DL_MCAN_HighPriorityMsgInfo;
+
+/**
+ *  @brief  Structure for MCAN new data flag for Rx buffer.
+ */
+typedef struct {
+    /*! New data flag for Rx buffer no. 0 to 31 */
+    uint32_t statusLow;
+    /*! New data flag for Rx buffer no. 32 to 63 */
+    uint32_t statusHigh;
+} DL_MCAN_RxNewDataStatus;
+
+/**
+ *  @brief  Structure for MCAN Rx FIFO Status.
+ */
+typedef struct {
+    /*! Rx FIFO number
+     *   One of @ref DL_MCAN_RX_FIFO_NUM
+     */
+    uint32_t num;
+    /*! Rx FIFO Fill Level */
+    uint32_t fillLvl;
+    /*! Rx FIFO Get Index */
+    uint32_t getIdx;
+    /*! Rx FIFO Put Index */
+    uint32_t putIdx;
+    /*! Rx FIFO Full
+     *   0 = Rx FIFO not full
+     *   1 = Rx FIFO full
+     */
+    uint32_t fifoFull;
+    /*! Rx FIFO Message Lost */
+    uint32_t msgLost;
+} DL_MCAN_RxFIFOStatus;
+
+/**
+ *  @brief  Structure for MCAN Tx FIFO Status.
+ */
+typedef struct {
+    /*! Tx FIFO Free Level */
+    uint32_t freeLvl;
+    /*! Tx FIFO Get Index
+     *   Read as zero when Tx Queue operation is configured.
+     */
+    uint32_t getIdx;
+    /*! Tx FIFO/Queue Put Index */
+    uint32_t putIdx;
+    /*! Tx FIFO/Queue Full
+     *   0 = Tx FIFO/Queue not full
+     *   1 = Tx FIFO/Queue full
+     */
+    uint32_t fifoFull;
+} DL_MCAN_TxFIFOStatus;
+
+/**
+ *  @brief  Structure for MCAN Tx Event FIFO Status.
+ */
+typedef struct {
+    /*! Event FIFO Fill Level */
+    uint32_t fillLvl;
+    /*! Event FIFO Gut Index */
+    uint32_t getIdx;
+    /*! Event FIFO Put Index */
+    uint32_t putIdx;
+    /*! Event FIFO Full
+     *   0 = Tx Event FIFO not full
+     *   1 = Tx Event FIFO full
+     */
+    uint32_t fifoFull;
+    /*! Tx Event FIFO Element Lost
+     *   0 = No Tx Event FIFO element lost
+     *   1 = Tx Event FIFO element lost, also set after write attempt to
+     *       Tx Event FIFO of size zero.
+     */
+    uint32_t eleLost;
+} DL_MCAN_TxEventFIFOStatus;
+
+/**
+ *  @brief  Structure for ECC Error forcing.
+ */
+typedef struct {
+    /*! Error type to be forced
+     *   Refer enum  #DL_MCAN_ECC_ERR_TYPE.
+     */
+    uint32_t errType;
+    /*! Row address where error needs to be applied. */
+    uint32_t rowNum;
+    /*! Column/Data bit that needs to be flipped when
+     *   force_sec or force_ded is set
+     */
+    uint32_t bit1;
+    /*! Data bit that needs to be flipped when force_ded is set */
+    uint32_t bit2;
+    /*! Force Error once
+     *   1: The error will inject an error to the specified row only once
+     */
+    uint32_t errOnce;
+    /*! Force error on the next RAM read */
+    uint32_t errForce;
+} DL_MCAN_ECCErrForceParams;
+
+/**
+ *  @brief  Structure for ECC Error Status.
+ */
+typedef struct {
+    /*! Single Bit Error Status
+     *   0 = No Single Bit Error pending
+     *   1 = Single Bit Error pending
+     */
+    uint32_t secErr;
+    /*! Double Bit Error Status
+     *   0 = No Double Bit Error pending
+     *   1 = Double Bit Error pending
+     */
+    uint32_t dedErr;
+    /*! Indicates the row/address where the single or double bit
+     *   error occurred.
+     */
+    uint32_t row;
+    /*! Indicates the bit position in the ram data that is in error */
+    uint32_t bit1;
+
+} DL_MCAN_ECCErrStatus;
+
+/**
+ *  @brief  Structure for accessing Revision ID and Core Release Info.
+ *         of MCAN module.
+ */
+typedef struct {
+    /*! Scheme */
+    uint32_t scheme;
+    /*! Module ID */
+    uint32_t modId;
+    /*! Major revision */
+    uint32_t major;
+    /*! Minor revision */
+    uint32_t minor;
+    /*! Time Stamp Day. Two digits, BCD-coded. */
+    uint32_t day;
+    /*! Time Stamp Month. Two digits, BCD-coded. */
+    uint32_t mon;
+    /*! Time Stamp Year. Single digit, BCD-coded. */
+    uint32_t year;
+    /*! Sub-step of Core Release Single digit, BCD-coded. */
+    uint32_t subStep;
+    /*! Step of Core Release.Two digits, BCD-coded Single digit, BCD-coded. */
+    uint32_t step;
+    /*! Core Release. Single digit, BCD-coded. */
+    uint32_t rel;
+} DL_MCAN_RevisionId;
+
+/**
+ *  @brief  Structure for accessing Revision ID of ECC AGGR.
+ */
+typedef struct {
+    /*! Scheme */
+    uint32_t scheme;
+    /*! Module ID */
+    uint32_t modId;
+    /*! Major revision */
+    uint32_t major;
+    /*! Minor revision */
+    uint32_t minor;
+} DL_MCAN_ECCAggrRevisionId;
+
+/**
+ *  @brief  Structure for MCAN ECC configuration parameters.
+ */
+typedef struct {
+    /*! Enable/disable ECC
+     *   0 = Disable ECC
+     *   1 = Enable ECC
+     */
+    uint32_t enable;
+    /*! Enable/disable ECC Check
+     *   0 = Disable ECC Check
+     *   1 = Enable ECC Check
+     */
+    uint32_t enableChk;
+    /*! Enable/disable Read Modify Write operation
+     *   0 = Disable Read Modify Write operation
+     *   1 = Enable Read Modify Write operation
+     */
+    uint32_t enableRdModWr;
+} DL_MCAN_ECCConfigParams;
+
+/**
+ *  @brief  Structure for accessing Revision ID of ECC wrapper.
+ */
+typedef struct {
+    /*! Scheme */
+    uint32_t scheme;
+    /*! Module ID */
+    uint32_t modId;
+    /*! Major revision */
+    uint32_t major;
+    /*! Minor revision */
+    uint32_t minor;
+} DL_MCAN_ECCWrapRevisionId;
+
+/**
+ *  @brief  Structure for MCAN Tx Buffer element.
+ */
+typedef struct {
+    /*! Identifier */
+    uint32_t id;
+    /*! Remote Transmission Request
+     *   0 = Transmit data frame
+     *   1 = Transmit remote frame
+     */
+    uint32_t rtr;
+    /*! Extended Identifier
+     *   0 = 11-bit standard identifier
+     *   1 = 29-bit extended identifier
+     */
+    uint32_t xtd;
+    /*! Error State Indicator
+     *   0 = ESI bit in CAN FD format depends only on error passive flag
+     *   1 = ESI bit in CAN FD format transmitted recessive
+     */
+    uint32_t esi;
+    /*! Data Length Code
+     *   0-8  = CAN + CAN FD: transmit frame has 0-8 data bytes
+     *   9-15 = CAN: transmit frame has 8 data bytes
+     *   9-15 = CAN FD: transmit frame has 12/16/20/24/32/48/64 data bytes
+     */
+    uint32_t dlc;
+    /*! Bit Rat Switching
+     *   0 = CAN FD frames transmitted without bit rate switching
+     *   1 = CAN FD frames transmitted with bit rate switching
+     */
+    uint32_t brs;
+    /*! FD Format
+     *   0 = Frame transmitted in Classic CAN format
+     *   1 = Frame transmitted in CAN FD format
+     */
+    uint32_t fdf;
+    /*! Event FIFO Control
+     *   0 = Don't store Tx events
+     *   1 = Store Tx events
+     */
+    uint32_t efc;
+    /*! Message Marker */
+    uint32_t mm;
+    /*! Data bytes.
+     *   Only first dlc number of bytes are valid.
+     */
+    uint16_t data[DL_MCAN_MAX_PAYLOAD_BYTES];
+} DL_MCAN_TxBufElement;
+
+/**
+ *  @brief  Structure for MCAN Rx Buffer element.
+ */
+typedef struct {
+    /*! Identifier */
+    uint32_t id;
+    /*! Remote Transmission Request
+     *   0 = Received frame is a data frame
+     *   1 = Received frame is a remote frame
+     */
+    uint32_t rtr;
+    /*! Extended Identifier
+     *   0 = 11-bit standard identifier
+     *   1 = 29-bit extended identifier
+     */
+    uint32_t xtd;
+    /*! Error State Indicator
+     *   0 = Transmitting node is error active
+     *   1 = Transmitting node is error passive
+     */
+    uint32_t esi;
+    /*! Rx Timestamp */
+    uint32_t rxts;
+    /*! Data Length Code
+     *   0-8  = CAN + CAN FD: received frame has 0-8 data bytes
+     *   9-15 = CAN: received frame has 8 data bytes
+     *   9-15 = CAN FD: received frame has 12/16/20/24/32/48/64 data bytes
+     */
+    uint32_t dlc;
+    /*! Bit Rat Switching
+     *   0 = Frame received without bit rate switching
+     *   1 = Frame received with bit rate switching
+     */
+    uint32_t brs;
+    /*! FD Format
+     *   0 = Standard frame format
+     *   1 = CAN FD frame format (new DLC-coding and CRC)
+     */
+    uint32_t fdf;
+    /*! Filter Index */
+    uint32_t fidx;
+    /*! Accepted Non-matching Frame
+     *   0 = Received frame matching filter index FIDX
+     *   1 = Received frame did not match any Rx filter element
+     */
+    uint32_t anmf;
+    /*! Data bytes.
+     *   Only first dlc number of bytes are valid.
+     */
+    uint16_t data[DL_MCAN_MAX_PAYLOAD_BYTES];
+} DL_MCAN_RxBufElement;
+
+/**
+ *  @brief  Structure for MCAN Tx Event FIFO element.
+ */
+typedef struct {
+    /*! Identifier */
+    uint32_t id;
+    /*! Remote Transmission Request
+     *   0 = Data frame transmitted
+     *   1 = Remote frame transmitted
+     */
+    uint32_t rtr;
+    /*! Extended Identifier
+     *   0 = 11-bit standard identifier
+     *   1 = 29-bit extended identifier
+     */
+    uint32_t xtd;
+    /*! Error State Indicator
+     *   0 = Transmitting node is error active
+     *   1 = Transmitting node is error passive
+     */
+    uint32_t esi;
+    /*! Tx Timestamp */
+    uint32_t txts;
+    /*! Data Length Code
+     *   0-8  = CAN + CAN FD: frame with 0-8 data bytes transmitted
+     *   9-15 = CAN: frame with 8 data bytes transmitted
+     *   9-15 = CAN FD: frame with 12/16/20/24/32/48/64 data bytes transmitted
+     */
+    uint32_t dlc;
+    /*! Bit Rat Switching
+     *   0 = Frame transmitted without bit rate switching
+     *   1 = Frame transmitted with bit rate switching
+     */
+    uint32_t brs;
+    /*! FD Format
+     *   0 = Standard frame format
+     *   1 = CAN FD frame format (new DLC-coding and CRC)
+     */
+    uint32_t fdf;
+    /*! Event Type
+     *   00 = Reserved
+     *   01 = Tx event
+     *   10 = Transmission in spite of cancellation
+     *        (always set for transmissions in DAR mode)
+     *   11 = Reserved
+     */
+    uint32_t et;
+    /*! Message Marker */
+    uint32_t mm;
+} DL_MCAN_TxEventFIFOElement;
+
+/**
+ *  @brief  Structure for MCAN Standard Message ID Filter Element.
+ */
+typedef struct {
+    /*! Standard Filter ID 2 */
+    uint32_t sfid2;
+    /*! Standard Filter ID 1 */
+    uint32_t sfid1;
+    /*! Standard Filter Element Configuration
+     *   000 = Disable filter element
+     *   001 = Store in Rx FIFO 0 if filter matches
+     *   010 = Store in Rx FIFO 1 if filter matches
+     *   011 = Reject ID if filter matches
+     *   100 = Set priority if filter matches
+     *   101 = Set priority and store in FIFO 0 if filter matches
+     *   110 = Set priority and store in FIFO 1 if filter matches
+     *   111 = Store into Rx Buffer or as debug message,
+     *         configuration of SFT[1:0] ignored.
+     *   If SFEC = 0b100, 0b101, or 0b110 a match sets high priority
+     *   message event is generated.
+     */
+    uint32_t sfec;
+    /*! Standard Filter Type
+     *   00 = Range filter from SFID1 to SFID2 (SFID2 ≥ SFID1)
+     *   01 = Dual ID filter for SFID1 or SFID2
+     *   10 = Classic filter: SFID1 = filter, SFID2 = mask
+     *   11 = Filter element disabled
+     */
+    uint32_t sft;
+} DL_MCAN_StdMsgIDFilterElement;
+
+/**
+ *  @brief  Structure for MCAN Extended Message ID Filter Element.
+ */
+typedef struct {
+    /*! Extended Filter ID 1 */
+    uint32_t efid1;
+    /*! Extended Filter Element Configuration
+     *   000 = Disable filter element
+     *   001 = Store in Rx FIFO 0 if filter matches
+     *   010 = Store in Rx FIFO 1 if filter matches
+     *   011 = Reject ID if filter matches
+     *   100 = Set priority if filter matches
+     *   101 = Set priority and store in FIFO 0 if filter matches
+     *   110 = Set priority and store in FIFO 1 if filter matches
+     *   111 = Store into Rx Buffer or as debug message,
+     *         configuration of SFT[1:0] ignored.
+     *   If EFEC = 0b100, 0b101, or 0b110 a match sets high priority
+     *   message event is generated.
+     */
+    uint32_t efec;
+    /*! Extended Filter ID 2 */
+    uint32_t efid2;
+    /*! Extended Filter Type
+     *   00 = Range filter from EFID1 to EFID2 (EFID2 ≥ EFID1)
+     *   01 = Dual ID filter for EFID1 or EFID2
+     *   10 = Classic filter: EFID1 = filter, EFID2 = mask
+     *   11 = Range filter from EFID1 to EFID2 (EFID2 ≥ EFID1),
+     *        XIDAM mask not applied
+     */
+    uint32_t eft;
+} DL_MCAN_ExtMsgIDFilterElement;
+
+/**
+ * @brief Configuration structure to backup MCAN peripheral state before
+ *        entering STOP or STANDBY mode. Not required after PG 1.0 silicon.
+ *        Used by @ref DL_MCAN_saveConfiguration and
+ *        @ref DL_MCAN_restoreConfiguration
+ */
+typedef struct {
+    /*! MCAN Clock Divider Configuration */
+    uint32_t clkDivConf;
+
+    /*! MCAN Clock Stop Configuration */
+    uint32_t clkConf;
+
+    /*! MCAN Clock Configuration */
+    uint32_t clkEnConf;
+
+    /*! MCAN Control Configuration */
+    uint32_t ctrlConf;
+
+    /*! MCAN Nominal Bit Time Configuration */
+    uint32_t nomBitTimeConf;
+
+    /*! MCAN Data Bit Time Configuration */
+    uint32_t dataBitTimeConf;
+
+    /*! MCAN Timestamp Configuration */
+    uint32_t timeCntConf;
+
+    /*! MCAN Timestamp Counter Value */
+    uint32_t timeCntVal;
+
+    /*! MCAN Time-out Configuration */
+    uint32_t timeOutConf;
+
+    /*! MCAN Time-out Counter Value */
+    uint32_t timeOutCntVal;
+
+    /*! MCAN Transmitter Delay Compensation */
+    uint32_t txDelCompConf;
+
+    /*! MCAN Interrupt Configuration */
+    uint32_t intEnConf;
+
+    /*! MCAN Interrupt Line Select */
+    uint32_t intLnSelConf;
+
+    /*! MCAN Interrupt Line Enable */
+    uint32_t intLnEnableConf;
+
+    /*! MCAN Global Filter Configuration */
+    uint32_t globFiltIDConf;
+
+    /*! MCAN Standard ID Filter Configuration */
+    uint32_t stdFiltIDConf;
+
+    /*! MCAN Extended ID Filter Configuration */
+    uint32_t exFiltIDConf;
+
+    /*! MCAN Extended ID and Mask */
+    uint32_t exFiltIDMsk;
+
+    /*! MCAN Rx FIFO 0 Configuration */
+    uint32_t rxFIFO0Conf;
+
+    /*! MCAN Rx Buffer Configuration */
+    uint32_t rxBuffConf;
+
+    /*! MCAN Rx FIFO 1 Configuration */
+    uint32_t rxFIFO1Conf;
+
+    /*! MCAN Rx Element Size for Rx Buff and FIFOs */
+    uint32_t rxDataSize;
+
+    /*! MCAN Tx Buffer Configuration */
+    uint32_t txBuffConf;
+
+    /*! MCAN Tx Element Size for Tx Buff*/
+    uint32_t txDataSize;
+
+    /*! MCAN Tx Buffer Transmission Interrupt Enable Configuration */
+    uint32_t txBuffTxIntConf;
+
+    /*! MCAN Tx Buffer Cancellation Finished Interrupt Enable */
+    uint32_t txBuffCancIntConf;
+
+    /*! MCAN Tx Event FIFO Configuration */
+    uint32_t txEvntFIFOConf;
+
+    /*! MCAN Subsystem Control Configuration */
+    uint32_t ssCtrlConf;
+
+    /*! MCAN Subsystem Interrupt Enable Configuration */
+    uint32_t ssIntEnConf;
+
+    /*! MCAN Subsystem External Timestamp Prescaler 0 */
+    uint32_t preSclConf;
+
+    /*! MCAN Error detection and correction vector */
+    uint32_t edcVecConf;
+
+    /*! MCAN Error detection and correction control Configuration 2 */
+    uint32_t edcConf2;
+
+    /*! MCAN Error detection and correction control Configuration 1 */
+    uint32_t edcConf1;
+
+    /*! MCAN Error detection and correction control Configuration 0 */
+    uint32_t edcConf0;
+
+    /*! MCAN Interrupt Configuration */
+    uint32_t intEvnt0Conf;
+
+    /*! MCAN Watchdog Configuration */
+    uint32_t ramWDConf;
+
+    /*! MCAN Test Configuration */
+    uint32_t testConf;
+
+    /*! Boolean flag indicating whether or not a valid configuration structure
+     *  exists. Should not be modified by the user. */
+    bool backupRdy;
+} DL_MCAN_backupConfig;
+
+/*! @enum DL_MCAN_CLOCK_DIVIDE */
+typedef enum {
+    /*! Divide MCAN clock by 1 */
+    DL_MCAN_CLOCK_DIVIDE_1 = MCAN_CLKDIV_RATIO_DIV_BY_1_,
+    /*! Divide MCAN clock by 2 */
+    DL_MCAN_CLOCK_DIVIDE_2 = MCAN_CLKDIV_RATIO_DIV_BY_2_,
+    /*! Divide MCAN clock by 4 */
+    DL_MCAN_CLOCK_DIVIDE_4 = MCAN_CLKDIV_RATIO_DIV_BY_4_
+} DL_MCAN_CLOCK_DIVIDE;
+
+/*! @enum DL_MCAN_IIDX */
+typedef enum {
+    /*! Interrupt index for MCAN clock stop wake up interrupt pending. */
+    DL_MCAN_IIDX_WAKEUP = MCAN_IIDX_STAT_WAKEUP,
+    /*! Interrupt index for MCAN external timestamp counter overflow interrupt
+     *  pending. */
+    DL_MCAN_IIDX_TIMESTAMP_OVERFLOW = MCAN_IIDX_STAT_EXT_TS_CNTR_OVFL,
+    /*! Interrupt index for MCAN message RAM double error detection interrupt
+     *  pending. */
+    DL_MCAN_IIDX_DOUBLE_ERROR_DETECTION = MCAN_IIDX_STAT_DED,
+    /*! Interrupt index for MCAN message RAM single error correction interrupt
+     *  pending. */
+    DL_MCAN_IIDX_SINGLE_ERROR_CORRECTION = MCAN_IIDX_STAT_SEC,
+    /*! Interrupt index for MCAN interrupt line 1 interrupt pending. */
+    DL_MCAN_IIDX_LINE1 = MCAN_IIDX_STAT_INTL1,
+    /*! Interrupt index for MCAN interrupt line 0 interrupt pending. */
+    DL_MCAN_IIDX_LINE0 = MCAN_IIDX_STAT_INTL0
+} DL_MCAN_IIDX;
+
+/**
+ *  @brief if MCAN instance is ready to be configured
+ *
+ *  @param[in] instance      Specifies the CANFD instance. One of
+ *                           @ref DL_MCAN_INSTANCE
+ *
+ *  @return true if MCAN instance is ready to configured
+ *  @return false if MCAN instance clock synchronization is ongoing.
+ */
+bool DL_MCAN_isReady(DL_MCAN_INSTANCE instance);
+
+/**
+ *  @brief      Configure CANCLK source clock
+ *  @param[in]  mcan        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  config         Pointer to the clock configuration struct
+ *                             @ref DL_MCAN_ClockConfig.
+ */
+void DL_MCAN_setClockConfig(MCAN_Regs *mcan, DL_MCAN_ClockConfig *config);
+
+/**
+ *  @brief     Get  CANCLK clock configuration
+ *  @param[in]  mcan        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  config         Pointer to the clock configuration struct
+ *                             @ref DL_MCAN_ClockConfig.
+ */
+void DL_MCAN_getClockConfig(MCAN_Regs *mcan, DL_MCAN_ClockConfig *config);
+/**
+ *  @brief   This function checks if the MCAN module is in Reset.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ * @retval  state     Returns TRUE if reset is in progress.
+ *                    Else returns FALSE.
+ */
+bool DL_MCAN_isInReset(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API will return flexible data rate operation status
+ *          MCAN module.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ * @return  state     Returns TRUE if flexible data rate operation
+ *                    is enabled. Else returns FALSE.
+ */
+bool DL_MCAN_isFDOpEnable(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This function checks if the memory initialization is done for
+ *          MCAN module.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @retval  state    Returns TRUE if memory initialization is done.
+ *                    Else returns FALSE.
+ */
+bool DL_MCAN_isMemInitDone(MCAN_Regs *mcan);
+
+/**
+ *  @brief  This API will set MCAN module mode of operation.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *  @param[in]  mode  Mode of operation. One of @ref DL_MCAN_OPERATION_MODE.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_setOpMode(MCAN_Regs *mcan, uint32_t mode);
+
+/**
+ *  @brief            This API will return MCAN module mode of operation.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  mode     Mode of operation. One of @ref DL_MCAN_OPERATION_MODE.
+ */
+uint32_t DL_MCAN_getOpMode(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API will initialize MCAN module.
+ *
+ *  @param[in]  mcan          Pointer to the register overlay for the peripheral
+ *  @param[in]  initParams    Initialization parameters.
+ *                            @ref DL_MCAN_InitParams.
+ *
+ *  @return  status           Initialization status.
+ */
+int32_t DL_MCAN_init(MCAN_Regs *mcan, const DL_MCAN_InitParams *initParams);
+
+/**
+ *  @brief   This API will configure MCAN module.
+ *
+ *  @param[in]  mcan          Pointer to the register overlay for the peripheral
+ *  @param[in]  configParams  Configuration parameters.
+ *                            @ref DL_MCAN_ConfigParams.
+ *
+ *  @return  status          Configuration status.
+ */
+int32_t DL_MCAN_config(
+    MCAN_Regs *mcan, const DL_MCAN_ConfigParams *configParams);
+
+/**
+ *  @brief   This API will enable/disable ECC on the Message RAM.
+ *
+ *  @param[in]  mcan         Pointer to the register overlay for the peripheral
+ *  @param[in]  configParams MCAN ECC Configuration Parameters.
+ *                           @ref DL_MCAN_ECCConfigParams.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_eccConfig(
+    MCAN_Regs *mcan, const DL_MCAN_ECCConfigParams *configParams);
+
+/**
+ *  @brief   This API will configure a bit timings for MCAN module.
+ *
+ *  @param[in]  mcan         Pointer to the register overlay for the peripheral
+ *  @param[in]  configParams Configuration parameters for MCAN bit timing.
+ *                           @ref DL_MCAN_BitTimingParams.
+ *
+ *  @return  status          Bit Timings configuration status.
+ */
+int32_t DL_MCAN_setBitTime(
+    MCAN_Regs *mcan, const DL_MCAN_BitTimingParams *configParams);
+
+/**
+ *  @brief   This API will configure Different sections of Message RAM.
+ *
+ *  @param[in]  mcan        Pointer to the register overlay for the peripheral
+ *  @param[in]  msgRAMConfigParams
+ *                          Message RAM Configuration parameters.
+ *                          @ref DL_MCAN_MsgRAMConfigParams.
+ *
+ *  @return  status          Configuration Status.
+ */
+int32_t DL_MCAN_msgRAMConfig(
+    MCAN_Regs *mcan, const DL_MCAN_MsgRAMConfigParams *msgRAMConfigParams);
+
+/**
+ *  @brief   This API will configure Extended ID AND Mask.
+ *
+ *  @param[in]  mcan      Pointer to the register overlay for the peripheral
+ *  @param[in]  idMask    Configuration parameters for MCAN Extended Id mask.
+ *                        This value is 29 bit wide.
+ *
+ *  @return  status       Extended ID AND Mask configuration status.
+ */
+int32_t DL_MCAN_setExtIDAndMask(MCAN_Regs *mcan, uint32_t idMask);
+
+/**
+ *  @brief   This API is used to write Tx message to message RAM.
+ *
+ *  @param[in]  mcan       Pointer to the register overlay for the peripheral
+ *  @param[in]  memType    Part of message ram to which given message to write.
+ *                         One of @ref DL_MCAN_MEM_TYPE.
+ *  @param[in]  bufNum     Buffer  number where message to write.
+ *                         This parameter will ignored if memType is FIFO/Q.
+ *  @param[in]  elem       Message Object.
+ *                         @ref DL_MCAN_TxBufElement.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_writeMsgRam(MCAN_Regs *mcan, uint32_t memType, uint32_t bufNum,
+    const DL_MCAN_TxBufElement *elem);
+
+/**
+ *  @brief   This API will set Tx Buffer Add Request.
+ *
+ *  @param[in]  mcan    Pointer to the register overlay for the peripheral
+ *  @param[in]  bufNum  Tx Buffer number for which request is to be added.
+ *
+ *  @return  status     Configuration Status.
+ */
+int32_t DL_MCAN_TXBufAddReq(MCAN_Regs *mcan, uint32_t bufNum);
+
+/**
+ *  @brief   This API will return New Data Message Status.
+ *
+ *  @param[in]  mcan          Pointer to the register overlay for the peripheral
+ *  @param[in]  newDataStatus Rx Buffer new data status.
+ *                            @ref DL_MCAN_RxNewDataStatus.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_getNewDataStatus(
+    MCAN_Regs *mcan, DL_MCAN_RxNewDataStatus *newDataStatus);
+
+/**
+ *  @brief   This API clear New Data Message Status.
+ *
+ *  @param[in]  mcan          Pointer to the register overlay for the peripheral
+ *  @param[in]  newDataStatus Rx Buffer new data status.
+ *                            @ref DL_MCAN_RxNewDataStatus.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_clearNewDataStatus(
+    MCAN_Regs *mcan, const DL_MCAN_RxNewDataStatus *newDataStatus);
+
+/**
+ *  @brief   This API is used to read received message form message RAM.
+ *
+ *  @param[in]  mcan        Pointer to the register overlay for the peripheral
+ *  @param[in]  memType     Part of message ram to which given message to
+ *                          write.One of @ref DL_MCAN_MEM_TYPE.
+ *  @param[in]  bufNum      Buffer  number from where message is to read.
+ *                          This parameter will ignored if memType is FIFO/Q.
+ *  @param[in]  fifoNum     FIFOs number from where message is to read.
+ *                          One of @ref DL_MCAN_RX_FIFO_NUM.
+ *                          This parameter will ignored if memType is buffer.
+ *  @param[in]  elem        Message Object.
+ *                          @ref DL_MCAN_RxBufElement.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_readMsgRam(MCAN_Regs *mcan, uint32_t memType, uint32_t bufNum,
+    uint32_t fifoNum, DL_MCAN_RxBufElement *elem);
+
+/**
+ *  @brief   This API is used to read message form Tx Event FIFO.
+ *
+ *  @param[in]  mcan         Pointer to the register overlay for the peripheral
+ *  @param[in]  txEventElem  Tx Event FIFO Message Object.
+ *                           @ref DL_MCAN_TxEventFIFOElement.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_readTxEventFIFO(
+    MCAN_Regs *mcan, DL_MCAN_TxEventFIFOElement *txEventElem);
+
+/**
+ *  @brief   This API is used to add Standard Message ID Filter Element.
+ *
+ *  @note MCAN RAM must be configured @ref DL_MCAN_msgRAMConfig before
+ *  calling this API.
+ *
+ *  @param[in]  mcan       Pointer to the register overlay for the peripheral
+ *  @param[in]  filtNum    Filter number.
+ *  @param[in]  elem       Filter Object. @ref DL_MCAN_StdMsgIDFilterElement.
+ *
+ *  @return  None.
+ *
+ *  @sa DL_MCAN_msgRAMConfig
+ */
+void DL_MCAN_addStdMsgIDFilter(MCAN_Regs *mcan, uint32_t filtNum,
+    const DL_MCAN_StdMsgIDFilterElement *elem);
+
+/**
+ *  @brief   This API is used to add Extended Message ID Filter Element.
+ *
+ *  @note MCAN RAM must be configured @ref DL_MCAN_msgRAMConfig before
+ *  calling this API.
+ *
+ *  @param[in]  mcan     Pointer to the register overlay for the peripheral
+ *  @param[in]  filtNum  Filter  number.
+ *  @param[in]  elem     Filter Object. @ref DL_MCAN_ExtMsgIDFilterElement.
+ *
+ *  @return  None.
+ *
+ *  @sa DL_MCAN_msgRAMConfig
+ */
+void DL_MCAN_addExtMsgIDFilter(MCAN_Regs *mcan, uint32_t filtNum,
+    const DL_MCAN_ExtMsgIDFilterElement *elem);
+
+/**
+ *  @brief   This API will enable/disable Loop Back Test Mode for
+ *           MCAN module.
+ *
+ *  @param[in]  mcan      Pointer to the register overlay for the peripheral
+ *  @param[in]  lpbkMode  Loopback mode for MCAN.
+ *                        One of @ref DL_MCAN_LPBK_MODE.
+ *  @param[in]  enable    Loop Back Mode is enabled if it is TRUE.
+ *                        Loop Back Mode is disabled if it is FALSE.
+ *
+ *  @return  None.
+ * \note    This API can be called only when MCAN is in Software
+ *          Initialization mode of operation.
+ */
+void DL_MCAN_lpbkModeEnable(MCAN_Regs *mcan, uint32_t lpbkMode, bool enable);
+
+/**
+ *  @brief   This API will return error counter status for MCAN module.
+ *
+ *  @param[in]  mcan       Pointer to the register overlay for the peripheral
+ *  @param[in]  errCounter Error Counter Status. @ref DL_MCAN_ErrCntStatus.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_getErrCounters(MCAN_Regs *mcan, DL_MCAN_ErrCntStatus *errCounter);
+
+/**
+ *  @brief   This API will return protocol status for MCAN module.
+ *
+ *  @param[in]  mcan        Pointer to the register overlay for the peripheral
+ *  @param[in]  protStatus  Protocol Status. @ref DL_MCAN_ProtocolStatus.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_getProtocolStatus(
+    MCAN_Regs *mcan, DL_MCAN_ProtocolStatus *protStatus);
+
+/**
+ *  @brief   This API is used to enable/disable interrupts.
+ *
+ *  @param[in]  mcan      Pointer to the register overlay for the peripheral
+ *  @param[in]  intrMask  Interrupts to enable. One of @ref DL_MCAN_INTR_SRC.
+ *  @param[in]  enable    Interrupt is enabled if it is TRUE.
+ *                        Interrupt is disabled if it is FALSE.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_enableIntr(MCAN_Regs *mcan, uint32_t intrMask, bool enable);
+
+/**
+ *  @brief   This API is used to select interrupt line.
+ *
+ *  @param[in]  mcan      Pointer to the register overlay for the peripheral
+ *  @param[in]  intrMask  Interrupt Number for which interrupt
+ *                        line is to be selected. One of @ref DL_MCAN_INTR_SRC.
+ *  @param[in]  lineNum   Interrupt Line to select.
+ *                        One of @ref DL_MCAN_INTR_LINE_NUM,
+ *
+ *  @return  None.
+ */
+void DL_MCAN_selectIntrLine(
+    MCAN_Regs *mcan, uint32_t intrMask, uint32_t lineNum);
+
+/**
+ *  @brief   This API is used to get interrupt line selected for each interrupt.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  status   Interrupt Line Select Status.
+ */
+uint32_t DL_MCAN_getIntrLineSelectStatus(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API is used to enable/disable selected interrupt line.
+ *
+ *  @param[in]  mcan      Pointer to the register overlay for the peripheral
+ *  @param[in]  lineNum   Interrupt Line to select.
+ *                        One of @ref DL_MCAN_INTR_LINE_NUM,
+ *  @param[in]  enable    Interrupt Line is enabled if it is TRUE.
+ *                        Interrupt Line is disabled if it is FALSE.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_enableIntrLine(MCAN_Regs *mcan, uint32_t lineNum, bool enable);
+
+/**
+ *  @brief   This API will return interrupt status.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  status   Interrupt Status.
+ */
+uint32_t DL_MCAN_getIntrStatus(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API is used to clear the interrupt status.
+ *
+ *  @param[in]  mcan       Pointer to the register overlay for the peripheral
+ *  @param[in]  intrMask   Interrupts to clear status.
+ *  @param[in]  eoi        Specified the associated. @ref DL_MCAN_INTR_SRC
+ *
+ *  @return  None.
+ */
+void DL_MCAN_clearIntrStatus(
+    MCAN_Regs *mcan, uint32_t intrMask, DL_MCAN_INTR_SRC_MCAN eoi);
+
+/**
+ *  @brief   This API will return High Priority Message Status.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *  @param[in]  hpm   High Priority Message Status.
+ *                    @ref DL_MCAN_HighPriorityMsgInfo.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_getHighPriorityMsgStatus(
+    MCAN_Regs *mcan, DL_MCAN_HighPriorityMsgInfo *hpm);
+
+/**
+ *  @brief   This API will Rx FIFO status.
+ *
+ *  @param[in]  mcan       Pointer to the register overlay for the peripheral
+ *  @param[in]  fifoStatus Rx FIFO Status. @ref DL_MCAN_RxFIFOStatus.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_getRxFIFOStatus(
+    MCAN_Regs *mcan, DL_MCAN_RxFIFOStatus *fifoStatus);
+
+/**
+ *  @brief   This API will write Rx FIFO Acknowledgement.
+ *
+ *  @param[in]  mcan     Pointer to the register overlay for the peripheral
+ *  @param[in]  fifoNum  FIFO Number. One of @ref DL_MCAN_RX_FIFO_NUM.
+ *  @param[in]  idx      Rx FIFO Acknowledge Index
+ *
+ *  @return  status      Acknowledgement Status.
+ */
+int32_t DL_MCAN_writeRxFIFOAck(
+    MCAN_Regs *mcan, uint32_t fifoNum, uint32_t idx);
+
+/**
+ *  @brief   This API will Tx FIFO status.
+ *
+ *  @param[in]  mcan        Pointer to the register overlay for the peripheral
+ *  @param[in]  fifoStatus  Tx FIFO Status. @ref DL_MCAN_TxFIFOStatus.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_getTxFIFOQueStatus(
+    MCAN_Regs *mcan, DL_MCAN_TxFIFOStatus *fifoStatus);
+
+/**
+ *  @brief   This API will return Tx Buffer Request Pending status.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  status   Tx Buffer Request Pending status.
+ */
+uint32_t DL_MCAN_getTxBufReqPend(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API will set Tx Buffer Cancellation Request.
+ *
+ *  @param[in]  mcan      Pointer to the register overlay for the peripheral
+ *  @param[in]  buffNum   Tx Buffer number for which request is to be added.
+ *
+ *  @return  status       Configuration Status.
+ */
+int32_t DL_MCAN_txBufCancellationReq(MCAN_Regs *mcan, uint32_t buffNum);
+
+/**
+ *  @brief   This API will return Tx Buffer Transmission Occurred status.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  status   Tx Buffer Transmission Occurred status.
+ */
+uint32_t DL_MCAN_getTxBufTransmissionStatus(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API will return Transmit Buffer Cancellation Finished status.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  status   Transmit Buffer Cancellation Finished status.
+ */
+uint32_t DL_MCAN_txBufCancellationStatus(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API is used to enable/disable Tx Buffer Transmission Interrupt.
+ *
+ *  @param[in]  mcan    Pointer to the register overlay for the peripheral
+ *  @param[in]  bufNum  Buffer number for which interrupt is to enable.
+ *  @param[in]  enable  Interrupt is enabled if it is TRUE.
+ *                      Interrupt is disabled if it is FALSE.
+ *
+ *  @return  status     Configuration status.
+ */
+int32_t DL_MCAN_TXBufTransIntrEnable(
+    MCAN_Regs *mcan, uint32_t bufNum, bool enable);
+
+/**
+ *  @brief   This API is used to enable/disable Tx Buffer Cancellation Finished
+ *          Interrupt.
+ *
+ *  @param[in]  mcan     Pointer to the register overlay for the peripheral
+ *  @param[in]  bufNum   Buffer number for which interrupt is to enable.
+ *  @param[in]  enable   Interrupt is enabled if it is TRUE.
+ *                       Interrupt is disabled if it is FALSE.
+ *
+ *  @return  status          Configuration status.
+ */
+int32_t DL_MCAN_getTxBufCancellationIntrEnable(
+    MCAN_Regs *mcan, uint32_t bufNum, bool enable);
+
+/**
+ *  @brief   This API add clock stop request for MCAN module to put it in
+ *          power down mode.
+ *
+ *  @param[in]  mcan    Pointer to the register overlay for the peripheral
+ *  @param[in]  enable  Add Clock Stop Request.
+ *                      Adds Clock Stop Request is TRUE otherwise
+ *                      removes it.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_addClockStopRequest(MCAN_Regs *mcan, bool enable);
+
+/**
+ *  @brief   This API will Tx Event FIFO status.
+ *
+ *  @param[in]  mcan        Pointer to the register overlay for the peripheral
+ *  @param[in]  fifoStatus  Tx Event FIFO Status.
+ *                          @ref DL_MCAN_TxEventFIFOStatus.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_getTxEventFIFOStatus(
+    MCAN_Regs *mcan, DL_MCAN_TxEventFIFOStatus *fifoStatus);
+
+/**
+ *  @brief   This API will write Event FIFO Acknowledge Index.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *  @param[in]  idx   Event FIFO Acknowledge Index
+ *
+ *  @return  status   Acknowledgement Status.
+ */
+int32_t DL_MCAN_writeTxEventFIFOAck(MCAN_Regs *mcan, uint32_t idx);
+
+/**
+ *  @brief   This API will Force Error on ECC.
+ *
+ *  @param[in]  mcan    Pointer to the register overlay for the peripheral
+ *  @param[in]  eccErr  Force Error on ECC configuration.
+ *                      @ref DL_MCAN_ECCErrForceParams.
+ *
+ *  @return  status     Configuration status.
+ */
+void DL_MCAN_eccForceError(
+    MCAN_Regs *mcan, const DL_MCAN_ECCErrForceParams *eccErr);
+
+/**
+ *  @brief   This API will return ECC Error status.
+ *
+ *  @param[in]  mcan    Pointer to the register overlay for the peripheral
+ *  @param[in]  eccErr  ECC error status. @ref DL_MCAN_ECCErrStatus.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_eccGetErrorStatus(MCAN_Regs *mcan, DL_MCAN_ECCErrStatus *eccErr);
+
+/**
+ *  @brief   This API is used to clear the ECC Error status.
+ *
+ *  @param[in]  mcan     Pointer to the register overlay for the peripheral
+ *  @param[in]  errType  Error type to clear status.
+ *                       One of @ref DL_MCAN_ECC_ERR_TYPE.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_eccClearErrorStatus(MCAN_Regs *mcan, uint32_t errType);
+
+/**
+ *  @brief   This API is used to write End of Interrupt for ECC interrupt.
+ *
+ *  @param[in]  mcan      Pointer to the register overlay for the peripheral
+ *  @param[in]  errType   Interrupt to enable. One of @ref DL_MCAN_ECC_ERR_TYPE.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_eccWriteEOI(MCAN_Regs *mcan, uint32_t errType);
+
+/**
+ *  @brief   This API is used to enable ECC interrupt.
+ *
+ *  @param[in]  mcan    Pointer to the register overlay for the peripheral
+ *  @param[in]  errType Interrupt to enable. One of @ref DL_MCAN_ECC_ERR_TYPE.
+ *  @param[in]  enable  ECC Interrupt is enabled if it is TRUE.
+ *                      ECC Interrupt is disabled if it is FALSE.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_eccEnableIntr(MCAN_Regs *mcan, uint32_t errType, bool enable);
+
+/**
+ *  @brief   This API is used to get ECC interrupt status.
+ *
+ *  @param[in]  mcan     Pointer to the register overlay for the peripheral
+ *  @param[in]  errType  Interrupt status to read.
+ *                       One of @ref DL_MCAN_ECC_ERR_TYPE.
+ *
+ *  @return  None.
+ */
+uint32_t DL_MCAN_eccGetIntrStatus(MCAN_Regs *mcan, uint32_t errType);
+
+/**
+ *  @brief   This API is used to clear ECC interrupt status.
+ *
+ *  @param[in]  mcan     Pointer to the register overlay for the peripheral
+ *  @param[in]  errType  Interrupt status to clear.
+ *                       One of @ref DL_MCAN_ECC_ERR_TYPE.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_eccClearIntrStatus(MCAN_Regs *mcan, uint32_t errType);
+
+/**
+ *  @brief   This API will configure external timestamp counter for MCAN module.
+ *
+ *  @param[in]  mcan        Pointer to the register overlay for the peripheral
+ *  @param[in]  prescalar   Timestamp Counter Prescaler. Range:[0x0-0xFFFFFF]
+ *
+ *  @return  None.
+ *
+ * \note    Actual value programmed prescalar values is (prescalar - 1).
+ */
+void DL_MCAN_extTSCounterConfig(MCAN_Regs *mcan, uint32_t prescalar);
+
+/**
+ *  @brief   This API will enable/disable fast external time stamp counter for
+ *          MCAN module.
+ *
+ *  @param[in]  mcan    Pointer to the register overlay for the peripheral
+ *  @param[in]  enable  External TS is enabled if it is TRUE.
+ *                      External TS is disabled if it is FALSE.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_extTSCounterEnable(MCAN_Regs *mcan, bool enable);
+
+/**
+ *  @brief   This API will enable/disable External TimeStamp Counter
+ *           Overflow Interrupt for MCAN module.
+ *
+ *  @param[in]  mcan    Pointer to the register overlay for the peripheral
+ *  @param[in]  enable  External TimeStamp Counter Overflow Interrupt is
+ *                      enabled if it is TRUE.
+ *                      External TimeStamp Counter Overflow Interrupt is
+ *                      disabled if it is FALSE.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_extTSEnableIntr(MCAN_Regs *mcan, bool enable);
+
+/**
+ *  @brief   This API is used to write End of Interrupt for External TimeStamp
+ *          Counter Overflow Interrupt.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  None.
+ */
+void DL_MCAN_extTSWriteEOI(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API returns Number of unserviced rollover/overflow
+ *          interrupts for external TimeStamp counter.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  status   Returns Number of unserviced rollover/overflow
+ *                    interrupts for external TimeStamp counter.
+ *                    Maximum number of unserviced interrupts is 0xF.
+ */
+uint32_t DL_MCAN_extTSGetUnservicedIntrCount(MCAN_Regs *mcan);
+
+/* ========================================================================== */
+/*                          Advance Functions                                 */
+/* ========================================================================== */
+
+/**
+ *  @brief   This API is used get the MCAN revision ID.
+ *
+ *  @param[in]  mcan     Pointer to the register overlay for the peripheral
+ *  @param[in]  revId    Contains Revision ID of MCAN module.
+ *                       @ref DL_MCAN_RevisionId.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_getRevisionId(MCAN_Regs *mcan, DL_MCAN_RevisionId *revId);
+
+/**
+ *  @brief   This API get clock stop acknowledgement for MCAN module.
+ *          It return whether MCAN is power down mode or not.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  status  Return Clock Stop Acknowledgement status.
+ *                   Return '1' if M_CAN is set in power down mode else
+ *                   returns '0'.
+ */
+uint32_t DL_MCAN_getClockStopAck(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API will set External TimeStamp Counter Overflow Interrupt
+ *          Raw status for MCAN module.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  None.
+ */
+void DL_MCAN_extTSSetRawStatus(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API will clear External TimeStamp Counter Overflow Interrupt
+ *          raw status for MCAN module.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  None.
+ */
+void DL_MCAN_extTSClearRawStatus(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API will return Rx pin state of MCAN module.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  state    MCAN Rx Pin State.
+ *                    0= The CAN bus is dominant
+ *                    1= The CAN bus is recessive
+ */
+uint32_t DL_MCAN_getRxPinState(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API will set Tx pin state of MCAN module.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *  @param[in]  state MCAN Tx Pin State.
+ *                    00= Reset value
+ *                    01= Sample Point can be monitored at tx pin
+ *                    10= The CAN bus is dominant
+ *                    11= The CAN bus is recessive
+ *                    other= It will treated as 11.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_setTxPinState(MCAN_Regs *mcan, uint32_t state);
+
+/**
+ *  @brief   This API will return Tx pin state of MCAN module.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  state    MCAN Tx Pin State.
+ *                    00= Reset value
+ *                    01= Sample Point can be monitored at tx pin
+ *                    10= The CAN bus is dominant
+ *                    11= The CAN bus is recessive
+ */
+uint32_t DL_MCAN_getTxPinState(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API will return current timestamp counter value.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  val             Current Timestamp counter value.
+ */
+uint32_t DL_MCAN_getTSCounterVal(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API will return clock stop acknowledgement
+ *          for MCAN module.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  ack   Clock Stop Acknowledge
+ *                 0= No clock stop acknowledged
+ *                 1= M_CAN may be set in power down
+ */
+uint32_t DL_MCAN_getClkStopAck(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API will get the configured bit timings for MCAN module.
+ *
+ *  @param[in]  mcan          Pointer to the register overlay for the peripheral
+ *  @param[in]  configParams  Configuration parameters for MCAN bit timing.
+ *                            @ref DL_MCAN_BitTimingParams.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_getBitTime(
+    MCAN_Regs *mcan, DL_MCAN_BitTimingParams *configParams);
+
+/**
+ *  @brief   This API will reset timestamp counter value.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  None.
+ */
+void DL_MCAN_resetTSCounter(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API will return current time-out counter value.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  val      Current Time-out counter value.
+ */
+uint32_t DL_MCAN_getTOCounterVal(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API is used get the ECC AGGR revision ID.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *  @param[in]  revId Contains Revision ID of ECC AGGR.
+ *                    @ref DL_MCAN_ECCAggrRevisionId.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_eccAggrGetRevisionId(
+    MCAN_Regs *mcan, DL_MCAN_ECCAggrRevisionId *revId);
+
+/**
+ *  @brief   This API is used get the ECC Wrapper revision ID.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *  @param[in]  revId Contains Revision ID of ECC Wrapper
+ *                    @ref DL_MCAN_ECCWrapRevisionId.
+ *
+ *  @return  None.
+ */
+void DL_MCAN_eccWrapGetRevisionId(
+    MCAN_Regs *mcan, DL_MCAN_ECCWrapRevisionId *revId);
+
+/**
+ *  @brief   This API returns External TimeStamp Counter Overflow Interrupt
+ *          enable status for MCAN module.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  status   Returns TRUE if External TimeStamp Counter Overflow
+ *                    Interrupt is enabled.
+ *                    Else returns FALSE.
+ */
+bool DL_MCAN_extTSIsIntrEnable(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This function return endianness value of MCAN module.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ * @retval  val             Endianness value. (0x87654321)
+ */
+uint32_t DL_MCAN_getEndianVal(MCAN_Regs *mcan);
+
+/**
+ *  @brief   This API will get the configured Extended ID AND Mask.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return  idMask          Extended ID AND Mask.
+ */
+uint32_t DL_MCAN_getExtIDANDMask(MCAN_Regs *mcan);
+
+/**
+ * @brief Enables power on MCAN module
+ *
+ *  @param mcan         Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_MCAN_enablePower(MCAN_Regs *mcan)
+{
+    mcan->MCANSS.PWREN = (MCAN_PWREN_KEY_UNLOCK_W | MCAN_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power on mcan module
+ *
+ *  @param mcan         Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_MCAN_disablePower(MCAN_Regs *mcan)
+{
+    mcan->MCANSS.PWREN = (MCAN_PWREN_KEY_UNLOCK_W | MCAN_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief Returns if  power on mcan module
+ *
+ *  @param mcan         Pointer to the register overlay for the peripheral
+ *
+ *  @return true if power is enabled
+ *  @return false if power is disabled
+ */
+__STATIC_INLINE bool DL_MCAN_isPowerEnabled(MCAN_Regs *mcan)
+{
+    return ((mcan->MCANSS.PWREN & MCAN_PWREN_ENABLE_MASK) ==
+            MCAN_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Resets mcan peripheral
+ *
+ *  @param mcan         Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_MCAN_reset(MCAN_Regs *mcan)
+{
+    mcan->MCANSS.RSTCTL =
+        (MCAN_RSTCTL_KEY_UNLOCK_W | MCAN_RSTCTL_RESETSTKYCLR_CLR |
+            MCAN_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief Returns if mcan peripheral was reset
+ *
+ *  @param mcan         Pointer to the register overlay for the peripheral
+ *
+ *  @return true if peripheral was reset
+ *  @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_MCAN_isReset(MCAN_Regs *mcan)
+{
+    return ((mcan->MCANSS.STAT & MCAN_STAT_RESETSTKY_MASK) ==
+            MCAN_STAT_RESETSTKY_RESET);
+}
+
+/**
+ *  @brief      Enable MCAN interrupts
+ *
+ *  @param[in]  mcan           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_MCAN_INTERRUPT.
+ */
+__STATIC_INLINE void DL_MCAN_enableInterrupt(
+    MCAN_Regs *mcan, uint32_t interruptMask)
+{
+    mcan->MCANSS.TI_WRAPPER.MSP.CPU_INT.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disable MCAN interrupts
+ *
+ *  @param[in]  mcan           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to disable. Bitwise OR of
+ *                             mcan interrupts.
+ */
+__STATIC_INLINE void DL_MCAN_disableInterrupt(
+    MCAN_Regs *mcan, uint32_t interruptMask)
+{
+    mcan->MCANSS.TI_WRAPPER.MSP.CPU_INT.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief      Check which MCAN interrupts are enabled
+ *
+ *  @param[in]  mcan           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_MCAN_INTERRUPT.
+ *
+ *  @return     Which of the requested MCAN interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_MCAN_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_MCAN_getEnabledInterrupts(
+    MCAN_Regs *mcan, uint32_t interruptMask)
+{
+    return (mcan->MCANSS.TI_WRAPPER.MSP.CPU_INT.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled MCAN interrupts
+ *
+ *  Checks if any of the MCAN interrupts that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  mcan           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_MCAN_INTERRUPT.
+ *
+ *  @return     Which of the requested MCAN interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_MCAN_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_MCAN_getEnabledInterruptStatus(
+    MCAN_Regs *mcan, uint32_t interruptMask)
+{
+    return (mcan->MCANSS.TI_WRAPPER.MSP.CPU_INT.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any MCAN interrupt
+ *
+ *  Checks if any of the MCAN interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  mcan           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_MCAN_INTERRUPT.
+ *
+ *  @return     Which of the requested MCAN interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_MCAN_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_MCAN_getRawInterruptStatus(
+    MCAN_Regs *mcan, uint32_t interruptMask)
+{
+    return (mcan->MCANSS.TI_WRAPPER.MSP.CPU_INT.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending MCAN interrupt
+ *
+ *  Checks if any of the MCAN interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The highest priority pending MCAN interrupt. One of
+ *              @ref DL_MCAN_IIDX
+ *
+ */
+__STATIC_INLINE DL_MCAN_IIDX DL_MCAN_getPendingInterrupt(MCAN_Regs *mcan)
+{
+    // TODO: Need to figure out return values for this.
+    return ((DL_MCAN_IIDX) mcan->MCANSS.TI_WRAPPER.MSP.CPU_INT.IIDX);
+}
+
+/**
+ *  @brief      Clear pending MCAN interrupts
+ *
+ *  @param[in]  mcan           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_MCAN_INTERRUPT.
+ */
+__STATIC_INLINE void DL_MCAN_clearInterruptStatus(
+    MCAN_Regs *mcan, uint32_t interruptMask)
+{
+    mcan->MCANSS.TI_WRAPPER.MSP.CPU_INT.ICLR = interruptMask;
+}
+
+/**
+ *  @brief      Checks if the MCAN module clock request is enabled
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If the MCAN module clock request is enabled
+ *
+ */
+__STATIC_INLINE bool DL_MCAN_isModuleClockEnabled(MCAN_Regs *mcan)
+{
+    return ((mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKEN &
+                MCAN_CLKEN_CLK_REQEN_MASK) == MCAN_CLKEN_CLK_REQEN_SET);
+}
+
+/**
+ *  @brief      Enables the MCAN functional module clock
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_MCAN_enableModuleClock(MCAN_Regs *mcan)
+{
+    mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKEN = MCAN_CLKEN_CLK_REQEN_SET;
+}
+
+/**
+ *  @brief      Disables the MCAN functional module clock
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_MCAN_disableModuleClock(MCAN_Regs *mcan)
+{
+    mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKEN = MCAN_CLKEN_CLK_REQEN_CLR;
+}
+
+/**
+ *  @brief      Gets the MCAN functional module clock divide ratio
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current clock divide ratio, one of @ref DL_MCAN_CLOCK_DIVIDE
+ *
+ */
+__STATIC_INLINE uint32_t DL_MCAN_getModuleClockDivider(MCAN_Regs *mcan)
+{
+    return (
+        mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKDIV & MCAN_CLKDIV_RATIO_MASK);
+}
+
+/**
+ *  @brief      Configures clock divide settings for the MCAN functional module
+ *              clock
+ *
+ *  @param[in]  mcan    Pointer to the register overlay for the peripheral
+ *  @param[in]  clkdiv  The desired clock divide ratio, one of
+ *                      @ref DL_MCAN_CLOCK_DIVIDE
+ *
+ */
+__STATIC_INLINE void DL_MCAN_setModuleClockDivider(
+    MCAN_Regs *mcan, uint32_t clkdiv)
+{
+    DL_Common_updateReg(&mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKDIV, clkdiv,
+        MCAN_CLKDIV_RATIO_MASK);
+}
+
+/**
+ *  @brief      Checks if the MCAN clock gating request is enabled
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If the the MCAN module clock gating request is enabled/disabled
+ *
+ */
+__STATIC_INLINE bool DL_MCAN_isClockStopGateRequestEnabled(MCAN_Regs *mcan)
+{
+    return ((mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKCTL &
+                MCAN_CLKCTL_STOPREQ_MASK) == MCAN_CLKCTL_STOPREQ_ENABLE);
+}
+
+/**
+ *  @brief      Enables the MCAN clock gating request
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_MCAN_enableClockStopGateRequest(MCAN_Regs *mcan)
+{
+    DL_Common_updateReg(&mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKCTL,
+        MCAN_CLKCTL_STOPREQ_ENABLE, MCAN_CLKCTL_STOPREQ_MASK);
+}
+
+/**
+ *  @brief      Disables the MCAN clock gating request
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_MCAN_disableClockStopGateRequest(MCAN_Regs *mcan)
+{
+    DL_Common_updateReg(&mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKCTL,
+        MCAN_CLKCTL_STOPREQ_DISABLE, MCAN_CLKCTL_STOPREQ_MASK);
+}
+
+/**
+ *  @brief      Checks if the MCAN clock stop wakeup interrupt is enabled
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If the the MCAN module clock wakeup interrupt is
+ *              enabled/disabled
+ *
+ */
+__STATIC_INLINE bool DL_MCAN_isClockStopWakeupInterruptEnabled(MCAN_Regs *mcan)
+{
+    return ((mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKCTL &
+                MCAN_CLKCTL_WAKEUP_INT_EN_MASK) ==
+            MCAN_CLKCTL_WAKEUP_INT_EN_ENABLE);
+}
+
+/**
+ *  @brief      Enables the MCAN clock stop wakeup interrupt
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_MCAN_enableClockStopWakeupInterrupt(MCAN_Regs *mcan)
+{
+    DL_Common_updateReg(&mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKCTL,
+        MCAN_CLKCTL_WAKEUP_INT_EN_ENABLE, MCAN_CLKCTL_WAKEUP_INT_EN_MASK);
+}
+
+/**
+ *  @brief      Disables the MCAN clock stop wakeup interrupt
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_MCAN_disableClockStopWakeupInterrupt(MCAN_Regs *mcan)
+{
+    DL_Common_updateReg(&mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKCTL,
+        MCAN_CLKCTL_WAKEUP_INT_EN_DISABLE, MCAN_CLKCTL_WAKEUP_INT_EN_MASK);
+}
+
+/**
+ *  @brief      Checks if the glitch filter on MCAN RXD input is enabled
+ *
+ *  When the glitch filter is enabled in MCAN RXD input, it wakes up the MCAN
+ *  controller to exit clock gating
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If the the glitch filter on MCAN RXD input is enabled/disabled
+ *
+ */
+__STATIC_INLINE bool DL_MCAN_isGlitchFilterWakeupEnabled(MCAN_Regs *mcan)
+{
+    return ((mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKCTL &
+                MCAN_CLKCTL_WKUP_GLTFLT_EN_MASK) ==
+            MCAN_CLKCTL_WKUP_GLTFLT_EN_ENABLE);
+}
+
+/**
+ *  @brief      Enables the glitch filter on MCAN RXD input
+ *
+ *  When the glitch filter is enabled in MCAN RXD input, it wakes up the MCAN
+ *  controller to exit clock gating
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_MCAN_enableGlitchFilterWakeup(MCAN_Regs *mcan)
+{
+    DL_Common_updateReg(&mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKCTL,
+        MCAN_CLKCTL_WKUP_GLTFLT_EN_ENABLE, MCAN_CLKCTL_WKUP_GLTFLT_EN_MASK);
+}
+
+/**
+ *  @brief      Disables the glitch filter on MCAN RXD input
+ *
+ *  When the glitch filter is enabled in MCAN RXD input, it wakes up the MCAN
+ *  controller to exit clock gating
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_MCAN_disableGlitchFilterWakeup(MCAN_Regs *mcan)
+{
+    DL_Common_updateReg(&mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKCTL,
+        MCAN_CLKCTL_WKUP_GLTFLT_EN_DISABLE, MCAN_CLKCTL_WKUP_GLTFLT_EN_MASK);
+}
+
+/**
+ *  @brief      Gets the clock stop acknowledge status
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The clock stop acknowledge status
+ *
+ */
+__STATIC_INLINE bool DL_MCAN_getClockStopAcknowledgeStatus(MCAN_Regs *mcan)
+{
+    return ((mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKSTS &
+                MCAN_CLKSTS_CLKSTOP_ACKSTS_MASK) ==
+            MCAN_CLKSTS_CLKSTOP_ACKSTS_SET);
+}
+
+/**
+ *  @brief      Gets the clock stop hardware override status
+ *
+ *  This bit indicates when the MCANSS_CLKCTL.STOPREQ bit has been cleared by
+ *  HW when a clock-stop wake-up event via CAN RX activity is triggered
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The clock stop hardware override status
+ *
+ */
+__STATIC_INLINE bool DL_MCAN_getClockStopHardwareOverrideStatus(
+    MCAN_Regs *mcan)
+{
+    return ((mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKSTS &
+                MCAN_CLKSTS_STOPREQ_HW_OVR_MASK) ==
+            MCAN_CLKSTS_STOPREQ_HW_OVR_SET);
+}
+
+/**
+ *  @brief      Gets the status of MCAN controller clock request from GPRCM
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of the MCAN controller clock request from GPRCM
+ *
+ */
+__STATIC_INLINE bool DL_MCAN_getControllerClockRequestStatus(MCAN_Regs *mcan)
+{
+    return ((mcan->MCANSS.TI_WRAPPER.MSP.MCANSS_CLKSTS &
+                MCAN_CLKSTS_CCLKDONE_MASK) == MCAN_CLKSTS_CCLKDONE_SET);
+}
+
+/**
+ *  @brief      Saves MCAN configuration before entering STOP or STANDBY mode.
+ *              Only necessary for PG 1.0 silicon.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr   Configuration backup setup structure. See
+ *                       @ref DL_MCAN_backupConfig.
+ *
+ *  @retval     FALSE if a configuration already exists in ptr (will not be
+ *              overwritten). TRUE if a configuration was successfully saved
+ *
+ */
+bool DL_MCAN_saveConfiguration(MCAN_Regs *mcan, DL_MCAN_backupConfig *ptr);
+
+/**
+ *  @brief      Restore MCAN configuration after leaving STOP or STANDBY mode.
+ *              Only necessary for PG 1.0 silicon.
+ *
+ *  @param[in]  mcan  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr      Configuration backup setup structure. See
+ *                       @ref DL_MCAN_backupConfig.
+ *
+ *  @retval     FALSE if a configuration does not exist in ptr (will not be
+ *              loaded). TRUE if a configuration successfully loaded
+ *
+ */
+bool DL_MCAN_restoreConfiguration(MCAN_Regs *mcan, DL_MCAN_backupConfig *ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_MCAN__ */
+
+#endif /* ti_dl_dl_mcan__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_opa.c
+++ b/mspm0/source/ti/driverlib/dl_opa.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_opa.h>
+
+#ifdef __MSPM0_HAS_OA__
+
+DL_OPA_GAIN DL_OPA_increaseGain(OA_Regs *opa)
+{
+    DL_OPA_GAIN currentGain = DL_OPA_getGain(opa);
+
+    /* if CFG.GAIN 0x5 do nothing */
+    if (currentGain == DL_OPA_GAIN_N31_P32) {
+        return DL_OPA_GAIN_N31_P32;
+    } else {
+        DL_OPA_setGain(opa,
+            (uint32_t)(currentGain + (((uint32_t) 0x1) << OA_CFG_GAIN_OFS)));
+        return DL_OPA_getGain(opa);
+    }
+}
+
+DL_OPA_GAIN DL_OPA_decreaseGain(OA_Regs *opa)
+{
+    DL_OPA_GAIN currentGain = DL_OPA_getGain(opa);
+
+    /* if CFG.GAIN is 0x1 do nothing */
+    if (currentGain == DL_OPA_GAIN_N1_P2) {
+        return DL_OPA_GAIN_N1_P2;
+    } else {
+        DL_OPA_setGain(opa,
+            (uint32_t)(currentGain - (((uint32_t) 0x1) << OA_CFG_GAIN_OFS)));
+        return DL_OPA_getGain(opa);
+    }
+}
+
+#endif /* __MSPM0_HAS_OA__ */

--- a/mspm0/source/ti/driverlib/dl_opa.h
+++ b/mspm0/source/ti/driverlib/dl_opa.h
@@ -1,0 +1,651 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_opa.h
+ *  @brief      Op-Amp (OPA) Driver Library
+ *  @defgroup   OPA Op-Amp (OPA)
+ *
+ *  @anchor ti_dl_dl_opa_Overview
+ *  # Overview
+ *
+ *  The OP-Amp Driver Library allows full configuration of the MSPM0 OPA module.
+ *  The OPA is a zero-drift chopper stabilized operational amplifier with a
+ *  programmable gain stage.
+ *
+ *  <hr>
+
+ ******************************************************************************
+ */
+/** @addtogroup OPA
+ * @{
+ */
+#ifndef ti_dl_dl_opa__include
+#define ti_dl_dl_opa__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_OA__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*! @enum DL_OPA_CHOPPING_MODE */
+typedef enum {
+    /*! Disable chopping mode */
+    DL_OPA_CHOPPING_MODE_DISABLE = OA_CFG_CHOP_OFF,
+    /*! Enable standard chopping mode */
+    DL_OPA_CHOPPING_MODE_STANDARD = OA_CFG_CHOP_ON,
+    /*! Enable ADC assisted chopping mode. Requires OPA output to be
+     connected to an ADC input with hardware averaging. */
+    DL_OPA_CHOPPING_MODE_ADC_AVERAGING = OA_CFG_CHOP_AVGON,
+} DL_OPA_CHOPPING_MODE;
+
+/*! @enum DL_OPA_OUTPUT_PIN_STATE */
+typedef enum {
+
+    /*! Output pin is enabled */
+    DL_OPA_OUTPUT_PIN_ENABLED = OA_CFG_OUTPIN_ENABLED,
+    /*! Outpin pin is disabled */
+    DL_OPA_OUTPUT_PIN_DISABLED = OA_CFG_OUTPIN_DISABLED,
+
+} DL_OPA_OUTPUT_PIN_STATE;
+
+/*! @enum DL_OPA_PSEL */
+typedef enum {
+    /*! Non-inverting input channel is Open */
+    DL_OPA_PSEL_OPEN = OA_CFG_PSEL_NC,
+    /*!  Non-inverting input is OPAx_IN0+ */
+    DL_OPA_PSEL_IN0_POS = OA_CFG_PSEL_EXTPIN0,
+    /*!  Non-inverting input is OPAx_IN1+ */
+    DL_OPA_PSEL_IN1_POS = OA_CFG_PSEL_EXTPIN1,
+    /*!  Non-inverting input is DAC_OUT */
+    DL_OPA_PSEL_DAC_OUT = OA_CFG_PSEL_DAC12OUT,
+    /*!  Non-inverting input is DAC8.x_OUT */
+    DL_OPA_PSEL_DAC8_OUT = OA_CFG_PSEL_DAC8OUT,
+    /*!  Non-inverting input is VREF */
+    DL_OPA_PSEL_VREF = OA_CFG_PSEL_VREF,
+    /*!  Non-inverting input is OPA[x-1]_RTOP */
+    DL_OPA_PSEL_RTOP = OA_CFG_PSEL_OANM1RTOP,
+
+    /*!  Non-inverting input is GPAMP OUT*/
+    DL_OPA_PSEL_GPAMP_OUT = OA_CFG_PSEL_GPAMP_OUT_INT,
+    /*!  Non-inverting input is GND */
+    DL_OPA_PSEL_GND = OA_CFG_PSEL_VSS,
+
+} DL_OPA_PSEL;
+
+/*! @enum DL_OPA_NSEL */
+typedef enum {
+    /*! Inverting input channel is Open */
+    DL_OPA_NSEL_OPEN = OA_CFG_NSEL_NC,
+    /*! Inverting input channel is OPAx_IN0- */
+    DL_OPA_NSEL_IN0_NEG = OA_CFG_NSEL_EXTPIN0,
+    /*! Inverting input channel is OPAx_IN1- */
+    DL_OPA_NSEL_IN1_NEG = OA_CFG_NSEL_EXTPIN1,
+    /*! Inverting input channel is OPA[x-1]_RBOT */
+    DL_OPA_NSEL_RBOT = OA_CFG_NSEL_OANP1RBOT,
+    /*! Inverting input channel is RTAP */
+    DL_OPA_NSEL_RTAP = OA_CFG_NSEL_OANRTAP,
+    /*! Inverting input channel is RTOP */
+    DL_OPA_NSEL_RTOP = OA_CFG_NSEL_OANRTOP,
+    /*! Spare input for inverting channel */
+    DL_OPA_NSEL_SPARE = OA_CFG_NSEL_SPARE,
+} DL_OPA_NSEL;
+
+/*! @enum DL_OPA_MSEL */
+typedef enum {
+    /*! M-MUX input channel is Open */
+    DL_OPA_MSEL_OPEN = OA_CFG_MSEL_NC,
+    /*! M-MUX input channel is OPAx_IN1- */
+    DL_OPA_MSEL_IN1_NEG = OA_CFG_MSEL_EXTNPIN1,
+    /*! M-MUX input channel is GND */
+    DL_OPA_MSEL_GND = OA_CFG_MSEL_VSS,
+    /*! M-MUX input channel is DAC_OUT */
+    DL_OPA_MSEL_DAC_OUT = OA_CFG_MSEL_DAC12OUT,
+    /*! M-MUX input channel is OPA[x-1]_RTOP */
+    DL_OPA_MSEL_RTOP = OA_CFG_MSEL_OANM1RTOP,
+} DL_OPA_MSEL;
+
+/*! @enum DL_OPA_GBW */
+typedef enum {
+    /*! High gain bandwidth (GBW). See device specific datasheet for values. */
+    DL_OPA_GBW_HIGH = OA_CFGBASE_GBW_HIGHGAIN,
+    /*! Low gain bandwidth (GBW). See device specific datasheet for values. */
+    DL_OPA_GBW_LOW = OA_CFGBASE_GBW_LOWGAIN,
+} DL_OPA_GBW;
+
+/*! @enum DL_OPA_GAIN */
+typedef enum {
+    /*! Gain value is Not Valid in Non-inverting and inverting PGA modes */
+    DL_OPA_GAIN_N0_P1 = (((uint32_t) 0x0) << OA_CFG_GAIN_OFS),
+    /*! Gain value is -1x in Inverting PGA mode, and 2x in Non-inverting
+    * PGA mode */
+    DL_OPA_GAIN_N1_P2 = (((uint32_t) 0x1) << OA_CFG_GAIN_OFS),
+    /*! Gain value is -3x in Inverting PGA mode, and 4x in Non-inverting
+    * PGA mode */
+    DL_OPA_GAIN_N3_P4 = (((uint32_t) 0x2) << OA_CFG_GAIN_OFS),
+    /*! Gain value is -7x in Inverting PGA mode, and 8x in Non-inverting
+    * PGA mode */
+    DL_OPA_GAIN_N7_P8 = (((uint32_t) 0x3) << OA_CFG_GAIN_OFS),
+    /*! Gain value is -15x in Inverting PGA mode, and 16x in Non-inverting
+    * PGA mode */
+    DL_OPA_GAIN_N15_P16 = (((uint32_t) 0x4) << OA_CFG_GAIN_OFS),
+    /*! Gain value is -31x in Inverting PGA mode, and 32x in Non-inverting
+      * PGA mode */
+    DL_OPA_GAIN_N31_P32 = (((uint32_t) 0x5) << OA_CFG_GAIN_OFS),
+} DL_OPA_GAIN;
+
+/*!
+ *  @brief  Configuration struct for @ref DL_OPA_init
+ */
+typedef struct {
+    /*! The chopping mode to set. One of @ref DL_OPA_CHOPPING_MODE */
+    DL_OPA_CHOPPING_MODE choppingMode;
+    /*! The state of the output pin. One of @ref DL_OPA_OUTPUT_PIN_STATE. */
+    DL_OPA_OUTPUT_PIN_STATE outputPinState;
+    /*! The non-inverting input channel to set. One of @ref DL_OPA_PSEL */
+    DL_OPA_PSEL pselChannel;
+    /*! The inverting input channel to set. One of @ref DL_OPA_NSEL */
+    DL_OPA_NSEL nselChannel;
+    /*! The M-MUX input channel to set. One of @ref DL_OPA_MSEL */
+    DL_OPA_MSEL mselChannel;
+    /*! The gain to set. Value between 0-7. */
+    DL_OPA_GAIN gain;
+} DL_OPA_Config;
+
+/**
+ * @brief Enables power on OPA module
+ *
+ * @param[in]  opa  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_OPA_enablePower(OA_Regs *opa)
+{
+    opa->GPRCM.PWREN = (OA_PWREN_KEY_UNLOCK_W | OA_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power on OPA module
+ *
+ * @param[in]  opa  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_OPA_disablePower(OA_Regs *opa)
+{
+    opa->GPRCM.PWREN = (OA_PWREN_KEY_UNLOCK_W | OA_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief Returns if  power on opa module
+ *
+ * @param[in]  opa  Pointer to the register overlay for the peripheral
+ *
+ * @return true if power is enabled
+ * @return false if power is disabled
+ */
+__STATIC_INLINE bool DL_OPA_isPowerEnabled(OA_Regs *opa)
+{
+    return (
+        (opa->GPRCM.PWREN & OA_PWREN_ENABLE_MASK) == OA_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Resets OPA peripheral
+ *
+ * @param[in]  opa  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_OPA_reset(OA_Regs *opa)
+{
+    opa->GPRCM.RSTCTL = (OA_RSTCTL_KEY_UNLOCK_W | OA_RSTCTL_RESETSTKYCLR_CLR |
+                         OA_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief Returns if OPA peripheral was reset
+ *
+ * @param[in]  opa  Pointer to the register overlay for the peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_OPA_isReset(OA_Regs *opa)
+{
+    return ((opa->GPRCM.STAT & OA_GPRCM_STAT_RESETSTKY_MASK) ==
+            OA_GPRCM_STAT_RESETSTKY_RESET);
+}
+
+/**
+ *  @brief      Enable the OPA peripheral
+ *
+ *  @param[in]  opa  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_OPA_enable(OA_Regs *opa)
+{
+    opa->CTL |= OA_CTL_ENABLE_ON;
+}
+
+/**
+ *  @brief      Checks if the OPA peripheral is enabled
+ *
+ *  @param[in]  opa  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the enabled status of the OPA
+ *
+ *  @retval     true  The OPA peripheral is enabled
+ *  @retval     false The OPA peripheral is disabled
+
+ */
+__STATIC_INLINE bool DL_OPA_isEnabled(OA_Regs *opa)
+{
+    return ((opa->CTL & OA_CTL_ENABLE_MASK) == OA_CTL_ENABLE_ON);
+}
+
+/**
+ *  @brief      Disable the OPA peripheral
+ *
+ *  @param[in]  opa  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_OPA_disable(OA_Regs *opa)
+{
+    opa->CTL &= ~(OA_CTL_ENABLE_MASK);
+}
+
+/**
+ *  @brief      Initialize the OPA peripheral
+ *
+ *  Initializes all the common configurable options for the OPA peripheral. Any
+ *  other custom configuration can be done after calling this API. The OPA is
+ *  not enabled in this API.
+ *
+ *  @param[in]  opa    Pointer to the register overlay for the peripheral
+ *  @param[in]  config  Configuration for OPA peripheral
+ */
+__STATIC_INLINE void DL_OPA_init(OA_Regs *opa, DL_OPA_Config *config)
+{
+    DL_Common_updateReg(&opa->CFG,
+        (uint32_t) config->choppingMode | (uint32_t) config->outputPinState |
+            (uint32_t) config->pselChannel | (uint32_t) config->nselChannel |
+            (uint32_t) config->mselChannel | (uint32_t) config->gain,
+        OA_CFG_CHOP_MASK | OA_CFG_OUTPIN_MASK | OA_CFG_PSEL_MASK |
+            OA_CFG_NSEL_MASK | OA_CFG_MSEL_MASK | OA_CFG_GAIN_MASK);
+}
+
+/**
+ *  @brief      Set the gain bandwidth (GBW)
+ *
+ *  @param[in]  opa        Pointer to the register overlay for the peripheral
+ *  @param[in]  bandwidth  The gain bandwidth to set. One of @ref DL_OPA_GBW
+ *
+ *
+ *  @pre The OPA must be ready (STAT.RDY == 1) before setting
+ *       this configuration.
+ *
+ */
+__STATIC_INLINE void DL_OPA_setGainBandwidth(
+    OA_Regs *opa, DL_OPA_GBW bandwidth)
+{
+    opa->CFGBASE |= ((uint32_t) bandwidth);
+}
+
+/**
+ *  @brief      Get the gain bandwidth (GBW)
+ *
+ *  @param[in]  opa   Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current gain bandwidth
+ *
+ *  @retval     One of @ref DL_OPA_GBW
+ */
+__STATIC_INLINE DL_OPA_GBW DL_OPA_getGainBandwidth(OA_Regs *opa)
+{
+    uint32_t bandwidth = (opa->CFGBASE & OA_CFGBASE_GBW_MASK);
+
+    return (DL_OPA_GBW)(bandwidth);
+}
+
+/**
+ *  @brief      Enable the rail-to-rail input (RRI)
+ *
+ *  @param[in]  opa  Pointer to the register overlay for the peripheral
+ *
+ *
+ *  @pre The OPA must be ready (STAT.RDY == 1) before setting
+ *       this configuration.
+ *
+ */
+__STATIC_INLINE void DL_OPA_enableRailToRailInput(OA_Regs *opa)
+{
+    opa->CFGBASE |= OA_CFGBASE_RRI_ON;
+}
+
+/**
+ *  @brief      Checks if the the rail-to-rail input (RRI) is enabled
+ *
+ *  @param[in]  opa  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the rail-to-rail input status of the OPA
+ *
+ *  @retval     true  The rail-to-rail input is enabled
+ *  @retval     false The rail-to-rail input is disabled
+
+ */
+__STATIC_INLINE bool DL_OPA_isRailToRailInputEnabled(OA_Regs *opa)
+{
+    return ((opa->CFGBASE &= OA_CFGBASE_RRI_MASK) == OA_CFGBASE_RRI_ON);
+}
+
+/**
+ *  @brief      Disable the rail-to-rail input (RRI)
+ *
+ *  @param[in]  opa  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_OPA_disableRailToRailInput(OA_Regs *opa)
+{
+    opa->CFGBASE &= ~(OA_CFGBASE_RRI_MASK);
+}
+
+/**
+ *  @brief      Set and enable the chopping mode
+ *
+ *  @param[in]  opa     Pointer to the register overlay for the peripheral
+ *  @param[in]  mode    The chopping mode to set.
+ *                      One of @ref DL_OPA_CHOPPING_MODE
+ */
+__STATIC_INLINE void DL_OPA_setChoppingMode(
+    OA_Regs *opa, DL_OPA_CHOPPING_MODE mode)
+{
+    DL_Common_updateReg(&opa->CFG, (uint32_t) mode, OA_CFG_CHOP_MASK);
+}
+
+/**
+ *  @brief      Get the chopping mode
+ *
+ *  @param[in]  opa     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current chopping mode
+ *
+ *  @retval     One of @ref DL_OPA_CHOPPING_MODE
+ */
+__STATIC_INLINE DL_OPA_CHOPPING_MODE DL_OPA_getChoppingMode(OA_Regs *opa)
+{
+    uint32_t mode = (opa->CFG & OA_CFG_CHOP_MASK);
+
+    return (DL_OPA_CHOPPING_MODE)(mode);
+}
+
+/**
+ *  @brief      Set the state of the output pin
+ *
+ * When the output pin is enabled, the OPA output goes to the device pin while
+ * still maintaining connection to the programmable gain stage and other analog
+ * peripherals.
+ * When disabled, the OPA output is a purely internal signal and is internally
+ * connected to the programmable gain stage and capable of being routed to
+ * other on-board analog peripherals.
+ *
+ *  @param[in]  opa     Pointer to the register overlay for the peripheral
+ *  @param[in]  state   The state to set the output pin to
+ *                      One of @ref DL_OPA_OUTPUT_PIN_STATE
+ */
+__STATIC_INLINE void DL_OPA_setOutputPinState(
+    OA_Regs *opa, DL_OPA_OUTPUT_PIN_STATE state)
+{
+    DL_Common_updateReg(&opa->CFG, (uint32_t) state, OA_CFG_OUTPIN_MASK);
+}
+
+/**
+ *  @brief      Get the state of the output pin
+ *
+ * When the output pin is enabled, the OPA output goes to the device pin while
+ * still maintaining connection to the programmable gain stage and other analog
+ * peripherals.
+ * When disabled, the OPA output is a purely internal signal and is internally
+ * connected to the programmable gain stage and capable of being routed to
+ * other on-board analog peripherals.
+ *
+ *  @param[in]  opa     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The state of the output pin
+ *
+ *  @retval     One of @ref DL_OPA_OUTPUT_PIN_STATE
+ */
+__STATIC_INLINE DL_OPA_OUTPUT_PIN_STATE DL_OPA_getOutputPinState(OA_Regs *opa)
+{
+    uint32_t state = (opa->CFG & OA_CFG_OUTPIN_MASK);
+
+    return (DL_OPA_OUTPUT_PIN_STATE)(state);
+}
+
+/**
+ *  @brief      Disable the OPA output signal to be accessed by a device pin
+ *
+ * When disabled, the OPA output is a purely internal signal and is internally
+ * connected to the programmable gain stage and capable of being routed to
+ * other on-board analog peripherals.
+ *
+ *  @param[in]  opa  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_OPA_disableOutputPin(OA_Regs *opa)
+{
+    opa->CFG &= ~(OA_CFG_OUTPIN_MASK);
+}
+
+/**
+ *  @brief      Set the non-inverting input channel
+ *
+ *  This API sets the PSEL control bit to select the non-inverting input
+ *  channel of the amplifier.
+ *
+ *  @param[in]  opa           Pointer to the register overlay for the peripheral
+ *  @param[in]  inputChannel  The non-inverting input channel to set.
+ *                            One of @ref DL_OPA_PSEL.
+ */
+__STATIC_INLINE void DL_OPA_setNonInvertingInputChannel(
+    OA_Regs *opa, DL_OPA_PSEL inputChannel)
+{
+    DL_Common_updateReg(&opa->CFG, (uint32_t) inputChannel, OA_CFG_PSEL_MASK);
+}
+
+/**
+ *  @brief      Get the non-inverting input channel
+ *
+ *  @param[in]  opa     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current non-inverting input channel
+ *
+ *  @retval     One of @ref DL_OPA_PSEL
+ */
+__STATIC_INLINE DL_OPA_PSEL DL_OPA_getNonInvertingInputChannel(OA_Regs *opa)
+{
+    uint32_t inputChannel = (opa->CFG & OA_CFG_PSEL_MASK);
+
+    return (DL_OPA_PSEL)(inputChannel);
+}
+
+/**
+ *  @brief      Set the inverting input channel
+ *
+ *  This API sets the NSEL control bit to select the inverting input
+ *  channel of the amplifier.
+ *
+ *  @param[in]  opa           Pointer to the register overlay for the peripheral
+ *  @param[in]  inputChannel  The inverting input channel to set.
+ *                            One of @ref DL_OPA_NSEL.
+ */
+__STATIC_INLINE void DL_OPA_setInvertingInputChannel(
+    OA_Regs *opa, DL_OPA_NSEL inputChannel)
+{
+    DL_Common_updateReg(&opa->CFG, (uint32_t) inputChannel, OA_CFG_NSEL_MASK);
+}
+
+/**
+ *  @brief      Get the inverting input channel
+ *
+ *  @param[in]  opa     Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current inverting input channel
+ *
+ *  @retval     One of @ref DL_OPA_NSEL
+ */
+__STATIC_INLINE DL_OPA_NSEL DL_OPA_getInvertingInputChannel(OA_Regs *opa)
+{
+    uint32_t inputChannel = (opa->CFG & OA_CFG_NSEL_MASK);
+
+    return (DL_OPA_NSEL)(inputChannel);
+}
+
+/**
+ *  @brief      Set the M-MUX input channel
+ *
+ *  This API sets the MSEL control bit to select the input channel for M-MUX,
+ *  which is connected to the programmable gain stage resistor ladder.
+ *
+ *  @param[in]  opa           Pointer to the register overlay for the peripheral
+ *  @param[in]  inputChannel  The M-MUX input channel to set.
+ *                            One of @ref DL_OPA_MSEL.
+ */
+__STATIC_INLINE void DL_OPA_setMMUXInputChannel(
+    OA_Regs *opa, DL_OPA_MSEL inputChannel)
+{
+    DL_Common_updateReg(&opa->CFG, (uint32_t) inputChannel, OA_CFG_MSEL_MASK);
+}
+
+/**
+ *  @brief      Get the M-MUX input channel
+ *
+ *  @param[in]  opa   Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current M-MUX input channel
+ *
+ *  @retval     One of @ref DL_OPA_MSEL
+ */
+__STATIC_INLINE DL_OPA_MSEL DL_OPA_getMMUXInputChannel(OA_Regs *opa)
+{
+    uint32_t inputChannel = (opa->CFG & OA_CFG_MSEL_MASK);
+
+    return (DL_OPA_MSEL)(inputChannel);
+}
+
+/**
+ *  @brief      Set the gain for the programmable gain stage
+ *
+ * The OPA integrates a programmable gain stage in the feedback loop to
+ * configure the OPA as a PGA(programmable gain amplifier). The gain stage
+ * is a feedback resistance ladder and it supports up to 32x amplification.
+ *
+ * Refer to the TRM for gain enumeration information.
+ *
+ *  @param[in]  opa   Pointer to the register overlay for the peripheral
+ *  @param[in]  gain  The gain to set. One of @ref DL_OPA_GAIN.
+ */
+__STATIC_INLINE void DL_OPA_setGain(OA_Regs *opa, DL_OPA_GAIN gain)
+{
+    DL_Common_updateReg(&opa->CFG, (uint32_t) gain, OA_CFG_GAIN_MASK);
+}
+
+/**
+ *  @brief      Get the gain from the programmable gain stage
+*
+ * Refer to the TRM for gain enumeration information.
+ *
+ *  @param[in]  opa   Pointer to the register overlay for the peripheral
+ *
+ *  @return     The gain
+ *
+ *  @retval     The gain. One of @ref DL_OPA_GAIN
+ */
+__STATIC_INLINE DL_OPA_GAIN DL_OPA_getGain(OA_Regs *opa)
+{
+    uint32_t gain = (opa->CFG & OA_CFG_GAIN_MASK);
+
+    return (DL_OPA_GAIN)(gain);
+}
+
+/**
+ *  @brief      Increment gain to the next @ref DL_OPA_GAIN enum value
+ *
+ * The OPA allows dynamic gain changes. If the gain is already at the maximum
+ * setting DL_OPA_GAIN_N31_P32 (CFG.GAIN = 0x5), this function does nothing.
+ *
+ * Refer to the TRM for more information about changing gain dynamically.
+ *
+ *  @param[in]  opa   Pointer to the register overlay for the peripheral
+ *
+ *  @return     The gain at the end of the operation.
+ *
+ *  @retval     The applied gain. One of @ref DL_OPA_GAIN
+ */
+DL_OPA_GAIN DL_OPA_increaseGain(OA_Regs *opa);
+
+/**
+ *  @brief      Decrement gain to the next @ref DL_OPA_GAIN enum value
+ *
+ * The OPA allows dynamic gain changes. If the gain is at the minimum setting
+ * DL_OPA_GAIN_N1_P2 (CFG.GAIN = 0x1), this function does nothing.
+ *
+ * Refer to the TRM for more information about changing gain dynamically.
+ *
+ *  @param[in]  opa   Pointer to the register overlay for the peripheral
+ *
+ *  @return     The gain at the end of the operation.
+ *
+ *  @retval     The applied gain. One of @ref DL_OPA_GAIN
+ */
+DL_OPA_GAIN DL_OPA_decreaseGain(OA_Regs *opa);
+
+/**
+ *  @brief      Checks if the OPA is ready
+ *
+ *  @param[in]  opa  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of the OPA ready bit
+ *
+ *  @retval     true   The OPA is ready
+ *  @retval     false  The OPA is not ready
+ *
+ */
+__STATIC_INLINE bool DL_OPA_isReady(OA_Regs *opa)
+{
+    return ((opa->STAT & OA_STAT_RDY_MASK) == OA_STAT_RDY_TRUE);
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __MSPM0_HAS_OA__ */
+
+#endif /* ti_dl_dl_opa__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_rtc.h
+++ b/mspm0/source/ti/driverlib/dl_rtc.h
@@ -1,0 +1,1091 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_rtc.h
+ *  @brief      Real Time Clock (RTC) Peripheral Interface
+ *  @defgroup   RTC Real Time Clock (RTC)
+ *
+ *  @anchor ti_devices_msp_dl_rtc_Overview
+ *  # Overview
+ *  The RTC Driver Library allows full configuration of the MSPM0 RTC module.
+ *  The real-time clock (RTC) module provides clock counters with calendar mode,
+ *  a flexible programmable alarm, offset calibration, and a provision for
+ *  temperature compensation.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup RTC
+ * @{
+ */
+#ifndef ti_dl_dl_rtc__include
+#define ti_dl_dl_rtc__include
+
+#include <ti/driverlib/dl_rtc_common.h>
+
+#ifdef __MSPM0_HAS_RTC__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/**
+ * @brief Redirects to common @ref DL_RTC_Common_Calendar
+ *
+ */
+typedef DL_RTC_Common_Calendar                  DL_RTC_Calendar;
+
+/**
+ * @brief Redirects to common @ref DL_RTC_Common_CalendarAlarm
+ *
+ */
+typedef DL_RTC_Common_CalendarAlarm             DL_RTC_CalendarAlarm;
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_FORMAT_BINARY
+ */
+#define DL_RTC_FORMAT_BINARY                    DL_RTC_COMMON_FORMAT_BINARY
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_FORMAT_BCD
+ */
+#define DL_RTC_FORMAT_BCD                       DL_RTC_COMMON_FORMAT_BCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_STATUS_READY
+ */
+#define DL_RTC_STATUS_READY                     DL_RTC_COMMON_STATUS_READY
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_STATUS_NOT_READY
+ */
+#define DL_RTC_STATUS_NOT_READY                 DL_RTC_COMMON_STATUS_NOT_READY
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_COMPENSATION_STATUS_READY
+ */
+#define DL_RTC_COMPENSATION_STATUS_READY        DL_RTC_COMMON_COMPENSATION_STATUS_READY
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_COMPENSATION_STATUS_NOT_READY
+ */
+#define DL_RTC_COMPENSATION_STATUS_NOT_READY    DL_RTC_COMMON_COMPENSATION_STATUS_NOT_READY
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_COMPENSATION_WRITE_RESULT_OK
+ */
+#define DL_RTC_COMPENSATION_WRITE_RESULT_OK     DL_RTC_COMMON_COMPENSATION_WRITE_RESULT_OK
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_COMPENSATION_WRITE_RESULT_NOT_OK
+ */
+#define DL_RTC_COMPENSATION_WRITE_RESULT_NOT_OK DL_RTC_COMMON_COMPENSATION_WRITE_RESULT_NOT_OK
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN_DOWN
+ */
+#define DL_RTC_OFFSET_CALIBRATION_SIGN_DOWN     DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN_DOWN
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN_UP
+ */
+#define DL_RTC_OFFSET_CALIBRATION_SIGN_UP       DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN_UP
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_OFF
+ */
+#define DL_RTC_OFFSET_CALIBRATION_FREQUENCY_OFF DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_OFF
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_512
+ */
+#define DL_RTC_OFFSET_CALIBRATION_FREQUENCY_512       DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_512
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_256
+ */
+#define DL_RTC_OFFSET_CALIBRATION_FREQUENCY_256       DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_256
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_1
+ */
+#define DL_RTC_OFFSET_CALIBRATION_FREQUENCY_1         DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_TEMP_CALIBRATION_DOWN1PPM
+ */
+#define DL_RTC_TEMP_CALIBRATION_DOWN1PPM        DL_RTC_COMMON_TEMP_CALIBRATION_DOWN1PPM
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_TEMP_CALIBRATION_UP1PPM
+ */
+#define DL_RTC_TEMP_CALIBRATION_UP1PPM          DL_RTC_COMMON_TEMP_CALIBRATION_UP1PPM
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERVAL_ALARM_MINUTECHANGE
+ */
+#define DL_RTC_INTERVAL_ALARM_MINUTECHANGE      DL_RTC_COMMON_INTERVAL_ALARM_MINUTECHANGE
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERVAL_ALARM_HOURCHANGE
+ */
+#define DL_RTC_INTERVAL_ALARM_HOURCHANGE        DL_RTC_COMMON_INTERVAL_ALARM_HOURCHANGE
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERVAL_ALARM_NOON
+ */
+#define DL_RTC_INTERVAL_ALARM_NOON              DL_RTC_COMMON_INTERVAL_ALARM_NOON
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERVAL_ALARM_MIDNIGHT
+ */
+#define DL_RTC_INTERVAL_ALARM_MIDNIGHT          DL_RTC_COMMON_INTERVAL_ALARM_MIDNIGHT
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER0_DIVIDE_8
+ */
+#define DL_RTC_PRESCALER0_DIVIDE_8              DL_RTC_COMMON_PRESCALER0_DIVIDE_8
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER0_DIVIDE_16
+ */
+#define DL_RTC_PRESCALER0_DIVIDE_16              DL_RTC_COMMON_PRESCaLER0_DIVIDE_16
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER0_DIVIDE_32
+ */
+#define DL_RTC_PRESCALER0_DIVIDE_32              DL_RTC_COMMON_PRESCALER0_DIVIDE_32
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER0_DIVIDE_64
+ */
+#define DL_RTC_PRESCALER0_DIVIDE_64              DL_RTC_COMMON_PRESCALER0_DIVIDE_64
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER0_DIVIDE_128
+ */
+#define DL_RTC_PRESCALER0_DIVIDE_128              DL_RTC_COMMON_PRESCALER0_DIVIDE_128
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER0_DIVIDE_256
+ */
+#define DL_RTC_PRESCALER0_DIVIDE_256              DL_RTC_COMMON_PRESCALER0_DIVIDE_256
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_2
+ */
+#define DL_RTC_PRESCALER1_DIVIDE_2              DL_RTC_COMMON_PRESCALER1_DIVIDE_2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_4
+ */
+#define DL_RTC_PRESCALER1_DIVIDE_4              DL_RTC_COMMON_PRESCALER1_DIVIDE_4
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_8
+ */
+#define DL_RTC_PRESCALER1_DIVIDE_8              DL_RTC_COMMON_PRESCALER1_DIVIDE_8
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_16
+ */
+#define DL_RTC_PRESCALER1_DIVIDE_16              DL_RTC_COMMON_PRESCALER1_DIVIDE_16
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_32
+ */
+#define DL_RTC_PRESCALER1_DIVIDE_32              DL_RTC_COMMON_PRESCALER1_DIVIDE_32
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_64
+ */
+#define DL_RTC_PRESCALER1_DIVIDE_64              DL_RTC_COMMON_PRESCALER1_DIVIDE_64
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_128
+ */
+#define DL_RTC_PRESCALER1_DIVIDE_128              DL_RTC_COMMON_PRESCALER1_DIVIDE_128
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_256
+ */
+#define DL_RTC_PRESCALER1_DIVIDE_256              DL_RTC_COMMON_PRESCALER1_DIVIDE_256
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_ALARM1
+ */
+#define DL_RTC_IIDX_ALARM1                      DL_RTC_COMMON_IIDX_ALARM1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_ALARM2
+ */
+#define DL_RTC_IIDX_ALARM2                      DL_RTC_COMMON_IIDX_ALARM2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_PRESCALER0
+ */
+#define DL_RTC_IIDX_PRESCALER0                  DL_RTC_COMMON_IIDX_PRESCALER0
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_PRESCALER1
+ */
+#define DL_RTC_IIDX_PRESCALER1                  DL_RTC_COMMON_IIDX_PRESCALER1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_INTERVAL_TIMER
+ */
+#define DL_RTC_IIDX_INTERVAL_TIMER            DL_RTC_COMMON_IIDX_INTERVAL_TIMER
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_READY
+ */
+#define DL_RTC_IIDX_READY                     DL_RTC_COMMON_IIDX_READY
+
+/** @addtogroup DL_RTC_INTERRUPT
+ *  @{
+ */
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM1
+ */
+#define DL_RTC_INTERRUPT_CALENDAR_ALARM1        DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM2
+ */
+#define DL_RTC_INTERRUPT_CALENDAR_ALARM2        DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_PRESCALER0
+ */
+#define DL_RTC_INTERRUPT_PRESCALER0             DL_RTC_COMMON_INTERRUPT_PRESCALER0
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_PRESCALER1
+ */
+#define DL_RTC_INTERRUPT_PRESCALER1             DL_RTC_COMMON_INTERRUPT_PRESCALER1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_INTERVAL_ALARM
+ */
+#define DL_RTC_INTERRUPT_INTERVAL_ALARM         DL_RTC_COMMON_INTERRUPT_INTERVAL_ALARM
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_READY
+ */
+#define DL_RTC_INTERRUPT_READY                  DL_RTC_COMMON_INTERRUPT_READY
+
+/** @}*/
+
+/** @addtogroup DL_RTC_EVENT
+ *  @{
+ */
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_CALENDAR_ALARM1
+ */
+#define DL_RTC_EVENT_CALENDAR_ALARM1            DL_RTC_COMMON_EVENT_CALENDAR_ALARM1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_CALENDAR_ALARM2
+ */
+#define DL_RTC_EVENT_CALENDAR_ALARM2            DL_RTC_COMMON_EVENT_CALENDAR_ALARM2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_PRESCALER0
+ */
+#define DL_RTC_EVENT_PRESCALER0                 DL_RTC_COMMON_EVENT_PRESCALER0
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_PRESCALER1
+ */
+#define DL_RTC_EVENT_PRESCALER1                 DL_RTC_COMMON_EVENT_PRESCALER1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_INTERVAL_ALARM
+ */
+#define DL_RTC_EVENT_INTERVAL_ALARM             DL_RTC_COMMON_EVENT_INTERVAL_ALARM
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_READY
+ */
+#define DL_RTC_EVENT_READY                      DL_RTC_COMMON_EVENT_READY
+
+/** @}*/
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enablePower
+ */
+#define DL_RTC_enablePower                      DL_RTC_Common_enablePower
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disablePower
+ */
+#define DL_RTC_disablePower                     DL_RTC_Common_disablePower
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_isPowerEnabled
+ */
+#define DL_RTC_isPowerEnabled                   DL_RTC_Common_isPowerEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_reset
+ */
+#define DL_RTC_reset                            DL_RTC_Common_reset
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_isReset
+ */
+#define DL_RTC_isReset                          DL_RTC_Common_isReset
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableClockControl
+ */
+#define DL_RTC_enableClockControl               DL_RTC_Common_enableClockControl
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableClockControl
+ */
+#define DL_RTC_disableClockControl              DL_RTC_Common_disableClockControl
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableDebugInterrupts
+ */
+#define DL_RTC_enableDebugInterrupts            DL_RTC_Common_enableDebugInterrupts
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableDebugInterrupts
+ */
+#define DL_RTC_disableDebugInterrupts           DL_RTC_Common_disableDebugInterrupts
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableDebugMode
+ */
+#define DL_RTC_enableDebugMode                  DL_RTC_Common_enableDebugMode
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableDebugMode
+ */
+#define DL_RTC_disableDebugMode                 DL_RTC_Common_disableDebugMode
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setClockFormat
+ */
+#define DL_RTC_setClockFormat                   DL_RTC_Common_setClockFormat
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getClockFormat
+ */
+#define DL_RTC_getClockFormat                   DL_RTC_Common_getClockFormat
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setIntervalAlarm
+ */
+#define DL_RTC_setIntervalAlarm                 DL_RTC_Common_setIntervalAlarm
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getIntervalAlarm
+ */
+#define DL_RTC_getIntervalAlarm                 DL_RTC_Common_getIntervalAlarm
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_isSafeToRead
+ */
+#define DL_RTC_isSafeToRead                     DL_RTC_Common_isSafeToRead
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_isReadyToCalibrate
+ */
+#define DL_RTC_isReadyToCalibrate               DL_RTC_Common_isReadyToCalibrate
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_isCalibrationWriteResultOK
+ */
+#define DL_RTC_isCalibrationWriteResultOK       DL_RTC_Common_isCalibrationWriteResultOK
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setOffsetCalibrationFrequency
+ */
+#define DL_RTC_setOffsetCalibrationFrequency    DL_RTC_Common_setOffsetCalibrationFrequency
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setOffsetCalibrationAdjValue
+ */
+#define DL_RTC_setOffsetCalibrationAdjValue     DL_RTC_Common_setOffsetCalibrationAdjValue
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setOffsetCalibration
+ */
+#define DL_RTC_setOffsetCalibration             DL_RTC_Common_setOffsetCalibration
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getOffsetCalibrationFrequency
+ */
+#define DL_RTC_getOffsetCalibrationFrequency    DL_RTC_Common_getOffsetCalibrationFrequency
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getOffsetCalibrationSign
+ */
+#define DL_RTC_getOffsetCalibrationSign         DL_RTC_Common_getOffsetCalibrationSign
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setTemperatureCompensation
+ */
+#define DL_RTC_setTemperatureCompensation       DL_RTC_Common_setTemperatureCompensation
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTemperatureCompensation
+ */
+#define DL_RTC_getTemperatureCompensation       DL_RTC_Common_getTemperatureCompensation
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarSecondsBCD
+ */
+#define DL_RTC_setCalendarSecondsBCD            DL_RTC_Common_setCalendarSecondsBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarSecondsBCD
+ */
+#define DL_RTC_getCalendarSecondsBCD            DL_RTC_Common_getCalendarSecondsBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarMinutesBCD
+ */
+#define DL_RTC_setCalendarMinutesBCD            DL_RTC_Common_setCalendarMinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarMinutesBCD
+ */
+#define DL_RTC_getCalendarMinutesBCD            DL_RTC_Common_getCalendarMinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarHoursBCD
+ */
+#define DL_RTC_setCalendarHoursBCD              DL_RTC_Common_setCalendarHoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarHoursBCD
+ */
+#define DL_RTC_getCalendarHoursBCD              DL_RTC_Common_getCalendarHoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarDayOfWeekBCD
+ */
+#define DL_RTC_setCalendarDayOfWeekBCD          DL_RTC_Common_setCalendarDayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarDayOfWeekBCD
+ */
+#define DL_RTC_getCalendarDayOfWeekBCD          DL_RTC_Common_getCalendarDayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarDayOfMonthBCD
+ */
+#define DL_RTC_setCalendarDayOfMonthBCD         DL_RTC_Common_setCalendarDayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarDayOfMonthBCD
+ */
+#define DL_RTC_getCalendarDayOfMonthBCD         DL_RTC_Common_getCalendarDayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarMonthBCD
+ */
+#define DL_RTC_setCalendarMonthBCD              DL_RTC_Common_setCalendarMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarMonthBCD
+ */
+#define DL_RTC_getCalendarMonthBCD              DL_RTC_Common_getCalendarMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarYearBCD
+ */
+#define DL_RTC_setCalendarYearBCD               DL_RTC_Common_setCalendarYearBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarYearBCD
+ */
+#define DL_RTC_getCalendarYearBCD               DL_RTC_Common_getCalendarYearBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1MinutesBCD
+ */
+#define DL_RTC_enableAlarm1MinutesBCD           DL_RTC_Common_enableAlarm1MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1MinutesBCD
+ */
+#define DL_RTC_disableAlarm1MinutesBCD          DL_RTC_Common_disableAlarm1MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1MinutesBCD
+ */
+#define DL_RTC_setAlarm1MinutesBCD              DL_RTC_Common_setAlarm1MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1MinutesBCD
+ */
+#define DL_RTC_getAlarm1MinutesBCD              DL_RTC_Common_getAlarm1MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1HoursBCD
+ */
+#define DL_RTC_enableAlarm1HoursBCD             DL_RTC_Common_enableAlarm1HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1HoursBCD
+ */
+#define DL_RTC_disableAlarm1HoursBCD            DL_RTC_Common_disableAlarm1HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1HoursBCD
+ */
+#define DL_RTC_setAlarm1HoursBCD                DL_RTC_Common_setAlarm1HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1HoursBCD
+ */
+#define DL_RTC_getAlarm1HoursBCD                DL_RTC_Common_getAlarm1HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1DayOfWeekBCD
+ */
+#define DL_RTC_enableAlarm1DayOfWeekBCD         DL_RTC_Common_enableAlarm1DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1DayOfWeekBCD
+ */
+#define DL_RTC_disableAlarm1DayOfWeekBCD        DL_RTC_Common_disableAlarm1DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1DayOfWeekBCD
+ */
+#define DL_RTC_setAlarm1DayOfWeekBCD            DL_RTC_Common_setAlarm1DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1DayOfWeekBCD
+ */
+#define DL_RTC_getAlarm1DayOfWeekBCD            DL_RTC_Common_getAlarm1DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1DayOfMonthBCD
+ */
+#define DL_RTC_enableAlarm1DayOfMonthBCD        DL_RTC_Common_enableAlarm1DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1DayOfMonthBCD
+ */
+#define DL_RTC_disableAlarm1DayOfMonthBCD       DL_RTC_Common_disableAlarm1DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1DayOfMonthBCD
+ */
+#define DL_RTC_setAlarm1DayOfMonthBCD           DL_RTC_Common_setAlarm1DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1DayOfMonthBCD
+ */
+#define DL_RTC_getAlarm1DayOfMonthBCD           DL_RTC_Common_getAlarm1DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2MinutesBCD
+ */
+#define DL_RTC_enableAlarm2MinutesBCD           DL_RTC_Common_enableAlarm2MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2MinutesBCD
+ */
+#define DL_RTC_disableAlarm2MinutesBCD          DL_RTC_Common_disableAlarm2MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2MinutesBCD
+ */
+#define DL_RTC_setAlarm2MinutesBCD              DL_RTC_Common_setAlarm2MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2MinutesBCD
+ */
+#define DL_RTC_getAlarm2MinutesBCD              DL_RTC_Common_getAlarm2MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2HoursBCD
+ */
+#define DL_RTC_enableAlarm2HoursBCD             DL_RTC_Common_enableAlarm2HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2HoursBCD
+ */
+#define DL_RTC_disableAlarm2HoursBCD            DL_RTC_Common_disableAlarm2HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2HoursBCD
+ */
+#define DL_RTC_setAlarm2HoursBCD                DL_RTC_Common_setAlarm2HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2HoursBCD
+ */
+#define DL_RTC_getAlarm2HoursBCD                DL_RTC_Common_getAlarm2HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2DayOfWeekBCD
+ */
+#define DL_RTC_enableAlarm2DayOfWeekBCD         DL_RTC_Common_enableAlarm2DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2DayOfWeekBCD
+ */
+#define DL_RTC_disableAlarm2DayOfWeekBCD        DL_RTC_Common_disableAlarm2DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2DayOfWeekBCD
+ */
+#define DL_RTC_setAlarm2DayOfWeekBCD            DL_RTC_Common_setAlarm2DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2DayOfWeekBCD
+ */
+#define DL_RTC_getAlarm2DayOfWeekBCD            DL_RTC_Common_getAlarm2DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2DayOfMonthBCD
+ */
+#define DL_RTC_enableAlarm2DayOfMonthBCD        DL_RTC_Common_enableAlarm2DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2DayOfMonthBCD
+ */
+#define DL_RTC_disableAlarm2DayOfMonthBCD       DL_RTC_Common_disableAlarm2DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2DayOfMonthBCD
+ */
+#define DL_RTC_setAlarm2DayOfMonthBCD           DL_RTC_Common_setAlarm2DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2DayOfMonthBCD
+ */
+#define DL_RTC_getAlarm2DayOfMonthBCD           DL_RTC_Common_getAlarm2DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarSecondsBinary
+ */
+#define DL_RTC_setCalendarSecondsBinary         DL_RTC_Common_setCalendarSecondsBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarSecondsBinary
+ */
+#define DL_RTC_getCalendarSecondsBinary         DL_RTC_Common_getCalendarSecondsBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarMinutesBinary
+ */
+#define DL_RTC_setCalendarMinutesBinary         DL_RTC_Common_setCalendarMinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarMinutesBinary
+ */
+#define DL_RTC_getCalendarMinutesBinary         DL_RTC_Common_getCalendarMinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarHoursBinary
+ */
+#define DL_RTC_setCalendarHoursBinary           DL_RTC_Common_setCalendarHoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarHoursBinary
+ */
+#define DL_RTC_getCalendarHoursBinary           DL_RTC_Common_getCalendarHoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarDayOfWeekBinary
+ */
+#define DL_RTC_setCalendarDayOfWeekBinary       DL_RTC_Common_setCalendarDayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarDayOfWeekBinary
+ */
+#define DL_RTC_getCalendarDayOfWeekBinary       DL_RTC_Common_getCalendarDayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarDayOfMonthBinary
+ */
+#define DL_RTC_setCalendarDayOfMonthBinary      DL_RTC_Common_setCalendarDayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarDayOfMonthBinary
+ */
+#define DL_RTC_getCalendarDayOfMonthBinary      DL_RTC_Common_getCalendarDayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarMonthBinary
+ */
+#define DL_RTC_setCalendarMonthBinary           DL_RTC_Common_setCalendarMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarMonthBinary
+ */
+#define DL_RTC_getCalendarMonthBinary           DL_RTC_Common_getCalendarMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarYearBinary
+ */
+#define DL_RTC_setCalendarYearBinary            DL_RTC_Common_setCalendarYearBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarYearBinary
+ */
+#define DL_RTC_getCalendarYearBinary            DL_RTC_Common_getCalendarYearBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1MinutesBinary
+ */
+#define DL_RTC_enableAlarm1MinutesBinary        DL_RTC_Common_enableAlarm1MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1MinutesBinary
+ */
+#define DL_RTC_disableAlarm1MinutesBinary       DL_RTC_Common_disableAlarm1MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1MinutesBinary
+ */
+#define DL_RTC_setAlarm1MinutesBinary           DL_RTC_Common_setAlarm1MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1MinutesBinary
+ */
+#define DL_RTC_getAlarm1MinutesBinary           DL_RTC_Common_getAlarm1MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1HoursBinary
+ */
+#define DL_RTC_enableAlarm1HoursBinary          DL_RTC_Common_enableAlarm1HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1HoursBinary
+ */
+#define DL_RTC_disableAlarm1HoursBinary         DL_RTC_Common_disableAlarm1HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1HoursBinary
+ */
+#define DL_RTC_setAlarm1HoursBinary             DL_RTC_Common_setAlarm1HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1HoursBinary
+ */
+#define DL_RTC_getAlarm1HoursBinary             DL_RTC_Common_getAlarm1HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1DayOfWeekBinary
+ */
+#define DL_RTC_enableAlarm1DayOfWeekBinary      DL_RTC_Common_enableAlarm1DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1DayOfWeekBinary
+ */
+#define DL_RTC_disableAlarm1DayOfWeekBinary     DL_RTC_Common_disableAlarm1DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1DayOfWeekBinary
+ */
+#define DL_RTC_setAlarm1DayOfWeekBinary         DL_RTC_Common_setAlarm1DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1DayOfWeekBinary
+ */
+#define DL_RTC_getAlarm1DayOfWeekBinary         DL_RTC_Common_getAlarm1DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1DayOfMonthBinary
+ */
+#define DL_RTC_enableAlarm1DayOfMonthBinary     DL_RTC_Common_enableAlarm1DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1DayOfMonthBinary
+ */
+#define DL_RTC_disableAlarm1DayOfMonthBinary    DL_RTC_Common_disableAlarm1DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1DayOfMonthBinary
+ */
+#define DL_RTC_setAlarm1DayOfMonthBinary        DL_RTC_Common_setAlarm1DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1DayOfMonthBinary
+ */
+#define DL_RTC_getAlarm1DayOfMonthBinary        DL_RTC_Common_getAlarm1DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2MinutesBinary
+ */
+#define DL_RTC_enableAlarm2MinutesBinary        DL_RTC_Common_enableAlarm2MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2MinutesBinary
+ */
+#define DL_RTC_disableAlarm2MinutesBinary       DL_RTC_Common_disableAlarm2MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2MinutesBinary
+ */
+#define DL_RTC_setAlarm2MinutesBinary           DL_RTC_Common_setAlarm2MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2MinutesBinary
+ */
+#define DL_RTC_getAlarm2MinutesBinary           DL_RTC_Common_getAlarm2MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2HoursBinary
+ */
+#define DL_RTC_enableAlarm2HoursBinary          DL_RTC_Common_enableAlarm2HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2HoursBinary
+ */
+#define DL_RTC_disableAlarm2HoursBinary         DL_RTC_Common_disableAlarm2HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2HoursBinary
+ */
+#define DL_RTC_setAlarm2HoursBinary             DL_RTC_Common_setAlarm2HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2HoursBinary
+ */
+#define DL_RTC_getAlarm2HoursBinary             DL_RTC_Common_getAlarm2HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2DayOfWeekBinary
+ */
+#define DL_RTC_enableAlarm2DayOfWeekBinary      DL_RTC_Common_enableAlarm2DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2DayOfWeekBinary
+ */
+#define DL_RTC_disableAlarm2DayOfWeekBinary     DL_RTC_Common_disableAlarm2DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2DayOfWeekBinary
+ */
+#define DL_RTC_setAlarm2DayOfWeekBinary         DL_RTC_Common_setAlarm2DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2DayOfWeekBinary
+ */
+#define DL_RTC_getAlarm2DayOfWeekBinary         DL_RTC_Common_getAlarm2DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2DayOfMonthBinary
+ */
+#define DL_RTC_enableAlarm2DayOfMonthBinary     DL_RTC_Common_enableAlarm2DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2DayOfMonthBinary
+ */
+#define DL_RTC_disableAlarm2DayOfMonthBinary    DL_RTC_Common_disableAlarm2DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2DayOfMonthBinary
+ */
+#define DL_RTC_setAlarm2DayOfMonthBinary        DL_RTC_Common_setAlarm2DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2DayOfMonthBinary
+ */
+#define DL_RTC_getAlarm2DayOfMonthBinary        DL_RTC_Common_getAlarm2DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setPrescalerEvents
+ */
+#define DL_RTC_setPrescalerEvents               DL_RTC_Common_setPrescalerEvents
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setPeriodicAlarm0
+ */
+#define DL_RTC_setPeriodicAlarm0                DL_RTC_Common_setPeriodicAlarm0
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setPeriodicAlarm1
+ */
+#define DL_RTC_setPeriodicAlarm1                DL_RTC_Common_setPeriodicAlarm1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getPrescaler0
+ */
+#define DL_RTC_getPrescaler0                    DL_RTC_Common_getPrescaler0
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getPrescaler1
+ */
+#define DL_RTC_getPrescaler1                    DL_RTC_Common_getPrescaler1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableInterrupt
+ */
+#define DL_RTC_enableInterrupt                  DL_RTC_Common_enableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableInterrupt
+ */
+#define DL_RTC_disableInterrupt                 DL_RTC_Common_disableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getEnabledInterrupts
+ */
+#define DL_RTC_getEnabledInterrupts             DL_RTC_Common_getEnabledInterrupts
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getEnabledInterruptStatus
+ */
+#define DL_RTC_getEnabledInterruptStatus        DL_RTC_Common_getEnabledInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getRawInterruptStatus
+ */
+#define DL_RTC_getRawInterruptStatus            DL_RTC_Common_getRawInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getPendingInterrupt
+ */
+#define DL_RTC_getPendingInterrupt              DL_RTC_Common_getPendingInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_clearInterruptStatus
+ */
+#define DL_RTC_clearInterruptStatus             DL_RTC_Common_clearInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableEvent
+ */
+#define DL_RTC_enableEvent                      DL_RTC_Common_enableEvent
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableEvent
+ */
+#define DL_RTC_disableEvent                     DL_RTC_Common_disableEvent
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getEnabledEvents
+ */
+#define DL_RTC_getEnabledEvents                 DL_RTC_Common_getEnabledEvents
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getEnabledEventStatus
+ */
+#define DL_RTC_getEnabledEventStatus            DL_RTC_Common_getEnabledEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getRawEventsStatus
+ */
+#define DL_RTC_getRawEventsStatus               DL_RTC_Common_getRawEventsStatus
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_clearEventsStatus
+ */
+#define DL_RTC_clearEventsStatus                DL_RTC_Common_clearEventsStatus
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_setPublisherChanID
+ */
+#define DL_RTC_setPublisherChanID               DL_RTC_Common_setPublisherChanID
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getPublisherChanID
+ */
+#define DL_RTC_getPublisherChanID               DL_RTC_Common_getPublisherChanID
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_initCalendar
+ */
+#define DL_RTC_initCalendar                     DL_RTC_Common_initCalendar
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarTime
+ */
+#define DL_RTC_getCalendarTime                  DL_RTC_Common_getCalendarTime
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarAlarm1
+ */
+#define DL_RTC_setCalendarAlarm1                DL_RTC_Common_setCalendarAlarm1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarAlarm1
+ */
+#define DL_RTC_getCalendarAlarm1                DL_RTC_Common_getCalendarAlarm1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableCalendarAlarm1
+ */
+#define DL_RTC_enableCalendarAlarm1             DL_RTC_Common_enableCalendarAlarm1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableCalendarAlarm1
+ */
+#define DL_RTC_disableCalendarAlarm1            DL_RTC_Common_disableCalendarAlarm1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarAlarm2
+ */
+#define DL_RTC_setCalendarAlarm2                DL_RTC_Common_setCalendarAlarm2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarAlarm2
+ */
+#define DL_RTC_getCalendarAlarm2                DL_RTC_Common_getCalendarAlarm2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableCalendarAlarm2
+ */
+#define DL_RTC_enableCalendarAlarm2             DL_RTC_Common_enableCalendarAlarm2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableCalendarAlarm2
+ */
+#define DL_RTC_disableCalendarAlarm2            DL_RTC_Common_disableCalendarAlarm2
+
+/* clang-format on */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_RTC__ */
+
+#endif /* ti_dl_dl_rtc__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_rtc_a.h
+++ b/mspm0/source/ti/driverlib/dl_rtc_a.h
@@ -1,0 +1,1520 @@
+/*
+ * Copyright (c) 2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY TfHEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_rtc_a.h
+ *  @brief      Real Time Clock A (RTC_a) Peripheral Interface
+ *  @defgroup   RTC_A Real Time Clock A (RTC_A)
+ *
+ *  @anchor ti_devices_msp_dl_rtc_a_Overview
+ *  # Overview
+ *  The RTC_A Driver Library allows full configuration of the MSPM0 RTC_A module.
+ *  The real-time clock (RTC_A) module provides clock counters with calendar mode,
+ *  a flexible programmable alarm, offset calibration, and a provision for
+ *  temperature compensation. The module also provides a separate time stamp calendar
+ *  capable of capturing a time stamp event upon loss of VDD or detection of a tamper event
+ *  on a tamper I/O pin.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup RTC_A
+ * @{
+ */
+#ifndef ti_dl_dl_rtc_a__include
+#define ti_dl_dl_rtc_a__include
+
+#include <ti/driverlib/dl_rtc_common.h>
+
+#ifdef __MSPM0_HAS_RTC_A__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_RTC_A_INTERRUPT
+ *  @{
+ */
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM1
+ */
+#define DL_RTC_A_INTERRUPT_CALENDAR_ALARM1          (DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM1)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM2
+ */
+#define DL_RTC_A_INTERRUPT_CALENDAR_ALARM2          (DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM2)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_PRESCALER0
+ */
+#define DL_RTC_A_INTERRUPT_PRESCALER0               (DL_RTC_COMMON_INTERRUPT_PRESCALER0)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_PRESCALER1
+ */
+#define DL_RTC_A_INTERRUPT_PRESCALER1               (DL_RTC_COMMON_INTERRUPT_PRESCALER1)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_PRESCALER2
+ */
+#define DL_RTC_A_INTERRUPT_PRESCALER2               (DL_RTC_COMMON_INTERRUPT_PRESCALER2)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_INTERVAL_ALARM
+ */
+#define DL_RTC_A_INTERRUPT_INTERVAL_ALARM           (DL_RTC_COMMON_INTERRUPT_INTERVAL_ALARM)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_READY
+ */
+#define DL_RTC_A_INTERRUPT_READY                    (DL_RTC_COMMON_INTERRUPT_READY)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERRUPT_READY
+ */
+#define DL_RTC_A_INTERRUPT_TSEVT                    (DL_RTC_COMMON_INTERRUPT_TSEVT)
+
+
+/** @}*/
+
+/** @addtogroup DL_RTC_A_EVENT
+ *  @{
+ */
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_CALENDAR_ALARM1
+ */
+#define DL_RTC_A_EVENT_CALENDAR_ALARM1          (DL_RTC_COMMON_EVENT_CALENDAR_ALARM1)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_CALENDAR_ALARM2
+ */
+#define DL_RTC_A_EVENT_CALENDAR_ALARM2          (DL_RTC_COMMON_EVENT_CALENDAR_ALARM2)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_PRESCALER0
+ */
+#define DL_RTC_A_EVENT_PRESCALER0               (DL_RTC_COMMON_EVENT_PRESCALER0)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_PRESCALER1
+ */
+#define DL_RTC_A_EVENT_PRESCALER1               (DL_RTC_COMMON_EVENT_PRESCALER1)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_PRESCALER2
+ */
+#define DL_RTC_A_EVENT_PRESCALER2               (DL_RTC_COMMON_EVENT_PRESCALER2)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_INTERVAL_ALARM
+ */
+#define DL_RTC_A_EVENT_INTERVAL_ALARM           (DL_RTC_COMMON_EVENT_INTERVAL_ALARM)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_READY
+ */
+#define DL_RTC_A_EVENT_READY                    (DL_RTC_COMMON_EVENT_READY)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_EVENT_READY
+ */
+#define DL_RTC_A_EVENT_TSEVT                    (DL_RTC_COMMON_EVENT_TSEVT)
+
+/** @}*/
+
+/** @addtogroup DL_RTC_A_TIME_STAMP_EVENT_CAUSE
+ *  @{
+ */
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_0
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_0       (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_0)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_1
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_1       (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_1)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_2
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_2       (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_2)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_3
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_3       (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_3)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_4
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_4       (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_4)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_5
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_5       (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_5)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_6
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_6       (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_6)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_7
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_7       (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_7)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_8
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_8       (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_8)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_9
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_9       (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_9)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_10
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_10      (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_10)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_11
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_11      (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_11)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_12
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_12      (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_12)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_13
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_13      (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_13)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_14
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_14      (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_14)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_15
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_TIO_15      (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_15)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_VDD_LOSS
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAUSE_VDD_LOSS    (DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_VDD_LOSS)
+
+/** @}*/
+
+/** @addtogroup DL_RTC_A_TIME_STAMP_EVENT_SOURCE
+ *  @{
+ */
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_0
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_0       (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_0)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_1
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_1       (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_1)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_2
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_2       (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_2)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_3
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_3       (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_3)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_4
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_4       (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_4)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_5
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_5       (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_5)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_6
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_6       (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_6)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_7
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_7       (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_7)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_8
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_8       (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_8)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_9
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_9       (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_9)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_10
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_10      (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_10)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_11
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_11      (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_11)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_12
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_12      (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_12)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_13
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_13      (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_13)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_14
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_14      (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_14)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_15
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_TIO_15      (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_15)
+
+/**
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_VDD_LOSS
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_SOURCE_VDD_LOSS    (DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_VDD_LOSS)
+
+/** @}*/
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_FORMAT_BINARY
+ */
+#define DL_RTC_A_FORMAT_BINARY                      DL_RTC_COMMON_FORMAT_BINARY
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_FORMAT_BCD
+ */
+#define DL_RTC_A_FORMAT_BCD                         DL_RTC_COMMON_FORMAT_BCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_STATUS_READY
+ */
+#define DL_RTC_A_STATUS_READY                       DL_RTC_COMMON_STATUS_READY
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_STATUS_NOT_READY
+ */
+#define DL_RTC_A_STATUS_NOT_READY                   DL_RTC_COMMON_STATUS_NOT_READY
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_COMPENSATION_STATUS_READY
+ */
+#define DL_RTC_A_COMPENSATION_STATUS_READY          DL_RTC_COMMON_COMPENSATION_STATUS_READY
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_COMPENSATION_STATUS_NOT_READY
+ */
+#define DL_RTC_A_COMPENSATION_STATUS_NOT_READY      DL_RTC_COMMON_COMPENSATION_STATUS_NOT_READY
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_COMPENSATION_WRITE_RESULT_OK
+ */
+#define DL_RTC_A_COMPENSATION_WRITE_RESULT_OK       DL_RTC_COMMON_COMPENSATION_WRITE_RESULT_OK
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_COMPENSATION_WRITE_RESULT_NOT_OK
+ */
+#define DL_RTC_A_COMPENSATION_WRITE_RESULT_NOT_OK   DL_RTC_COMMON_COMPENSATION_WRITE_RESULT_NOT_OK
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN_DOWN
+ */
+#define DL_RTC_A_OFFSET_CALIBRATION_SIGN_DOWN       DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN_DOWN
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN_UP
+ */
+#define DL_RTC_A_OFFSET_CALIBRATION_SIGN_UP         DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN_UP
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_32_KHZ
+ */
+#define DL_RTC_A_OFFSET_CALIBRATION_FREQUENCY_32_KHZ        DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_32_KHZ
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_512
+ */
+#define DL_RTC_A_OFFSET_CALIBRATION_FREQUENCY_512              DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_512
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_256
+ */
+#define DL_RTC_A_OFFSET_CALIBRATION_FREQUENCY_256              DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_256
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_1
+ */
+#define DL_RTC_A_OFFSET_CALIBRATION_FREQUENCY_1              DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_TEMP_CALIBRATION_DOWN1PPM
+ */
+#define DL_RTC_A_TEMP_CALIBRATION_DOWN1PPM                  DL_RTC_COMMON_TEMP_CALIBRATION_DOWN1PPM
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_TEMP_CALIBRATION_UP1PPM
+ */
+#define DL_RTC_A_TEMP_CALIBRATION_UP1PPM                    DL_RTC_COMMON_TEMP_CALIBRATION_UP1PPM
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERVAL_ALARM_MINUTECHANGE
+ */
+#define DL_RTC_A_INTERVAL_ALARM_MINUTECHANGE                DL_RTC_COMMON_INTERVAL_ALARM_MINUTECHANGE
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERVAL_ALARM_HOURCHANGE
+ */
+#define DL_RTC_A_INTERVAL_ALARM_HOURCHANGE                  DL_RTC_COMMON_INTERVAL_ALARM_HOURCHANGE
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERVAL_ALARM_NOON
+ */
+#define DL_RTC_A_INTERVAL_ALARM_NOON                        DL_RTC_COMMON_INTERVAL_ALARM_NOON
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_INTERVAL_ALARM_MIDNIGHT
+ */
+#define DL_RTC_A_INTERVAL_ALARM_MIDNIGHT                    DL_RTC_COMMON_INTERVAL_ALARM_MIDNIGHT
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER0_DIVIDE_8
+ */
+#define DL_RTC_A_PRESCALER0_DIVIDE_8                        DL_RTC_COMMON_PRESCALER0_DIVIDE_8
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER0_DIVIDE_16
+ */
+#define DL_RTC_A_PRESCALER0_DIVIDE_16                       DL_RTC_COMMON_PRESCaLER0_DIVIDE_16
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER0_DIVIDE_32
+ */
+#define DL_RTC_A_PRESCALER0_DIVIDE_32                       DL_RTC_COMMON_PRESCALER0_DIVIDE_32
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER0_DIVIDE_64
+ */
+#define DL_RTC_A_PRESCALER0_DIVIDE_64                       DL_RTC_COMMON_PRESCALER0_DIVIDE_64
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER0_DIVIDE_128
+ */
+#define DL_RTC_A_PRESCALER0_DIVIDE_128                      DL_RTC_COMMON_PRESCALER0_DIVIDE_128
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER0_DIVIDE_256
+ */
+#define DL_RTC_A_PRESCALER0_DIVIDE_256                      DL_RTC_COMMON_PRESCALER0_DIVIDE_256
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_2
+ */
+#define DL_RTC_A_PRESCALER1_DIVIDE_2                        DL_RTC_COMMON_PRESCALER1_DIVIDE_2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_4
+ */
+#define DL_RTC_A_PRESCALER1_DIVIDE_4                        DL_RTC_COMMON_PRESCALER1_DIVIDE_4
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_8
+ */
+#define DL_RTC_A_PRESCALER1_DIVIDE_8                        DL_RTC_COMMON_PRESCALER1_DIVIDE_8
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_16
+ */
+#define DL_RTC_A_PRESCALER1_DIVIDE_16                       DL_RTC_COMMON_PRESCALER1_DIVIDE_16
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_32
+ */
+#define DL_RTC_A_PRESCALER1_DIVIDE_32                       DL_RTC_COMMON_PRESCALER1_DIVIDE_32
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_64
+ */
+#define DL_RTC_A_PRESCALER1_DIVIDE_64                       DL_RTC_COMMON_PRESCALER1_DIVIDE_64
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_128
+ */
+#define DL_RTC_A_PRESCALER1_DIVIDE_128                      DL_RTC_COMMON_PRESCALER1_DIVIDE_128
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER1_DIVIDE_256
+ */
+#define DL_RTC_A_PRESCALER1_DIVIDE_256                      DL_RTC_COMMON_PRESCALER1_DIVIDE_256
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER2_4_SEC
+ */
+#define DL_RTC_A_PRESCALER2_4_SEC                           DL_RTC_COMMON_PRESCALER2_4_SEC
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER2_8_SEC
+ */
+#define DL_RTC_A_PRESCALER2_8_SEC                           DL_RTC_COMMON_PRESCALER2_8_SEC
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_PRESCALER2_16_SEC
+ */
+#define DL_RTC_A_PRESCALER2_16_SEC                          DL_RTC_COMMON_PRESCALER2_16_SEC
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_ALARM1
+ */
+#define DL_RTC_A_IIDX_ALARM1                                DL_RTC_COMMON_IIDX_ALARM1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_ALARM2
+ */
+#define DL_RTC_A_IIDX_ALARM2                                DL_RTC_COMMON_IIDX_ALARM2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_PRESCALER0
+ */
+#define DL_RTC_A_IIDX_PRESCALER0                            DL_RTC_COMMON_IIDX_PRESCALER0
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_PRESCALER1
+ */
+#define DL_RTC_A_IIDX_PRESCALER1                            DL_RTC_COMMON_IIDX_PRESCALER1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_INTERVAL_TIMER
+ */
+#define DL_RTC_A_IIDX_INTERVAL_TIMER                        DL_RTC_COMMON_IIDX_INTERVAL_TIMER
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_READY
+ */
+#define DL_RTC_A_IIDX_READY                                 DL_RTC_COMMON_IIDX_READY
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TSEVT
+ */
+#define DL_RTC_A_IIDX_TSEVT                                 DL_RTC_COMMON_IIDX_TSEVT
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_0
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_0                           DL_RTC_COMMON_IIDX_TAMPER_IO_0
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_1
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_1                           DL_RTC_COMMON_IIDX_TAMPER_IO_1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_2
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_2                           DL_RTC_COMMON_IIDX_TAMPER_IO_2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_3
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_3                         DL_RTC_COMMON_IIDX_TAMPER_IO_3
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_4
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_4                           DL_RTC_COMMON_IIDX_TAMPER_IO_4
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_5
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_5                           DL_RTC_COMMON_IIDX_TAMPER_IO_5
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_6
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_6                           DL_RTC_COMMON_IIDX_TAMPER_IO_6
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_7
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_7                           DL_RTC_COMMON_IIDX_TAMPER_IO_7
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_8
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_8                           DL_RTC_COMMON_IIDX_TAMPER_IO_8
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_9
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_9                           DL_RTC_COMMON_IIDX_TAMPER_IO_9
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_10
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_10                          DL_RTC_COMMON_IIDX_TAMPER_IO_10
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_11
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_11                          DL_RTC_COMMON_IIDX_TAMPER_IO_11
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_12
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_12                          DL_RTC_COMMON_IIDX_TAMPER_IO_12
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_13
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_13                          DL_RTC_COMMON_IIDX_TAMPER_IO_13
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_14
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_14                          DL_RTC_COMMON_IIDX_TAMPER_IO_14
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_IIDX_TAMPER_IO_15
+ */
+#define DL_RTC_A_IIDX_TAMPER_IO_15                          DL_RTC_COMMON_IIDX_TAMPER_IO_15
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAPTURE_FIRST
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAPTURE_FIRST             DL_RTC_COMMON_TIME_STAMP_EVENT_CAPTURE_FIRST
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAPTURE_LAST
+ */
+#define DL_RTC_A_TIME_STAMP_EVENT_CAPTURE_LAST              DL_RTC_COMMON_TIME_STAMP_EVENT_CAPTURE_LAST
+
+/**
+ * @brief Redirects to common @ref DL_RTC_Common_Calendar
+ *
+ */
+typedef DL_RTC_Common_Calendar                      DL_RTC_A_Calendar;
+
+/**
+ * @brief Redirects to common @ref DL_RTC_Common_CalendarAlarm
+ *
+ */
+typedef DL_RTC_Common_CalendarAlarm                 DL_RTC_A_CalendarAlarm;
+
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_isClockSourceLFCLK
+ */
+#define DL_RTC_A_isClockSourceLFCLK                 DL_RTC_Common_isClockSourceLFCLK
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableClockControl
+ */
+#define DL_RTC_A_enableClockControl                 DL_RTC_Common_enableClockControl
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableClockControl
+ */
+#define DL_RTC_A_disableClockControl                DL_RTC_Common_disableClockControl
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_reset
+ */
+#define DL_RTC_A_reset                              DL_RTC_Common_reset
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_isReset
+ */
+#define DL_RTC_A_isReset                            DL_RTC_Common_isReset
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableDebugInterrupts
+ */
+#define DL_RTC_A_enableDebugInterrupts              DL_RTC_Common_enableDebugInterrupts
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableDebugInterrupts
+ */
+#define DL_RTC_A_disableDebugInterrupts             DL_RTC_Common_disableDebugInterrupts
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableDebugMode
+ */
+#define DL_RTC_A_enableDebugMode                    DL_RTC_Common_enableDebugMode
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableDebugMode
+ */
+#define DL_RTC_A_disableDebugMode                   DL_RTC_Common_disableDebugMode
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setClockFormat
+ */
+#define DL_RTC_A_setClockFormat                     DL_RTC_Common_setClockFormat
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getClockFormat
+ */
+#define DL_RTC_A_getClockFormat                     DL_RTC_Common_getClockFormat
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setIntervalAlarm
+ */
+#define DL_RTC_A_setIntervalAlarm                   DL_RTC_Common_setIntervalAlarm
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getIntervalAlarm
+ */
+#define DL_RTC_A_getIntervalAlarm                   DL_RTC_Common_getIntervalAlarm
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_isSafeToRead
+ */
+#define DL_RTC_A_isSafeToRead                       DL_RTC_Common_isSafeToRead
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_isReadyToCalibrate
+ */
+#define DL_RTC_A_isReadyToCalibrate                 DL_RTC_Common_isReadyToCalibrate
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_isCalibrationWriteResultOK
+ */
+#define DL_RTC_A_isCalibrationWriteResultOK         DL_RTC_Common_isCalibrationWriteResultOK
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setOffsetCalibrationFrequency
+ */
+#define DL_RTC_A_setOffsetCalibrationFrequency      DL_RTC_Common_setOffsetCalibrationFrequency
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setOffsetCalibrationAdjValue
+ */
+#define DL_RTC_A_setOffsetCalibrationAdjValue       DL_RTC_Common_setOffsetCalibrationAdjValue
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setOffsetCalibration
+ */
+#define DL_RTC_A_setOffsetCalibration               DL_RTC_Common_setOffsetCalibration
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getOffsetCalibrationFrequency
+ */
+#define DL_RTC_A_getOffsetCalibrationFrequency      DL_RTC_Common_getOffsetCalibrationFrequency
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getOffsetCalibrationSign
+ */
+#define DL_RTC_A_getOffsetCalibrationSign           DL_RTC_Common_getOffsetCalibrationSign
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setTemperatureCompensation
+ */
+#define DL_RTC_A_setTemperatureCompensation         DL_RTC_Common_setTemperatureCompensation
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTemperatureCompensation
+ */
+#define DL_RTC_A_getTemperatureCompensation         DL_RTC_Common_getTemperatureCompensation
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarSecondsBCD
+ */
+#define DL_RTC_A_setCalendarSecondsBCD              DL_RTC_Common_setCalendarSecondsBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarSecondsBCD
+ */
+#define DL_RTC_A_getCalendarSecondsBCD              DL_RTC_Common_getCalendarSecondsBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarMinutesBCD
+ */
+#define DL_RTC_A_setCalendarMinutesBCD              DL_RTC_Common_setCalendarMinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarMinutesBCD
+ */
+#define DL_RTC_A_getCalendarMinutesBCD              DL_RTC_Common_getCalendarMinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarHoursBCD
+ */
+#define DL_RTC_A_setCalendarHoursBCD                DL_RTC_Common_setCalendarHoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarHoursBCD
+ */
+#define DL_RTC_A_getCalendarHoursBCD                DL_RTC_Common_getCalendarHoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarDayOfWeekBCD
+ */
+#define DL_RTC_A_setCalendarDayOfWeekBCD            DL_RTC_Common_setCalendarDayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarDayOfWeekBCD
+ */
+#define DL_RTC_A_getCalendarDayOfWeekBCD            DL_RTC_Common_getCalendarDayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarDayOfMonthBCD
+ */
+#define DL_RTC_A_setCalendarDayOfMonthBCD           DL_RTC_Common_setCalendarDayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarDayOfMonthBCD
+ */
+#define DL_RTC_A_getCalendarDayOfMonthBCD           DL_RTC_Common_getCalendarDayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarMonthBCD
+ */
+#define DL_RTC_A_setCalendarMonthBCD                DL_RTC_Common_setCalendarMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarMonthBCD
+ */
+#define DL_RTC_A_getCalendarMonthBCD                DL_RTC_Common_getCalendarMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarYearBCD
+ */
+#define DL_RTC_A_setCalendarYearBCD                 DL_RTC_Common_setCalendarYearBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarYearBCD
+ */
+#define DL_RTC_A_getCalendarYearBCD                 DL_RTC_Common_getCalendarYearBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1MinutesBCD
+ */
+#define DL_RTC_A_enableAlarm1MinutesBCD             DL_RTC_Common_enableAlarm1MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1MinutesBCD
+ */
+#define DL_RTC_A_disableAlarm1MinutesBCD            DL_RTC_Common_disableAlarm1MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1MinutesBCD
+ */
+#define DL_RTC_A_setAlarm1MinutesBCD                DL_RTC_Common_setAlarm1MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1MinutesBCD
+ */
+#define DL_RTC_A_getAlarm1MinutesBCD                DL_RTC_Common_getAlarm1MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1HoursBCD
+ */
+#define DL_RTC_A_enableAlarm1HoursBCD               DL_RTC_Common_enableAlarm1HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1HoursBCD
+ */
+#define DL_RTC_A_disableAlarm1HoursBCD              DL_RTC_Common_disableAlarm1HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1HoursBCD
+ */
+#define DL_RTC_A_setAlarm1HoursBCD                  DL_RTC_Common_setAlarm1HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1HoursBCD
+ */
+#define DL_RTC_A_getAlarm1HoursBCD                  DL_RTC_Common_getAlarm1HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1DayOfWeekBCD
+ */
+#define DL_RTC_A_enableAlarm1DayOfWeekBCD           DL_RTC_Common_enableAlarm1DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1DayOfWeekBCD
+ */
+#define DL_RTC_A_disableAlarm1DayOfWeekBCD          DL_RTC_Common_disableAlarm1DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1DayOfWeekBCD
+ */
+#define DL_RTC_A_setAlarm1DayOfWeekBCD              DL_RTC_Common_setAlarm1DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1DayOfWeekBCD
+ */
+#define DL_RTC_A_getAlarm1DayOfWeekBCD              DL_RTC_Common_getAlarm1DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1DayOfMonthBCD
+ */
+#define DL_RTC_A_enableAlarm1DayOfMonthBCD          DL_RTC_Common_enableAlarm1DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1DayOfMonthBCD
+ */
+#define DL_RTC_A_disableAlarm1DayOfMonthBCD         DL_RTC_Common_disableAlarm1DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1DayOfMonthBCD
+ */
+#define DL_RTC_A_setAlarm1DayOfMonthBCD             DL_RTC_Common_setAlarm1DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1DayOfMonthBCD
+ */
+#define DL_RTC_A_getAlarm1DayOfMonthBCD             DL_RTC_Common_getAlarm1DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2MinutesBCD
+ */
+#define DL_RTC_A_enableAlarm2MinutesBCD             DL_RTC_Common_enableAlarm2MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2MinutesBCD
+ */
+#define DL_RTC_A_disableAlarm2MinutesBCD            DL_RTC_Common_disableAlarm2MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2MinutesBCD
+ */
+#define DL_RTC_A_setAlarm2MinutesBCD                DL_RTC_Common_setAlarm2MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2MinutesBCD
+ */
+#define DL_RTC_A_getAlarm2MinutesBCD                DL_RTC_Common_getAlarm2MinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2HoursBCD
+ */
+#define DL_RTC_A_enableAlarm2HoursBCD               DL_RTC_Common_enableAlarm2HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2HoursBCD
+ */
+#define DL_RTC_A_disableAlarm2HoursBCD              DL_RTC_Common_disableAlarm2HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2HoursBCD
+ */
+#define DL_RTC_A_setAlarm2HoursBCD                  DL_RTC_Common_setAlarm2HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2HoursBCD
+ */
+#define DL_RTC_A_getAlarm2HoursBCD                  DL_RTC_Common_getAlarm2HoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2DayOfWeekBCD
+ */
+#define DL_RTC_A_enableAlarm2DayOfWeekBCD           DL_RTC_Common_enableAlarm2DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2DayOfWeekBCD
+ */
+#define DL_RTC_A_disableAlarm2DayOfWeekBCD          DL_RTC_Common_disableAlarm2DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2DayOfWeekBCD
+ */
+#define DL_RTC_A_setAlarm2DayOfWeekBCD              DL_RTC_Common_setAlarm2DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2DayOfWeekBCD
+ */
+#define DL_RTC_A_getAlarm2DayOfWeekBCD              DL_RTC_Common_getAlarm2DayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2DayOfMonthBCD
+ */
+#define DL_RTC_A_enableAlarm2DayOfMonthBCD          DL_RTC_Common_enableAlarm2DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2DayOfMonthBCD
+ */
+#define DL_RTC_A_disableAlarm2DayOfMonthBCD         DL_RTC_Common_disableAlarm2DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2DayOfMonthBCD
+ */
+#define DL_RTC_A_setAlarm2DayOfMonthBCD             DL_RTC_Common_setAlarm2DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2DayOfMonthBCD
+ */
+#define DL_RTC_A_getAlarm2DayOfMonthBCD             DL_RTC_Common_getAlarm2DayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarSecondsBinary
+ */
+#define DL_RTC_A_setCalendarSecondsBinary           DL_RTC_Common_setCalendarSecondsBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarSecondsBinary
+ */
+#define DL_RTC_A_getCalendarSecondsBinary           DL_RTC_Common_getCalendarSecondsBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarMinutesBinary
+ */
+#define DL_RTC_A_setCalendarMinutesBinary           DL_RTC_Common_setCalendarMinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarMinutesBinary
+ */
+#define DL_RTC_A_getCalendarMinutesBinary           DL_RTC_Common_getCalendarMinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarHoursBinary
+ */
+#define DL_RTC_A_setCalendarHoursBinary             DL_RTC_Common_setCalendarHoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarHoursBinary
+ */
+#define DL_RTC_A_getCalendarHoursBinary             DL_RTC_Common_getCalendarHoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarDayOfWeekBinary
+ */
+#define DL_RTC_A_setCalendarDayOfWeekBinary         DL_RTC_Common_setCalendarDayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarDayOfWeekBinary
+ */
+#define DL_RTC_A_getCalendarDayOfWeekBinary         DL_RTC_Common_getCalendarDayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarDayOfMonthBinary
+ */
+#define DL_RTC_A_setCalendarDayOfMonthBinary        DL_RTC_Common_setCalendarDayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarDayOfMonthBinary
+ */
+#define DL_RTC_A_getCalendarDayOfMonthBinary        DL_RTC_Common_getCalendarDayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarMonthBinary
+ */
+#define DL_RTC_A_setCalendarMonthBinary             DL_RTC_Common_setCalendarMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarMonthBinary
+ */
+#define DL_RTC_A_getCalendarMonthBinary             DL_RTC_Common_getCalendarMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarYearBinary
+ */
+#define DL_RTC_A_setCalendarYearBinary              DL_RTC_Common_setCalendarYearBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarYearBinary
+ */
+#define DL_RTC_A_getCalendarYearBinary              DL_RTC_Common_getCalendarYearBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1MinutesBinary
+ */
+#define DL_RTC_A_enableAlarm1MinutesBinary          DL_RTC_Common_enableAlarm1MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1MinutesBinary
+ */
+#define DL_RTC_A_disableAlarm1MinutesBinary         DL_RTC_Common_disableAlarm1MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1MinutesBinary
+ */
+#define DL_RTC_A_setAlarm1MinutesBinary             DL_RTC_Common_setAlarm1MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1MinutesBinary
+ */
+#define DL_RTC_A_getAlarm1MinutesBinary             DL_RTC_Common_getAlarm1MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1HoursBinary
+ */
+#define DL_RTC_A_enableAlarm1HoursBinary            DL_RTC_Common_enableAlarm1HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1HoursBinary
+ */
+#define DL_RTC_A_disableAlarm1HoursBinary           DL_RTC_Common_disableAlarm1HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1HoursBinary
+ */
+#define DL_RTC_A_setAlarm1HoursBinary               DL_RTC_Common_setAlarm1HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1HoursBinary
+ */
+#define DL_RTC_A_getAlarm1HoursBinary               DL_RTC_Common_getAlarm1HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1DayOfWeekBinary
+ */
+#define DL_RTC_A_enableAlarm1DayOfWeekBinary        DL_RTC_Common_enableAlarm1DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1DayOfWeekBinary
+ */
+#define DL_RTC_A_disableAlarm1DayOfWeekBinary       DL_RTC_Common_disableAlarm1DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1DayOfWeekBinary
+ */
+#define DL_RTC_A_setAlarm1DayOfWeekBinary           DL_RTC_Common_setAlarm1DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1DayOfWeekBinary
+ */
+#define DL_RTC_A_getAlarm1DayOfWeekBinary           DL_RTC_Common_getAlarm1DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm1DayOfMonthBinary
+ */
+#define DL_RTC_A_enableAlarm1DayOfMonthBinary       DL_RTC_Common_enableAlarm1DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm1DayOfMonthBinary
+ */
+#define DL_RTC_A_disableAlarm1DayOfMonthBinary      DL_RTC_Common_disableAlarm1DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm1DayOfMonthBinary
+ */
+#define DL_RTC_A_setAlarm1DayOfMonthBinary          DL_RTC_Common_setAlarm1DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm1DayOfMonthBinary
+ */
+#define DL_RTC_A_getAlarm1DayOfMonthBinary          DL_RTC_Common_getAlarm1DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2MinutesBinary
+ */
+#define DL_RTC_A_enableAlarm2MinutesBinary          DL_RTC_Common_enableAlarm2MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2MinutesBinary
+ */
+#define DL_RTC_A_disableAlarm2MinutesBinary         DL_RTC_Common_disableAlarm2MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2MinutesBinary
+ */
+#define DL_RTC_A_setAlarm2MinutesBinary             DL_RTC_Common_setAlarm2MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2MinutesBinary
+ */
+#define DL_RTC_A_getAlarm2MinutesBinary             DL_RTC_Common_getAlarm2MinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2HoursBinary
+ */
+#define DL_RTC_A_enableAlarm2HoursBinary            DL_RTC_Common_enableAlarm2HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2HoursBinary
+ */
+#define DL_RTC_A_disableAlarm2HoursBinary           DL_RTC_Common_disableAlarm2HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2HoursBinary
+ */
+#define DL_RTC_A_setAlarm2HoursBinary               DL_RTC_Common_setAlarm2HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2HoursBinary
+ */
+#define DL_RTC_A_getAlarm2HoursBinary               DL_RTC_Common_getAlarm2HoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2DayOfWeekBinary
+ */
+#define DL_RTC_A_enableAlarm2DayOfWeekBinary        DL_RTC_Common_enableAlarm2DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2DayOfWeekBinary
+ */
+#define DL_RTC_A_disableAlarm2DayOfWeekBinary       DL_RTC_Common_disableAlarm2DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2DayOfWeekBinary
+ */
+#define DL_RTC_A_setAlarm2DayOfWeekBinary           DL_RTC_Common_setAlarm2DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2DayOfWeekBinary
+ */
+#define DL_RTC_A_getAlarm2DayOfWeekBinary           DL_RTC_Common_getAlarm2DayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableAlarm2DayOfMonthBinary
+ */
+#define DL_RTC_A_enableAlarm2DayOfMonthBinary       DL_RTC_Common_enableAlarm2DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableAlarm2DayOfMonthBinary
+ */
+#define DL_RTC_A_disableAlarm2DayOfMonthBinary      DL_RTC_Common_disableAlarm2DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setAlarm2DayOfMonthBinary
+ */
+#define DL_RTC_A_setAlarm2DayOfMonthBinary          DL_RTC_Common_setAlarm2DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getAlarm2DayOfMonthBinary
+ */
+#define DL_RTC_A_getAlarm2DayOfMonthBinary          DL_RTC_Common_getAlarm2DayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setPrescalerEvents
+ */
+#define DL_RTC_A_setPrescalerEvents                 DL_RTC_Common_setPrescalerEvents
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setPeriodicAlarm0
+ */
+#define DL_RTC_A_setPeriodicAlarm0                  DL_RTC_Common_setPeriodicAlarm0
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setPeriodicAlarm1
+ */
+#define DL_RTC_A_setPeriodicAlarm1                  DL_RTC_Common_setPeriodicAlarm1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setPeriodicAlarm2
+ */
+#define DL_RTC_A_setPeriodicAlarm2                  DL_RTC_Common_setPeriodicAlarm2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getPrescaler0
+ */
+#define DL_RTC_A_getPrescaler0                      DL_RTC_Common_getPrescaler0
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getPrescaler1
+ */
+#define DL_RTC_A_getPrescaler1                      DL_RTC_Common_getPrescaler1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getPrescaler2
+ */
+#define DL_RTC_A_getPrescaler2                      DL_RTC_Common_getPrescaler2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampSecondsBCD
+ */
+#define DL_RTC_A_getTimeStampSecondsBCD             DL_RTC_Common_getTimeStampSecondsBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampMinutesBCD
+ */
+#define DL_RTC_A_getTimeStampMinutesBCD             DL_RTC_Common_getTimeStampMinutesBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampHoursBCD
+ */
+#define DL_RTC_A_getTimeStampHoursBCD               DL_RTC_Common_getTimeStampHoursBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampDayOfWeekBCD
+ */
+#define DL_RTC_A_getTimeStampDayOfWeekBCD           DL_RTC_Common_getTimeStampDayOfWeekBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampDayOfMonthBCD
+ */
+#define DL_RTC_A_getTimeStampDayOfMonthBCD          DL_RTC_Common_getTimeStampDayOfMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampMonthBCD
+ */
+#define DL_RTC_A_getTimeStampMonthBCD               DL_RTC_Common_getTimeStampMonthBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampYearBCD
+ */
+#define DL_RTC_A_getTimeStampYearBCD                DL_RTC_Common_getTimeStampYearBCD
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampSecondsBinary
+ */
+#define DL_RTC_A_getTimeStampSecondsBinary          DL_RTC_Common_getTimeStampSecondsBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampMinutesBinary
+ */
+#define DL_RTC_A_getTimeStampMinutesBinary          DL_RTC_Common_getTimeStampMinutesBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampHoursBinary
+ */
+#define DL_RTC_A_getTimeStampHoursBinary            DL_RTC_Common_getTimeStampHoursBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampDayOfWeekBinary
+ */
+#define DL_RTC_A_getTimeStampDayOfWeekBinary        DL_RTC_Common_getTimeStampDayOfWeekBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampDayOfMonthBinary
+ */
+#define DL_RTC_A_getTimeStampDayOfMonthBinary       DL_RTC_Common_getTimeStampDayOfMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampMonthBinary
+ */
+#define DL_RTC_A_getTimeStampMonthBinary            DL_RTC_Common_getTimeStampMonthBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampYearBinary
+ */
+#define DL_RTC_A_getTimeStampYearBinary             DL_RTC_Common_getTimeStampYearBinary
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableInterrupt
+ */
+#define DL_RTC_A_enableInterrupt                    DL_RTC_Common_enableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableInterrupt
+ */
+#define DL_RTC_A_disableInterrupt                   DL_RTC_Common_disableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getEnabledInterrupts
+ */
+#define DL_RTC_A_getEnabledInterrupts               DL_RTC_Common_getEnabledInterrupts
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getEnabledInterruptStatus
+ */
+#define DL_RTC_A_getEnabledInterruptStatus          DL_RTC_Common_getEnabledInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getRawInterruptStatus
+ */
+#define DL_RTC_A_getRawInterruptStatus              DL_RTC_Common_getRawInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getPendingInterrupt
+ */
+#define DL_RTC_A_getPendingInterrupt                DL_RTC_Common_getPendingInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_clearInterruptStatus
+ */
+#define DL_RTC_A_clearInterruptStatus               DL_RTC_Common_clearInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableEvent
+ */
+#define DL_RTC_A_enableEvent                        DL_RTC_Common_enableEvent
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableEvent
+ */
+#define DL_RTC_A_disableEvent                       DL_RTC_Common_disableEvent
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getEnabledEvents
+ */
+#define DL_RTC_A_getEnabledEvents                   DL_RTC_Common_getEnabledEvents
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getEnabledEventStatus
+ */
+#define DL_RTC_A_getEnabledEventStatus              DL_RTC_Common_getEnabledEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getRawEventsStatus
+ */
+#define DL_RTC_A_getRawEventsStatus                 DL_RTC_Common_getRawEventsStatus
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_clearEventsStatus
+ */
+#define DL_RTC_A_clearEventsStatus                  DL_RTC_Common_clearEventsStatus
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setPublisherChanID
+ */
+#define DL_RTC_A_setPublisherChanID                 DL_RTC_Common_setPublisherChanID
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getPublisherChanID
+ */
+#define DL_RTC_A_getPublisherChanID                 DL_RTC_Common_getPublisherChanID
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_initCalendar
+ */
+#define DL_RTC_A_initCalendar                       DL_RTC_Common_initCalendar
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarTime
+ */
+#define DL_RTC_A_getCalendarTime                    DL_RTC_Common_getCalendarTime
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarAlarm1
+ */
+#define DL_RTC_A_setCalendarAlarm1                  DL_RTC_Common_setCalendarAlarm1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarAlarm1
+ */
+#define DL_RTC_A_getCalendarAlarm1                  DL_RTC_Common_getCalendarAlarm1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableCalendarAlarm1
+ */
+#define DL_RTC_A_enableCalendarAlarm1               DL_RTC_Common_enableCalendarAlarm1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableCalendarAlarm1
+ */
+#define DL_RTC_A_disableCalendarAlarm1              DL_RTC_Common_disableCalendarAlarm1
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setCalendarAlarm2
+ */
+#define DL_RTC_A_setCalendarAlarm2                  DL_RTC_Common_setCalendarAlarm2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getCalendarAlarm2
+ */
+#define DL_RTC_A_getCalendarAlarm2                  DL_RTC_Common_getCalendarAlarm2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableCalendarAlarm2
+ */
+#define DL_RTC_A_enableCalendarAlarm2               DL_RTC_Common_enableCalendarAlarm2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableCalendarAlarm2
+ */
+#define DL_RTC_A_disableCalendarAlarm2              DL_RTC_Common_disableCalendarAlarm2
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setTimeStampEventSource
+ */
+#define DL_RTC_A_setTimeStampEventSource            DL_RTC_Common_setTimeStampEventSource
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampEventSource
+ */
+#define DL_RTC_A_getTimeStampEventSource            DL_RTC_Common_getTimeStampEventSource
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampEventCause
+ */
+#define DL_RTC_A_getTimeStampEventCause             DL_RTC_Common_getTimeStampEventCause
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_setTimeStampEventCapture
+ */
+#define DL_RTC_A_setTimeStampEventCapture           DL_RTC_Common_setTimeStampEventCapture
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_getTimeStampEventCapture
+ */
+#define DL_RTC_A_getTimeStampEventCapture           DL_RTC_Common_getTimeStampEventCapture
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_clearTimeStamp
+ */
+#define DL_RTC_A_clearTimeStamp                     DL_RTC_Common_clearTimeStamp
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_enableWriteProtect
+ */
+#define DL_RTC_A_enableWriteProtect                 DL_RTC_Common_enableWriteProtect
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_isWriteProtectEnabled
+ */
+#define DL_RTC_A_isWriteProtectEnabled              DL_RTC_Common_isWriteProtectEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_RTC_Common_disableWriteProtect
+ */
+#define DL_RTC_A_disableWriteProtect                DL_RTC_Common_disableWriteProtect
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_RTC_A__ */
+
+#endif /* ti_dl_dl_rtc_a__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_rtc_common.c
+++ b/mspm0/source/ti/driverlib/dl_rtc_common.c
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_rtc_common.h>
+
+#if defined __MSPM0_HAS_RTC_A__ || defined __MSPM0_HAS_RTC__
+
+void DL_RTC_Common_initCalendar(RTC_Regs *rtc_common,
+    DL_RTC_Common_Calendar calendarTime, DL_RTC_COMMON_FORMAT formatSelect)
+{
+    DL_RTC_Common_setClockFormat(rtc_common, formatSelect);
+
+    if (formatSelect == DL_RTC_COMMON_FORMAT_BINARY) {
+        DL_RTC_Common_setCalendarSecondsBinary(
+            rtc_common, calendarTime.seconds);
+        DL_RTC_Common_setCalendarMinutesBinary(
+            rtc_common, calendarTime.minutes);
+        DL_RTC_Common_setCalendarHoursBinary(rtc_common, calendarTime.hours);
+        /*
+         * Back to back writes to counter/calendar registers such as
+         * SEC, MIN, HOUR, DAY, MON, YEAR need to be avoided since writes
+         * to calendar registers take 2 to 3 RTCCLK cycles to take effect.
+         */
+        DL_Common_updateReg(&rtc_common->DAY,
+            (uint32_t) calendarTime.dayOfWeek |
+                ((uint32_t) calendarTime.dayOfMonth << RTC_DAY_DOMBIN_OFS),
+            RTC_DAY_DOW_MASK | RTC_DAY_DOMBIN_MASK);
+        DL_RTC_Common_setCalendarMonthBinary(rtc_common, calendarTime.month);
+        DL_RTC_Common_setCalendarYearBinary(rtc_common, calendarTime.year);
+    } else {
+        DL_RTC_Common_setCalendarSecondsBCD(rtc_common, calendarTime.seconds);
+        DL_RTC_Common_setCalendarMinutesBCD(rtc_common, calendarTime.minutes);
+        DL_RTC_Common_setCalendarHoursBCD(rtc_common, calendarTime.hours);
+        DL_Common_updateReg(&rtc_common->DAY,
+            (uint32_t) calendarTime.dayOfWeek |
+                ((uint32_t) calendarTime.dayOfMonth << RTC_DAY_DOMLOWBCD_OFS),
+            RTC_DAY_DOW_MASK | RTC_DAY_DOMLOWBCD_MASK |
+                RTC_DAY_DOMHIGHBCD_MASK);
+        DL_RTC_Common_setCalendarMonthBCD(rtc_common, calendarTime.month);
+        DL_RTC_Common_setCalendarYearBCD(rtc_common, calendarTime.year);
+    }
+}
+
+DL_RTC_Common_Calendar DL_RTC_Common_getCalendarTime(RTC_Regs *rtc_common)
+{
+    DL_RTC_Common_Calendar calendarTime;
+    DL_RTC_COMMON_FORMAT format;
+
+    format = DL_RTC_Common_getClockFormat(rtc_common);
+
+    if (format == DL_RTC_COMMON_FORMAT_BINARY) {
+        calendarTime.seconds =
+            DL_RTC_Common_getCalendarSecondsBinary(rtc_common);
+        calendarTime.minutes =
+            DL_RTC_Common_getCalendarMinutesBinary(rtc_common);
+        calendarTime.hours = DL_RTC_Common_getCalendarHoursBinary(rtc_common);
+        calendarTime.dayOfWeek =
+            DL_RTC_Common_getCalendarDayOfWeekBinary(rtc_common);
+        calendarTime.dayOfMonth =
+            DL_RTC_Common_getCalendarDayOfMonthBinary(rtc_common);
+        calendarTime.month = DL_RTC_Common_getCalendarMonthBinary(rtc_common);
+        calendarTime.year  = DL_RTC_Common_getCalendarYearBinary(rtc_common);
+    } else {
+        calendarTime.seconds = DL_RTC_Common_getCalendarSecondsBCD(rtc_common);
+        calendarTime.minutes = DL_RTC_Common_getCalendarMinutesBCD(rtc_common);
+        calendarTime.hours   = DL_RTC_Common_getCalendarHoursBCD(rtc_common);
+        calendarTime.dayOfWeek =
+            DL_RTC_Common_getCalendarDayOfWeekBCD(rtc_common);
+        calendarTime.dayOfMonth =
+            DL_RTC_Common_getCalendarDayOfMonthBCD(rtc_common);
+        calendarTime.month = DL_RTC_Common_getCalendarMonthBCD(rtc_common);
+        calendarTime.year  = DL_RTC_Common_getCalendarYearBCD(rtc_common);
+    }
+
+    return calendarTime;
+}
+
+void DL_RTC_Common_setCalendarAlarm1(
+    RTC_Regs *rtc_common, DL_RTC_Common_CalendarAlarm alarmTime)
+{
+    DL_RTC_COMMON_FORMAT format;
+
+    format = DL_RTC_Common_getClockFormat(rtc_common);
+
+    if (format == DL_RTC_COMMON_FORMAT_BINARY) {
+        DL_RTC_Common_setAlarm1MinutesBinary(rtc_common, alarmTime.minutes);
+        DL_RTC_Common_setAlarm1HoursBinary(rtc_common, alarmTime.hours);
+        DL_RTC_Common_setAlarm1DayOfWeekBinary(
+            rtc_common, alarmTime.dayOfWeek);
+        DL_RTC_Common_setAlarm1DayOfMonthBinary(
+            rtc_common, alarmTime.dayOfMonth);
+    } else {
+        DL_RTC_Common_setAlarm1MinutesBCD(rtc_common, alarmTime.minutes);
+        DL_RTC_Common_setAlarm1HoursBCD(rtc_common, alarmTime.hours);
+        DL_RTC_Common_setAlarm1DayOfWeekBCD(rtc_common, alarmTime.dayOfWeek);
+        DL_RTC_Common_setAlarm1DayOfMonthBCD(rtc_common, alarmTime.dayOfMonth);
+    }
+}
+
+DL_RTC_Common_CalendarAlarm DL_RTC_Common_getCalendarAlarm1(
+    RTC_Regs *rtc_common)
+{
+    DL_RTC_Common_CalendarAlarm alarmTime;
+    DL_RTC_COMMON_FORMAT format;
+
+    format = DL_RTC_Common_getClockFormat(rtc_common);
+
+    if (format == DL_RTC_COMMON_FORMAT_BINARY) {
+        alarmTime.minutes = DL_RTC_Common_getAlarm1MinutesBinary(rtc_common);
+        alarmTime.hours   = DL_RTC_Common_getAlarm1HoursBinary(rtc_common);
+        alarmTime.dayOfWeek =
+            DL_RTC_Common_getAlarm1DayOfWeekBinary(rtc_common);
+        alarmTime.dayOfMonth =
+            DL_RTC_Common_getAlarm1DayOfMonthBinary(rtc_common);
+    } else {
+        alarmTime.minutes   = DL_RTC_Common_getAlarm1MinutesBCD(rtc_common);
+        alarmTime.hours     = DL_RTC_Common_getAlarm1HoursBCD(rtc_common);
+        alarmTime.dayOfWeek = DL_RTC_Common_getAlarm1DayOfWeekBCD(rtc_common);
+        alarmTime.dayOfMonth =
+            DL_RTC_Common_getAlarm1DayOfMonthBCD(rtc_common);
+    }
+
+    return alarmTime;
+}
+
+void DL_RTC_Common_enableCalendarAlarm1(RTC_Regs *rtc_common)
+{
+    DL_RTC_COMMON_FORMAT format;
+
+    format = DL_RTC_Common_getClockFormat(rtc_common);
+
+    if (format == DL_RTC_COMMON_FORMAT_BINARY) {
+        DL_RTC_Common_enableAlarm1MinutesBinary(rtc_common);
+        DL_RTC_Common_enableAlarm1HoursBinary(rtc_common);
+        DL_RTC_Common_enableAlarm1DayOfWeekBinary(rtc_common);
+        DL_RTC_Common_enableAlarm1DayOfMonthBinary(rtc_common);
+    } else {
+        DL_RTC_Common_enableAlarm1MinutesBCD(rtc_common);
+        DL_RTC_Common_enableAlarm1HoursBCD(rtc_common);
+        DL_RTC_Common_enableAlarm1DayOfWeekBCD(rtc_common);
+        DL_RTC_Common_enableAlarm1DayOfMonthBCD(rtc_common);
+    }
+}
+
+void DL_RTC_Common_disableCalendarAlarm1(RTC_Regs *rtc_common)
+{
+    DL_RTC_COMMON_FORMAT format;
+
+    format = DL_RTC_Common_getClockFormat(rtc_common);
+
+    if (format == DL_RTC_COMMON_FORMAT_BINARY) {
+        DL_RTC_Common_disableAlarm1MinutesBinary(rtc_common);
+        DL_RTC_Common_disableAlarm1HoursBinary(rtc_common);
+        DL_RTC_Common_disableAlarm1DayOfWeekBinary(rtc_common);
+        DL_RTC_Common_disableAlarm1DayOfMonthBinary(rtc_common);
+    } else {
+        DL_RTC_Common_disableAlarm1MinutesBCD(rtc_common);
+        DL_RTC_Common_disableAlarm1HoursBCD(rtc_common);
+        DL_RTC_Common_disableAlarm1DayOfWeekBCD(rtc_common);
+        DL_RTC_Common_disableAlarm1DayOfMonthBCD(rtc_common);
+    }
+}
+
+void DL_RTC_Common_setCalendarAlarm2(
+    RTC_Regs *rtc_common, DL_RTC_Common_CalendarAlarm alarmTime)
+{
+    DL_RTC_COMMON_FORMAT format;
+
+    format = DL_RTC_Common_getClockFormat(rtc_common);
+
+    if (format == DL_RTC_COMMON_FORMAT_BINARY) {
+        DL_RTC_Common_setAlarm2MinutesBinary(rtc_common, alarmTime.minutes);
+        DL_RTC_Common_setAlarm2HoursBinary(rtc_common, alarmTime.hours);
+        DL_RTC_Common_setAlarm2DayOfWeekBinary(
+            rtc_common, alarmTime.dayOfWeek);
+        DL_RTC_Common_setAlarm2DayOfMonthBinary(
+            rtc_common, alarmTime.dayOfMonth);
+    } else {
+        DL_RTC_Common_setAlarm2MinutesBCD(rtc_common, alarmTime.minutes);
+        DL_RTC_Common_setAlarm2HoursBCD(rtc_common, alarmTime.hours);
+        DL_RTC_Common_setAlarm2DayOfWeekBCD(rtc_common, alarmTime.dayOfWeek);
+        DL_RTC_Common_setAlarm2DayOfMonthBCD(rtc_common, alarmTime.dayOfMonth);
+    }
+}
+
+DL_RTC_Common_CalendarAlarm DL_RTC_Common_getCalendarAlarm2(
+    RTC_Regs *rtc_common)
+{
+    DL_RTC_Common_CalendarAlarm alarmTime;
+    DL_RTC_COMMON_FORMAT format;
+
+    format = DL_RTC_Common_getClockFormat(rtc_common);
+
+    if (format == DL_RTC_COMMON_FORMAT_BINARY) {
+        alarmTime.minutes = DL_RTC_Common_getAlarm2MinutesBinary(rtc_common);
+        alarmTime.hours   = DL_RTC_Common_getAlarm2HoursBinary(rtc_common);
+        alarmTime.dayOfWeek =
+            DL_RTC_Common_getAlarm2DayOfWeekBinary(rtc_common);
+        alarmTime.dayOfMonth =
+            DL_RTC_Common_getAlarm2DayOfMonthBinary(rtc_common);
+    } else {
+        alarmTime.minutes   = DL_RTC_Common_getAlarm2MinutesBCD(rtc_common);
+        alarmTime.hours     = DL_RTC_Common_getAlarm2HoursBCD(rtc_common);
+        alarmTime.dayOfWeek = DL_RTC_Common_getAlarm2DayOfWeekBCD(rtc_common);
+        alarmTime.dayOfMonth =
+            DL_RTC_Common_getAlarm2DayOfMonthBCD(rtc_common);
+    }
+
+    return alarmTime;
+}
+
+void DL_RTC_Common_enableCalendarAlarm2(RTC_Regs *rtc_common)
+{
+    DL_RTC_COMMON_FORMAT format;
+
+    format = DL_RTC_Common_getClockFormat(rtc_common);
+
+    if (format == DL_RTC_COMMON_FORMAT_BINARY) {
+        DL_RTC_Common_enableAlarm2MinutesBinary(rtc_common);
+        DL_RTC_Common_enableAlarm2HoursBinary(rtc_common);
+        DL_RTC_Common_enableAlarm2DayOfWeekBinary(rtc_common);
+        DL_RTC_Common_enableAlarm2DayOfMonthBinary(rtc_common);
+    } else {
+        DL_RTC_Common_enableAlarm2MinutesBCD(rtc_common);
+        DL_RTC_Common_enableAlarm2HoursBCD(rtc_common);
+        DL_RTC_Common_enableAlarm2DayOfWeekBCD(rtc_common);
+        DL_RTC_Common_enableAlarm2DayOfMonthBCD(rtc_common);
+    }
+}
+
+void DL_RTC_Common_disableCalendarAlarm2(RTC_Regs *rtc_common)
+{
+    DL_RTC_COMMON_FORMAT format;
+
+    format = DL_RTC_Common_getClockFormat(rtc_common);
+
+    if (format == DL_RTC_COMMON_FORMAT_BINARY) {
+        DL_RTC_Common_disableAlarm2MinutesBinary(rtc_common);
+        DL_RTC_Common_disableAlarm2HoursBinary(rtc_common);
+        DL_RTC_Common_disableAlarm2DayOfWeekBinary(rtc_common);
+        DL_RTC_Common_disableAlarm2DayOfMonthBinary(rtc_common);
+    } else {
+        DL_RTC_Common_disableAlarm2MinutesBCD(rtc_common);
+        DL_RTC_Common_disableAlarm2HoursBCD(rtc_common);
+        DL_RTC_Common_disableAlarm2DayOfWeekBCD(rtc_common);
+        DL_RTC_Common_disableAlarm2DayOfMonthBCD(rtc_common);
+    }
+}
+
+#endif /* __MSPM0_HAS_RTC_A__ || defined __MSPM0_HAS_RTC__ */

--- a/mspm0/source/ti/driverlib/dl_rtc_common.h
+++ b/mspm0/source/ti/driverlib/dl_rtc_common.h
@@ -1,0 +1,3323 @@
+/*
+ * Copyright (c) 2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY TfHEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_rtc_common.h
+ *  @brief      Real Time Clock A (RTC Common) Peripheral Interface
+ *  @defgroup   Common Real Time Clock (RTC_Common)
+ *
+ *  @anchor ti_devices_msp_dl_rtc_common_Overview
+ *  # Overview
+ *  The RTC Common Driver Library allows full configuration of the MSPM0 RTC Common module.
+ *  The real-time clock (RTC Common) module provides clock counters with calendar mode,
+ *  a flexible programmable alarm, offset calibration, and a provision for
+ *  temperature compensation. The module also provides a separate time stamp calendar
+ *  capable of capturing a time stamp event upon loss of VDD or detection of a tamper event
+ *  on a tamper I/O pin.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup RTC_Common
+ * @{
+ */
+#ifndef ti_dl_dl_rtc_common__include
+#define ti_dl_dl_rtc_common__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#if defined __MSPM0_HAS_RTC_A__ || defined __MSPM0_HAS_RTC__ || \
+    defined(DOXYGEN__INCLUDE)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_RTC_COMMON_INTERRUPT
+ *  @{
+ */
+
+/**
+ * @brief RTC Common alarm 1 interrupt
+ */
+#define DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM1          (RTC_CPU_INT_IMASK_RTCA1_SET)
+
+/**
+ * @brief RTC Common alarm 2 interrupt
+ */
+#define DL_RTC_COMMON_INTERRUPT_CALENDAR_ALARM2          (RTC_CPU_INT_IMASK_RTCA2_SET)
+
+/**
+ * @brief RTC Common prescaler 0 interrupt
+ */
+#define DL_RTC_COMMON_INTERRUPT_PRESCALER0               (RTC_CPU_INT_IMASK_RT0PS_SET)
+
+/**
+ * @brief RTC Common prescaler 1 interrupt
+ */
+#define DL_RTC_COMMON_INTERRUPT_PRESCALER1               (RTC_CPU_INT_IMASK_RT1PS_SET)
+
+#ifdef __MSPM0_HAS_RTC_A__
+/**
+ * @brief RTC Common prescaler 2 interrupt
+ */
+#define DL_RTC_COMMON_INTERRUPT_PRESCALER2                (RTC_CPU_INT_IMASK_RT2PS_SET)
+#endif
+
+/**
+ * @brief RTC Common interval timer interrupt
+ */
+#define DL_RTC_COMMON_INTERRUPT_INTERVAL_ALARM           (RTC_CPU_INT_IMASK_RTCTEV_SET)
+
+/**
+ * @brief RTC Common ready interrupt
+ */
+#define DL_RTC_COMMON_INTERRUPT_READY                    (RTC_CPU_INT_IMASK_RTCRDY_SET)
+
+#ifdef __MSPM0_HAS_RTC_A__
+/**
+ * @brief RTC Time Stamp Event interrupt
+ */
+#define DL_RTC_COMMON_INTERRUPT_TSEVT                    (RTC_CPU_INT_IMASK_TSEVT_SET)
+#endif
+
+/** @}*/
+
+/** @addtogroup DL_RTC_COMMON_EVENT
+ *  @{
+ */
+
+/**
+ * @brief RTC Common alarm 1 event
+ */
+#define DL_RTC_COMMON_EVENT_CALENDAR_ALARM1              (RTC_GEN_EVENT_IMASK_RTCA1_SET)
+
+/**
+ * @brief RTC Common alarm 2 event
+ */
+#define DL_RTC_COMMON_EVENT_CALENDAR_ALARM2              (RTC_GEN_EVENT_IMASK_RTCA2_SET)
+
+/**
+ * @brief RTC Common prescaler 0 event
+ */
+#define DL_RTC_COMMON_EVENT_PRESCALER0                   (RTC_GEN_EVENT_IMASK_RT0PS_SET)
+
+/**
+ * @brief RTC Common prescaler 1 event
+ */
+#define DL_RTC_COMMON_EVENT_PRESCALER1                   (RTC_GEN_EVENT_IMASK_RT1PS_SET)
+
+#ifdef __MSPM0_HAS_RTC_A__
+/**
+ * @brief RTC Common prescaler 2 event
+ */
+#define DL_RTC_COMMON_EVENT_PRESCALER2                   (RTC_GEN_EVENT_IMASK_RT2PS_SET)
+#endif
+
+/**
+ * @brief RTC Common interval timer event
+ */
+#define DL_RTC_COMMON_EVENT_INTERVAL_ALARM               (RTC_GEN_EVENT_IMASK_RTCTEV_SET)
+
+/**
+ * @brief RTC Common ready event
+ */
+#define DL_RTC_COMMON_EVENT_READY                        (RTC_GEN_EVENT_IMASK_RTCRDY_SET)
+
+#ifdef __MSPM0_HAS_RTC_A__
+/**
+ * @brief RTC Common time stamp event
+ */
+#define DL_RTC_COMMON_EVENT_TSEVT                        (RTC_GEN_EVENT_IMASK_TSEVT_SET)
+#endif
+
+/** @}*/
+
+#ifdef __MSPM0_HAS_RTC_A__
+/** @addtogroup DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE
+ *  @{
+ */
+
+/**
+ * @brief Tamper IO 0 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_0       (RTC_TSSTAT_TSTIOEVT0_SET)
+
+/**
+ * @brief Tamper IO 1 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_1       (RTC_TSSTAT_TSTIOEVT1_SET)
+
+/**
+ * @brief Tamper IO 2 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_2       (RTC_TSSTAT_TSTIOEVT2_SET)
+
+/**
+ * @brief Tamper IO 3 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_3       (RTC_TSSTAT_TSTIOEVT3_SET)
+
+/**
+ * @brief Tamper IO 4 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_4       (RTC_TSSTAT_TSTIOEV4_SET)
+
+/**
+ * @brief Tamper IO 5 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_5       (RTC_TSSTAT_TSTIOEVT5_SET)
+
+/**
+ * @brief Tamper IO 6 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_6       (RTC_TSSTAT_TSTIOEVT6_SET)
+
+/**
+ * @brief Tamper IO 7 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_7       (RTC_TSSTAT_TSTIOEVT7_SET)
+
+/**
+ * @brief Tamper IO 8 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_8       (RTC_TSSTAT_TSTIOEV8_SET)
+
+/**
+ * @brief Tamper IO 9 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_9       (RTC_TSSTAT_TSTIOEVT9_SET)
+
+/**
+ * @brief Tamper IO 10 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_10      (RTC_TSSTAT_TSTIOEVT10_SET)
+
+/**
+ * @brief Tamper IO 11 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_11      (RTC_TSSTAT_TSTIOEVT11_SET)
+
+/**
+ * @brief Tamper IO 12 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_12      (RTC_TSSTAT_TSTIOEVT12_SET)
+
+/**
+ * @brief Tamper IO 13 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_13      (RTC_TSSTAT_TSTIOEVT13_SET)
+
+/**
+ * @brief Tamper IO 14 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_14      (RTC_TSSTAT_TSTIOEVT14_SET)
+
+/**
+ * @brief Tamper IO 15 caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_TIO_15      (RTC_TSSTAT_TSTIOEVT15_SET)
+
+/**
+ * @brief Loss of VDD caused the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE_VDD_LOSS    (RTC_TSSTAT_TSVDDEVT_SET)
+
+/** @}*/
+
+/** @addtogroup DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE
+ *  @{
+ */
+
+/**
+ * @brief Enable Tamper IO 0 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_0      (RTC_TSCTL_TSTIOEN0_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 1 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_1      (RTC_TSCTL_TSTIOEN1_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 2 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_2      (RTC_TSCTL_TSTIOEN2_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 3 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_3      (RTC_TSCTL_TSTIOEN3_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 4 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_4      (RTC_TSCTL_TSTIOEN4_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 5 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_5      (RTC_TSCTL_TSTIOEN5_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 6 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_6      (RTC_TSCTL_TSTIOEN6_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 7 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_7      (RTC_TSCTL_TSTIOEN8_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 8 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_8      (RTC_TSCTL_TSTIOEN8_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 9 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_9      (RTC_TSCTL_TSTIOEN9_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 10 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_10     (RTC_TSCTL_TSTIOEN10_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 11 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_11     (RTC_TSCTL_TSTIOEN11_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 12 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_12     (RTC_TSCTL_TSTIOEN12_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 13 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_13     (RTC_TSCTL_TSTIOEN13_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 14 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_14     (RTC_TSCTL_TSTIOEN14_ENABLE)
+
+/**
+ * @brief Enable Tamper IO 15 as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_TIO_15     (RTC_TSCTL_TSTIOEN15_ENABLE)
+
+/**
+ * @brief Enable VDD loss detection as a source to trigger the time stamp event
+ */
+#define DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE_VDD_LOSS   (RTC_TSCTL_TSVDDEN_ENABLE)
+
+/** @}*/
+#endif
+
+/*! @enum DL_RTC_COMMON_STATUS */
+typedef enum {
+    /*! RTC Common is safe for reading */
+    DL_RTC_COMMON_STATUS_READY = RTC_STA_RTCRDY_READY,
+    /*! RTC Common is not safe for reading */
+    DL_RTC_COMMON_STATUS_NOT_READY = RTC_STA_RTCRDY_NOT_READY
+} DL_RTC_COMMON_STATUS;
+
+/*! @enum DL_RTC_COMMON_COMPENSATION_STATUS */
+typedef enum {
+    /*! RTC Common ready to get new compensation values */
+    DL_RTC_COMMON_COMPENSATION_STATUS_READY = RTC_STA_RTCTCRDY_READY,
+    /*! RTC Common not ready to get new compensaiton values */
+    DL_RTC_COMMON_COMPENSATION_STATUS_NOT_READY = RTC_STA_RTCTCRDY_NOT_READY
+} DL_RTC_COMMON_COMPENSATION_STATUS;
+
+/*! @enum DL_RTC_COMMON_COMPENSATION_WRITE_RESULT */
+typedef enum {
+    /*! Compensation write successful */
+    DL_RTC_COMMON_COMPENSATION_WRITE_RESULT_OK = RTC_STA_RTCTCOK_OK,
+    /*! Compensation write unsuccessful */
+    DL_RTC_COMMON_COMPENSATION_WRITE_RESULT_NOT_OK = RTC_STA_RTCTCOK_NOT_OK
+} DL_RTC_COMMON_COMPENSATION_WRITE_RESULT;
+
+/*! @enum DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN */
+typedef enum {
+    /*! Calibration frequency adjusted down */
+    DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN_DOWN = RTC_CAL_RTCOCALS_DOWN,
+    /*! Calibration frequency adjusted up */
+    DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN_UP = RTC_CAL_RTCOCALS_UP
+} DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN;
+
+/*! @enum DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY */
+typedef enum {
+    #ifdef __MSPM0_HAS_RTC__
+    /*! No frequency output to RTCCLK pin */
+    DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_OFF = RTC_CAL_RTCCALFX_OFF,
+    #endif
+    #ifdef __MSPM0_HAS_RTC_A__
+    /*! 32 kHz frequency output to RTCLK pin */
+    DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_32_KHZ = LFSS_CAL_RTCCALFX_F32KHZ,
+    #endif
+    /*! 512 Hz frequency output to RTCLK pin */
+    DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_512 = RTC_CAL_RTCCALFX_F512HZ,
+    /*! 256 Hz frequency output to RTCLK pin */
+    DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_256 = RTC_CAL_RTCCALFX_F256HZ,
+    /*! 1 Hz frequency output to RTCLK pin */
+    DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY_1 = RTC_CAL_RTCCALFX_F1HZ
+} DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY;
+
+/*! @enum DL_RTC_COMMON_TEMP_CALIBRATION */
+typedef enum {
+    /*! Calibrate at steps of -1 */
+    DL_RTC_COMMON_TEMP_CALIBRATION_DOWN1PPM = RTC_TCMP_RTCTCMPS_DOWN,
+    /*! Calibrate at steps of +1 */
+    DL_RTC_COMMON_TEMP_CALIBRATION_UP1PPM = RTC_TCMP_RTCTCMPS_UP
+} DL_RTC_COMMON_TEMP_CALIBRATION;
+
+/*! @enum DL_RTC_COMMON_FORMAT */
+typedef enum {
+    /*! Select binary format for the real-time clock */
+    DL_RTC_COMMON_FORMAT_BINARY = RTC_CTL_RTCBCD_BINARY,
+    /*! Select BCD format for the real-time clock */
+    DL_RTC_COMMON_FORMAT_BCD = RTC_CTL_RTCBCD_BCD
+} DL_RTC_COMMON_FORMAT;
+
+/*! @enum DL_RTC_COMMON_INTERVAL_ALARM */
+typedef enum {
+    /*! Assert Calendar interrupt on every minute */
+    DL_RTC_COMMON_INTERVAL_ALARM_MINUTECHANGE = RTC_CTL_RTCTEVTX_MINUTE,
+    /*! Assert Calendar interrupt on every hour */
+    DL_RTC_COMMON_INTERVAL_ALARM_HOURCHANGE = RTC_CTL_RTCTEVTX_HOUR,
+    /*! Assert Calendar interrupt when hour is 12 */
+    DL_RTC_COMMON_INTERVAL_ALARM_NOON = RTC_CTL_RTCTEVTX_NOON,
+    /*! Assert Calendar interrupt when hour is 0 */
+    DL_RTC_COMMON_INTERVAL_ALARM_MIDNIGHT = RTC_CTL_RTCTEVTX_MIDNIGHT
+} DL_RTC_COMMON_INTERVAL_ALARM;
+
+/*! @enum DL_RTC_COMMON_PRESCALER0_DIVIDE */
+typedef enum {
+    /*! Prescaler 0 Divide by 8 */
+    DL_RTC_COMMON_PRESCALER0_DIVIDE_8 = RTC_PSCTL_RT0IP_DIV8,
+    /*! Prescaler 0 Divide by 16 */
+    DL_RTC_COMMON_PRESCALER0_DIVIDE_16 = RTC_PSCTL_RT0IP_DIV16,
+    /*! Prescaler 0 Divide by 32 */
+    DL_RTC_COMMON_PRESCALER0_DIVIDE_32 = RTC_PSCTL_RT0IP_DIV32,
+    /*! Prescaler 0 Divide by 64 */
+    DL_RTC_COMMON_PRESCALER0_DIVIDE_64 = RTC_PSCTL_RT0IP_DIV64,
+    /*! Prescaler 0 Divide by 128 */
+    DL_RTC_COMMON_PRESCALER0_DIVIDE_128 = RTC_PSCTL_RT0IP_DIV128,
+    /*! Prescaler 0 Divide by 256 */
+    DL_RTC_COMMON_PRESCALER0_DIVIDE_256 = RTC_PSCTL_RT0IP_DIV256
+} DL_RTC_COMMON_PRESCALER0_DIVIDE;
+
+/*! @enum DL_RTC_COMMON_PRESCALER1_DIVIDE */
+typedef enum {
+    /*! Prescaler 1 Divide by 2 */
+    DL_RTC_COMMON_PRESCALER1_DIVIDE_2 = RTC_PSCTL_RT1IP_DIV2,
+    /*! Prescaler 1 Divide by 4 */
+    DL_RTC_COMMON_PRESCALER1_DIVIDE_4 = RTC_PSCTL_RT1IP_DIV4,
+    /*! Prescaler 1 Divide by 8 */
+    DL_RTC_COMMON_PRESCALER1_DIVIDE_8 = RTC_PSCTL_RT1IP_DIV8,
+    /*! Prescaler 1 Divide by 16 */
+    DL_RTC_COMMON_PRESCALER1_DIVIDE_16 = RTC_PSCTL_RT1IP_DIV16,
+    /*! Prescaler 1 Divide by 32 */
+    DL_RTC_COMMON_PRESCALER1_DIVIDE_32 = RTC_PSCTL_RT1IP_DIV32,
+    /*! Prescaler 1 Divide by 64 */
+    DL_RTC_COMMON_PRESCALER1_DIVIDE_64 = RTC_PSCTL_RT1IP_DIV64,
+    /*! Prescaler 1 Divide by 128 */
+    DL_RTC_COMMON_PRESCALER1_DIVIDE_128 = RTC_PSCTL_RT1IP_DIV128,
+    /*! Prescaler 1 Divide by 256 */
+    DL_RTC_COMMON_PRESCALER1_DIVIDE_256 = RTC_PSCTL_RT1IP_DIV256
+} DL_RTC_COMMON_PRESCALER1_DIVIDE;
+
+/*! @enum DL_RTC_COMMON_PRESCALER2_DIVIDE */
+typedef enum {
+    /*! Interval every 4 seconds */
+    DL_RTC_COMMON_PRESCALER2_4_SEC = RTC_EXTPSCTL_RT2PS_INT4S,
+    /*! Interval every 8 seconds */
+    DL_RTC_COMMON_PRESCALER2_8_SEC = RTC_EXTPSCTL_RT2PS_INT8S,
+    /*! Interval every 16 seconds */
+    DL_RTC_COMMON_PRESCALER2_16_SEC = RTC_EXTPSCTL_RT2PS_INT16S
+} DL_RTC_COMMON_PRESCALER2_DIVIDE;
+
+/*! @enum DL_RTC_COMMON_IIDX */
+typedef enum {
+    /*! RTC Common interrupt index for alarm 1 */
+    DL_RTC_COMMON_IIDX_ALARM1 = RTC_CPU_INT_IIDX_STAT_RTCA1,
+    /*! RTC Common interrupt index for alarm 2 */
+    DL_RTC_COMMON_IIDX_ALARM2 = RTC_CPU_INT_IIDX_STAT_RTCA2,
+    /*! RTC Common interrupt index for prescaler 0 */
+    DL_RTC_COMMON_IIDX_PRESCALER0 = RTC_CPU_INT_IIDX_STAT_RT0PS,
+    /*! RTC Common interrupt index for prescaler 1 */
+    DL_RTC_COMMON_IIDX_PRESCALER1 = RTC_CPU_INT_IIDX_STAT_RT1PS,
+    /*! RTC Common interrupt index for prescaler 2 */
+    DL_RTC_COMMON_IIDX_PRESCALER2 = RTC_CPU_INT_IIDX_STAT_RT2PS,
+    /*! RTC Common interrupt index for interval timer */
+    DL_RTC_COMMON_IIDX_INTERVAL_TIMER = RTC_CPU_INT_IIDX_STAT_RTCTEV,
+    /*! RTC Common interrupt index for RTC Common ready */
+    DL_RTC_COMMON_IIDX_READY = RTC_CPU_INT_IIDX_STAT_RTCRDY,
+    /*! RTC Common interrupt index for Time Stamp */
+    #ifdef __MSPM0_HAS_RTC_A__
+    DL_RTC_COMMON_IIDX_TSEVT = RTC_CPU_INT_IIDX_STAT_TSEVT,
+    /*! RTC Common interrupt index for Tamper IO 0 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_0 = RTC_CPU_INT_IIDX_STAT_TIO0,
+    /*! RTC Common interrupt index for Tamper IO 1 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_1 = RTC_CPU_INT_IIDX_STAT_TIO1,
+    /*! RTC Common interrupt index for Tamper IO 2 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_2 = RTC_CPU_INT_IIDX_STAT_TIO2,
+    /*! RTC Common interrupt index for Tamper IO 3 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_3 = RTC_CPU_INT_IIDX_STAT_TIO3,
+    /*! RTC Common interrupt index for Tamper IO 4 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_4 = RTC_CPU_INT_IIDX_STAT_TIO4,
+    /*! RTC Common interrupt index for Tamper IO 5 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_5 = RTC_CPU_INT_IIDX_STAT_TIO5,
+    /*! RTC Common interrupt index for Tamper IO 6 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_6 = RTC_CPU_INT_IIDX_STAT_TIO6,
+    /*! RTC Common interrupt index for Tamper IO 7 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_7 = RTC_CPU_INT_IIDX_STAT_TIO7,
+    /*! RTC Common interrupt index for Tamper IO 8 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_8 = RTC_CPU_INT_IIDX_STAT_TIO8,
+    /*! RTC Common interrupt index for Tamper IO 9 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_9 = RTC_CPU_INT_IIDX_STAT_TIO9,
+    /*! RTC Common interrupt index for Tamper IO 10 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_10 = RTC_CPU_INT_IIDX_STAT_TIO10,
+    /*! RTC Common interrupt index for Tamper IO 11 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_11 = RTC_CPU_INT_IIDX_STAT_TIO11,
+    /*! RTC Common interrupt index for Tamper IO 12 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_12 = RTC_CPU_INT_IIDX_STAT_TIO12,
+    /*! RTC Common interrupt index for Tamper IO 13 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_13 = RTC_CPU_INT_IIDX_STAT_TIO13,
+    /*! RTC Common interrupt index for Tamper IO 14 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_14 = RTC_CPU_INT_IIDX_STAT_TIO14,
+    /*! RTC Common interrupt index for Tamper IO 15 */
+    DL_RTC_COMMON_IIDX_TAMPER_IO_15 = RTC_CPU_INT_IIDX_STAT_TIO15,
+    #endif
+} DL_RTC_COMMON_IIDX;
+
+#ifdef __MSPM0_HAS_RTC_A__
+/*! @enum DL_RTC_COMMON_TIME_STAMP_EVENT_CAPTURE */
+typedef enum {
+    /*! Time stamp holds RTC capture at first occurrence of time stamp event */
+    DL_RTC_COMMON_TIME_STAMP_EVENT_CAPTURE_FIRST = RTC_TSCTL_TSCAPTURE_FIRST,
+    /*! Time stamp holds RTC capture at last occurrence of time stamp event */
+    DL_RTC_COMMON_TIME_STAMP_EVENT_CAPTURE_LAST = RTC_TSCTL_TSCAPTURE_LAST,
+} DL_RTC_COMMON_TIME_STAMP_EVENT_CAPTURE;
+#endif
+
+/* clang-format on */
+
+/**
+ * @brief   Alarm struct to use in DL_RTC_Common_setCalendarAlarm
+ *
+ * @note    All struct values must be in the same format (Binary OR BCD).
+ *          RTC Common format is set during initialization.
+ */
+typedef struct {
+    /** The minute to set the Alarm time to. Valid values are 0-59 in Binary
+     * format OR 0x0-0x59 in BCD format. */
+    uint8_t minutes;
+    /** The hour to set the Alarm time to. Valid values are 0-23 in Binary
+     * format OR 0x0-0x23 in BCD format. */
+    uint8_t hours;
+    /** The day of the week to set the Alarm time to. Valid values are 0-6
+     * in Binary format OR 0x0-0x6 in BCD format. */
+    uint8_t dayOfWeek;
+    /** The day of the month to set the Alarm time to. Valid values are 1-31
+     * in Binary format OR 0x1-0x31 in BCD format. */
+    uint8_t dayOfMonth;
+} DL_RTC_Common_CalendarAlarm;
+
+/**
+ * @brief   Calendar struct to use in DL_RTC_Common_initCalendar()
+ *
+ * @note    All struct values must be in the same format (Binary OR BCD).
+ *          RTC Common format is set during initialization.
+ */
+typedef struct {
+    /** The second to set the Calendar time to. Valid values are 0-59 in Binary
+     * format OR 0x0-0x59 in BCD format. */
+    uint8_t seconds;
+    /** The minute to set the Calendar time to. Valid values are 0-59 in Binary
+     * format OR 0x0-0x59 in BCD format. */
+    uint8_t minutes;
+    /** The hour to set the Calendar time to. Valid values are 0-23 in Binary
+     * format OR 0x0-0x23 in BCD format. */
+    uint8_t hours;
+    /** The day of the week to set the Calendar time to. Valid values are 0-6
+     * in Binary format OR 0x0-0x6 in BCD format. */
+    uint8_t dayOfWeek;
+    /** The day of the month to set the Calendar time to. Valid values are 1-31
+     * in Binary format OR 0x1-0x31 in BCD format. */
+    uint8_t dayOfMonth;
+    /** The month to set the Calendar time to. Valid values are 1-12 in Binary
+     * format OR 0x1-0x12 in BCD format. */
+    uint8_t month;
+    /** The year to set the Calendar time to. Valid values are 0-4095 in Binary
+     * format OR 0x0-0x4095 in BCD format. */
+    uint16_t year;
+} DL_RTC_Common_Calendar;
+
+/**
+ *  @brief Returns if LFCLK is selected as clock source
+ *
+ * If the LFCLK is enabled, the RTC Common module will select it as the clock source.
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return true  If LFCLK is selected as the clock source
+ *  @return false If LFCLK is not selected as the clock source
+ */
+__STATIC_INLINE bool DL_RTC_Common_isClockSourceLFCLK(RTC_Regs *rtc_common)
+{
+    return ((rtc_common->CLKSEL & RTC_CLKSEL_LFCLK_SEL_MASK) ==
+            RTC_CLKSEL_LFCLK_SEL_MASK);
+}
+
+/**
+ *  @brief      Enables the supply of the 32kHz clock to the RTC Common. It will not
+ *              power up the 32kHz crystal oscillator. This needs to be done
+ *              in the Clock System Module.
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ */
+__STATIC_INLINE void DL_RTC_Common_enableClockControl(RTC_Regs *rtc_common)
+{
+    rtc_common->CLKCTL = RTC_CLKCTL_MODCLKEN_ENABLE;
+}
+
+/**
+ *  @brief      Disables the supply of the 32kHz clock to the RTC Common.
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ */
+__STATIC_INLINE void DL_RTC_Common_disableClockControl(RTC_Regs *rtc_common)
+{
+    rtc_common->CLKCTL = RTC_CLKCTL_MODCLKEN_DISABLE;
+}
+
+/**
+ *  @brief      Enable power to the RTC Common module.
+ *
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ */
+__STATIC_INLINE void DL_RTC_Common_enablePower(RTC_Regs *rtc_common)
+{
+    rtc_common->GPRCM.PWREN =
+        (RTC_PWREN_KEY_UNLOCK_W | RTC_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ *  @brief      Disable power to the RTC Common module.
+ *
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ */
+__STATIC_INLINE void DL_RTC_Common_disablePower(RTC_Regs *rtc_common)
+{
+    rtc_common->GPRCM.PWREN =
+        (RTC_PWREN_KEY_UNLOCK_W | RTC_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ *  @brief Returns if power is enabled for the RTC Common module
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return true if power is enabled
+ *  @return false if power is disabled
+ */
+__STATIC_INLINE bool DL_RTC_Common_isPowerEnabled(RTC_Regs *rtc_common)
+{
+    return ((rtc_common->GPRCM.PWREN & RTC_PWREN_ENABLE_MASK) ==
+            RTC_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ *  @brief      Resets all registers in the RTC Common module.
+ *
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ */
+__STATIC_INLINE void DL_RTC_Common_reset(RTC_Regs *rtc_common)
+{
+    rtc_common->GPRCM.RSTCTL =
+        (RTC_RSTCTL_KEY_UNLOCK_W | RTC_RSTCTL_RESETSTKYCLR_CLR |
+            RTC_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ *  @brief      Returns if the RTC Common module was reset
+ *
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return true if module was reset
+ *  @return false if module was not reset
+ */
+__STATIC_INLINE bool DL_RTC_Common_isReset(RTC_Regs *rtc_common)
+{
+    return ((rtc_common->GPRCM.STAT & RTC_STAT_RESETSTKY_MASK) ==
+            RTC_STAT_RESETSTKY_RESET);
+}
+
+/**
+ *  @brief      Enables interrupts when the CPU is in debug mode. Interrupt
+ *              requests are signaled to the interrupt controller.
+ *
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ */
+__STATIC_INLINE void DL_RTC_Common_enableDebugInterrupts(RTC_Regs *rtc_common)
+{
+    rtc_common->DBGCTL |= RTC_DBGCTL_DBGINT_ON;
+}
+
+/**
+ *  @brief      Disables interrupts when the CPU is in debug mode. Interrupts
+ *              of the RTC Common module will not be captured. There will be no
+ *              updates to the RTCRIS, RTCMISC and RTCIIDX registers.
+ *
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ */
+__STATIC_INLINE void DL_RTC_Common_disableDebugInterrupts(RTC_Regs *rtc_common)
+{
+    rtc_common->DBGCTL &= ~(RTC_DBGCTL_DBGINT_MASK);
+}
+
+/**
+ *  @brief      Enables the RTC Common modules debug mode.
+ *
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ */
+__STATIC_INLINE void DL_RTC_Common_enableDebugMode(RTC_Regs *rtc_common)
+{
+    rtc_common->DBGCTL |= RTC_DBGCTL_DBGRUN_RUN;
+}
+
+/**
+ *  @brief      Disables the RTC Common modules debug mode.
+ *
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ */
+__STATIC_INLINE void DL_RTC_Common_disableDebugMode(RTC_Regs *rtc_common)
+{
+    rtc_common->DBGCTL &= ~(RTC_DBGCTL_DBGRUN_MASK);
+}
+
+/**
+ *  @brief      Set the format of the real-time clock
+ *
+ * The format must be selected before the time is set.
+ *
+ *  @param[in]  rtc_common     Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  formatSelect    Selectable format the RTC Common peripheral will
+ *                              provide time in. One of @ref DL_RTC_COMMON_FORMAT
+ */
+__STATIC_INLINE void DL_RTC_Common_setClockFormat(
+    RTC_Regs *rtc_common, DL_RTC_COMMON_FORMAT formatSelect)
+{
+    rtc_common->CTL |= (uint32_t) formatSelect;
+}
+
+/**
+ *  @brief      Get the format currently being used for counting the
+ *              real-time clock.
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            Format for counting the real-time clock.
+ *
+ *  @retval            One of @ref DL_RTC_COMMON_FORMAT
+ */
+__STATIC_INLINE DL_RTC_COMMON_FORMAT DL_RTC_Common_getClockFormat(
+    RTC_Regs *rtc_common)
+{
+    uint32_t format = (rtc_common->CTL & RTC_CTL_RTCBCD_MASK);
+
+    return (DL_RTC_COMMON_FORMAT)(format);
+}
+
+/**
+ *  @brief      Sets the interval alarm event condition
+ *
+ * The interval alarm can be configured to generate an interval alarm event
+ * when one of the following events occurs:
+ * - MIN changes
+ * - HOUR changes
+ * - Every day at midnight (00:00:00)
+ * - Every day at noon (12:00:00)
+ *
+ * The interval alarm sources the @ref DL_RTC_COMMON_INTERRUPT_INTERVAL_ALARM interrupt
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  alarmEvent  The interval alarm interrupt condition. One of
+ *                          @ref DL_RTC_COMMON_INTERVAL_ALARM
+ */
+__STATIC_INLINE void DL_RTC_Common_setIntervalAlarm(
+    RTC_Regs *rtc_common, DL_RTC_COMMON_INTERVAL_ALARM alarmEvent)
+{
+    DL_Common_updateReg(
+        &rtc_common->CTL, (uint32_t) alarmEvent, RTC_CTL_RTCTEVTX_MASK);
+}
+
+/**
+ *  @brief      Gets the interval alarm event condition
+ *
+ * The interval alarm can be configured to generate an interval alarm event
+ * when one of the following events occurs:
+ * - MIN changes
+ * - HOUR changes
+ * - Every day at midnight (00:00:00)
+ * - Every day at noon (12:00:00)
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return DL_RTC_COMMON_INTERVAL_ALARM
+ */
+__STATIC_INLINE DL_RTC_COMMON_INTERVAL_ALARM DL_RTC_Common_getIntervalAlarm(
+    RTC_Regs *rtc_common)
+{
+    uint32_t alarm = (rtc_common->CTL & RTC_CTL_RTCTEVTX_MASK);
+
+    return (DL_RTC_COMMON_INTERVAL_ALARM)(alarm);
+}
+
+/**
+ *  @brief      Checks if RTC Common is safe for reading
+ *
+ * This API checks if the counter/calender registers can be safely read.
+ *
+ * The RTC Common counter/calendar registers are updated once per second. To prevent
+ * reading any counter/calendar register at the time of an update (which could
+ * result in an invalid time being read), a keep-out window is provided. The
+ * keep-out window is approximately 128/32768 seconds before the counters
+ * update.
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return true if RTC Common is safe for reading
+ *  @return false if RTC Common values are in transition
+ *
+ */
+__STATIC_INLINE bool DL_RTC_Common_isSafeToRead(RTC_Regs *rtc_common)
+{
+    return ((rtc_common->STA & RTC_STA_RTCRDY_MASK) == RTC_STA_RTCRDY_READY);
+}
+
+/**
+ *  @brief      Checks if RTC Common is ready to get new calibration values
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return true if RTC Common can get new calibration values
+ *  @return false if RTC Common is not ready to get new calibration values
+ *
+ */
+__STATIC_INLINE bool DL_RTC_Common_isReadyToCalibrate(RTC_Regs *rtc_common)
+{
+    return (
+        (rtc_common->STA & RTC_STA_RTCTCRDY_MASK) == RTC_STA_RTCTCRDY_READY);
+}
+
+/**
+ *  @brief      Checks if RTC Common new calibration values were written OK
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return true if calibration write was successful
+ *  @return false if calibration write was unsuccessful
+ *
+ */
+__STATIC_INLINE bool DL_RTC_Common_isCalibrationWriteResultOK(
+    RTC_Regs *rtc_common)
+{
+    return ((rtc_common->STA & RTC_STA_RTCTCOK_MASK) == RTC_STA_RTCTCOK_OK);
+}
+
+/**
+ *  @brief      Sets output frequency for offset calibration
+ *
+ * Sets the frequency output to RTC_OUT pin for calibration measurement.
+ * The corresponding port must be configured for the peripheral module
+ * function.
+ *
+ *  @param[in]  rtc_common   Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  offsetFrequency   The frequency of offset calibration.
+ *                                Valid values are one of
+ *                                @ref DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY
+ */
+__STATIC_INLINE void DL_RTC_Common_setOffsetCalibrationFrequency(
+    RTC_Regs *rtc_common,
+    DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY offsetFrequency)
+{
+    DL_Common_updateReg(
+        &rtc_common->CAL, (uint32_t) offsetFrequency, RTC_CAL_RTCCALFX_MASK);
+}
+
+/**
+ *  @brief      Sets the offset error calibration adjustment value.
+ *
+ * Each LSB represents approximately +1ppm (RTCOCALXS = 1) or
+ * -1ppm (RTCOCALXS = 0) adjustment in frequency. Maximum effective calibration
+ * value is +/-240ppm.
+ * Excess values written above +/-240ppm will be ignored by hardware.
+ *
+ *  @param[in]  rtc_common   Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  offsetSign        The sign of offset calibration.
+ *                                Valid values are one of
+ *                                @ref DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN
+ *  @param[in]  offsetValue       The value that the offset will be a factor of.
+ *                                Must be any integer from 1-240.
+ */
+__STATIC_INLINE void DL_RTC_Common_setOffsetCalibrationAdjValue(
+    RTC_Regs *rtc_common, DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN offsetSign,
+    uint8_t offsetValue)
+{
+    DL_Common_updateReg(&rtc_common->CAL,
+        ((uint32_t) offsetSign | (uint32_t) offsetValue),
+        (RTC_CAL_RTCOCALX_MASK | RTC_CAL_RTCOCALS_MASK));
+}
+
+/**
+ *  @brief      Sets the offset error calibration.
+ *
+ * Each LSB represents approximately +1ppm (RTCOCALXS = 1) or
+ * -1ppm (RTCOCALXS = 0) adjustment in frequency. Maximum effective calibration
+ * value is +/-240ppm.
+ * Excess values written above +/-240ppm will be ignored by hardware.
+ *
+ * Sets the frequency output to RTCCLK pin for calibration measurement.
+ * The corresponding port must be configured for the peripheral module
+ * function.
+ *
+ *  @param[in]  rtc_common   Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  offsetFrequency   The frequency of offset calibration.
+ *                                Valid values are one of
+ *                                @ref DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY
+ *  @param[in]  offsetSign        The sign of offset calibration.
+ *                                Valid values are one of
+ *                                @ref DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN
+ *  @param[in]  offsetValue       The value that the offset will be a factor of.
+ *                                Must be any integer from 1-240.
+ */
+__STATIC_INLINE void DL_RTC_Common_setOffsetCalibration(RTC_Regs *rtc_common,
+    DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY offsetFrequency,
+    DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN offsetSign, uint8_t offsetValue)
+{
+    rtc_common->CAL = (offsetValue & RTC_CAL_RTCOCALX_MASK) |
+                      (uint32_t) offsetFrequency | (uint32_t) offsetSign;
+}
+
+/**
+ *  @brief      Gets the offset calibration frequency.
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            Frequency used in offset calibration.
+ *
+ *  @retval            One of @ref DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY
+ */
+__STATIC_INLINE DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY
+DL_RTC_Common_getOffsetCalibrationFrequency(RTC_Regs *rtc_common)
+{
+    uint32_t freq = (rtc_common->CAL & RTC_CAL_RTCCALFX_MASK);
+
+    return (DL_RTC_COMMON_OFFSET_CALIBRATION_FREQUENCY)(freq);
+}
+
+/**
+ *  @brief      Gets the offset calibration sign.
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            Sign used in offset calibration.
+ *
+ *  @retval            One of @ref DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN
+ */
+__STATIC_INLINE DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN
+DL_RTC_Common_getOffsetCalibrationSign(RTC_Regs *rtc_common)
+{
+    uint32_t sign = (rtc_common->CAL & RTC_CAL_RTCOCALS_MASK);
+
+    return (DL_RTC_COMMON_OFFSET_CALIBRATION_SIGN)(sign);
+}
+
+/**
+ *  @brief      Set the specified RTC Common temperature compensation.
+ *
+ *  This function sets the calibration offset to make the RTC Common as accurate as
+ *  possible. The offsetDirection can be either +1-ppm or -1-ppm, and the
+ *  offsetValue should be from 1-240 and is multiplied by the direction setting
+ *  (i.e. +1-ppm * 8 (offsetValue) = +8-ppm).
+ *
+ *  @param[in]  rtc_common             Pointer to the register overlay for the RTC Common
+ *                                peripheral
+ *  @param[in]  offsetDirection   The direction that the calibration offset
+ *                                will go. Valid values are one of
+ *                                @ref DL_RTC_COMMON_TEMP_CALIBRATION
+ *  @param[in]  offsetValue       The value that the offset will be a factor of.
+ *                                Must be any integer from 1-240.
+ */
+__STATIC_INLINE void DL_RTC_Common_setTemperatureCompensation(
+    RTC_Regs *rtc_common, DL_RTC_COMMON_TEMP_CALIBRATION offsetDirection,
+    uint32_t offsetValue)
+{
+    rtc_common->TCMP =
+        (offsetValue & RTC_TCMP_RTCTCMPX_MASK) | (uint32_t) offsetDirection;
+}
+
+/**
+ *  @brief      Get the RTC Common temperature compensation.
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The cumulative temperature compensation
+ *
+ *  @retval            Signed addition of RTCOCALX and RTCTCMPX values, and
+ *                     the updated sign bit (RTCTCMPS) of the addition result.
+ *
+ */
+__STATIC_INLINE uint32_t DL_RTC_Common_getTemperatureCompensation(
+    RTC_Regs *rtc_common)
+{
+    return (rtc_common->TCMP);
+}
+
+/**
+ *  @brief      Set the seconds in BCD in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  seconds    Value for the seconds of the RTC Common calendar
+ *                         Valid values are 0x0-0x59.
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarSecondsBCD(
+    RTC_Regs *rtc_common, uint8_t seconds)
+{
+    rtc_common->SEC = ((uint32_t) seconds << RTC_SEC_SECLOWBCD_OFS) &
+                      (RTC_SEC_SECLOWBCD_MASK | RTC_SEC_SECHIGHBCD_MASK);
+}
+
+/**
+ *  @brief      Get the seconds in in BCD the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The seconds in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0x0-0x59
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getCalendarSecondsBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->SEC &
+                         (RTC_SEC_SECLOWBCD_MASK | RTC_SEC_SECHIGHBCD_MASK)) >>
+                     RTC_SEC_SECLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Set the minutes in in BCD the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  minutes    Value for the minutes of the RTC Common calendar
+ *                         Valid values are 0x0-0x59.
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarMinutesBCD(
+    RTC_Regs *rtc_common, uint8_t minutes)
+{
+    rtc_common->MIN = ((uint32_t) minutes << RTC_MIN_MINLOWBCD_OFS) &
+                      (RTC_MIN_MINLOWBCD_MASK | RTC_MIN_MINHIGHBCD_MASK);
+}
+
+/**
+ *  @brief      Get the minutes in in BCD the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The minutes in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0x0-0x59
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getCalendarMinutesBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->MIN &
+                         (RTC_MIN_MINLOWBCD_MASK | RTC_MIN_MINHIGHBCD_MASK)) >>
+                     RTC_MIN_MINLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Set the hours in in BCD the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  hours    Value for the hours of the RTC Common calendar
+ *                       Valid values are 0x0-0x23
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarHoursBCD(
+    RTC_Regs *rtc_common, uint8_t hours)
+{
+    rtc_common->HOUR = ((uint32_t) hours << RTC_HOUR_HOURLOWBCD_OFS) &
+                       (RTC_HOUR_HOURLOWBCD_MASK | RTC_HOUR_HOURHIGHBCD_MASK);
+}
+
+/**
+ *  @brief      Get the hours in in BCD the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The hours in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0x0-0x23
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getCalendarHoursBCD(RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->HOUR & (RTC_HOUR_HOURLOWBCD_MASK |
+                                             RTC_HOUR_HOURHIGHBCD_MASK)) >>
+                     RTC_HOUR_HOURLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Set the day of the week in BCD in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  day    Value for the day of the week of the RTC Common calendar
+ *                     Valid values are 0x0-0x6
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarDayOfWeekBCD(
+    RTC_Regs *rtc_common, uint8_t day)
+{
+    DL_Common_updateReg(&rtc_common->DAY, day, RTC_DAY_DOW_MASK);
+}
+
+/**
+ *  @brief      Get the day of the week in BCD in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The day of the week in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0x0-0x6
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getCalendarDayOfWeekBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->DAY & RTC_DAY_DOW_MASK);
+}
+
+/**
+ *  @brief      Set the day of the month in BCD in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  day    Value for the day of the month of the RTC Common calendar
+ *                     Valid values are 0x1-0x31
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarDayOfMonthBCD(
+    RTC_Regs *rtc_common, uint8_t day)
+{
+    DL_Common_updateReg(&rtc_common->DAY,
+        (uint32_t) day << RTC_DAY_DOMLOWBCD_OFS,
+        (RTC_DAY_DOMLOWBCD_MASK | RTC_DAY_DOMHIGHBCD_MASK));
+}
+
+/**
+ *  @brief      Get the day of the month in BCD in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The day of the month in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0x1-0x31
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getCalendarDayOfMonthBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->DAY &
+                         (RTC_DAY_DOMLOWBCD_MASK | RTC_DAY_DOMHIGHBCD_MASK)) >>
+                     RTC_DAY_DOMLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Set the month in in BCD the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  month    Value for the month of the RTC Common calendar
+ *                       Valid values are 0x1-0x12
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarMonthBCD(
+    RTC_Regs *rtc_common, uint8_t month)
+{
+    rtc_common->MON = ((uint32_t) month << RTC_MON_MONLOWBCD_OFS) &
+                      (RTC_MON_MONLOWBCD_MASK | RTC_MON_MONHIGHBCD_MASK);
+}
+
+/**
+ *  @brief      Get the month of the year in BCD in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The month of the year in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0x1-0x12
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getCalendarMonthBCD(RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->MON &
+                         (RTC_MON_MONLOWBCD_MASK | RTC_MON_MONHIGHBCD_MASK)) >>
+                     RTC_MON_MONLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Set the year in in BCD the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  year    Value for the year of the RTC Common calendar
+ *                      Valid values are 0x0-0x4095
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarYearBCD(
+    RTC_Regs *rtc_common, uint16_t year)
+{
+    rtc_common->YEAR =
+        ((uint32_t) year << RTC_YEAR_YEARLOWESTBCD_OFS) &
+        (RTC_YEAR_YEARLOWESTBCD_MASK | RTC_YEAR_DECADEBCD_MASK |
+            RTC_YEAR_CENTLOWBCD_MASK | RTC_YEAR_CENTHIGHBCD_MASK);
+}
+
+/**
+ *  @brief      Get the year in in BCD the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The year in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0x0-0x4095
+ *
+ */
+__STATIC_INLINE uint16_t DL_RTC_Common_getCalendarYearBCD(RTC_Regs *rtc_common)
+{
+    return (uint16_t)(
+        (rtc_common->YEAR &
+            (RTC_YEAR_YEARLOWESTBCD_MASK | RTC_YEAR_DECADEBCD_MASK |
+                RTC_YEAR_CENTLOWBCD_MASK | RTC_YEAR_CENTHIGHBCD_MASK)) >>
+        RTC_YEAR_YEARLOWESTBCD_OFS);
+}
+
+/**
+ *  @brief      Enable minutes in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm1MinutesBCD(RTC_Regs *rtc_common)
+{
+    rtc_common->A1MIN |= RTC_A1MIN_AMINAEBCD_ENABLE;
+}
+
+/**
+ *  @brief      Disable minutes in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm1MinutesBCD(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A1MIN &= ~(RTC_A1MIN_AMINAEBCD_MASK);
+}
+
+/**
+ *  @brief      Set the minutes in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  minutes    Value for the minutes of alarm 1
+ *                         Valid values are 0x0-0x59
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm1MinutesBCD(
+    RTC_Regs *rtc_common, uint8_t minutes)
+{
+    rtc_common->A1MIN =
+        ((uint32_t) minutes << RTC_A1MIN_AMINLOWBCD_OFS) &
+        (RTC_A1MIN_AMINLOWBCD_MASK | RTC_A1MIN_AMINHIGHBCD_MASK);
+}
+
+/**
+ *  @brief      Get the minutes in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The minutes of alarm 1
+ *
+ *  @retval            Value in range: 0x0-0x59
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm1MinutesBCD(RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->A1MIN & (RTC_A1MIN_AMINLOWBCD_MASK |
+                                              RTC_A1MIN_AMINHIGHBCD_MASK)) >>
+                     RTC_A1MIN_AMINLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Enable hours in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm1HoursBCD(RTC_Regs *rtc_common)
+{
+    rtc_common->A1HOUR |= RTC_A1HOUR_AHOURAEBIN_ENABLE;
+}
+
+/**
+ *  @brief      Disable hours in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm1HoursBCD(RTC_Regs *rtc_common)
+{
+    rtc_common->A1HOUR &= ~(RTC_A1HOUR_AHOURAEBIN_MASK);
+}
+
+/**
+ *  @brief      Set the hours in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  hours    Value for the hours of alarm 1
+ *                       Valid values are 0x0-0x23
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm1HoursBCD(
+    RTC_Regs *rtc_common, uint8_t hours)
+{
+    rtc_common->A1HOUR =
+        ((uint32_t) hours << RTC_A1HOUR_AHOURLOWBCD_OFS) &
+        (RTC_A1HOUR_AHOURLOWBCD_MASK | RTC_A1HOUR_AHOURHIGHBCD_MASK);
+}
+
+/**
+ *  @brief      Get the hours in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The hours of alarm 1
+ *
+ *  @retval            Value in range: 0x0-0x23
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm1HoursBCD(RTC_Regs *rtc_common)
+{
+    return (uint8_t)(
+        (rtc_common->A1HOUR &
+            (RTC_A1HOUR_AHOURLOWBCD_MASK | RTC_A1HOUR_AHOURHIGHBCD_MASK)) >>
+        RTC_A1HOUR_AHOURLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Enable day of the week in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm1DayOfWeekBCD(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A1DAY |= RTC_A1DAY_ADOWAE_ENABLE;
+}
+
+/**
+ *  @brief      Disable day of the week in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm1DayOfWeekBCD(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A1DAY &= ~(RTC_A1DAY_ADOWAE_MASK);
+}
+
+/**
+ *  @brief      Set the day of the week in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  day    Value for the day of the week of the RTC Common calendar
+ *                     Valid values are 0x0-0x6
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm1DayOfWeekBCD(
+    RTC_Regs *rtc_common, uint8_t day)
+{
+    DL_Common_updateReg(&rtc_common->A1DAY, day, RTC_A1DAY_ADOW_MASK);
+}
+
+/**
+ *  @brief      Get the day of the week in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The day of the week in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0x0-0x6
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm1DayOfWeekBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->DAY & RTC_A1DAY_ADOW_MASK);
+}
+
+/**
+ *  @brief      Enable day of the month in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm1DayOfMonthBCD(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A1DAY |= RTC_A1DAY_ADOMAEBCD_ENABLE;
+}
+
+/**
+ *  @brief      Disable day of the month in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm1DayOfMonthBCD(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A1DAY &= ~(RTC_A1DAY_ADOMAEBCD_MASK);
+}
+
+/**
+ *  @brief      Set the day of the month in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  day    Value for the day of the month of the RTC Common calendar
+ *                     Valid values are 0x1-0x31
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm1DayOfMonthBCD(
+    RTC_Regs *rtc_common, uint8_t day)
+{
+    DL_Common_updateReg(&rtc_common->A1DAY,
+        (uint32_t) day << RTC_A1DAY_ADOMLOWBCD_OFS,
+        (RTC_A1DAY_ADOMLOWBCD_MASK | RTC_A1DAY_ADOMHIGHBCD_MASK));
+}
+
+/**
+ *  @brief      Get the day of the month in BCD for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The day of the month in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0x1-0x31
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm1DayOfMonthBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->A1DAY & (RTC_A1DAY_ADOMLOWBCD_MASK |
+                                              RTC_A1DAY_ADOMHIGHBCD_MASK)) >>
+                     RTC_A1DAY_ADOMLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Enable minutes in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm2MinutesBCD(RTC_Regs *rtc_common)
+{
+    rtc_common->A2MIN |= RTC_A2MIN_AMINAEBCD_ENABLE;
+}
+
+/**
+ *  @brief      Disable minutes in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm2MinutesBCD(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A2MIN &= ~(RTC_A2MIN_AMINAEBCD_MASK);
+}
+
+/**
+ *  @brief      Set the minutes in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common      Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  minutes    Value for the minutes of alarm 2
+ *                         Valid values are 0x0-0x59
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm2MinutesBCD(
+    RTC_Regs *rtc_common, uint8_t minutes)
+{
+    rtc_common->A2MIN =
+        ((uint32_t) minutes << RTC_A2MIN_AMINLOWBCD_OFS) &
+        (RTC_A2MIN_AMINLOWBCD_MASK | RTC_A2MIN_AMINHIGHBCD_MASK);
+}
+
+/**
+ *  @brief      Get the minutes in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The minutes of alarm 2
+ *
+ *  @retval            Value in range: 0x0-0x59
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm2MinutesBCD(RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->A2MIN & (RTC_A2MIN_AMINLOWBCD_MASK |
+                                              RTC_A2MIN_AMINHIGHBCD_MASK)) >>
+                     RTC_A2MIN_AMINLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Enable hours in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm2HoursBCD(RTC_Regs *rtc_common)
+{
+    rtc_common->A2HOUR |= RTC_A2HOUR_AHOURAEBIN_ENABLE;
+}
+
+/**
+ *  @brief      Disable hours in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm2HoursBCD(RTC_Regs *rtc_common)
+{
+    rtc_common->A2HOUR &= ~(RTC_A2HOUR_AHOURAEBIN_MASK);
+}
+
+/**
+ *  @brief      Set the hours in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  hours    Value for the hours of alarm 2
+ *                       Valid values are 0x0-0x23
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm2HoursBCD(
+    RTC_Regs *rtc_common, uint8_t hours)
+{
+    rtc_common->A2HOUR =
+        ((uint32_t) hours << RTC_A2HOUR_AHOURLOWBCD_OFS) &
+        (RTC_A2HOUR_AHOURLOWBCD_MASK | RTC_A2HOUR_AHOURHIGHBCD_MASK);
+}
+
+/**
+ *  @brief      Get the hours in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The hours of alarm 2
+ *
+ *  @retval            Value in range: 0x0-0x23
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm2HoursBCD(RTC_Regs *rtc_common)
+{
+    return (uint8_t)(
+        (rtc_common->A2HOUR &
+            (RTC_A2HOUR_AHOURLOWBCD_MASK | RTC_A2HOUR_AHOURHIGHBCD_MASK)) >>
+        RTC_A2HOUR_AHOURLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Enable day of the week in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm2DayOfWeekBCD(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A2DAY |= RTC_A2DAY_ADOWAE_ENABLE;
+}
+
+/**
+ *  @brief      Disable day of the week in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm2DayOfWeekBCD(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A2DAY &= ~(RTC_A2DAY_ADOWAE_MASK);
+}
+
+/**
+ *  @brief      Set the day of the week in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  day    Value for the day of the week of the RTC Common calendar
+ *                     Valid values are 0x0-0x6
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm2DayOfWeekBCD(
+    RTC_Regs *rtc_common, uint8_t day)
+{
+    DL_Common_updateReg(&rtc_common->A2DAY, day, RTC_A2DAY_ADOW_MASK);
+}
+
+/**
+ *  @brief      Get the day of the week in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The day of the week in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0x0-0x6
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm2DayOfWeekBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->DAY & RTC_A2DAY_ADOW_MASK);
+}
+
+/**
+ *  @brief      Enable day of the month in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm2DayOfMonthBCD(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A2DAY |= RTC_A2DAY_ADOMAEBCD_ENABLE;
+}
+
+/**
+ *  @brief      Disable day of the month in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm2DayOfMonthBCD(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A2DAY &= ~(RTC_A2DAY_ADOMAEBCD_MASK);
+}
+
+/**
+ *  @brief      Set the day of the month in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  day    Value for the day of the month of the RTC Common calendar
+ *                     Valid values are 0x1-0x31
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm2DayOfMonthBCD(
+    RTC_Regs *rtc_common, uint8_t day)
+{
+    DL_Common_updateReg(&rtc_common->A2DAY,
+        (uint32_t) day << RTC_A2DAY_ADOMLOWBCD_OFS,
+        (RTC_A2DAY_ADOMLOWBCD_MASK | RTC_A2DAY_ADOMHIGHBCD_MASK));
+}
+
+/**
+ *  @brief      Get the day of the month in BCD for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The day of the month in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0x1-0x31
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm2DayOfMonthBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->A2DAY & (RTC_A2DAY_ADOMLOWBCD_MASK |
+                                              RTC_A2DAY_ADOMHIGHBCD_MASK)) >>
+                     RTC_A2DAY_ADOMLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Set the seconds in binary the RTC Common calendar
+ *
+ *  @param[in]  rtc_common      Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  seconds    Value for the seconds of the RTC Common calendar
+ *                         Valid values are 0-59
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarSecondsBinary(
+    RTC_Regs *rtc_common, uint8_t seconds)
+{
+    rtc_common->SEC = (seconds & RTC_SEC_SECBIN_MASK);
+}
+
+/**
+ *  @brief      Get the seconds in binary in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The seconds in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0-59
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getCalendarSecondsBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->SEC & RTC_SEC_SECBIN_MASK);
+}
+
+/**
+ *  @brief      Set the minutes in binary in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  minutes    Value for the minutes of the RTC Common calendar
+ *                         Valid values are 0-59
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarMinutesBinary(
+    RTC_Regs *rtc_common, uint8_t minutes)
+{
+    rtc_common->MIN = (minutes & RTC_MIN_MINBIN_MASK);
+}
+
+/**
+ *  @brief      Get the minutes in binary in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The minutes in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0-59
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getCalendarMinutesBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->MIN & RTC_MIN_MINBIN_MASK);
+}
+
+/**
+ *  @brief      Set the hours in binary in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  hours    Value for the hours of the RTC Common calendar
+ *                       Valid values are 0-23
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarHoursBinary(
+    RTC_Regs *rtc_common, uint8_t hours)
+{
+    rtc_common->HOUR = (hours & RTC_HOUR_HOURBIN_MASK);
+}
+
+/**
+ *  @brief      Get the hours in binary in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The hours in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0-23
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getCalendarHoursBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->HOUR & RTC_HOUR_HOURBIN_MASK);
+}
+
+/**
+ *  @brief      Set the day of the week in binary in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  day    Value for the day of the week of the RTC Common calendar
+ *                     Valid values are 0-6
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarDayOfWeekBinary(
+    RTC_Regs *rtc_common, uint8_t day)
+{
+    DL_Common_updateReg(&rtc_common->DAY, day, RTC_DAY_DOW_MASK);
+}
+
+/**
+ *  @brief      Get the day of the week in binary in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The day of the week in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0-6
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getCalendarDayOfWeekBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->DAY & RTC_DAY_DOW_MASK);
+}
+
+/**
+ *  @brief      Set the day of the month in binary in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  day    Value for the day of the month of the RTC Common calendar
+ *                     Valid values are 1-31
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarDayOfMonthBinary(
+    RTC_Regs *rtc_common, uint8_t day)
+{
+    DL_Common_updateReg(&rtc_common->DAY, (uint32_t) day << RTC_DAY_DOMBIN_OFS,
+        RTC_DAY_DOMBIN_MASK);
+}
+
+/**
+ *  @brief      Get the day of the month in binary in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The day of the month in the RTC Common calendar
+ *
+ *  @retval            Value in range: 1-31
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getCalendarDayOfMonthBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(
+        (rtc_common->DAY & RTC_DAY_DOMBIN_MASK) >> RTC_DAY_DOMBIN_OFS);
+}
+
+/**
+ *  @brief      Set the month in binary in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  month    Value for the month of the RTC Common calendar
+ *                       Valid values are 1-12
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarMonthBinary(
+    RTC_Regs *rtc_common, uint8_t month)
+{
+    rtc_common->MON = (month & RTC_MON_MONBIN_MASK);
+}
+
+/**
+ *  @brief      Get the month of the year in binary in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The month of the year in the RTC Common calendar
+ *
+ *  @retval            Value in range: 1-12
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getCalendarMonthBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->MON & RTC_MON_MONBIN_MASK);
+}
+
+/**
+ *  @brief      Set the year in binary in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  year    Value for the year of the RTC Common calendar
+ *                      Valid values are 0-4095
+ */
+__STATIC_INLINE void DL_RTC_Common_setCalendarYearBinary(
+    RTC_Regs *rtc_common, uint16_t year)
+{
+    rtc_common->YEAR = ((uint32_t) year & (RTC_YEAR_YEARLOWBIN_MASK |
+                                              RTC_YEAR_YEARHIGHBIN_MASK));
+}
+
+/**
+ *  @brief      Get the year in binary in the RTC Common calendar
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The year in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0-4095
+ *
+ */
+__STATIC_INLINE uint16_t DL_RTC_Common_getCalendarYearBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint16_t)(rtc_common->YEAR &
+                      (RTC_YEAR_YEARLOWBIN_MASK | RTC_YEAR_YEARHIGHBIN_MASK));
+}
+
+/**
+ *  @brief      Enable minutes in binary in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm1MinutesBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A1MIN |= RTC_A1MIN_AMINAEBIN_ENABLE;
+}
+
+/**
+ *  @brief      Disable minutes in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm1MinutesBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A1MIN &= ~(RTC_A1MIN_AMINAEBIN_MASK);
+}
+
+/**
+ *  @brief      Set the minutes in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  minutes    Value for the minutes of alarm 1
+ *                         Valid values are 0-59
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm1MinutesBinary(
+    RTC_Regs *rtc_common, uint8_t minutes)
+{
+    rtc_common->A1MIN = (minutes & RTC_A1MIN_AMINBIN_MASK);
+}
+
+/**
+ *  @brief      Get the minutes in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The minutes of alarm 1
+ *
+ *  @retval            Value in range: 0-59
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm1MinutesBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->A1MIN & RTC_A1MIN_AMINBIN_MASK);
+}
+
+/**
+ *  @brief      Enable hours in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm1HoursBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A1HOUR |= RTC_A1HOUR_AHOURAEBIN_ENABLE;
+}
+
+/**
+ *  @brief      Disable hours in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm1HoursBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A1HOUR &= ~(RTC_A1HOUR_AHOURAEBIN_MASK);
+}
+
+/**
+ *  @brief      Set the hours in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  hours    Value for the hours of alarm 1
+ *                       Valid values are 0-23
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm1HoursBinary(
+    RTC_Regs *rtc_common, uint8_t hours)
+{
+    rtc_common->A1HOUR = (hours & RTC_A1HOUR_AHOURBIN_MASK);
+}
+
+/**
+ *  @brief      Get the hours in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The hours of alarm 1
+ *
+ *  @retval            Value in range: 0-23
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm1HoursBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->A1HOUR & RTC_A1HOUR_AHOURBIN_MASK);
+}
+
+/**
+ *  @brief      Enable day of the week in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm1DayOfWeekBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A1DAY |= RTC_A1DAY_ADOWAE_ENABLE;
+}
+
+/**
+ *  @brief      Disable day of the week in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm1DayOfWeekBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A1DAY &= ~(RTC_A1DAY_ADOWAE_MASK);
+}
+
+/**
+ *  @brief      Set the day of the week in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  day    Value for the day of the week of the RTC Common calendar
+ *                     Valid values are 0-6
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm1DayOfWeekBinary(
+    RTC_Regs *rtc_common, uint8_t day)
+{
+    DL_Common_updateReg(&rtc_common->A1DAY, day, RTC_A1DAY_ADOW_MASK);
+}
+
+/**
+ *  @brief      Get the day of the week in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The day of the week in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0-6
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm1DayOfWeekBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->A1DAY & RTC_A1DAY_ADOW_MASK);
+}
+
+/**
+ *  @brief      Enable day of the month in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm1DayOfMonthBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A1DAY |= RTC_A1DAY_ADOMAEBIN_ENABLE;
+}
+
+/**
+ *  @brief      Disable day of the month in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm1DayOfMonthBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A1DAY &= ~(RTC_A1DAY_ADOMAEBIN_MASK);
+}
+
+/**
+ *  @brief      Set the day of the month in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  day    Value for the day of the month of the RTC Common calendar
+ *                     Valid values are 1-31
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm1DayOfMonthBinary(
+    RTC_Regs *rtc_common, uint8_t day)
+{
+    DL_Common_updateReg(&rtc_common->A1DAY,
+        (uint32_t) day << RTC_A1DAY_ADOMBIN_OFS, RTC_A1DAY_ADOMBIN_MASK);
+}
+
+/**
+ *  @brief      Get the day of the month in binary for RTC Common Calendar Alarm 1
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The day of the month in the RTC Common calendar
+ *
+ *  @retval            Value in range: 1-31
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm1DayOfMonthBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(
+        (rtc_common->A1DAY & RTC_A1DAY_ADOMBIN_MASK) >> RTC_A1DAY_ADOMBIN_OFS);
+}
+
+/**
+ *  @brief      Enable minutes in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm2MinutesBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A2MIN |= RTC_A2MIN_AMINAEBIN_ENABLE;
+}
+
+/**
+ *  @brief      Disable minutes in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm2MinutesBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A2MIN &= ~(RTC_A2MIN_AMINAEBIN_MASK);
+}
+
+/**
+ *  @brief      Set the minutes in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  minutes    Value for the minutes of alarm 2
+ *                         Valid values are 0-59
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm2MinutesBinary(
+    RTC_Regs *rtc_common, uint8_t minutes)
+{
+    rtc_common->A2MIN = (minutes & RTC_A2MIN_AMINBIN_MASK);
+}
+
+/**
+ *  @brief      Get the minutes in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The minutes of alarm 2
+ *
+ *  @retval            Value in range: 0-59
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm2MinutesBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->A2MIN & RTC_A2MIN_AMINBIN_MASK);
+}
+
+/**
+ *  @brief      Enable hours in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm2HoursBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A2HOUR |= RTC_A2HOUR_AHOURAEBIN_ENABLE;
+}
+
+/**
+ *  @brief      Disable hours in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm2HoursBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A2HOUR &= ~(RTC_A2HOUR_AHOURAEBIN_MASK);
+}
+
+/**
+ *  @brief      Set the hours in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  hours    Value for the hours of alarm 2
+ *                       Valid values are 0-23
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm2HoursBinary(
+    RTC_Regs *rtc_common, uint8_t hours)
+{
+    rtc_common->A2HOUR = (hours & RTC_A2HOUR_AHOURBIN_MASK);
+}
+
+/**
+ *  @brief      Get the hours in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The hours of alarm 2
+ *
+ *  @retval            Value in range: 0-23
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm2HoursBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->A2HOUR & RTC_A2HOUR_AHOURBIN_MASK);
+}
+
+/**
+ *  @brief      Enable day of the week in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm2DayOfWeekBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A2DAY |= RTC_A2DAY_ADOWAE_ENABLE;
+}
+
+/**
+ *  @brief      Disable day of the week in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm2DayOfWeekBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A2DAY &= ~(RTC_A2DAY_ADOWAE_MASK);
+}
+
+/**
+ *  @brief      Set the day of the week in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  day    Value for the day of the week of the RTC Common calendar
+ *                     Valid values are 0-6
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm2DayOfWeekBinary(
+    RTC_Regs *rtc_common, uint8_t day)
+{
+    DL_Common_updateReg(&rtc_common->A2DAY, day, RTC_A2DAY_ADOW_MASK);
+}
+
+/**
+ *  @brief      Get the day of the week in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The day of the week in the RTC Common calendar
+ *
+ *  @retval            Value in range: 0-6
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm2DayOfWeekBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->A2DAY & RTC_A2DAY_ADOW_MASK);
+}
+
+/**
+ *  @brief      Enable day of the month in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_enableAlarm2DayOfMonthBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A2DAY |= RTC_A2DAY_ADOMAEBIN_ENABLE;
+}
+
+/**
+ *  @brief      Disable day of the month in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_disableAlarm2DayOfMonthBinary(
+    RTC_Regs *rtc_common)
+{
+    rtc_common->A2DAY &= ~(RTC_A2DAY_ADOMAEBIN_MASK);
+}
+
+/**
+ *  @brief      Set the day of the month in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  day    Value for the day of the month of the RTC Common calendar
+ *                     Valid values are 1-31
+ */
+__STATIC_INLINE void DL_RTC_Common_setAlarm2DayOfMonthBinary(
+    RTC_Regs *rtc_common, uint8_t day)
+{
+    DL_Common_updateReg(&rtc_common->A2DAY,
+        (uint32_t) day << RTC_A2DAY_ADOMBIN_OFS, RTC_A2DAY_ADOMBIN_MASK);
+}
+
+/**
+ *  @brief      Get the day of the month in binary for RTC Common Calendar Alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            The day of the month in the RTC Common calendar
+ *
+ *  @retval            Value in range: 1-31
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getAlarm2DayOfMonthBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(
+        (rtc_common->A2DAY & RTC_A2DAY_ADOMBIN_MASK) >> RTC_A2DAY_ADOMBIN_OFS);
+}
+
+/**
+ *  @brief      Set prescale interrupt interval for timer 0 and 1
+ *
+ *  Set prescale timer interrupt interval to DL_RTC_COMMON_PRESCALE_NONE to keep the
+ *  timer disabled.
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @param[in]  prescaler0Divider    Value to set for prescaler 0
+ *                                       interrupt interval
+ *                                       One of @ref DL_RTC_COMMON_PRESCALER0_DIVIDE
+ *
+ *  @param[in]  prescaler1Divider    Value to set for prescaler 1
+ *                                       interrupt interval
+ *                                       One of @ref DL_RTC_COMMON_PRESCALER1_DIVIDE
+ *  @param[in]  prescaler2Divider    Value to set for prescaler 2
+ *                                   interrupt interval.
+ *                                   One of @ref DL_RTC_COMMON_PRESCALER2_DIVIDE
+ */
+__STATIC_INLINE void DL_RTC_Common_setPrescalerEvents(RTC_Regs *rtc_common,
+    DL_RTC_COMMON_PRESCALER0_DIVIDE prescaler0Divider,
+    DL_RTC_COMMON_PRESCALER1_DIVIDE prescaler1Divider,
+    DL_RTC_COMMON_PRESCALER2_DIVIDE prescaler2Divider)
+{
+    rtc_common->PSCTL =
+        (((uint32_t) prescaler0Divider & RTC_PSCTL_RT0IP_MASK) |
+            ((uint32_t) prescaler1Divider & RTC_PSCTL_RT1IP_MASK));
+    rtc_common->EXTPSCTL =
+        ((uint32_t) prescaler2Divider & RTC_EXTPSCTL_RT2PS_MASK);
+}
+
+/**
+ *  @brief      Set periodic alarm 0
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @param[in]  prescaler0Divider  Value to set for prescaler 0 interrupt
+ *                                 interval. One of @ref DL_RTC_COMMON_PRESCALER0_DIVIDE
+ *
+ */
+__STATIC_INLINE void DL_RTC_Common_setPeriodicAlarm0(
+    RTC_Regs *rtc_common, DL_RTC_COMMON_PRESCALER0_DIVIDE prescaler0Divider)
+{
+    DL_Common_updateReg(&rtc_common->PSCTL, (uint32_t) prescaler0Divider,
+        RTC_PSCTL_RT0IP_MASK);
+}
+
+/**
+ *  @brief      Set periodic alarm 1
+
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @param[in]  prescaler1Divider  Value to set for prescaler 1 interrupt
+ *                                 interval. One of @ref DL_RTC_COMMON_PRESCALER1_DIVIDE
+ */
+__STATIC_INLINE void DL_RTC_Common_setPeriodicAlarm1(
+    RTC_Regs *rtc_common, DL_RTC_COMMON_PRESCALER1_DIVIDE prescaler1Divider)
+{
+    DL_Common_updateReg(&rtc_common->PSCTL, (uint32_t) prescaler1Divider,
+        RTC_PSCTL_RT1IP_MASK);
+}
+
+/**
+ *  @brief      Set periodic alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @param[in]  prescaler2Divider  Value to set for prescaler 2 interrupt
+ *                                 interval. One of @ref DL_RTC_COMMON_PRESCALER2_DIVIDE
+ */
+__STATIC_INLINE void DL_RTC_Common_setPeriodicAlarm2(
+    RTC_Regs *rtc_common, DL_RTC_COMMON_PRESCALER2_DIVIDE prescaler2Divider)
+{
+    DL_Common_updateReg(&rtc_common->EXTPSCTL, (uint32_t) prescaler2Divider,
+        RTC_EXTPSCTL_RT2PS_MASK);
+}
+
+/**
+ *  @brief      Get prescaler 0 interrupt interval
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            Value for prescaler 0 interrupt interval
+ *
+ *  @retval            One of @ref DL_RTC_COMMON_PRESCALER0_DIVIDE
+ *
+ */
+__STATIC_INLINE DL_RTC_COMMON_PRESCALER0_DIVIDE DL_RTC_Common_getPrescaler0(
+    RTC_Regs *rtc_common)
+{
+    uint32_t prescaler = (rtc_common->PSCTL & RTC_PSCTL_RT0IP_MASK);
+
+    return (DL_RTC_COMMON_PRESCALER0_DIVIDE)(prescaler);
+}
+
+/**
+ *  @brief      Get prescaler 1 interrupt interval
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            Value for prescaler 1 interrupt interval
+ *
+ *  @retval            One of @ref DL_RTC_COMMON_PRESCALER1_DIVIDE
+ */
+__STATIC_INLINE DL_RTC_COMMON_PRESCALER1_DIVIDE DL_RTC_Common_getPrescaler1(
+    RTC_Regs *rtc_common)
+{
+    uint32_t prescaler = (rtc_common->PSCTL & RTC_PSCTL_RT1IP_MASK);
+
+    return (DL_RTC_COMMON_PRESCALER1_DIVIDE)(prescaler);
+}
+
+/**
+ *  @brief      Get prescaler 2 interrupt interval
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return            Value for prescaler 2 interrupt interval
+ *
+ *  @retval            One of @ref DL_RTC_COMMON_PRESCALER2_DIVIDE
+ */
+__STATIC_INLINE DL_RTC_COMMON_PRESCALER2_DIVIDE DL_RTC_Common_getPrescaler2(
+    RTC_Regs *rtc_common)
+{
+    uint32_t prescaler = (rtc_common->EXTPSCTL & RTC_EXTPSCTL_RT2PS_MASK);
+
+    return (DL_RTC_COMMON_PRESCALER2_DIVIDE)(prescaler);
+}
+
+/**
+ *  @brief      Get the seconds in BCD in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The seconds in the time stamp
+ *
+ *  @retval            Value in range: 0x0-0x59
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getTimeStampSecondsBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->TSSEC & (RTC_TSSEC_SECLOWBCD_MASK |
+                                              RTC_TSSEC_SECHIGHBCD_MASK)) >>
+                     RTC_TSSEC_SECLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Get the minutes in BCD in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The minutes in the time stamp
+ *
+ *  @retval            Value in range: 0x0-0x59
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getTimeStampMinutesBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->TSMIN & (RTC_TSMIN_MINLOWBCD_MASK |
+                                              RTC_TSMIN_MINHIGHBCD_MASK)) >>
+                     RTC_TSMIN_MINLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Get the hours in BCD in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The hours in the time stamp
+ *
+ *  @retval            Value in range: 0x0-0x23
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getTimeStampHoursBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->TSHOUR & (RTC_TSHOUR_HOURLOWBCD_MASK |
+                                               RTC_TSHOUR_HOURHIGHBCD_MASK)) >>
+                     RTC_TSHOUR_HOURLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Get the day of the week in BCD in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The day of the week in the time stamp
+ *
+ *  @retval            Value in range: 0x0-0x6
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getTimeStampDayOfWeekBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->TSDAY & RTC_TSDAY_DOW_MASK);
+}
+
+/**
+ *  @brief      Get the day of the month in BCD in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The day of the month in the time stamp
+ *
+ *  @retval            Value in range: 0x1-0x31
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getTimeStampDayOfMonthBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->TSDAY & (RTC_TSDAY_DOMLOWBCD_MASK |
+                                              RTC_TSDAY_DOMHIGHBCD_MASK)) >>
+                     RTC_TSDAY_DOMLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Get the month of the year in BCD in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The month of the year in the time stamp
+ *
+ *  @retval            Value in range: 0x1-0x12
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getTimeStampMonthBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)((rtc_common->TSMON & (RTC_TSMON_MONLOWBCD_MASK |
+                                              RTC_TSMON_MONHIGHBCD_MASK)) >>
+                     RTC_TSMON_MONLOWBCD_OFS);
+}
+
+/**
+ *  @brief      Get the year in BCD in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The year in the time stamp
+ *
+ *  @retval            Value in range: 0x0-0x4095
+ *
+ */
+__STATIC_INLINE uint16_t DL_RTC_Common_getTimeStampYearBCD(
+    RTC_Regs *rtc_common)
+{
+    return (uint16_t)(
+        (rtc_common->TSYEAR &
+            (RTC_TSYEAR_YERARLOWESTBCD_MASK | RTC_TSYEAR_DECADEBCD_MASK |
+                RTC_TSYEAR_CENTLOWBCD_MASK | RTC_TSYEAR_CENTHIGHBCD_MASK)) >>
+        RTC_TSYEAR_YERARLOWESTBCD_OFS);
+}
+
+/**
+ *  @brief      Get the seconds in binary in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The seconds in the time stamp
+ *  @retval            Value in range: 0-59
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getTimeStampSecondsBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->TSSEC & RTC_TSSEC_SECBIN_MASK);
+}
+
+/**
+ *  @brief      Get the minutes in binary in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The minutes in the time stamp
+ *
+ *  @retval            Value in range: 0-59
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getTimeStampMinutesBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->TSMIN & RTC_TSMIN_MINBIN_MASK);
+}
+
+/**
+ *  @brief      Get the hours in binary in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The hours in the time stamp
+ *
+ *  @retval            Value in range: 0-23
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getTimeStampHoursBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->TSHOUR & RTC_TSHOUR_HOURBIN_MASK);
+}
+
+/**
+ *  @brief      Get the day of the week in binary in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The day of the week in the time stamp
+ *
+ *  @retval            Value in range: 0-6
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getTimeStampDayOfWeekBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->TSDAY & RTC_TSDAY_DOW_MASK);
+}
+
+/**
+ *  @brief      Get the day of the month in binary in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The day of the month in the time stamp
+ *
+ *  @retval            Value in range: 1-31
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getTimeStampDayOfMonthBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(
+        (rtc_common->TSDAY & RTC_TSDAY_DOMBIN_MASK) >> RTC_TSDAY_DOMBIN_OFS);
+}
+
+/**
+ *  @brief      Get the month of the year in binary in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The month of the year in the time stamp
+ *
+ *  @retval            Value in range: 1-12
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getTimeStampMonthBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->TSMON & RTC_TSMON_MONBIN_MASK);
+}
+
+/**
+ *  @brief      Get the year in binary in the time stamp
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @pre To prevent reading any counter/calendar registers while those registers
+ *  are being updated, the user can call @ref DL_RTC_Common_isSafeToRead to ensure that
+ *  the registers are safe to read.
+ *
+ *  @return            The year in the time stamp
+ *
+ *  @retval            Value in range: 0-4095
+ *
+ */
+__STATIC_INLINE uint16_t DL_RTC_Common_getTimeStampYearBinary(
+    RTC_Regs *rtc_common)
+{
+    return (uint16_t)(rtc_common->TSYEAR & (RTC_TSYEAR_YEARLOWBIN_MASK |
+                                               RTC_TSYEAR_YEARHIGHBIN_MASK));
+}
+
+/**
+ *  @brief      Enable RTC Common interrupts
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Logical OR of
+ *                             @ref DL_RTC_COMMON_INTERRUPT.
+ */
+__STATIC_INLINE void DL_RTC_Common_enableInterrupt(
+    RTC_Regs *rtc_common, uint32_t interruptMask)
+{
+    rtc_common->CPU_INT.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disable RTC Common interrupts
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Logical OR of
+ *                             @ref DL_RTC_COMMON_INTERRUPT
+ */
+__STATIC_INLINE void DL_RTC_Common_disableInterrupt(
+    RTC_Regs *rtc_common, uint32_t interruptMask)
+{
+    rtc_common->CPU_INT.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief      Check which RTC Common interrupts are enabled
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Logical OR of
+ *                             @ref DL_RTC_COMMON_INTERRUPT
+ *
+ *  @return     Which of the requested RTC Common interrupts are enabled
+ *
+ *  @retval     Logical OR of @ref DL_RTC_COMMON_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_RTC_Common_getEnabledInterrupts(
+    RTC_Regs *rtc_common, uint32_t interruptMask)
+{
+    return (rtc_common->CPU_INT.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled RTC Common interrupts
+ *
+ *  Checks if any of the RTC Common interrupts that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Logical OR of
+ *                             @ref DL_RTC_COMMON_INTERRUPT
+ *
+ *  @return     Which of the requested RTC Common interrupts are pending
+ *
+ *  @retval     Logical OR of @ref DL_RTC_COMMON_INTERRUPT values
+ *
+ *  @sa         DL_RTC_COMMON_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_RTC_Common_getEnabledInterruptStatus(
+    RTC_Regs *rtc_common, uint32_t interruptMask)
+{
+    return (rtc_common->CPU_INT.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any RTC Common interrupt
+ *
+ *  Checks if any of the RTC Common interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Logical OR of
+ *                             @ref DL_RTC_COMMON_INTERRUPT
+ *
+ *  @return     Which of the requested RTC Common interrupts are pending
+ *
+ *  @retval     Logical OR of @ref DL_RTC_COMMON_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_RTC_Common_getRawInterruptStatus(
+    RTC_Regs *rtc_common, uint32_t interruptMask)
+{
+    return (rtc_common->CPU_INT.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending RTC Common interrupt
+ *
+ *  Checks if any of the RTC Common interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return     The highest priority pending RTC Common interrupt
+ *
+ *  @retval     One of @ref DL_RTC_COMMON_IIDX
+ */
+__STATIC_INLINE DL_RTC_COMMON_IIDX DL_RTC_Common_getPendingInterrupt(
+    RTC_Regs *rtc_common)
+{
+    return (DL_RTC_COMMON_IIDX)(rtc_common->CPU_INT.IIDX);
+}
+
+/**
+ *  @brief      Clear pending RTC Common interrupts
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Logical OR of
+ *                             @ref DL_RTC_COMMON_INTERRUPT
+ */
+__STATIC_INLINE void DL_RTC_Common_clearInterruptStatus(
+    RTC_Regs *rtc_common, uint32_t interruptMask)
+{
+    rtc_common->CPU_INT.ICLR = interruptMask;
+}
+
+/**
+ *  @brief      Enable RTC Common event
+ *
+ *  @param[in]  rtc_common       Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask   Bit mask of interrupts to enable. Bitwise OR of
+ *                          @ref DL_RTC_COMMON_EVENT.
+ */
+__STATIC_INLINE void DL_RTC_Common_enableEvent(
+    RTC_Regs *rtc_common, uint32_t eventMask)
+{
+    rtc_common->GEN_EVENT.IMASK |= (eventMask);
+}
+
+/**
+ *  @brief      Disable RTC Common event
+ *
+ *  @param[in]  rtc_common       Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask   Bit mask of interrupts to enable. Bitwise OR of
+ *                          @ref DL_RTC_COMMON_EVENT.
+ */
+__STATIC_INLINE void DL_RTC_Common_disableEvent(
+    RTC_Regs *rtc_common, uint32_t eventMask)
+{
+    rtc_common->GEN_EVENT.IMASK &= ~(eventMask);
+}
+
+/**
+ *  @brief      Check which RTC Common events are enabled
+ *
+ *  @param[in]  rtc_common       Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask   Bit mask of interrupts to check. Bitwise OR of
+ *                          @ref DL_RTC_COMMON_EVENT.
+ *
+ *  @return     Which of the requested RTC Common interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_RTC_COMMON_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_RTC_Common_getEnabledEvents(
+    RTC_Regs *rtc_common, uint32_t eventMask)
+{
+    return ((rtc_common->GEN_EVENT.IMASK) & (eventMask));
+}
+
+/**
+ *  @brief      Check event flag of enabled RTC Common event
+ *
+ *  Checks if any of the RTC Common events that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  rtc_common       Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask   Bit mask of interrupts to check. Bitwise OR of
+ *                          @ref DL_RTC_COMMON_EVENT.
+ *
+ *  @return     Which of the requested RTC Common interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_RTC_COMMON_EVENT values
+ *
+ *  @sa         DL_RTC_COMMON_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_RTC_Common_getEnabledEventStatus(
+    RTC_Regs *rtc_common, uint32_t eventMask)
+{
+    return ((rtc_common->GEN_EVENT.MIS) & eventMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any RTC Common event
+ *
+ *  Checks if any events are pending. Events do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  rtc_common       Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask   Bit mask of interrupts to check. Bitwise OR of
+ *                          @ref DL_RTC_COMMON_EVENT.
+ *
+ *  @return     Which of the requested RTC Common interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_RTC_COMMON_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_RTC_Common_getRawEventsStatus(
+    RTC_Regs *rtc_common, uint32_t eventMask)
+{
+    return ((rtc_common->GEN_EVENT.RIS) & eventMask);
+}
+
+/**
+ *  @brief      Clear pending RTC Common events
+ *
+ *  @param[in]  rtc_common       Pointer to the register overlay for the peripheral
+ *  @param[in]  eventMask   Bit mask of interrupts to clear. Bitwise OR of
+ *                          @ref DL_RTC_COMMON_EVENT.
+ */
+__STATIC_INLINE void DL_RTC_Common_clearEventsStatus(
+    RTC_Regs *rtc_common, uint32_t eventMask)
+{
+    rtc_common->GEN_EVENT.ICLR |= (eventMask);
+}
+
+/**
+ *  @brief Sets the event publisher channel ID
+ *
+ *  @param[in]  rtc_common   Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  chanID  Channel ID number. Valid range 0-15. If ChanID == 0
+ *                      publisher is disconnected.
+ */
+__STATIC_INLINE void DL_RTC_Common_setPublisherChanID(
+    RTC_Regs *rtc_common, uint8_t chanID)
+{
+    rtc_common->FPUB_0 = (chanID & RTC_FPUB_0_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event publisher channel ID
+ *
+ *  @param[in]  rtc_common Pointer to the register overlay for the
+ *                  peripheral
+ *
+ *  @return     Event publisher channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_RTC_Common_getPublisherChanID(RTC_Regs *rtc_common)
+{
+    return (uint8_t)(rtc_common->FPUB_0 & RTC_FPUB_0_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief      Gets the cause of the time stamp event
+
+ *  @param[in]  rtc_common Pointer to the register overlay for the peripheral
+ *  @param[in]  tsEventMask  Bit mask of events to check. Logical OR of
+ *                           @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE.
+ *
+ *  @return     The cause of the time stamp event
+ *
+ *  @retval     Logical OR of @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAUSE values
+ */
+__STATIC_INLINE uint32_t DL_RTC_Common_getTimeStampEventCause(
+    RTC_Regs *rtc_common, uint32_t tsEventMask)
+{
+    return (rtc_common->TSSTAT & tsEventMask);
+}
+
+/**
+ *  @brief      Initializes the settings to operate the RTC Common in Calendar mode.
+ *
+ *  @param[in]  rtc_common               Pointer to the register overlay for the
+ *                                  RTC Common peripheral
+ *  @param[in]  calendarTime        Structure containing the values for the
+ *                                  Calendar to be initialized to
+ *  @param[in]  formatSelect        Selectable format the RTC Common peripheral will
+ *                                  provide time in.
+ *                                  @ref DL_RTC_COMMON_FORMAT
+ *
+ */
+void DL_RTC_Common_initCalendar(RTC_Regs *rtc_common,
+    DL_RTC_Common_Calendar calendarTime, DL_RTC_COMMON_FORMAT formatSelect);
+
+/**
+ *  @brief      Returns the Calendar Time
+ *
+ *  @param[in]  rtc_common             Pointer to the register overlay for the
+ *                                  RTC Common peripheral
+ *
+ * This function returns the current Calendar Time in the form of a Calendar
+ * structure.
+ * The time returned will be in the previously selected format.
+ *
+ *  @return            A Calendar structure containing the current time.
+ *
+ */
+DL_RTC_Common_Calendar DL_RTC_Common_getCalendarTime(RTC_Regs *rtc_common);
+
+/**
+ *  @brief      Set calendar alarm 1
+ *
+ *  @param[in]  rtc_common             Pointer to the register overlay for the
+ *                                  RTC Common peripheral
+ *  @param[in]  alarmTime           Structure containing the values for the
+ *                                  alarm to be set to
+ *
+ */
+void DL_RTC_Common_setCalendarAlarm1(
+    RTC_Regs *rtc_common, DL_RTC_Common_CalendarAlarm alarmTime);
+
+/**
+ *  @brief      Get calendar alarm 1
+ *
+ *  @param[in]  rtc_common               Pointer to the register overlay for the
+ *                                  RTC Common peripheral
+ *
+ *  @return     A Alarm structure containing the set time for alarm 1
+ *
+ */
+DL_RTC_Common_CalendarAlarm DL_RTC_Common_getCalendarAlarm1(
+    RTC_Regs *rtc_common);
+
+/**
+ *  @brief      Enable calendar alarm 1
+ *
+ *  @param[in]  rtc_common               Pointer to the register overlay for the
+ *                                  RTC Common peripheral
+ *
+ */
+void DL_RTC_Common_enableCalendarAlarm1(RTC_Regs *rtc_common);
+
+/**
+ *  @brief      Disable calendar alarm 1
+ *
+ *  @param[in]  rtc_common               Pointer to the register overlay for the
+ *                                  RTC Common peripheral
+ *
+ */
+void DL_RTC_Common_disableCalendarAlarm1(RTC_Regs *rtc_common);
+
+/**
+ *  @brief      Set calendar alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  alarmTime           Structure containing the values for the
+ *                                  alarm to be set to
+ *
+ */
+void DL_RTC_Common_setCalendarAlarm2(
+    RTC_Regs *rtc_common, DL_RTC_Common_CalendarAlarm alarmTime);
+
+/**
+ *  @brief      Get calendar alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return     A Alarm structure containing the set time for alarm 2
+ *
+ */
+DL_RTC_Common_CalendarAlarm DL_RTC_Common_getCalendarAlarm2(
+    RTC_Regs *rtc_common);
+
+/**
+ *  @brief      Enable calendar alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+void DL_RTC_Common_enableCalendarAlarm2(RTC_Regs *rtc_common);
+
+/**
+ *  @brief      Disable calendar alarm 2
+ *
+ *  @param[in]  rtc_common  Pointer to the register overlay for the RTC Common peripheral
+ *
+ */
+void DL_RTC_Common_disableCalendarAlarm2(RTC_Regs *rtc_common);
+
+#ifdef __MSPM0_HAS_RTC_A__
+/**
+ *  @brief      Set the sources to trigger a time stamp capture event
+ *
+ *  The timestamp event can be triggered by an edge detection of any of the
+ *  tamper IO. This API sets which source(s) will trigger a time stamp capture
+ *  event.
+ *
+ *  @param[in]  rtc_common      Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  sourceMask  The sources that can trigger a time stamp capture
+ *                          event. Logical OR of
+ *                          @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE
+ */
+__STATIC_INLINE void DL_RTC_Common_setTimeStampEventSource(
+    RTC_Regs *rtc_common, uint32_t sourceMask)
+{
+    rtc_common->TSCTL |= (RTC_TSCTL_KEY_UNLOCK_W | sourceMask);
+}
+
+/**
+ *  @brief      Get the sources that can trigger a time stamp capture event
+ *
+ *  @param[in]  rtc_common      Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  sourceMask  The sources that can trigger a time stamp capture
+ *                          event. Logical OR of
+ *                          @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE
+  *
+ *  @return     The sources of the time stamp event
+ *
+ *  @retval     Logical OR of @ref DL_RTC_COMMON_TIME_STAMP_EVENT_SOURCE values
+ */
+__STATIC_INLINE uint32_t DL_RTC_Common_getTimeStampEventSource(
+    RTC_Regs *rtc_common, uint32_t sourceMask)
+{
+    return (rtc_common->TSCTL & sourceMask);
+}
+
+/**
+ *  @brief      Set the capture method when a time stamp capture event occurs
+ *
+ *  The timestamp event can be triggered by an edge detection of any of the
+ *  tamper IO. This API sets whether the first or last occurrence of the event
+ *  is captured.
+ *
+ *  @param[in]  rtc_common   Pointer to the register overlay for the RTC Common peripheral
+ *  @param[in]  capture  The capture method for the time stamp event.
+ *                       One of @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAPTURE
+ */
+__STATIC_INLINE void DL_RTC_Common_setTimeStampEventCapture(
+    RTC_Regs *rtc_common, DL_RTC_COMMON_TIME_STAMP_EVENT_CAPTURE capture)
+{
+    DL_Common_updateReg(&rtc_common->TSCTL,
+        (RTC_TSCTL_KEY_UNLOCK_W | (uint32_t) capture),
+        (RTC_TSCTL_TSCAPTURE_MASK | RTC_TSCTL_KEY_MASK));
+}
+
+/**
+ *  @brief      Get the capture method when a time stamp capture event occurs
+ *
+ *  The timestamp event can be triggered by an edge detection of any of the
+ *  tamper IO. This API sets whether the first or last occurrence of the event
+ *  is captured.
+ *
+ *  @param[in]  rtc_common   Pointer to the register overlay for the RTC Common peripheral
+  *
+ *  @return     The capture method for a time stamp capture event
+ *
+ *  @retval     One of @ref DL_RTC_COMMON_TIME_STAMP_EVENT_CAPTURE
+ */
+__STATIC_INLINE DL_RTC_COMMON_TIME_STAMP_EVENT_CAPTURE
+DL_RTC_Common_getTimeStampEventCapture(RTC_Regs *rtc_common)
+{
+    uint32_t capture = (rtc_common->TSCTL & RTC_TSCTL_TSCAPTURE_MASK);
+
+    return (DL_RTC_COMMON_TIME_STAMP_EVENT_CAPTURE)(capture);
+}
+
+/**
+ * @brief Clear the time stamp and time stamp event status
+ *
+ *  The time stamp and the time stamp event status are sticky, and will stay
+ *  active until cleared by software.
+ *
+ * @param[in] rtc_common      Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_RTC_Common_clearTimeStamp(RTC_Regs *rtc_common)
+{
+    rtc_common->TSCLR = (RTC_TSCLR_KEY_UNLOCK_W | RTC_TSCLR_CLR_CLR);
+}
+
+/**
+ *  @brief      Enable write protection lock of the CLKCTL, SEC, MIN, HOUR,
+ *              DAY, MON, YEAR and LFSSRST registers from accidental updates
+ *
+ *  When enabled, the CLKCTL, SEC, MIN, HOUR, DAY, MON, YEAR and LFSSRST
+ *  registers will have read-only properties.
+ *
+ *  @param[in]  rtc_common    Pointer to the register overlay for the RTC Common peripheral
+ */
+__STATIC_INLINE void DL_RTC_Common_enableWriteProtect(RTC_Regs *rtc_common)
+{
+    rtc_common->RTCLOCK = (RTC_RTCLOCK_PROTECT_SET | RTC_RTCLOCK_KEY_UNLOCK_W);
+}
+
+/**
+ *  @brief      Checks if write protection lock of the CLKCTL, SEC, MIN, HOUR,
+ *              DAY, MON, YEAR and LFSSRST registers is enabled
+ *
+ *  @param[in]  rtc_common    Pointer to the register overlay for the RTC Common peripheral
+ *
+ *  @return     Returns the enabled status of the write protection lock
+ *
+ *  @retval     true  Write protection lock is enabled
+ *  @retval     false Write protection lock is disabled
+ */
+__STATIC_INLINE bool DL_RTC_Common_isWriteProtectEnabled(RTC_Regs *rtc_common)
+{
+    return ((rtc_common->RTCLOCK & RTC_RTCLOCK_PROTECT_MASK) ==
+            RTC_RTCLOCK_PROTECT_SET);
+}
+
+/**
+ *  @brief      Disable write protection lock of the CLKCTL, SEC, MIN, HOUR,
+ *              DAY, MON, YEAR and LFSSRST registers
+ *
+ *  @param[in]  rtc_common    Pointer to the register overlay for the RTC Common peripheral
+ */
+__STATIC_INLINE void DL_RTC_Common_disableWriteProtect(RTC_Regs *rtc_common)
+{
+    rtc_common->RTCLOCK = (RTC_RTCLOCK_PROTECT_CLR | RTC_RTCLOCK_KEY_UNLOCK_W);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_RTC_A__ || __MSPM0_HAS_RTC__ */
+
+#endif /* ti_dl_dl_rtc_common__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_scratchpad.h
+++ b/mspm0/source/ti/driverlib/dl_scratchpad.h
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_scratchpad.h
+ *  @brief      Scratchpad Memory Driver Library
+ *  @defgroup   Scratchpad Memory
+ *
+ *  @anchor ti_dl_dl_scratchpad_Overview
+ *  # Overview
+ *
+ *  The Scratchpad Memory Library allows full configuration of
+ *  the MSPM0 Scratchpad Memory within the LFSS IP.
+ *
+ *  The LFSS scratch pad memory is a 16- to 128-byte register based memory,
+ *  which will retain data similar to a non-volatile memory as long as VBAT is
+ *  supplied. The number of implemented bytes shall be configurable in a granularity
+ *  of 4 bytes. This means the scratch pad memory retains data when the main VDD supply
+ *  is lost or during the SHUTDOWN mode. However, the memory content won’t be retained,
+ *  when the VBAT domain itself is lost.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup Scratchpad Memory
+ * @{
+ */
+#ifndef ti_dl_dl_scratchpad__include
+#define ti_dl_dl_scratchpad__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/driverlib/dl_lfss.h>
+
+#ifdef __MSPM0_HAS_SCRATCHPAD__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_WORD_0
+ */
+#define DL_SCRATCHPAD_MEM_WORD_0                            DL_LFSS_SCRATCHPAD_MEM_WORD_0
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_WORD_1
+ */
+#define DL_SCRATCHPAD_MEM_WORD_1                            DL_LFSS_SCRATCHPAD_MEM_WORD_1
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_WORD_1
+ */
+#define DL_SCRATCHPAD_MEM_WORD_1                            DL_LFSS_SCRATCHPAD_MEM_WORD_1
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_WORD_2
+ */
+#define DL_SCRATCHPAD_MEM_WORD_2                            DL_LFSS_SCRATCHPAD_MEM_WORD_2
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_WORD_3
+ */
+#define DL_SCRATCHPAD_MEM_WORD_3                            DL_LFSS_SCRATCHPAD_MEM_WORD_3
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_WORD_4
+ */
+#define DL_SCRATCHPAD_MEM_WORD_4                            DL_LFSS_SCRATCHPAD_MEM_WORD_4
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_WORD_5
+ */
+#define DL_SCRATCHPAD_MEM_WORD_5                            DL_LFSS_SCRATCHPAD_MEM_WORD_5
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_WORD_6
+ */
+#define DL_SCRATCHPAD_MEM_WORD_6                            DL_LFSS_SCRATCHPAD_MEM_WORD_6
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_WORD_7
+ */
+#define DL_SCRATCHPAD_MEM_WORD_7                            DL_LFSS_SCRATCHPAD_MEM_WORD_7
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_BYTE_0
+ */
+#define DL_SCRATCHPAD_MEM_BYTE_0                            DL_LFSS_SCRATCHPAD_MEM_BYTE_0
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_BYTE_1
+ */
+#define DL_SCRATCHPAD_MEM_BYTE_1                            DL_LFSS_SCRATCHPAD_MEM_BYTE_1
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_BYTE_2
+ */
+#define DL_SCRATCHPAD_MEM_BYTE_2                            DL_LFSS_SCRATCHPAD_MEM_BYTE_2
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_WORD_2
+ */
+#define DL_SCRATCHPAD_MEM_WORD_2                            DL_LFSS_SCRATCHPAD_MEM_WORD_2
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_SCRATCHPAD_MEM_BYTE_3
+ */
+#define DL_SCRATCHPAD_MEM_BYTE_3                            DL_LFSS_SCRATCHPAD_MEM_BYTE_3
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_writeScratchPadData32
+ */
+#define DL_ScratchPad_writeDataWord(lfss, memIndex, data)              DL_LFSS_writeScratchPadData32(lfss,    \
+                                                                      (DL_LFSS_SCRATCHPAD_MEM_WORD)memIndex,  \
+                                                                                                      data)
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_writeScratchPadData8
+ */
+#define DL_ScratchPad_writeDataByte(lfss, memIndex, byteIndex, data)   DL_LFSS_writeScratchPadData8(lfss,     \
+                                                                      (DL_LFSS_SCRATCHPAD_MEM_WORD)memIndex,  \
+                                                                      (DL_LFSS_SCRATCHPAD_MEM_BYTE)byteIndex, \
+                                                                                                      data)
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_readScratchPadDataWord
+ */
+#define DL_ScratchPad_readDataWord(lfss, memIndex)                      DL_LFSS_readScratchPadDataWord(lfss,  \
+                                                                       (DL_LFSS_SCRATCHPAD_MEM_WORD)memIndex)
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_readScratchPadDataByte
+ */
+#define DL_ScratchPad_readDataByte(lfss, memIndex, byteIndex)          DL_LFSS_readScratchPadDataByte(lfss,  \
+                                                                      (DL_LFSS_SCRATCHPAD_MEM_WORD)memIndex, \
+                                                                      (DL_LFSS_SCRATCHPAD_MEM_BYTE)byteIndex)
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_enableScratchPadWriteProtectByte
+ */
+#define DL_ScratchPad_enableWriteProtectByte(lfss, memIndex, byteIndex)                    DL_LFSS_enableScratchPadWriteProtectByte(lfss, \
+                                                                                          (DL_LFSS_SCRATCHPAD_MEM_WORD)memIndex,          \
+                                                                                          (DL_LFSS_SCRATCHPAD_MEM_BYTE)byteIndex)
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_isScratchPadWriteProtectByteEnabled
+ */
+#define DL_ScratchPad_isWriteProtectByteEnabled(lfss, memIndex, byteIndex)                 DL_LFSS_isScratchPadWriteProtectByteEnabled(lfss, \
+                                                                                          (DL_LFSS_SCRATCHPAD_MEM_WORD)memIndex,             \
+                                                                                          (DL_LFSS_SCRATCHPAD_MEM_BYTE)byteIndex)
+
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_disableScratchPadWriteProtectByte
+ */
+#define DL_ScratchPad_disableWriteProtectByte(lfss, memIndex, byteIndex)                    DL_LFSS_disableScratchPadWriteProtectByte(lfss,  \
+                                                                                           (DL_LFSS_SCRATCHPAD_MEM_WORD)memIndex,            \
+                                                                                           (DL_LFSS_SCRATCHPAD_MEM_BYTE)byteIndex)
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_enableScratchPadTamperEraseByte
+ */
+#define DL_ScratchPad_enableTamperEraseByte(lfss, memIndex, byteIndex)                      DL_LFSS_enableScratchPadTamperEraseByte(lfss, \
+                                                                                           (DL_LFSS_SCRATCHPAD_MEM_WORD)memIndex,         \
+                                                                                           (DL_LFSS_SCRATCHPAD_MEM_BYTE)byteIndex)
+
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_isScratchPadTamperEraseByteEnabled
+ */
+#define DL_ScratchPad_isTamperEraseByteEnabled(lfss, memIndex, byteIndex)                   DL_LFSS_isScratchPadTamperEraseByteEnabled(lfss, \
+                                                                                           (DL_LFSS_SCRATCHPAD_MEM_WORD)memIndex,            \
+                                                                                           (DL_LFSS_SCRATCHPAD_MEM_BYTE)byteIndex)
+
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_disableScratchPadTamperEraseByte
+ */
+#define DL_ScratchPad_disableTamperEraseByte(lfss, memIndex, byteIndex)                     DL_LFSS_disableScratchPadTamperEraseByte(lfss, \
+                                                                                           (DL_LFSS_SCRATCHPAD_MEM_WORD)memIndex,         \
+                                                                                           (DL_LFSS_SCRATCHPAD_MEM_BYTE)byteIndex)
+
+/* clang-format on */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_SCRATCHPAD__ */
+
+#endif /* ti_dl_dl_scratchpad__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_spi.c
+++ b/mspm0/source/ti/driverlib/dl_spi.c
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_spi.h>
+
+#ifdef __MSPM0_HAS_SPI__
+
+void DL_SPI_init(SPI_Regs *spi, DL_SPI_Config *config)
+{
+    DL_Common_updateReg(&spi->CTL0,
+        (uint32_t) config->chipSelectPin | (uint32_t) config->frameFormat |
+            (uint32_t) config->dataSize,
+        SPI_CTL0_CSSEL_MASK | SPI_CTL0_FRF_MASK | SPI_CTL0_SPO_MASK |
+            SPI_CTL0_SPH_MASK | SPI_CTL0_DSS_MASK);
+
+    DL_Common_updateReg(&spi->CTL1,
+        (uint32_t) config->parity | (uint32_t) config->bitOrder |
+            (uint32_t) config->mode,
+        SPI_CTL1_PES_MASK | SPI_CTL1_PREN_MASK | SPI_CTL1_PTEN_MASK |
+            SPI_CTL1_MSB_MASK | SPI_CTL1_CP_MASK);
+}
+
+void DL_SPI_setClockConfig(SPI_Regs *spi, DL_SPI_ClockConfig *config)
+{
+    spi->CLKSEL = (uint32_t) config->clockSel;
+
+    spi->CLKDIV = (uint32_t) config->divideRatio;
+}
+
+void DL_SPI_getClockConfig(SPI_Regs *spi, DL_SPI_ClockConfig *config)
+{
+    config->clockSel = (DL_SPI_CLOCK) spi->CLKSEL;
+
+    config->divideRatio = (DL_SPI_CLOCK_DIVIDE_RATIO) spi->CLKDIV;
+}
+
+uint8_t DL_SPI_receiveDataBlocking8(SPI_Regs *spi)
+{
+    while (DL_SPI_isRXFIFOEmpty(spi)) {
+    };
+
+    return DL_SPI_receiveData8(spi);
+}
+
+uint16_t DL_SPI_receiveDataBlocking16(SPI_Regs *spi)
+{
+    while (DL_SPI_isRXFIFOEmpty(spi)) {
+    };
+    return DL_SPI_receiveData16(spi);
+}
+
+uint32_t DL_SPI_receiveDataBlocking32(SPI_Regs *spi)
+{
+    while (DL_SPI_isRXFIFOEmpty(spi)) {
+    };
+    return DL_SPI_receiveData32(spi);
+}
+
+void DL_SPI_transmitDataBlocking8(SPI_Regs *spi, uint8_t data)
+{
+    while (DL_SPI_isTXFIFOFull(spi)) {
+    };
+    DL_SPI_transmitData8(spi, data);
+}
+
+void DL_SPI_transmitDataBlocking16(SPI_Regs *spi, uint16_t data)
+{
+    while (DL_SPI_isTXFIFOFull(spi)) {
+    };
+    DL_SPI_transmitData16(spi, data);
+}
+
+void DL_SPI_transmitDataBlocking32(SPI_Regs *spi, uint32_t data)
+{
+    while (DL_SPI_isTXFIFOFull(spi)) {
+    };
+    DL_SPI_transmitData32(spi, data);
+}
+
+bool DL_SPI_receiveDataCheck8(SPI_Regs *spi, uint8_t *buffer)
+{
+    bool status;
+    if (DL_SPI_isRXFIFOEmpty(spi)) {
+        status = false;
+    } else {
+        *buffer = DL_SPI_receiveData8(spi);
+        status  = true;
+    }
+
+    return status;
+}
+
+bool DL_SPI_receiveDataCheck16(SPI_Regs *spi, uint16_t *buffer)
+{
+    bool status;
+    if (DL_SPI_isRXFIFOEmpty(spi)) {
+        status = false;
+    } else {
+        *buffer = DL_SPI_receiveData16(spi);
+        status  = true;
+    }
+
+    return status;
+}
+
+bool DL_SPI_receiveDataCheck32(SPI_Regs *spi, uint32_t *buffer)
+{
+    bool status;
+    if (DL_SPI_isRXFIFOEmpty(spi)) {
+        status = false;
+    } else {
+        *buffer = DL_SPI_receiveData32(spi);
+        status  = true;
+    }
+
+    return status;
+}
+
+bool DL_SPI_transmitDataCheck8(SPI_Regs *spi, uint8_t data)
+{
+    bool status;
+    if (DL_SPI_isTXFIFOFull(spi)) {
+        status = false;
+    } else {
+        DL_SPI_transmitData8(spi, data);
+        status = true;
+    }
+
+    return status;
+}
+
+bool DL_SPI_transmitDataCheck16(SPI_Regs *spi, uint16_t data)
+{
+    bool status;
+    if (DL_SPI_isTXFIFOFull(spi)) {
+        status = false;
+    } else {
+        DL_SPI_transmitData16(spi, data);
+        status = true;
+    }
+
+    return status;
+}
+
+bool DL_SPI_transmitDataCheck32(SPI_Regs *spi, uint32_t data)
+{
+    bool status;
+    if (DL_SPI_isTXFIFOFull(spi)) {
+        status = false;
+    } else {
+        DL_SPI_transmitData32(spi, data);
+        status = true;
+    }
+
+    return status;
+}
+
+uint32_t DL_SPI_drainRXFIFO8(SPI_Regs *spi, uint8_t *buffer, uint32_t maxCount)
+{
+    uint32_t i;
+    for (i = 0; i < maxCount; i++) {
+        if (!DL_SPI_isRXFIFOEmpty(spi)) {
+            buffer[i] = DL_SPI_receiveData8(spi);
+        } else {
+            break;
+        }
+    }
+
+    return i;
+}
+
+uint32_t DL_SPI_drainRXFIFO16(
+    SPI_Regs *spi, uint16_t *buffer, uint32_t maxCount)
+{
+    uint32_t i;
+    for (i = 0; i < maxCount; i++) {
+        if (!DL_SPI_isRXFIFOEmpty(spi)) {
+            buffer[i] = DL_SPI_receiveData16(spi);
+        } else {
+            break;
+        }
+    }
+
+    return i;
+}
+
+uint32_t DL_SPI_drainRXFIFO32(
+    SPI_Regs *spi, uint32_t *buffer, uint32_t maxCount)
+{
+    uint32_t i;
+    for (i = 0; i < maxCount; i++) {
+        if (!DL_SPI_isRXFIFOEmpty(spi)) {
+            buffer[i] = DL_SPI_receiveData32(spi);
+        } else {
+            break;
+        }
+    }
+
+    return i;
+}
+
+uint32_t DL_SPI_fillTXFIFO8(SPI_Regs *spi, uint8_t *buffer, uint32_t count)
+{
+    uint32_t i;
+    for (i = 0; i < count; i++) {
+        if (!DL_SPI_isTXFIFOFull(spi)) {
+            DL_SPI_transmitData8(spi, buffer[i]);
+        } else {
+            break;
+        }
+    }
+
+    return i;
+}
+
+uint32_t DL_SPI_fillTXFIFO16(SPI_Regs *spi, uint16_t *buffer, uint32_t count)
+{
+    uint32_t i;
+    for (i = 0; i < count; i++) {
+        if (!DL_SPI_isTXFIFOFull(spi)) {
+            DL_SPI_transmitData16(spi, buffer[i]);
+        } else {
+            break;
+        }
+    }
+
+    return i;
+}
+
+bool DL_SPI_saveConfiguration(SPI_Regs *spi, DL_SPI_backupConfig *ptr)
+{
+    bool stateSaved = !ptr->backupRdy;
+    if (stateSaved) {
+        ptr->controlWord0                 = spi->CTL0;
+        ptr->controlWord1                 = spi->CTL1;
+        ptr->clockControl                 = spi->CLKCTL;
+        ptr->clockSel                     = spi->CLKSEL;
+        ptr->divideRatio                  = spi->CLKDIV;
+        ptr->interruptFifoLevelSelectWord = spi->IFLS;
+        ptr->interruptMask0               = spi->CPU_INT.IMASK;
+        ptr->interruptMask1               = spi->DMA_TRIG_RX.IMASK;
+        ptr->interruptMask2               = spi->DMA_TRIG_TX.IMASK;
+        ptr->backupRdy                    = true;
+    }
+    return stateSaved;
+}
+
+bool DL_SPI_restoreConfiguration(SPI_Regs *spi, DL_SPI_backupConfig *ptr)
+{
+    bool stateRestored = ptr->backupRdy;
+    if (stateRestored) {
+        /* Set CTL1.ENABLE=0 during initialization */
+        spi->CTL1              = ptr->controlWord1 & ~(SPI_CTL1_ENABLE_MASK);
+        spi->CTL0              = ptr->controlWord0;
+        spi->CLKCTL            = ptr->clockControl;
+        spi->CLKSEL            = ptr->clockSel;
+        spi->CLKDIV            = ptr->divideRatio;
+        spi->IFLS              = ptr->interruptFifoLevelSelectWord;
+        spi->CPU_INT.IMASK     = ptr->interruptMask0;
+        spi->DMA_TRIG_RX.IMASK = ptr->interruptMask1;
+        spi->DMA_TRIG_TX.IMASK = ptr->interruptMask2;
+
+        /* Re-enable SPI if it was originally enabled */
+        if ((ptr->controlWord1 & SPI_CTL1_ENABLE_MASK) ==
+            SPI_CTL1_ENABLE_MASK) {
+            DL_SPI_enable(spi);
+        }
+        ptr->backupRdy = false;
+    }
+    return stateRestored;
+}
+
+uint32_t DL_SPI_fillTXFIFO32(SPI_Regs *spi, uint32_t *buffer, uint32_t count)
+{
+    uint32_t i;
+    for (i = 0; i < count; i++) {
+        if (!DL_SPI_isTXFIFOFull(spi)) {
+            DL_SPI_transmitData32(spi, buffer[i]);
+        } else {
+            break;
+        }
+    }
+
+    return i;
+}
+
+#endif /* __MSPM0_HAS_SPI__ */

--- a/mspm0/source/ti/driverlib/dl_spi.h
+++ b/mspm0/source/ti/driverlib/dl_spi.h
@@ -1,0 +1,2393 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_spi.h
+ *  @brief      SPI Driver Library
+ *  @defgroup   SPI Serial Peripheral Interface (SPI)
+ *
+ *  @anchor ti_dl_dl_spi_Overview
+ *  # Overview
+ *
+ *  The Serial Peripheral Interface Driver Library allows full configuration of
+ *  the MSPM0 SPI module.
+ *  The serial peripheral interface (SPI) module provides a standardized
+ *  serial interface to transfer data between MSPM0 devices and other external
+ *  devices with SPI interface.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup SPI
+ * @{
+ */
+#ifndef ti_dl_dl_spi__include
+#define ti_dl_dl_spi__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_SPI__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_SPI_CD_MODE
+ *  @{
+ */
+/*!
+ * @brief Data mode
+ */
+#define DL_SPI_CD_MODE_DATA        (SPI_CTL1_CDMODE_DATA >> SPI_CTL1_CDMODE_OFS)
+
+/*!
+ * @brief Command mode
+ */
+#define DL_SPI_CD_MODE_COMMAND  (SPI_CTL1_CDMODE_COMMAND >> SPI_CTL1_CDMODE_OFS)
+
+
+/** @}*/
+
+/** @addtogroup DL_SPI_INTERRUPT
+ *  @{
+ */
+
+/*!
+ * @brief DMA done 1 event for transmit interrupt
+ */
+#define DL_SPI_INTERRUPT_DMA_DONE_TX    (SPI_CPU_INT_IMASK_DMA_DONE_TX_SET)
+
+/*!
+ * @brief DMA done 1 event for receive interrupt
+ */
+#define DL_SPI_INTERRUPT_DMA_DONE_RX    (SPI_CPU_INT_IMASK_DMA_DONE_RX_SET)
+/*!
+ * @brief SPI has finished transfers and changed into idle mode interrupt
+ */
+#define DL_SPI_INTERRUPT_IDLE                   (SPI_CPU_INT_IMASK_IDLE_SET)
+
+/*!
+ * @brief Transmit FIFO empty interrupt
+ */
+#define DL_SPI_INTERRUPT_TX_EMPTY            (SPI_CPU_INT_IMASK_TXEMPTY_SET)
+
+/*!
+ * @brief Transmit FIFO interrupt
+ */
+#define DL_SPI_INTERRUPT_TX                       (SPI_CPU_INT_IMASK_TX_SET)
+
+/*!
+ * @brief Receive FIFO interrupt
+ */
+#define DL_SPI_INTERRUPT_RX                       (SPI_CPU_INT_IMASK_RX_SET)
+
+/*!
+ * @brief Receive timeout interrupt
+ */
+#define DL_SPI_INTERRUPT_RX_TIMEOUT            (SPI_CPU_INT_IMASK_RTOUT_SET)
+
+/*!
+ * @brief Receive FIFO full interrupt
+ */
+#define DL_SPI_INTERRUPT_RX_FULL              (SPI_CPU_INT_IMASK_RXFULL_SET)
+
+/*!
+ * @brief Transmit FIFO underflow interrupt
+ */
+#define DL_SPI_INTERRUPT_TX_UNDERFLOW     (SPI_CPU_INT_IMASK_TXFIFO_UNF_SET)
+
+/*!
+ * @brief Parity error
+ */
+#define DL_SPI_INTERRUPT_PARITY_ERROR            (SPI_CPU_INT_IMASK_PER_SET)
+
+/*!
+ * @brief Receive FIFO overflow interrupt
+ */
+#define DL_SPI_INTERRUPT_RX_OVERFLOW      (SPI_CPU_INT_IMASK_RXFIFO_OVF_SET)
+
+/** @}*/
+
+/*! @enum DL_SPI_DMA_IIDX_RX */
+typedef enum {
+    /*! SPI interrupt index for enabling SPI receive as DMA trigger */
+    DL_SPI_DMA_IIDX_RX_TRIGGER = SPI_DMA_TRIG_RX_IIDX_STAT_RX_EVT,
+    /*! SPI interrupt index for enabling SPI receive timeout as DMA trigger */
+    DL_SPI_DMA_IIDX_RX_TIMEOUT_TRIGGER = SPI_DMA_TRIG_RX_IIDX_STAT_RTOUT_EVT
+} DL_SPI_DMA_IIDX_RX;
+
+/*! @enum DL_SPI_DMA_IIDX_TX */
+typedef enum {
+    /*! SPI interrupt index for enabling SPI transmit as DMA trigger */
+    DL_SPI_DMA_IIDX_TX_TRIGGER = SPI_DMA_TRIG_TX_IIDX_STAT_TX_EVT
+} DL_SPI_DMA_IIDX_TX;
+
+/** @addtogroup DL_SPI_DMA_INTERRUPT_RX
+ *  @{
+ */
+/*!
+ * @brief SPI interrupt for enabling SPI receive as DMA trigger
+ */
+#define DL_SPI_DMA_INTERRUPT_RX               (SPI_DMA_TRIG_RX_IMASK_RX_SET)
+
+/*!
+ * @brief SPI interrupt for enabling SPI receive timeout as DMA trigger
+ */
+#define DL_SPI_DMA_INTERRUPT_RX_TIMEOUT       (SPI_DMA_TRIG_RX_IMASK_RTOUT_SET)
+
+/** @}*/
+
+/*!
+ * @brief SPI interrupt for enabling SPI transmit as DMA trigger
+ */
+#define DL_SPI_DMA_INTERRUPT_TX               (SPI_DMA_TRIG_TX_IMASK_TX_SET)
+
+/* clang-format on */
+
+/*! @enum DL_SPI_PARITY */
+typedef enum {
+    /*! Use even parity, enable transmit and receive parity */
+    DL_SPI_PARITY_EVEN =
+        (SPI_CTL1_PES_ENABLE | SPI_CTL1_PREN_ENABLE | SPI_CTL1_PTEN_ENABLE),
+    /*! Use odd parity, enable transmit and receive parity  */
+    DL_SPI_PARITY_ODD =
+        (SPI_CTL1_PES_DISABLE | SPI_CTL1_PREN_ENABLE | SPI_CTL1_PTEN_ENABLE),
+    /*! Disable receive and transmit parity */
+    DL_SPI_PARITY_NONE = (SPI_CTL1_PREN_DISABLE | SPI_CTL1_PTEN_DISABLE)
+} DL_SPI_PARITY;
+
+/*! @enum DL_SPI_FRAME_FORMAT */
+typedef enum {
+    /*! Motorola 3 Wire with Polarity 0, Phase 0 */
+    DL_SPI_FRAME_FORMAT_MOTO3_POL0_PHA0 =
+        (SPI_CTL0_SPO_LOW | SPI_CTL0_SPH_FIRST | SPI_CTL0_FRF_MOTOROLA_3WIRE),
+    /*! Motorola 3 Wire with Polarity 0, Phase 1 */
+    DL_SPI_FRAME_FORMAT_MOTO3_POL0_PHA1 =
+        (SPI_CTL0_SPO_LOW | SPI_CTL0_SPH_SECOND | SPI_CTL0_FRF_MOTOROLA_3WIRE),
+    /*! Motorola 3 Wire with Polarity 1, Phase 0 */
+    DL_SPI_FRAME_FORMAT_MOTO3_POL1_PHA0 =
+        (SPI_CTL0_SPO_HIGH | SPI_CTL0_SPH_FIRST | SPI_CTL0_FRF_MOTOROLA_3WIRE),
+    /*! Motorola 3 Wire with Polarity 1, Phase 1 */
+    DL_SPI_FRAME_FORMAT_MOTO3_POL1_PHA1 =
+        (SPI_CTL0_SPO_HIGH | SPI_CTL0_SPH_SECOND |
+            SPI_CTL0_FRF_MOTOROLA_3WIRE),
+    /*! Motorola 4 Wire with Polarity 0, Phase 0 */
+    DL_SPI_FRAME_FORMAT_MOTO4_POL0_PHA0 =
+        (SPI_CTL0_SPO_LOW | SPI_CTL0_SPH_FIRST | SPI_CTL0_FRF_MOTOROLA_4WIRE),
+    /*! Motorola 4 Wire with Polarity 0, Phase 1 */
+    DL_SPI_FRAME_FORMAT_MOTO4_POL0_PHA1 =
+        (SPI_CTL0_SPO_LOW | SPI_CTL0_SPH_SECOND | SPI_CTL0_FRF_MOTOROLA_4WIRE),
+    /*! Motorola 4 Wire with Polarity 1, Phase 0 */
+    DL_SPI_FRAME_FORMAT_MOTO4_POL1_PHA0 =
+        (SPI_CTL0_SPO_HIGH | SPI_CTL0_SPH_FIRST | SPI_CTL0_FRF_MOTOROLA_4WIRE),
+    /*! Motorola 4 Wire with Polarity 1, Phase 1 */
+    DL_SPI_FRAME_FORMAT_MOTO4_POL1_PHA1 =
+        (SPI_CTL0_SPO_HIGH | SPI_CTL0_SPH_SECOND |
+            SPI_CTL0_FRF_MOTOROLA_4WIRE),
+    /*! TI Sync Frame Format */
+    DL_SPI_FRAME_FORMAT_TI_SYNC = (SPI_CTL0_FRF_TI_SYNC),
+} DL_SPI_FRAME_FORMAT;
+
+/*! @enum DL_SPI_MODE */
+typedef enum {
+    /*! Controller mode */
+    DL_SPI_MODE_CONTROLLER = (SPI_CTL1_CP_ENABLE),
+    /*! Peripheral mode */
+    DL_SPI_MODE_PERIPHERAL = (SPI_CTL1_CP_DISABLE)
+} DL_SPI_MODE;
+
+/*! @enum DL_SPI_BIT_ORDER */
+typedef enum {
+    /*! MSB First */
+    DL_SPI_BIT_ORDER_MSB_FIRST = (SPI_CTL1_MSB_ENABLE),
+    /*! LSB First */
+    DL_SPI_BIT_ORDER_LSB_FIRST = (SPI_CTL1_MSB_DISABLE)
+} DL_SPI_BIT_ORDER;
+
+/*! @enum DL_SPI_DATA_SIZE */
+typedef enum {
+    /*! Data size 4 bits */
+    DL_SPI_DATA_SIZE_4 = (SPI_CTL0_DSS_DSS_4),
+    /*! Data size 5 bits */
+    DL_SPI_DATA_SIZE_5 = (SPI_CTL0_DSS_DSS_5),
+    /*! Data size 6 bits */
+    DL_SPI_DATA_SIZE_6 = (SPI_CTL0_DSS_DSS_6),
+    /*! Data size 7 bits */
+    DL_SPI_DATA_SIZE_7 = (SPI_CTL0_DSS_DSS_7),
+    /*! Data size 8 bits */
+    DL_SPI_DATA_SIZE_8 = (SPI_CTL0_DSS_DSS_8),
+    /*! Data size 9 bits */
+    DL_SPI_DATA_SIZE_9 = (SPI_CTL0_DSS_DSS_9),
+    /*! Data size 10 bits */
+    DL_SPI_DATA_SIZE_10 = (SPI_CTL0_DSS_DSS_10),
+    /*! Data size 11 bits */
+    DL_SPI_DATA_SIZE_11 = (SPI_CTL0_DSS_DSS_11),
+    /*! Data size 12 bits */
+    DL_SPI_DATA_SIZE_12 = (SPI_CTL0_DSS_DSS_12),
+    /*! Data size 13 bits */
+    DL_SPI_DATA_SIZE_13 = (SPI_CTL0_DSS_DSS_13),
+    /*! Data size 14 bits */
+    DL_SPI_DATA_SIZE_14 = (SPI_CTL0_DSS_DSS_14),
+    /*! Data size 15 bits */
+    DL_SPI_DATA_SIZE_15 = (SPI_CTL0_DSS_DSS_15),
+    /*! Data size 16 bits */
+    DL_SPI_DATA_SIZE_16 = (SPI_CTL0_DSS_DSS_16),
+} DL_SPI_DATA_SIZE;
+
+/*! @enum DL_SPI_CHIP_SELECT */
+typedef enum {
+    /*! Chip Select 0 */
+    DL_SPI_CHIP_SELECT_0 = (SPI_CTL0_CSSEL_CSSEL_0),
+    /*! Chip Select 1 */
+    DL_SPI_CHIP_SELECT_1 = (SPI_CTL0_CSSEL_CSSEL_1),
+    /*! Chip Select 2 */
+    DL_SPI_CHIP_SELECT_2 = (SPI_CTL0_CSSEL_CSSEL_2),
+    /*! Chip Select 3 */
+    DL_SPI_CHIP_SELECT_3 = (SPI_CTL0_CSSEL_CSSEL_3),
+    /*! No chip select */
+    DL_SPI_CHIP_SELECT_NONE = (0)
+} DL_SPI_CHIP_SELECT;
+
+/*! @enum DL_SPI_TX_FIFO_LEVEL */
+typedef enum {
+    /*! Interrupt triggers when TX FIFO <= 3/4 empty */
+    DL_SPI_TX_FIFO_LEVEL_3_4_EMPTY = SPI_IFLS_TXIFLSEL_LVL_3_4,
+    /*! Interrupt triggers when TX FIFO <= 1/2 empty (default) */
+    DL_SPI_TX_FIFO_LEVEL_1_2_EMPTY = SPI_IFLS_TXIFLSEL_LVL_1_2,
+    /*! Interrupt triggers when TX FIFO <= 1/4 empty */
+    DL_SPI_TX_FIFO_LEVEL_1_4_EMPTY = SPI_IFLS_TXIFLSEL_LVL_1_4,
+    /*! Interrupt triggers when TX FIFO is empty */
+    DL_SPI_TX_FIFO_LEVEL_EMPTY = SPI_IFLS_TXIFLSEL_LVL_EMPTY,
+    /*! Interrupt triggers when TX FIFO has >= 1 frame free. Should be used with DMA */
+    DL_SPI_TX_FIFO_LEVEL_ONE_FRAME = SPI_IFLS_TXIFLSEL_LEVEL_1
+} DL_SPI_TX_FIFO_LEVEL;
+
+/*! @enum DL_SPI_RX_FIFO_LEVEL */
+typedef enum {
+    /*! Interrupt triggers when RX FIFO contains >= 1 frame. Should be used with DMA */
+    DL_SPI_RX_FIFO_LEVEL_ONE_FRAME = SPI_IFLS_RXIFLSEL_LEVEL_1,
+    /*! Interrupt triggers when RX FIFO is full */
+    DL_SPI_RX_FIFO_LEVEL_FULL = SPI_IFLS_RXIFLSEL_LVL_FULL,
+    /*! Interrupt triggers when RX FIFO >= 3/4 full */
+    DL_SPI_RX_FIFO_LEVEL_3_4_FULL = SPI_IFLS_RXIFLSEL_LVL_3_4,
+    /*! Interrupt triggers when RX FIFO >= 1/2 full (default) */
+    DL_SPI_RX_FIFO_LEVEL_1_2_FULL = SPI_IFLS_RXIFLSEL_LVL_1_2,
+    /*! Interrupt triggers when RX FIFO >= 1/4 full */
+    DL_SPI_RX_FIFO_LEVEL_1_4_FULL = SPI_IFLS_RXIFLSEL_LVL_1_4,
+} DL_SPI_RX_FIFO_LEVEL;
+
+/*! @enum DL_SPI_IIDX */
+typedef enum {
+
+    /*! SPI interrupt index for DMA Done 1 event for transmit */
+    DL_SPI_IIDX_DMA_DONE_TX = SPI_CPU_INT_IIDX_STAT_DMA_DONE_TX_EVT,
+    /*! SPI interrupt index for DMA Done 1 event for receive */
+    DL_SPI_IIDX_DMA_DONE_RX = SPI_CPU_INT_IIDX_STAT_DMA_DONE_RX_EVT,
+    /*! SPI interrupt index for SPI to signal it has finished transfers and
+     * changed into idle mode */
+
+    DL_SPI_IIDX_IDLE = SPI_CPU_INT_IIDX_STAT_IDLE_EVT,
+    /*! SPI interrupt index for transmit FIFO empty */
+    DL_SPI_IIDX_TX_EMPTY = SPI_CPU_INT_IIDX_STAT_TX_EMPTY,
+    /*! SPI interrupt index for transmit FIFO */
+    DL_SPI_IIDX_TX = SPI_CPU_INT_IIDX_STAT_TX_EVT,
+    /*! SPI interrupt index for receive FIFO */
+    DL_SPI_IIDX_RX = SPI_CPU_INT_IIDX_STAT_RX_EVT,
+    /*! SPI interrupt index for receive timeout */
+    DL_SPI_IIDX_RX_TIMEOUT = SPI_CPU_INT_IIDX_STAT_RTOUT_EVT,
+
+    /*! SPI interrupt index for receive FIFO full  */
+    DL_SPI_IIDX_RX_FULL = SPI_CPU_INT_IIDX_STAT_RXFULL_EVT,
+    /*! SPI interrupt index for transmit FIFO underflow  */
+    DL_SPI_IIDX_TX_UNDERFLOW = SPI_CPU_INT_IIDX_STAT_TXFIFO_UNF_EVT,
+
+    /*! SPI interrupt index for parity error */
+    DL_SPI_IIDX_PARITY_ERROR = SPI_CPU_INT_IIDX_STAT_PER_EVT,
+    /*! SPI interrupt index for receive FIFO overflow */
+    DL_SPI_IIDX_RX_OVERFLOW = SPI_CPU_INT_IIDX_STAT_RXFIFO_OFV_EVT
+} DL_SPI_IIDX;
+
+/*! @enum DL_SPI_CLOCK_DIVIDE_RATIO */
+typedef enum {
+    /*! SPI source clock divide ratio set to 1 */
+    DL_SPI_CLOCK_DIVIDE_RATIO_1 = SPI_CLKDIV_RATIO_DIV_BY_1,
+    /*! SPI source clock divide ratio set to 2 */
+    DL_SPI_CLOCK_DIVIDE_RATIO_2 = SPI_CLKDIV_RATIO_DIV_BY_2,
+    /*! SPI source clock divide ratio set to 3 */
+    DL_SPI_CLOCK_DIVIDE_RATIO_3 = SPI_CLKDIV_RATIO_DIV_BY_3,
+    /*! SPI source clock divide ratio set to 4 */
+    DL_SPI_CLOCK_DIVIDE_RATIO_4 = SPI_CLKDIV_RATIO_DIV_BY_4,
+    /*! SPI source clock divide ratio set to 5 */
+    DL_SPI_CLOCK_DIVIDE_RATIO_5 = SPI_CLKDIV_RATIO_DIV_BY_5,
+    /*! SPI source clock divide ratio set to 6 */
+    DL_SPI_CLOCK_DIVIDE_RATIO_6 = SPI_CLKDIV_RATIO_DIV_BY_6,
+    /*! SPI source clock divide ratio set to 7 */
+    DL_SPI_CLOCK_DIVIDE_RATIO_7 = SPI_CLKDIV_RATIO_DIV_BY_7,
+    /*! SPI source clock divide ratio set to 8 */
+    DL_SPI_CLOCK_DIVIDE_RATIO_8 = SPI_CLKDIV_RATIO_DIV_BY_8
+} DL_SPI_CLOCK_DIVIDE_RATIO;
+
+/*! @enum DL_SPI_CLOCK */
+typedef enum {
+    /*! Selects BUSCLK as the clock source */
+    DL_SPI_CLOCK_BUSCLK = SPI_CLKSEL_SYSCLK_SEL_ENABLE,
+    /*! Selects MFCLK as the clock source */
+    DL_SPI_CLOCK_MFCLK = SPI_CLKSEL_MFCLK_SEL_ENABLE,
+    /*! Selects LFCLK as the clock source */
+    DL_SPI_CLOCK_LFCLK = SPI_CLKSEL_LFCLK_SEL_ENABLE
+} DL_SPI_CLOCK;
+
+/*!
+ *  @brief  Configuration struct for @ref DL_SPI_init.
+ */
+typedef struct {
+    /*! The controller/peripheral mode configuration. One of @ref DL_SPI_MODE */
+    DL_SPI_MODE mode;
+
+    /*!
+     *  The frame format to use for data transfer. One of @ref
+     *  DL_SPI_FRAME_FORMAT
+     */
+    DL_SPI_FRAME_FORMAT frameFormat;
+
+    /*!
+     *  The parity configuration to use for data transfer. One of @ref
+     *  DL_SPI_PARITY.
+     */
+    DL_SPI_PARITY parity;
+
+    /*! The size of the data transfer. One of @ref DL_SPI_DATA_SIZE */
+    DL_SPI_DATA_SIZE dataSize;
+
+    /*! The order of bits during data transfer. One of @ref DL_SPI_BIT_ORDER */
+    DL_SPI_BIT_ORDER bitOrder;
+
+    /*! The pin to use for chip select. Used in Controller or Peripheral modes
+     *  with Motorola 4-Wire or TI Sync frame formats. One of
+     *  @ref DL_SPI_CHIP_SELECT.
+     */
+    DL_SPI_CHIP_SELECT chipSelectPin;
+
+} DL_SPI_Config;
+
+/*!
+ *  @brief  Configuration struct for @ref DL_SPI_setClockConfig.
+ */
+typedef struct {
+    /*! Selects SPI module clock source @ref DL_SPI_CLOCK */
+    DL_SPI_CLOCK clockSel;
+
+    /*! Selects the divide ratio. One of @ref DL_SPI_CLOCK_DIVIDE_RATIO */
+    DL_SPI_CLOCK_DIVIDE_RATIO divideRatio;
+
+} DL_SPI_ClockConfig;
+
+/**
+ * @brief Configuration structure to backup SPI peripheral state before going
+ *        to STOP/STANDBY mode. Not required after PG 1.0 silicon. Used by
+ *        @ref DL_SPI_saveConfiguration and @ref DL_SPI_restoreConfiguration
+ */
+typedef struct {
+    /*! Combination of basic SPI control configurations that are
+     *  compressed to a single word as they are stored in the SPI
+     *  registers See @ref DL_SPI_init for how the peripheral control word 0
+     *  is created. */
+    uint32_t controlWord0;
+
+    /*! Combination of basic SPI control configurations that are
+     *  compressed to a single word as they are stored in the SPI
+     *  registers. See @ref DL_SPI_init for how the peripheral control word 1
+     *  is created. */
+    uint32_t controlWord1;
+
+    /*! Combination of serial clock divider and delayed sampling settings
+     *  compressed to a single word as they are stored in the SPI registers. */
+    uint32_t clockControl;
+
+    /*! SPI module clock source. One of  @ref DL_SPI_CLOCK */
+    uint32_t clockSel;
+
+    /*! SPI clock divider. One of @ref DL_SPI_CLOCK_DIVIDE_RATIO */
+    uint32_t divideRatio;
+
+    /*! Combination of SPI interrupt FIFO level select configurations that are
+     *  compressed to a single word as they are stored in the SPI
+     *  registers. */
+    uint32_t interruptFifoLevelSelectWord;
+
+    /*! SPI interrupt status for EVENT0.
+     *  Bitwise OR of @ref DL_SPI_INTERRUPT */
+    uint32_t interruptMask0;
+
+    /*! SPI interrupt status for EVENT1.
+     *  Bitwise OR of @ref DL_SPI_DMA_INTERRUPT_RX */
+    uint32_t interruptMask1;
+
+    /*! SPI interrupt status for EVENT2.
+     *  Bitwise OR of @ref DL_SPI_DMA_INTERRUPT_TX */
+    uint32_t interruptMask2;
+
+    /*! Boolean flag indicating whether or not a valid configuration structure
+     *  exists. Should not be modified by the user. */
+    bool backupRdy;
+} DL_SPI_backupConfig;
+
+/**
+ *  @brief      Initialize the SPI peripheral
+ *
+ *  Initializes all the common configurable options for the SPI peripheral. Any
+ *  other custom configuration can be done after calling this API. The SPI is
+ *  not enabled in this API.
+ *
+ *  @param[in]  spi     Pointer to the register overlay for the peripheral
+ *  @param[in]  config  Configuration for SPI peripheral
+ */
+void DL_SPI_init(SPI_Regs *spi, DL_SPI_Config *config);
+
+/**
+ * @brief Enables power on SPI module
+ *
+ * @param spi        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_enablePower(SPI_Regs *spi)
+{
+    spi->GPRCM.PWREN = (SPI_PWREN_KEY_UNLOCK_W | SPI_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power on spi module
+ *
+ * @param spi        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_disablePower(SPI_Regs *spi)
+{
+    spi->GPRCM.PWREN = (SPI_PWREN_KEY_UNLOCK_W | SPI_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief Returns if  power on spi module
+ *
+ * @param spi        Pointer to the register overlay for the peripheral
+ *
+ * @return true if power is enabled
+ * @return false if power is disabled
+ */
+__STATIC_INLINE bool DL_SPI_isPowerEnabled(SPI_Regs *spi)
+{
+    return (
+        (spi->GPRCM.PWREN & SPI_PWREN_ENABLE_MASK) == SPI_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Resets spi peripheral
+ *
+ * @param spi        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_reset(SPI_Regs *spi)
+{
+    spi->GPRCM.RSTCTL =
+        (SPI_RSTCTL_KEY_UNLOCK_W | SPI_RSTCTL_RESETSTKYCLR_CLR |
+            SPI_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief Returns if spi peripheral was reset
+ *
+ * @param spi        Pointer to the register overlay for the peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_SPI_isReset(SPI_Regs *spi)
+{
+    return ((spi->GPRCM.STAT & SPI_GPRCM_STAT_RESETSTKY_MASK) ==
+            SPI_GPRCM_STAT_RESETSTKY_RESET);
+}
+
+/**
+ *  @brief      Enable the SPI peripheral
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_enable(SPI_Regs *spi)
+{
+    spi->CTL1 |= SPI_CTL1_ENABLE_ENABLE;
+}
+
+/**
+ *  @brief      Checks if the SPI peripheral is enabled
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the enabled status of the SPI
+ *
+ *  @retval     true  The SPI peripheral is enabled
+ *  @retval     false The SPI peripheral is disabled
+ */
+__STATIC_INLINE bool DL_SPI_isEnabled(SPI_Regs *spi)
+{
+    return ((spi->CTL1 & SPI_CTL1_ENABLE_MASK) == SPI_CTL1_ENABLE_ENABLE);
+}
+
+/**
+ *  @brief      Disable the SPI peripheral
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_disable(SPI_Regs *spi)
+{
+    spi->CTL1 &= ~(SPI_CTL1_ENABLE_MASK);
+}
+
+/**
+ *  @brief      Configure SPI source clock
+ *
+ *  @param[in]  spi    Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  config  Pointer to the clock configuration struct
+ *                       @ref DL_SPI_ClockConfig.
+ */
+void DL_SPI_setClockConfig(SPI_Regs *spi, DL_SPI_ClockConfig *config);
+
+/**
+ *  @brief      Get SPI source clock configuration
+ *
+ *  @param[in]  spi    Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  config  Pointer to the clock configuration struct
+ *                      @ref DL_SPI_ClockConfig.
+ */
+void DL_SPI_getClockConfig(SPI_Regs *spi, DL_SPI_ClockConfig *config);
+
+/**
+ *  @brief      Checks if the SPI is busy transmitting
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the busy status of the SPI
+ *
+ *  @retval     true  The SPI is transmitting
+ *  @retval     false The SPI is idle
+ */
+__STATIC_INLINE bool DL_SPI_isBusy(SPI_Regs *spi)
+{
+    return ((spi->STAT & SPI_STAT_BUSY_MASK) == SPI_STAT_BUSY_ACTIVE);
+}
+
+/**
+ *  @brief      Checks if the TX FIFO is empty
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the empty status of the TX FIFO
+ *
+ *  @retval     true  The TX FIFO is empty
+ *  @retval     false The TX FIFO is not empty
+ */
+__STATIC_INLINE bool DL_SPI_isTXFIFOEmpty(SPI_Regs *spi)
+{
+    return ((spi->STAT & SPI_STAT_TFE_MASK) == SPI_STAT_TFE_EMPTY);
+}
+
+/**
+ *  @brief      Checks if the TX FIFO is full
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the full status of the TX FIFO
+ *
+ *  @retval     true  The TX FIFO is full
+ *  @retval     false The TX FIFO is not full
+ */
+__STATIC_INLINE bool DL_SPI_isTXFIFOFull(SPI_Regs *spi)
+{
+    return ((spi->STAT & SPI_STAT_TNF_MASK) == SPI_STAT_TNF_FULL);
+}
+
+/**
+ *  @brief      Checks if the RX FIFO is empty
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the empty status of the RX FIFO
+ *
+ *  @retval     true  The RX FIFO is empty
+ *  @retval     false The RX FIFO is not empty
+ */
+__STATIC_INLINE bool DL_SPI_isRXFIFOEmpty(SPI_Regs *spi)
+{
+    return ((spi->STAT & SPI_STAT_RFE_MASK) == SPI_STAT_RFE_EMPTY);
+}
+
+/**
+ *  @brief      Checks if the RX FIFO is full
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the full status of the RX FIFO
+ *
+ *  @retval     true  The RX FIFO is full
+ *  @retval     false The RX FIFO is not full
+ */
+__STATIC_INLINE bool DL_SPI_isRXFIFOFull(SPI_Regs *spi)
+{
+    return ((spi->STAT & SPI_STAT_RNF_MASK) == SPI_STAT_RNF_FULL);
+}
+
+/**
+ *  @brief      Sets the parity configuration used for transactions
+ *
+ *  This API sets the configuration for both receive parity and transmit parity.
+ *  This includes which bit is used, and whether even or odd parity is set.
+ *
+ *  To individually enable or dsiable the receive or transmit parity, refer to
+ *  the APIs listed below.
+ *
+ *  @param[in]  spi     Pointer to the register overlay for the peripheral
+ *  @param[in]  parity  Parity configuration to use. One of @ref DL_SPI_PARITY.
+ *
+ *  @sa         DL_SPI_init
+ *  @sa         DL_SPI_enableReceiveParity
+ *  @sa         DL_SPI_disableReceiveParity
+ *  @sa         DL_SPI_enableTransmitParity
+ *  @sa         DL_SPI_disableTransmitParity
+ */
+__STATIC_INLINE void DL_SPI_setParity(SPI_Regs *spi, DL_SPI_PARITY parity)
+{
+    DL_Common_updateReg(&spi->CTL1, (uint32_t) parity,
+        (SPI_CTL1_PREN_MASK | SPI_CTL1_PTEN_MASK | SPI_CTL1_PES_MASK));
+}
+
+/**
+ *  @brief      Get the current receive and transmit parity configuration
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current parity configuration being used
+ *
+ *  @retval     One of @ref DL_SPI_PARITY
+ */
+__STATIC_INLINE DL_SPI_PARITY DL_SPI_getParity(SPI_Regs *spi)
+{
+    uint32_t parity = spi->CTL1 & (SPI_CTL1_PES_MASK | SPI_CTL1_PREN_MASK |
+                                      SPI_CTL1_PTEN_MASK);
+
+    return (DL_SPI_PARITY)(parity);
+}
+
+/**
+ *  @brief      Enables receive parity
+ *
+ *  This API only enables receive parity, it does not configure the parity mode
+ *  used.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ *
+ *  @sa         DL_SPI_setParity
+ */
+__STATIC_INLINE void DL_SPI_enableReceiveParity(SPI_Regs *spi)
+{
+    spi->CTL1 |= SPI_CTL1_PREN_ENABLE;
+}
+
+/**
+ *  @brief      Disables receive parity
+ *
+ *  This API only disable receive parity, it does not configure the parity mode
+ *  used.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ *
+ *  @sa         DL_SPI_setParity
+ */
+__STATIC_INLINE void DL_SPI_disableReceiveParity(SPI_Regs *spi)
+{
+    spi->CTL1 &= ~(SPI_CTL1_PREN_MASK);
+}
+
+/**
+ *  @brief      Checks if receive parity is enabled
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ *
+ *  @return     If receive parity is enabled
+ *
+ *  @retval     true   Receive parity is enabled
+ *  @retval     false  Receive parity is disabled
+ */
+__STATIC_INLINE bool DL_SPI_isReceiveParityEnabled(SPI_Regs *spi)
+{
+    return ((spi->CTL1 & SPI_CTL1_PREN_MASK) == SPI_CTL1_PREN_ENABLE);
+}
+
+/**
+ *  @brief      Enables transmit parity
+ *
+ *  This API only enables transmit parity, it does not configure the parity mode
+ *  used.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ *
+ *  @sa         DL_SPI_setParity
+ */
+__STATIC_INLINE void DL_SPI_enableTransmitParity(SPI_Regs *spi)
+{
+    spi->CTL1 |= SPI_CTL1_PTEN_ENABLE;
+}
+
+/**
+ *  @brief      Disables transmit parity
+ *
+ *  This API only disables transmit parity, it does not configure the parity
+ *  mode used.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ *
+ *  @sa         DL_SPI_setParity
+ */
+__STATIC_INLINE void DL_SPI_disableTransmitParity(SPI_Regs *spi)
+{
+    spi->CTL1 &= ~(SPI_CTL1_PTEN_MASK);
+}
+
+/**
+ *  @brief      Checks if transmit parity is enabled
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ *
+ *  @return     If transmit parity is enabled
+ *
+ *  @retval     true   Transmit parity is enabled
+ *  @retval     false  Transmit parity is disabled
+ */
+__STATIC_INLINE bool DL_SPI_isTransmitParityEnabled(SPI_Regs *spi)
+{
+    return ((spi->CTL1 & SPI_CTL1_PTEN_MASK) == SPI_CTL1_PTEN_ENABLE);
+}
+
+/**
+ *  @brief      Set the frame format to use
+ *
+ *  Configures the frame format to use for transactions. If you are using chip
+ *  select you must use one of the Motorola 4 wire frame formats.
+ *
+ *  @param[in]  spi          Pointer to the register overlay for the peripheral
+ *  @param[in]  frameFormat  Frame format to use. One of @ref
+ *                           DL_SPI_FRAME_FORMAT.
+ *
+ *  @sa         DL_SPI_init
+ */
+__STATIC_INLINE void DL_SPI_setFrameFormat(
+    SPI_Regs *spi, DL_SPI_FRAME_FORMAT frameFormat)
+{
+    DL_Common_updateReg(&spi->CTL0, (uint32_t) frameFormat,
+        (SPI_CTL0_FRF_MASK | SPI_CTL0_SPO_MASK | SPI_CTL0_SPH_MASK));
+}
+
+/**
+ *  @brief      Get the frame format configuration
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current frame format being used
+ *
+ *  @retval     One of @ref DL_SPI_FRAME_FORMAT
+ */
+__STATIC_INLINE DL_SPI_FRAME_FORMAT DL_SPI_getFrameFormat(SPI_Regs *spi)
+{
+    uint32_t frameFormat = spi->CTL0 & (SPI_CTL0_FRF_MASK | SPI_CTL0_SPO_MASK |
+                                           SPI_CTL0_SPH_MASK);
+
+    return (DL_SPI_FRAME_FORMAT)(frameFormat);
+}
+
+/**
+ *  @brief      Set the size for transfers
+ *
+ *  @param[in]  spi       Pointer to the register overlay for the peripheral
+ *  @param[in]  dataSize  Number of bits used in a transfer.
+ *                        One of @ref DL_SPI_DATA_SIZE
+ *
+ *  @sa         DL_SPI_init
+ */
+__STATIC_INLINE void DL_SPI_setDataSize(
+    SPI_Regs *spi, DL_SPI_DATA_SIZE dataSize)
+{
+    DL_Common_updateReg(&spi->CTL0, (uint32_t) dataSize, SPI_CTL0_DSS_MASK);
+}
+
+/**
+ *  @brief      Get the configured size for transfers
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The currently configured size for transfers
+ *
+ *  @retval     One of @ref DL_SPI_DATA_SIZE
+ */
+__STATIC_INLINE DL_SPI_DATA_SIZE DL_SPI_getDataSize(SPI_Regs *spi)
+{
+    uint32_t dataSize = spi->CTL0 & SPI_CTL0_DSS_MASK;
+
+    return (DL_SPI_DATA_SIZE)(dataSize);
+}
+
+/**
+ *  @brief      Set whether the device should be in controller/peripheral mode
+ *
+ *  @param[in]  spi   Pointer to the register overlay for the peripheral
+ *  @param[in]  mode  Mode to configure the SPI into. One of @ref DL_SPI_MODE.
+ *
+ *  @sa         DL_SPI_init
+ */
+__STATIC_INLINE void DL_SPI_setMode(SPI_Regs *spi, DL_SPI_MODE mode)
+{
+    DL_Common_updateReg(&spi->CTL1, SPI_CTL1_CP_ENABLE, SPI_CTL1_CP_MASK);
+}
+
+/**
+ *  @brief      Get the current mode for the SPI (controller/peripheral)
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The currently configured mode for the SPI (controller/peripheral)
+ *
+ *  @retval     One of @ref DL_SPI_MODE.
+ */
+__STATIC_INLINE DL_SPI_MODE DL_SPI_getMode(SPI_Regs *spi)
+{
+    uint32_t mode = spi->CTL1 & SPI_CTL1_CP_MASK;
+
+    return (DL_SPI_MODE)(mode);
+}
+
+/**
+ *  @brief      Set the bit order used for transfers
+ *
+ *  @param[in]  spi       Pointer to the register overlay for the peripheral
+ *  @param[in]  bitOrder  Order for bits to be sent out during transfer. One of
+ *                        @ref DL_SPI_BIT_ORDER.
+ *
+ *  @sa         DL_SPI_init
+ */
+__STATIC_INLINE void DL_SPI_setBitOrder(
+    SPI_Regs *spi, DL_SPI_BIT_ORDER bitOrder)
+{
+    DL_Common_updateReg(&spi->CTL1, (uint32_t) bitOrder, SPI_CTL1_MSB_MASK);
+}
+
+/**
+ *  @brief      Get the current bit order used for transfers
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The currently configured bit order
+ *
+ *  @retval     One of @ref DL_SPI_BIT_ORDER.
+ */
+__STATIC_INLINE DL_SPI_BIT_ORDER DL_SPI_getBitOrder(SPI_Regs *spi)
+{
+    uint32_t bitOrder = spi->CTL1 & SPI_CTL1_MSB_MASK;
+
+    return (DL_SPI_BIT_ORDER)(bitOrder);
+}
+
+/**
+ *  @brief      Enables loopback mode
+ *
+ *  Enables the loopback mode. When enabled, the output of the transmit serial
+ *  shifter is connected to the input of the receive serial shifter internally.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_enableLoopbackMode(SPI_Regs *spi)
+{
+    spi->CTL1 |= SPI_CTL1_LBM_ENABLE;
+}
+
+/**
+ *  @brief      Disables loopback mode
+ *
+ *  Disables the loopback mode. When disabled, the transmit serial shifter and
+ *  receive serial shifter are not connected internally.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_disableLoopbackMode(SPI_Regs *spi)
+{
+    spi->CTL1 &= ~(SPI_CTL1_LBM_MASK);
+}
+
+/**
+ *  @brief      Checks if the loopback mode is enabled
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of the loopback mode
+ *
+ *  @retval     true if loopback mode is enabled
+ *  @retval     false if loopback mode is disabled
+ */
+__STATIC_INLINE bool DL_SPI_isLoopbackModeEnabled(SPI_Regs *spi)
+{
+    return ((spi->CTL1 & SPI_CTL1_LBM_MASK) == SPI_CTL1_LBM_ENABLE);
+}
+
+/**
+ *  @brief      Set counter for repeated transmit
+ *
+ *  Repeated transmit allows you to send the same data multiple times. This is
+ *  essentially the same as writing the data into the transmit buffer
+ *  repeatedly.
+ *
+ *  @param[in]  spi         pointer to the register overlay for the peripheral
+ *  @param[in]  numRepeats  number of times to repeat the transfer. Should be a
+ *                          value between 0-255.
+ *                          @arg 0 disables the repeated transfer
+ *                          @arg 1-255 repeats that many times. So will be sent
+ *                               numRepeats + 1 times in total.
+ */
+__STATIC_INLINE void DL_SPI_setRepeatTransmit(
+    SPI_Regs *spi, uint32_t numRepeats)
+{
+    DL_Common_updateReg(&spi->CTL1, numRepeats << SPI_CTL1_REPEATTX_OFS,
+        SPI_CTL1_REPEATTX_MASK);
+}
+
+/**
+ *  @brief      Get counter for repeated transmit
+ *
+ *  Repeated transmit allows you to send the same data multiple times. This is
+ *  essentially the same as writing the data into the transmit buffer
+ *  repeatedly.
+ *
+ *  @param[in]  spi    pointer to the register overlay for the peripheral
+ *
+ *  @return     Number of repeats used for transfer
+ *
+ *  @retval     0      Repeated transfer is disabled
+ *  @retval     1-255  Repeat that many times.
+ */
+__STATIC_INLINE uint32_t DL_SPI_getRepeatTransmit(SPI_Regs *spi)
+{
+    return ((spi->CTL1 & SPI_CTL1_REPEATTX_MASK) >> SPI_CTL1_REPEATTX_OFS);
+}
+
+/**
+ *  @brief      Enables data alignment on chip select for peripherals
+ *
+ *  When enabled, the receieve bit counter is cleared automatically when the
+ *  chip select gets set inactive. This helps the peripheral synchronize again to
+ *  the controller in case of a disturbance or glitch on the clock line or during
+ *  initialization.
+ *
+ *  This is only relevant when in peripheral mode.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_enablePeripheralAlignDataOnChipSelect(
+    SPI_Regs *spi)
+{
+    spi->CTL0 |= SPI_CTL0_CSCLR_ENABLE;
+}
+
+/**
+ *  @brief      Disables data alignment on chip select for peripherals
+ *
+ *  When disable, the receieve bit counter is not cleared automatically when
+ *  the chip select gets set inactive.
+ *
+ *  This is only relevant when in peripheral mode.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_disablePeripheralAlignDataOnChipSelect(
+    SPI_Regs *spi)
+{
+    spi->CTL0 &= ~(SPI_CTL0_CSCLR_MASK);
+}
+
+/**
+ *  @brief      Checks if data alignment on chip select for peripherals is enabled
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of data alignment on chip select
+ *
+ *  @retval     true   Data alignment on chip select is enabled
+ *  @retval     false  Data alignment on chip select is disabled
+ */
+__STATIC_INLINE bool DL_SPI_isPeripheralAlignDataOnChipSelectEnabled(
+    SPI_Regs *spi)
+{
+    return ((spi->CTL0 & SPI_CTL0_CSCLR_MASK) == SPI_CTL0_CSCLR_ENABLE);
+}
+
+/**
+ *  @brief      Enables packing feature
+ *
+ *  When enabled, two entries of the RX FIFO are returned as a 32-bit value.
+ *  When reading the TX FIFO, if the last write to that field was a 32-bit
+ *  write, those 32-bits will be returned.
+ *  When writing to the TX FIFO, a 32-bit write will be written as one FIFO
+ *  entry.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_enablePacking(SPI_Regs *spi)
+{
+    spi->CTL0 |= SPI_CTL0_PACKEN_ENABLED;
+}
+
+/**
+ *  @brief      Disables packing feature
+ *
+ *  When disabled, 1 entry of the RX FIFO is returned as a 16-bit value.
+ *  When reading the TX FIFO, if the last write to that field was a 16-bit
+ *  write, those 16-bits wil be returned.
+ *  When writing to the TX FIFO, a 32-bit write will be written as two FIFO
+ *  entries.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_disablePacking(SPI_Regs *spi)
+{
+    spi->CTL0 &= ~(SPI_CTL0_PACKEN_MASK);
+}
+
+/**
+ *  @brief      Checks if packing feature is enabled
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ *
+ *  @return     If packing is enabled
+ *
+ *  @retval     true   Packing is enabled
+ *  @retval     false  Packing is disabled
+ */
+__STATIC_INLINE bool DL_SPI_isPackingEnabled(SPI_Regs *spi)
+{
+    return ((spi->CTL0 & SPI_CTL0_PACKEN_MASK) == SPI_CTL0_PACKEN_ENABLED);
+}
+
+/**
+ *  @brief      Set chip select used for controller or peripheral mode
+ *
+ *  Choose which chip select should be used for data transfer. User must ensure
+ *  one of the 4-wire frame formats were selected using @ref DL_SPI_init or
+ *  @ref DL_SPI_setFrameFormat.
+ *
+ * This API is for both controller and peripheral modes, and the chip select
+ * can be changed in the application by calling this API.
+ *
+ *  @param[in]  spi         pointer to the register overlay for the peripheral
+ *  @param[in]  chipSelect  the chip select pin to use. One of @ref
+ *                          DL_SPI_CHIP_SELECT.
+ */
+__STATIC_INLINE void DL_SPI_setChipSelect(
+    SPI_Regs *spi, DL_SPI_CHIP_SELECT chipSelect)
+{
+    DL_Common_updateReg(
+        &spi->CTL0, (uint32_t) chipSelect, SPI_CTL0_CSSEL_MASK);
+}
+
+/**
+ *  @brief      Get chip select used for controller or peripheral mode
+ *
+ *  This API is for both controller and peripheral modes.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ *
+ *  @return     The current chip selected used for data transfer
+ *
+ *  @retval     One of @ref DL_SPI_CHIP_SELECT.
+ */
+__STATIC_INLINE DL_SPI_CHIP_SELECT DL_SPI_getChipSelect(SPI_Regs *spi)
+{
+    uint32_t chipSelect = spi->CTL0 & SPI_CTL0_CSSEL_MASK;
+
+    return (DL_SPI_CHIP_SELECT)(chipSelect);
+}
+
+/**
+ *  @brief      Set peripheral receive timeout
+ *
+ *  Sets the number of clock cycles before a receive timeout occurs.
+ *
+ *  This is only relevant when in peripheral mode.
+ *
+ *  @param[in]  spi      pointer to the register overlay for the peripheral
+ *  @param[in]  timeout  Number of clock cycles before a receive timeout
+ *                       occurs. Must be between 0-63.
+ *                       @arg 0 Disables receive timeout
+ *                       @arg 1-63 Number of clock cycles before timeout
+ */
+__STATIC_INLINE void DL_SPI_setPeripheralReceiveTimeout(
+    SPI_Regs *spi, uint32_t timeout)
+{
+    DL_Common_updateReg(&spi->CTL1, timeout << SPI_CTL1_RXTIMEOUT_OFS,
+        SPI_CTL1_RXTIMEOUT_MASK);
+}
+
+/**
+ *  @brief      Get peripheral receive timeout
+ *
+ *  This is only relevant when in peripheral mode.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *
+ *  @return     The current amount of cycles used for a peripheral timeout
+ *
+ *  @retval     0     indicating that receive timeout is disabled
+ *  @retval     1-63  number of clock cycles before a receive timeout occurs
+ */
+__STATIC_INLINE uint32_t DL_SPI_getPeripheralReceiveTimeout(SPI_Regs *spi)
+{
+    return ((spi->CTL1 & SPI_CTL1_RXTIMEOUT_MASK) >> SPI_CTL1_RXTIMEOUT_OFS);
+}
+
+/**
+ *  @brief      Configure the command/data mode
+ *
+ *  Command/data mode allows the hardware to control the C/D pin to indicate
+ *  whether the data being transferred is a command or just data. The C/D pin
+ *  is low for commands and high for data.
+ *
+ *  You can use this API to manually set the C/D pin by passing in @ref
+ *  DL_SPI_CD_MODE_DATA or @ref DL_SPI_CD_MODE_COMMAND. You can also have the
+ *  C/D pin switch automatically by passing in how many bytes are part of the
+ *  command transfer. The C/D pin will stay low until that many bytes are sent
+ *  out and then automatically switch to high.
+ *
+ *  This is only relevant when in controller mode.
+ *
+ *  @param[in]  spi    pointer to the register overlay for the peripheral
+ *  @param[in]  config configuration for command/data mode. One of:
+ *                     @arg DL_SPI_CD_MODE_DATA
+ *                     @arg DL_SPI_CD_MODE_COMMAND
+ *                     @arg A value between 1-14 to indicate how many bytes
+ *                          should be sent as command
+ */
+__STATIC_INLINE void DL_SPI_setControllerCommandDataModeConfig(
+    SPI_Regs *spi, uint32_t config)
+{
+    DL_Common_updateReg(
+        &spi->CTL1, config << SPI_CTL1_CDMODE_OFS, SPI_CTL1_CDMODE_MASK);
+}
+
+/**
+ *  @brief      Get the command/data mode configuration
+ *
+ *  Returns the current configuration for command/data mode. When using the
+ *  automatic C/D pin the value read back will be the number of command bytes
+ *  remaining to be sent.
+ *
+ *  @param[in]  spi    pointer to the register overlay for the peripheral
+ *
+ *  @return     The current configuration for command/data mode
+ *
+ *  @retval     DL_SPI_CD_MODE_DATA    if in manual data mode
+ *  @retval     DL_SPI_CD_MODE_COMMAND if in manual command mode
+ *  @retval     1-14 indicating how many command bytes still need to be sent
+ */
+__STATIC_INLINE uint32_t DL_SPI_getControllerCommandDataModeConfig(
+    SPI_Regs *spi)
+{
+    return ((spi->CTL1 & SPI_CTL1_CDMODE_MASK) >> SPI_CTL1_CDMODE_OFS);
+}
+
+/**
+ *  @brief      Enables command/data mode
+ *
+ *  When command/data mode is enabled, the C/D pin is used to differentiate
+ *  between command and data during the transaction.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ *
+ *  @sa         DL_SPI_setControllerCommandDataModeConfig
+ */
+__STATIC_INLINE void DL_SPI_enableControllerCommandDataMode(SPI_Regs *spi)
+{
+    spi->CTL1 |= SPI_CTL1_CDENABLE_ENABLE;
+}
+
+/**
+ *  @brief      Disables command/data mode
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_disableControllerCommandDataMode(SPI_Regs *spi)
+{
+    spi->CTL1 &= ~(SPI_CTL1_CDENABLE_MASK);
+}
+
+/**
+ *  @brief      Checks if command/data mode is enabled
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of command/data mode
+ *
+ *  @retval     true  Command/data mode is enabled
+ *  @retval     false Command/data mode is disabled
+ */
+__STATIC_INLINE bool DL_SPI_isControllerCommandDataModeEnabled(SPI_Regs *spi)
+{
+    return ((spi->CTL1 & SPI_CTL1_CDENABLE_MASK) == SPI_CTL1_CDENABLE_ENABLE);
+}
+
+/**
+ *  @brief      Enables peripheral data output
+ *
+ *  When peripheral data output is enabled, the peripheral can drive the POCI output pin.
+ *  This will cause problems if all peripherals have their RXD lines tied together
+ *  and the controller is trying to broadcast a message to all peripherals while
+ *  ensuring only one peripheral drives data onto its serial output line.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_enablePeripheralDataOutput(SPI_Regs *spi)
+{
+    spi->CTL1 &= ~(SPI_CTL1_POD_MASK);
+}
+
+/**
+ *  @brief      Disables peripheral data output
+ *
+ *  When peripheral data output is disabled, the peripheral cannot drive the POCI output
+ *  pin. This allows multiple peripherals that have their RXD lines tied together to
+ *  receive a broadcasted message from a controller.
+ *
+ *  This is only relevant when in peripheral mode.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_SPI_disablePeripheralDataOutput(SPI_Regs *spi)
+{
+    spi->CTL1 |= SPI_CTL1_POD_ENABLE;
+}
+
+/**
+ *  @brief      Checks if peripheral data output is enabled
+ *
+ *  This is only relevant when in peripheral mode.
+ *
+ *  @param[in]  spi  pointer to the register overlay for the peripheral
+ *
+ *  @return     If peripheral data output is enabled
+ *
+ *  @retval     true if peripheral data output is enabled
+ *  @retval     false if peripheral data output is disabled
+ */
+__STATIC_INLINE bool DL_SPI_isPeripheralDataOutputEnabled(SPI_Regs *spi)
+{
+    return ((spi->CTL1 & SPI_CTL1_POD_MASK) == SPI_CTL1_POD_DISABLE);
+}
+
+/**
+ *  @brief      Set the delay sampling
+ *
+ *  In controller mode only, the data on the input pin will be delayed sampled
+ *  by the defined SPI clock cycles. The delay can be adjusted in steps of SPI
+ *  input clock steps. The maximum allowed delay should not exceed the length
+ *  of one data frame
+ *
+ *  @param[in]  spi     Pointer to the register overlay for the peripheral
+ *  @param[in]  delay   The number of SPI clock cycles to delay sampling on
+ *                      input pin. Value between 0-15.
+ */
+__STATIC_INLINE void DL_SPI_setDelayedSampling(SPI_Regs *spi, uint32_t delay)
+{
+    DL_Common_updateReg(&spi->CLKCTL, delay << SPI_CLKCTL_DSAMPLE_OFS,
+        SPI_CLKCTL_DSAMPLE_MASK);
+}
+
+/**
+ *  @brief      Get the delay sampling
+ *
+ *  In controller mode only, the data on the input pin will be delayed sampled
+ *  by the defined SPI clock cycles. The delay can be adjusted in steps of SPI
+ *  input clock steps. The maximum allowed delay should not exceed the length
+ *  of one data frame
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The amount of delay sampling on the input pin in SPI
+ *              clock cycles.
+ *
+ *  @retval     0 - 15. The amount of delay sampling in SPI clock cycles.
+ */
+__STATIC_INLINE uint32_t DL_SPI_getDelayedSampling(SPI_Regs *spi)
+{
+    return (spi->CLKCTL & SPI_CLKCTL_DSAMPLE_MASK >> SPI_CLKCTL_DSAMPLE_OFS);
+}
+
+/**
+ *  @brief      Set the RX and TX FIFO interrupt threshold level
+ *
+ *  Select the threshold for the receive and transmit FIFO interrupts. The
+ *  interrupts are generated based on a transition through a level rather
+ *  than being based on the level. That is, the interrupts are generated when
+ *  the fill level progresses through the trigger level.
+ *
+ *  For example, if the trigger level is set to the half-way mark, the interrupt
+ *  is triggered when the FIFO becomes half empty/full.
+ *
+ *  Out of reset, the FIFOs are triggered to interrupt at half-way mark.
+ *
+ *  @param[in]  spi             Pointer to the register overlay for the peripheral
+ *  @param[in]  rxThreshold     One of @ref DL_SPI_RX_FIFO_LEVEL
+ *  @param[in]  txThreshold     One of @ref DL_SPI_TX_FIFO_LEVEL
+ *
+ */
+__STATIC_INLINE void DL_SPI_setFIFOThreshold(SPI_Regs *spi,
+    DL_SPI_RX_FIFO_LEVEL rxThreshold, DL_SPI_TX_FIFO_LEVEL txThreshold)
+{
+    DL_Common_updateReg(&spi->IFLS,
+        (uint32_t) rxThreshold | (uint32_t) txThreshold,
+        SPI_IFLS_RXIFLSEL_MASK | SPI_IFLS_TXIFLSEL_MASK);
+}
+
+/**
+ *  @brief      Get the TX FIFO interrupt threshold level
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The TX FIFO interrupt threshold level
+ *
+ *  @retval     One of @ref DL_SPI_TX_FIFO_LEVEL
+ */
+__STATIC_INLINE DL_SPI_TX_FIFO_LEVEL DL_SPI_getTXFIFOThreshold(SPI_Regs *spi)
+{
+    uint32_t txThreshold = spi->IFLS & SPI_IFLS_TXIFLSEL_MASK;
+
+    return (DL_SPI_TX_FIFO_LEVEL)(txThreshold);
+}
+
+/**
+ *  @brief      Get the RX FIFO interrupt threshold level
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The RX FIFO interrupt threshold level
+ *
+ *  @retval     One of @ref DL_SPI_RX_FIFO_LEVEL
+ */
+__STATIC_INLINE DL_SPI_RX_FIFO_LEVEL DL_SPI_getRXFIFOThreshold(SPI_Regs *spi)
+{
+    uint32_t rxThreshold = spi->IFLS & SPI_IFLS_RXIFLSEL_MASK;
+
+    return (DL_SPI_RX_FIFO_LEVEL)(rxThreshold);
+}
+
+/**
+ *  @brief      Set the SPI bit rate serial clock divider (SCR)
+ *
+ * The SPI includes a programmable bit rate clock divider and prescaler to
+ * generate the serial output clock. The bit rates are supported up to
+ * FUNCCLK/2. The functional clock selection depends on the specific device,
+ * please refer to the device datasheet and PMU/Clock section.
+ *
+ * The SPI output bit rate is calculated with the following formula:
+ * SPI bit rate = (SPI functional clock) / ((1 + SCR)*2)
+ * Given this formula, the SCR can be calculated:
+ * SCR = (SPI functional clock) / ((2 * SPI bit rate) - 1)
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *  @param[in]  SCR  The SPI serial clock divider. Value between 0-1023.
+ */
+__STATIC_INLINE void DL_SPI_setBitRateSerialClockDivider(
+    SPI_Regs *spi, uint32_t SCR)
+{
+    DL_Common_updateReg(&spi->CLKCTL, SCR, SPI_CLKCTL_SCR_MASK);
+}
+
+/**
+ *  @brief      Get the SPI bit rate serial clock divider (SCR)
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current bit rate serial clock divider
+ *
+ *  @retval     The SPI SCR. Value from 0-1023
+ */
+__STATIC_INLINE uint32_t DL_SPI_getBitRateSerialClockDivider(SPI_Regs *spi)
+{
+    return (spi->CLKCTL & SPI_CLKCTL_SCR_MASK);
+}
+
+/**
+ *  @brief      Writes 8-bit data into the TX FIFO for transmit
+ *
+ *  Puts the data into the TX FIFO without checking its status. Use if already
+ *  sure the TX FIFO has space for the write. See related APIs for additional
+ *  transmit options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 8 bits.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *  @param[in]  data  data to send
+ *
+ *  @sa         DL_SPI_transmitDataBlocking8
+ *  @sa         DL_SPI_transmitDataCheck8
+ */
+__STATIC_INLINE void DL_SPI_transmitData8(SPI_Regs *spi, uint8_t data)
+{
+    spi->TXDATA = data;
+}
+
+/**
+ *  @brief      Writes 16-bit data into the TX FIFO for transmit
+ *
+ *  Puts the data into the TX FIFO without checking its status. Use if already
+ *  sure the TX FIFO has space for the write. See related APIs for additional
+ *  transmit options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 16 bits.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *  @param[in]  data  data to send
+ *
+ *  @sa         DL_SPI_transmitDataBlocking16
+ *  @sa         DL_SPI_transmitDataCheck16
+ */
+__STATIC_INLINE void DL_SPI_transmitData16(SPI_Regs *spi, uint16_t data)
+{
+    spi->TXDATA = data;
+}
+
+/**
+ *  @brief      Writes 32-bit data into the TX FIFO for transmit
+ *
+ *  Puts the data into the TX FIFO without checking its status. Use if already
+ *  sure the TX FIFO has space for the write. See related APIs for additional
+ *  transmit options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 32 bits.
+ *
+ *  NOTE: If packing is enabled by calling @ref DL_SPI_enablePacking prior to
+ *  calling this API, then a 32-bit write will be written as one FIFO entry. If
+ *  packing is disabled, then a 32-bit write will be written as two FIFO
+ *  entries.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *  @param[in]  data  data to send
+ *
+ *  @sa         DL_SPI_enablePacking
+ *  @sa         DL_SPI_transmitDataBlocking32
+ *  @sa         DL_SPI_transmitDataCheck32
+ */
+__STATIC_INLINE void DL_SPI_transmitData32(SPI_Regs *spi, uint32_t data)
+{
+    spi->TXDATA = data;
+}
+
+/**
+ *  @brief      Reads 8-bit data from the RX FIFO
+ *
+ *  Reads the data from the RX FIFO without checking its status. Use if
+ *  already sure the RX FIFO has data available. See related APIs for
+ *  additional receive options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 8 bits.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *
+ *  @return     The data in the RX FIFO
+ *
+ *  @sa         DL_SPI_receiveDataBlocking8
+ *  @sa         DL_SPI_receiveDataCheck8
+ */
+__STATIC_INLINE uint8_t DL_SPI_receiveData8(SPI_Regs *spi)
+{
+    return ((uint8_t)(spi->RXDATA));
+}
+
+/**
+ *  @brief      Reads 16-bit data from the RX FIFO
+ *
+ *  Reads the data from the RX FIFO without checking its status. Use if
+ *  already sure the RX FIFO has data available. See related APIs for
+ *  additional receive options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 16 bits.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *
+ *  @return     The data in the RX FIFO
+ *
+ *  @sa         DL_SPI_receiveDataBlocking16
+ *  @sa         DL_SPI_receiveDataCheck16
+ */
+__STATIC_INLINE uint16_t DL_SPI_receiveData16(SPI_Regs *spi)
+{
+    return ((uint16_t)(spi->RXDATA));
+}
+
+/**
+ *  @brief      Reads 32-bit data from the RX FIFO
+ *
+ *  Reads the data from the RX FIFO without checking its status. Use if
+ *  already sure the RX FIFO has data available. See related APIs for
+ *  additional receive options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 32 bits.
+ *
+ *  NOTE: Requires that packing has been enabled by calling
+ *  @ref DL_SPI_enablePacking prior to calling this API. When packing is
+ *  enabled, two entries of the RX FIFO are returned as a 32-bit value.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *
+ *  @return     The data in the RX FIFO
+ *
+ *  @pre         DL_SPI_enablePacking
+ *
+ *  @sa         DL_SPI_receiveDataBlocking32
+ *  @sa         DL_SPI_receiveDataCheck32
+ */
+__STATIC_INLINE uint32_t DL_SPI_receiveData32(SPI_Regs *spi)
+{
+    return spi->RXDATA;
+}
+
+/**
+ *  @brief      Enable SPI interrupts
+ *
+ *  @param[in]  spi            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_SPI_INTERRUPT.
+ */
+__STATIC_INLINE void DL_SPI_enableInterrupt(
+    SPI_Regs *spi, uint32_t interruptMask)
+{
+    spi->CPU_INT.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disable SPI interrupts
+ *
+ *  @param[in]  spi            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to disable. Bitwise OR of
+ *                             @ref DL_SPI_INTERRUPT.
+ */
+__STATIC_INLINE void DL_SPI_disableInterrupt(
+    SPI_Regs *spi, uint32_t interruptMask)
+{
+    spi->CPU_INT.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief      Check which SPI interrupts are enabled
+ *
+ *  @param[in]  spi            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SPI_INTERRUPT.
+ *
+ *  @return     Which of the requested SPI interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_SPI_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_SPI_getEnabledInterrupts(
+    SPI_Regs *spi, uint32_t interruptMask)
+{
+    return (spi->CPU_INT.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled SPI interrupts
+ *
+ *  Checks if any of the SPI interrupts that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  spi            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SPI_INTERRUPT.
+ *
+ *  @return     Which of the requested SPI interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_SPI_INTERRUPT values
+ *
+ *  @sa         DL_SPI_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_SPI_getEnabledInterruptStatus(
+    SPI_Regs *spi, uint32_t interruptMask)
+{
+    return (spi->CPU_INT.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any SPI interrupt
+ *
+ *  Checks if any of the SPI interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  spi            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SPI_INTERRUPT.
+ *
+ *  @return     Which of the requested SPI interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_SPI_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_SPI_getRawInterruptStatus(
+    SPI_Regs *spi, uint32_t interruptMask)
+{
+    return (spi->CPU_INT.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending SPI interrupt
+ *
+ *  Checks if any of the SPI interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  spi            Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     The highest priority pending SPI interrupt. One of @ref
+ *               DL_SPI_IIDX
+ */
+__STATIC_INLINE DL_SPI_IIDX DL_SPI_getPendingInterrupt(SPI_Regs *spi)
+{
+    return ((DL_SPI_IIDX) spi->CPU_INT.IIDX);
+}
+
+/**
+ *  @brief      Clear pending SPI interrupts
+ *
+ *  @param[in]  spi            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_SPI_INTERRUPT.
+ */
+__STATIC_INLINE void DL_SPI_clearInterruptStatus(
+    SPI_Regs *spi, uint32_t interruptMask)
+{
+    spi->CPU_INT.ICLR = interruptMask;
+}
+
+/**
+ *  @brief      Blocks to ensure transmit is ready before sending data
+ *
+ *  Puts the data into the TX FIFO after blocking to ensure the TX FIFO is not
+ *  full. Will wait indefinitely until there is space in the TX FIFO. See
+ *  related APIs for additional transmit options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 8 bits.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *  @param[in]  data  data to send
+ *
+ *  @sa         DL_SPI_transmitData8
+ *  @sa         DL_SPI_transmitDataCheck8
+ */
+void DL_SPI_transmitDataBlocking8(SPI_Regs *spi, uint8_t data);
+
+/**
+ *  @brief      Blocks to ensure transmit is ready before sending data
+ *
+ *  Puts the data into the TX FIFO after blocking to ensure the TX FIFO is not
+ *  full. Will wait indefinitely until there is space in the TX FIFO. See related
+ *  APIs for additional transmit options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 16 bits.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *  @param[in]  data  data to send
+ *
+ *  @sa         DL_SPI_transmitData16
+ *  @sa         DL_SPI_transmitDataCheck16
+ */
+void DL_SPI_transmitDataBlocking16(SPI_Regs *spi, uint16_t data);
+
+/**
+ *  @brief      Blocks to ensure transmit is ready before sending data
+ *
+ *  Puts the data into the TX FIFO after blocking to ensure the TX FIFO is not
+ *  full. Will wait indefinitely until there is space in the TX FIFO. See related
+ *  APIs for additional transmit options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 32 bits.
+ *
+ *  NOTE: If packing is enabled by calling @ref DL_SPI_enablePacking prior to
+ *  calling this API, then a 32-bit write will be written as one FIFO entry. If
+ *  packing is disabled, then a 32-bit write will be written as two FIFO
+ *  entries.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *  @param[in]  data  data to send
+ *
+ *  @sa         DL_SPI_enablePacking
+ *  @sa         DL_SPI_transmitData32
+ *  @sa         DL_SPI_transmitDataCheck32
+ */
+void DL_SPI_transmitDataBlocking32(SPI_Regs *spi, uint32_t data);
+
+/**
+ *  @brief      Blocks to ensure receive is ready before reading data
+ *
+ *  Reads the data from the RX FIFO after blocking to ensure the RX FIFO is not
+ *  empty. Will wait indefinitely until there is data in the RX FIFO. See
+ *  related APIs for additional receive options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 8 bits.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *
+ *  @return     The data in the RX FIFO
+ *
+ *  @sa         DL_SPI_transmitData8
+ *  @sa         DL_SPI_transmitDataCheck8
+ */
+uint8_t DL_SPI_receiveDataBlocking8(SPI_Regs *spi);
+
+/**
+ *  @brief      Blocks to ensure receive is ready before reading data
+ *
+ *  Reads the data from the RX FIFO after blocking to ensure the RX FIFO is not
+ *  empty. Will wait indefinitely until there is data in the RX FIFO. See
+ *  related APIs for additional receive options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 16 bits.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *
+ *  @return     The data in the RX FIFO
+ *
+ *  @sa         DL_SPI_transmitData16
+ *  @sa         DL_SPI_transmitDataCheck16
+ */
+uint16_t DL_SPI_receiveDataBlocking16(SPI_Regs *spi);
+
+/**
+ *  @brief      Blocks to ensure receive is ready before reading data
+ *
+ *  Reads the data from the RX FIFO after blocking to ensure the RX FIFO is not
+ *  empty. Will wait indefinitely until there is data in the RX FIFO. See
+ *  related APIs for additional receive options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 32 bits.
+ *
+ *  NOTE: Requires that packing has been enabled by calling
+ *  @ref DL_SPI_enablePacking prior to calling this API. When packing is
+ *  enabled, two entries of the RX FIFO are returned as a 32-bit value.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *
+ *  @return     The data in the RX FIFO
+ *
+ *  @pre         DL_SPI_enablePacking
+ *
+ *  @sa         DL_SPI_transmitData32
+ *  @sa         DL_SPI_transmitDataCheck32
+ */
+uint32_t DL_SPI_receiveDataBlocking32(SPI_Regs *spi);
+
+/**
+ *  @brief      Checks the TX FIFO before trying to transmit data
+ *
+ *  Checks if the TX FIFO is already full before trying to add new data to the
+ *  FIFO. Exits immediately if full rather than trying to block. See related
+ *  APIs for additional transmit options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 8 bits.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *  @param[in]  data  data to send
+ *
+ *  @return     If the transmit occurred
+ *
+ *  @retval     true  if data was added to the TX FIFO
+ *  @retval     false if the TX FIFO was full and data was not added
+ *
+ *  @sa         DL_SPI_transmitData8
+ *  @sa         DL_SPI_transmitDataBlocking8
+ */
+bool DL_SPI_transmitDataCheck8(SPI_Regs *spi, uint8_t data);
+
+/**
+ *  @brief      Checks the TX FIFO before trying to transmit data
+ *
+ *  Checks if the TX FIFO is already full before trying to add new data to the
+ *  FIFO. Exits immediately if full rather than trying to block. See related
+ *  APIs for additional transmit options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 16 bits.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *  @param[in]  data  data to send
+ *
+ *  @return     If the transmit occurred
+ *
+ *  @retval     true  if data was added to the TX FIFO
+ *  @retval     false if the TX FIFO was full and data was not added
+ *
+ *  @sa         DL_SPI_transmitData16
+ *  @sa         DL_SPI_transmitDataBlocking16
+ */
+bool DL_SPI_transmitDataCheck16(SPI_Regs *spi, uint16_t data);
+
+/**
+ *  @brief      Checks the TX FIFO before trying to transmit data
+ *
+ *  Checks if the TX FIFO is already full before trying to add new data to the
+ *  FIFO. Exits immediately if full rather than trying to block. See related
+ *  APIs for additional transmit options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 32 bits.
+ *
+ *  NOTE: If packing is enabled by calling @ref DL_SPI_enablePacking prior to
+ *  calling this API, then a 32-bit write will be written as one FIFO entry. If
+ *  packing is disabled, then a 32-bit write will be written as two FIFO
+ *  entries.
+ *
+ *  @param[in]  spi   pointer to the register overlay for the peripheral
+ *  @param[in]  data  data to send
+ *
+ *  @return     If the transmit occurred
+ *
+ *  @retval     true  if data was added to the TX FIFO
+ *  @retval     false if the TX FIFO was full and data was not added
+ *
+ *  @sa         DL_SPI_enablePacking
+ *  @sa         DL_SPI_transmitData32
+ *  @sa         DL_SPI_transmitDataBlocking32
+ */
+bool DL_SPI_transmitDataCheck32(SPI_Regs *spi, uint32_t data);
+
+/**
+ *  @brief      Checks the RX FIFO before trying to transmit data
+ *
+ *  Checks if the RX FIFO is already empty before trying to read new data from
+ *  the FIFO. Exits immediately if empty rather than trying to block. See
+ *  related APIs for additional receive options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 8 bits.
+ *
+ *  @param[in]  spi    pointer to the register overlay for the peripheral
+ *  @param[in]  buffer a buffer to write the received data into
+ *
+ *  @return     If the receive occurred
+ *
+ *  @retval     true  if data was read from the RX FIFO
+ *  @retval     false if the RX FIFO was empty and data was not read
+ *
+ *  @sa         DL_SPI_receiveData8
+ *  @sa         DL_SPI_receiveDataBlocking8
+ */
+bool DL_SPI_receiveDataCheck8(SPI_Regs *spi, uint8_t *buffer);
+
+/**
+ *  @brief      Checks the RX FIFO before trying to transmit data
+ *
+ *  Checks if the RX FIFO is already empty before trying to read new data from
+ *  the FIFO. Exits immediately if empty rather than trying to block. See
+ *  related APIs for additional receive options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 16 bits.
+ *
+ *  @param[in]  spi    pointer to the register overlay for the peripheral
+ *  @param[in]  buffer a buffer to write the received data into
+ *
+ *  @return     If the receive occurred
+ *
+ *  @retval     true  if data was read from the RX FIFO
+ *  @retval     false if the RX FIFO was empty and data was not read
+ *
+ *  @sa         DL_SPI_receiveData16
+ *  @sa         DL_SPI_receiveDataBlocking16
+ */
+bool DL_SPI_receiveDataCheck16(SPI_Regs *spi, uint16_t *buffer);
+
+/**
+ *  @brief      Checks the RX FIFO before trying to transmit data
+ *
+ *  Checks if the RX FIFO is already empty before trying to read new data from
+ *  the FIFO. Exits immediately if empty rather than trying to block. See
+ *  related APIs for additional receive options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 32 bits.
+ *
+ *  NOTE: Requires that packing has been enabled by calling
+ *  @ref DL_SPI_enablePacking prior to calling this API. When packing is
+ *  enabled, two entries of the RX FIFO are returned as a 32-bit value.
+ *
+ *  @param[in]  spi    pointer to the register overlay for the peripheral
+ *  @param[in]  buffer a buffer to write the received data into
+ *
+ *  @return     If the receive occurred
+ *
+ *  @retval     true  if data was read from the RX FIFO
+ *  @retval     false if the RX FIFO was empty and data was not read
+ *
+ *  @pre         DL_SPI_enablePacking
+ *
+ *  @sa         DL_SPI_receiveData32
+ *  @sa         DL_SPI_receiveDataBlocking32
+ */
+bool DL_SPI_receiveDataCheck32(SPI_Regs *spi, uint32_t *buffer);
+
+/**
+ *  @brief       Read all available data out of the RX FIFO using 8 bit access
+ *
+ *  @param[in]   spi       Pointer to the register overlay for the peripheral
+ *  @param[out]  buffer    Buffer to write received data into
+ *  @param[in]   maxCount  Max number of bytes to read from the RX FIFO
+ *
+ *  @return      Number of bytes read from the RX FIFO
+ */
+uint32_t DL_SPI_drainRXFIFO8(
+    SPI_Regs *spi, uint8_t *buffer, uint32_t maxCount);
+
+/**
+ *  @brief       Read all available data out of the RX FIFO using 16 bit access
+ *
+ *  @param[in]   spi       Pointer to the register overlay for the peripheral
+ *  @param[out]  buffer    Buffer to write received data into
+ *  @param[in]   maxCount  Max number of halfwords to read from the RX FIFO
+ *
+ *  @return      Number of halfwords read from the RX FIFO
+ */
+uint32_t DL_SPI_drainRXFIFO16(
+    SPI_Regs *spi, uint16_t *buffer, uint32_t maxCount);
+
+/**
+ *  @brief       Read all available data out of the RX FIFO using 32 bit access
+ *
+ *  NOTE: Requires that packing has been enabled by calling
+ *  @ref DL_SPI_enablePacking prior to calling this API. When packing is
+ *  enabled, two entries of the RX FIFO are returned as a 32-bit value.
+ *
+ *  @param[in]   spi       Pointer to the register overlay for the peripheral
+ *  @param[out]  buffer    Buffer to write received data into
+ *  @param[in]   maxCount  Max number of words to read from the RX FIFO
+ *
+ *  @return      Number of words read from the RX FIFO
+ *
+ *  @pre         DL_SPI_enablePacking
+ *
+ */
+uint32_t DL_SPI_drainRXFIFO32(
+    SPI_Regs *spi, uint32_t *buffer, uint32_t maxCount);
+
+/**
+ *  @brief      Fill the TX FIFO using 8 bit access
+ *
+ *  Continuously write data into the TX FIFO until it is filled up or count has
+ *  been reached.
+ *
+ *  @param[in]  spi     Pointer to the register overlay for the peripheral
+ *  @param[in]  buffer  Buffer of data to write to the TX FIFO
+ *  @param[in]  count   Max number of bytes to write to the TX FIFO
+ *
+ *  @return     Number of bytes written to the TX FIFO
+ */
+uint32_t DL_SPI_fillTXFIFO8(SPI_Regs *spi, uint8_t *buffer, uint32_t count);
+
+/**
+ *  @brief      Fill the TX FIFO using 16 bit access
+ *
+ *  Continuously write data into the TX FIFO until it is filled up or count has
+ *  been reached.
+ *
+ *  @param[in]  spi     Pointer to the register overlay for the peripheral
+ *  @param[in]  buffer  Buffer of data to write to the TX FIFO
+ *  @param[in]  count   Max number of halfwords to write to the TX FIFO
+ *
+ *  @return     Number of halfwords written to the TX FIFO
+ */
+uint32_t DL_SPI_fillTXFIFO16(SPI_Regs *spi, uint16_t *buffer, uint32_t count);
+
+/**
+ *  @brief      Fill the TX FIFO using 32 bit access
+ *
+ *  Continuously write data into the TX FIFO until it is filled up or count has
+ *  been reached.
+ *
+ *  NOTE: If packing is enabled by calling @ref DL_SPI_enablePacking prior to
+ *  calling this API, then a 32-bit write will be written as one FIFO entry. If
+ *  packing is disabled, then a 32-bit write will be written as two FIFO
+ *  entries.
+ *
+ *  @param[in]  spi     Pointer to the register overlay for the peripheral
+ *  @param[in]  buffer  Buffer of data to write to the TX FIFO
+ *  @param[in]  count   Max number of words to write to the TX FIFO
+ *
+ *  @return     Number of words written to the TX FIFO
+ *
+ *  @sa         DL_SPI_enablePacking
+ */
+uint32_t DL_SPI_fillTXFIFO32(SPI_Regs *spi, uint32_t *buffer, uint32_t count);
+
+/**
+ *  @brief      Enable SPI interrupt for triggering the DMA receive event
+ *
+ * Enables the SPI interrupt to be used as the condition to generate an
+ * event to directly trigger the DMA. This API configures the DMA_TRIG_RX
+ * register, which is the event publisher used for triggering the DMA to do
+ * a receive data transfer.
+ *
+ * @note Only one interrupt source should be enabled at a time.
+ *
+ *  @param[in]  spi       Pointer to the register overlay for the
+ *                         peripheral
+ *  @param[in]  interrupt  Interrupt to enable as the trigger condition for
+ *                         the DMA. One of @ref DL_SPI_DMA_INTERRUPT_RX.
+ */
+__STATIC_INLINE void DL_SPI_enableDMAReceiveEvent(
+    SPI_Regs *spi, uint32_t interrupt)
+{
+    spi->DMA_TRIG_RX.IMASK = interrupt;
+}
+
+/**
+ *  @brief      Enable SPI interrupt for triggering the DMA transmit event
+ *
+ * Enables the SPI interrupt to be used as the condition to generate an
+ * event to directly trigger the DMA. This API configures the DMA_TRIG_TX
+ * register, which is the event publisher used for triggering the DMA to do
+ * a transmit data transfer.
+ *
+ * @note DMA_TRIG_TX only has one transmit interrupt source
+ *
+ *  @param[in]  spi       Pointer to the register overlay for the
+ *                         peripheral
+ */
+__STATIC_INLINE void DL_SPI_enableDMATransmitEvent(SPI_Regs *spi)
+{
+    spi->DMA_TRIG_TX.IMASK = SPI_DMA_TRIG_TX_IMASK_TX_SET;
+}
+
+/**
+ *  @brief      Disables SPI interrupt from triggering the DMA receive event
+ *
+ * Disables the SPI interrupt as the condition to generate an event to
+ * directly trigger the DMA. This API configures the DMA_TRIG_RX
+ * register, which is the event publisher used for triggering the DMA to do
+ * a receive data transfer.
+ *
+ *  @param[in]  spi       Pointer to the register overlay for the
+ *                         peripheral
+ *  @param[in]  interrupt  Interrupt to disable as the trigger condition for
+ *                         the DMA. One of @ref DL_SPI_DMA_INTERRUPT_RX.
+ */
+__STATIC_INLINE void DL_SPI_disableDMAReceiveEvent(
+    SPI_Regs *spi, uint32_t interrupt)
+{
+    spi->DMA_TRIG_RX.IMASK &= ~(interrupt);
+}
+
+/**
+ *  @brief      Disables SPI interrupt from triggering the DMA transmit event
+ *
+ * Disables the SPI interrupt as the condition to generate an event to
+ * directly trigger the DMA. This API configures the DMA_TRIG_TX
+ * register, which is the event publisher used for triggering the DMA to do
+ * a transmit data transfer.
+ *
+ * @note DMA_TRIG_TX only has one transmit interrupt source
+ *
+ * @param[in]  spi       Pointer to the register overlay for the
+ *                       peripheral
+ */
+__STATIC_INLINE void DL_SPI_disableDMATransmitEvent(SPI_Regs *spi)
+{
+    spi->DMA_TRIG_TX.IMASK = SPI_DMA_TRIG_TX_IMASK_TX_CLR;
+}
+
+/**
+ *  @brief      Check which SPI interrupt for DMA receive events is enabled
+ *
+ *  This API checks the DMA_TRIG_RX register, which is the event publisher used
+ *  for triggering the DMA to do a receive data transfer.
+ *
+ *  @param[in]  spi            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SPI_DMA_INTERRUPT_RX.
+ *
+ *  @note Only one interrupt source should be enabled at a time.
+ *
+ *  @return     Which of the requested SPI interrupts is enabled
+ *
+ *  @retval     One of @ref DL_SPI_DMA_INTERRUPT_RX
+ */
+__STATIC_INLINE uint32_t DL_SPI_getEnabledDMAReceiveEvent(
+    SPI_Regs *spi, uint32_t interruptMask)
+{
+    return (spi->DMA_TRIG_RX.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check if SPI interrupt for DMA transmit event is enabled
+ *
+ *  This API checks the DMA_TRIG_TX register, which is the event publisher used
+ *  for triggering the DMA to do a transmit data transfer.
+ *
+ *  @param[in]  spi           Pointer to the register overlay for the
+ *                            peripheral
+ *
+ *  @return     The requested SPI interrupt status
+ *
+ *  @retval     DL_SPI_DMA_INTERRUPT_TX if enabled, 0 if not enabled
+ */
+__STATIC_INLINE uint32_t DL_SPI_getEnabledDMATransmitEvent(SPI_Regs *spi)
+{
+    return (spi->DMA_TRIG_TX.IMASK & SPI_DMA_TRIG_TX_IMASK_TX_MASK);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled SPI interrupt for DMA receive event
+ *
+ * Checks if any of the SPI interrupts for the DMA receive event that were
+ * previously enabled are pending.
+ * This API checks the DMA_TRIG_RX register, which is the event publisher used
+ * for triggering the DMA to do a receive data transfer.
+ *
+ *  @param[in]  spi            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SPI_DMA_INTERRUPT_RX.
+ *
+ *  @note Only one interrupt source should be enabled at a time.
+ *
+ *  @return     The requested SPI interrupt status
+ *
+ *  @retval     One of @ref DL_SPI_DMA_INTERRUPT_RX
+ *
+ *  @sa         DL_SPI_enableDMAReceiveEvent
+ */
+__STATIC_INLINE uint32_t DL_SPI_getEnabledDMAReceiveEventStatus(
+    SPI_Regs *spi, uint32_t interruptMask)
+{
+    return (spi->DMA_TRIG_RX.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled SPI interrupt for DMA transmit event
+ *
+ * Checks if the SPI interrupt for the DMA transmit event that was
+ * previously enabled is pending.
+ * This API checks the DMA_TRIG_TX register, which is the event publisher used
+ * for triggering the DMA to do a transmit data transfer.
+ *
+ *  @param[in]  spi           Pointer to the register overlay for the
+ *                            peripheral
+ *
+ *  @return     The requested SPI interrupt status
+ *
+ *  @retval     DL_SPI_DMA_INTERRUPT_TX if enabled, 0 if not enabled
+ *
+ *  @sa         DL_SPI_enableDMATransmitEvent
+ */
+__STATIC_INLINE uint32_t DL_SPI_getEnabledDMATransmitEventStatus(SPI_Regs *spi)
+{
+    return (spi->DMA_TRIG_TX.MIS & SPI_DMA_TRIG_TX_MIS_TX_MASK);
+}
+
+/**
+ *  @brief      Check interrupt flag of any SPI interrupt for DMA receive event
+ *
+ *  Checks if any of the SPI interrupts for DMA receive event are pending.
+ *  Interrupts do not have to be previously enabled.
+ *  This API checks the DMA_TRIG_RX register, which is the event publisher used
+ *  for triggering the DMA to do a receive data transfer.
+ *
+ *  @param[in]  spi            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SPI_DMA_INTERRUPT_RX.
+ *
+ *  @return     Which of the requested SPI interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_SPI_DMA_INTERRUPT_RX values
+ */
+__STATIC_INLINE uint32_t DL_SPI_getRawDMAReceiveEventStatus(
+    SPI_Regs *spi, uint32_t interruptMask)
+{
+    return (spi->DMA_TRIG_RX.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any SPI interrupt for DMA transmit event
+ *
+ *  Checks if any of the SPI interrupts for DMA transmit event are pending.
+ *  Interrupts do not have to be previously enabled.
+ *  This API checks the DMA_TRIG_TX register, which is the event publisher used
+ *  for triggering the DMA to do a transmit data transfer.
+ *
+ *  @param[in]  spi           Pointer to the register overlay for the
+ *                            peripheral
+ *
+ *  @return     The requested SPI interrupt status
+ *
+ *  @retval     DL_SPI_DMA_INTERRUPT_TX if enabled, 0 if not enabled
+ */
+__STATIC_INLINE uint32_t DL_SPI_getRawDMATransmitEventStatus(SPI_Regs *spi)
+{
+    return (spi->DMA_TRIG_TX.RIS & SPI_DMA_TRIG_TX_RIS_TX_MASK);
+}
+
+/**
+ *  @brief      Get highest priority pending SPI interrupt for DMA receive event
+ *
+ *  Checks if any of the SPI interrupts for DMA receive event are pending.
+ *  Interrupts do not have to be previously enabled.
+ *  This API checks the DMA_TRIG_RX register, which is the event publisher used
+ *  for triggering the DMA to do a receive data transfer.
+ *
+ *
+ *  @param[in]  spi           Pointer to the register overlay for the
+ *                            peripheral
+ *
+ *  @return     The highest priority pending SPI interrupt
+ *
+ *  @retval     One of @ref DL_SPI_DMA_IIDX_RX
+ */
+__STATIC_INLINE DL_SPI_DMA_IIDX_RX DL_SPI_getPendingDMAReceiveEvent(
+    SPI_Regs *spi)
+{
+    return (DL_SPI_DMA_IIDX_RX)(spi->DMA_TRIG_RX.IIDX);
+}
+
+/**
+ *  @brief      Get highest priority pending SPI interrupt for DMA transmit event
+ *
+ *  Checks if the SPI interrupt for DMA transmit event is pending.
+ *  Interrupts do not have to be previously enabled.
+ *  This API checks the DMA_TRIG_TX register, which is the event publisher used
+ *  for triggering the DMA to do a transmit data transfer.
+ *
+ *
+ *  @param[in]  spi           Pointer to the register overlay for the
+ *                            peripheral
+ *
+ *  @return     The highest priority pending SPI interrupt
+ *
+ *  @retval     DL_SPI_DMA_IIDX_TX if pending, 0 if not pending
+ */
+__STATIC_INLINE DL_SPI_DMA_IIDX_TX DL_SPI_getPendingDMATransmitEvent(
+    SPI_Regs *spi)
+{
+    return (DL_SPI_DMA_IIDX_TX)(spi->DMA_TRIG_TX.IIDX);
+}
+
+/**
+ *  @brief      Clear pending SPI interrupts for DMA receive event
+ *
+ *  This API checks the DMA_TRIG_RX register, which is the event publisher used
+ *  for triggering the DMA to do a receive data transfer.
+ *
+ *  @param[in]  spi            Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_SPI_DMA_INTERRUPT_RX.
+ */
+__STATIC_INLINE void DL_SPI_clearDMAReceiveEventStatus(
+    SPI_Regs *spi, uint32_t interruptMask)
+{
+    spi->DMA_TRIG_RX.ICLR = interruptMask;
+}
+
+/**
+ *  @brief      Clear pending SPI interrupt for DMA transmit event
+ *
+ *  This API checks the DMA_TRIG_TX register, which is the event publisher used
+ *  for triggering the DMA to do a transmit data transfer.
+ *
+ *  @param[in]  spi           Pointer to the register overlay for the
+ *                            peripheral
+ * @note DMA_TRIG_TX only has one transmit interrupt source
+ */
+__STATIC_INLINE void DL_SPI_clearDMATransmitEventStatus(SPI_Regs *spi)
+{
+    spi->DMA_TRIG_TX.ICLR = SPI_DMA_TRIG_TX_ICLR_TX_CLR;
+}
+
+/**
+ *  @brief      Save SPI configuration before entering a power loss state.
+ *
+ *  Some MSPM0G peripherals residing in PD1 domain do not retain register
+ *  contents when entering STOP or STANDBY modes. Please refer to the datasheet
+ *  for the full list of peripheral instances that exhibit this behavior.
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr  Configuration backup setup structure. See
+ *                  @ref DL_SPI_backupConfig.
+ *
+ *  @retval     FALSE if a configuration already exists in ptr (will not be
+ *              overwritten). TRUE if a configuration was successfully saved
+ *
+ *  @sa         DL_SPI_restoreConfiguration
+ */
+bool DL_SPI_saveConfiguration(SPI_Regs *spi, DL_SPI_backupConfig *ptr);
+
+/**
+ *  @brief      Restore SPI configuration after leaving a power loss state.
+ *
+ *  Some MSPM0G peripherals residing in PD1 domain do not retain register
+ *  contents when entering STOP or STANDBY modes. Please refer to the datasheet
+ *  for the full list of peripheral instances that exhibit this behavior.
+ *
+ *  @param[in]  spi  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr   Configuration backup setup structure. See
+ *                    @ref DL_SPI_backupConfig.
+ *
+ *  @retval     FALSE if a configuration does not exist in ptr (will not be
+ *              loaded). TRUE if a configuration successfully loaded
+ *
+ *  @sa         DL_SPI_saveConfiguration
+ */
+bool DL_SPI_restoreConfiguration(SPI_Regs *spi, DL_SPI_backupConfig *ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_SPI__ */
+
+#endif /* ti_dl_dl_spi__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_tamperio.h
+++ b/mspm0/source/ti/driverlib/dl_tamperio.h
@@ -1,0 +1,828 @@
+/*
+ * Copyright (c) 2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_tamperio.h
+ *  @brief      Tamper Input/Output (TIO) Driver Library
+ *  @defgroup   Tamper Input/Output (TIO)
+ *
+ *  @anchor ti_dl_dl_tio_Overview
+ *  # Overview
+ *
+ *  The tamper I/O is a GPIO which is sourced by the VBAT power domain.
+ *  The LFSS IP will contain up to 16 I/O’s of this type. The I/O’s have two modes of operation.
+ *  In IOMUX mode the tamper I/O input and output path are connected to the SoC IOMUX module
+ *  and the I/O’s can be used as a 2nd function like SPI, UART or Timer PWM. The second mode is
+ *  the Tamper mode. In this mode the I/O is completely controlled by the LFSS IP and will remain
+ *  functional during the power loss of the main supply or during SHUTDOWN mode.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup TAMPERIO
+ * @{
+ */
+#ifndef ti_dl_dl_tio__include
+#define ti_dl_dl_tio__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/driverlib/dl_lfss.h>
+
+#ifdef __MSPM0_HAS_TIO__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_0
+ */
+#define DL_TAMPERIO_0                               DL_LFSS_TAMPERIO_0
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_1
+ */
+#define DL_TAMPERIO_1                               DL_LFSS_TAMPERIO_1
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_2
+ */
+#define DL_TAMPERIO_2                               DL_LFSS_TAMPERIO_2
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_3
+ */
+#define DL_TAMPERIO_3                               DL_LFSS_TAMPERIO_3
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_4
+ */
+#define DL_TAMPERIO_4                               DL_LFSS_TAMPERIO_4
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_5
+ */
+#define DL_TAMPERIO_5                               DL_LFSS_TAMPERIO_5
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_6
+ */
+#define DL_TAMPERIO_6                               DL_LFSS_TAMPERIO_6
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_7
+ */
+#define DL_TAMPERIO_7                               DL_LFSS_TAMPERIO_7
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_8
+ */
+#define DL_TAMPERIO_8                               DL_LFSS_TAMPERIO_8
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_9
+ */
+#define DL_TAMPERIO_9                               DL_LFSS_TAMPERIO_9
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_10
+ */
+#define DL_TAMPERIO_10                              DL_LFSS_TAMPERIO_10
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_11
+ */
+#define DL_TAMPERIO_11                               DL_LFSS_TAMPERIO_11
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_12
+ */
+#define DL_TAMPERIO_12                              DL_LFSS_TAMPERIO_12
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_13
+ */
+#define DL_TAMPERIO_13                               DL_LFSS_TAMPERIO_13
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_14
+ */
+#define DL_TAMPERIO_14                              DL_LFSS_TAMPERIO_14
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_15
+ */
+#define DL_TAMPERIO_15                               DL_LFSS_TAMPERIO_15
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_VALUE_0
+ */
+#define DL_TAMPERIO_VALUE_0                          DL_LFSS_TAMPERIO_VALUE_0
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_VALUE_1
+ */
+#define DL_TAMPERIO_VALUE_1                          DL_LFSS_TAMPERIO_VALUE_1
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_0
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_0                    DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_0
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_1
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_1                    DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_1
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_2
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_2                    DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_2
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_3
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_3                    DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_3
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_4
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_4                    DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_4
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_5
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_5                    DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_5
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_6
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_6                    DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_6
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_7
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_7                    DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_8
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_8
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_8                    DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_8
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_9
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_9                    DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_9
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_10
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_10                   DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_10
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_11
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_11                   DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_11
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_12
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_12                   DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_12
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_13
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_13                   DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_13
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_14
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_14                   DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_14
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_15
+ */
+#define DL_TAMPERIO_INTERRUPT_TAMPERIO_15                   DL_LFSS_TAMPERIO_INTERRUPT_TAMPERIO_15
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_0
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_0                        DL_LFSS_TAMPERIO_EVENT_TAMPERIO_0
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_1
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_1                        DL_LFSS_TAMPERIO_EVENT_TAMPERIO_1
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_2
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_2                        DL_LFSS_TAMPERIO_EVENT_TAMPERIO_2
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_3
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_3                        DL_LFSS_TAMPERIO_EVENT_TAMPERIO_3
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_4
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_4                        DL_LFSS_TAMPERIO_EVENT_TAMPERIO_4
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_5
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_5                        DL_LFSS_TAMPERIO_EVENT_TAMPERIO_5
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_6
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_6                        DL_LFSS_TAMPERIO_EVENT_TAMPERIO_6
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_7
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_7                        DL_LFSS_TAMPERIO_EVENT_TAMPERIO_8
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_8
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_8                        DL_LFSS_TAMPERIO_EVENT_TAMPERIO_8
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_9
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_9                        DL_LFSS_TAMPERIO_EVENT_TAMPERIO_9
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_10
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_10                       DL_LFSS_TAMPERIO_EVENT_TAMPERIO_10
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_11
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_11                       DL_LFSS_TAMPERIO_EVENT_TAMPERIO_11
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_12
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_12                       DL_LFSS_TAMPERIO_EVENT_TAMPERIO_12
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_13
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_13                       DL_LFSS_TAMPERIO_EVENT_TAMPERIO_13
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_14
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_14                       DL_LFSS_TAMPERIO_EVENT_TAMPERIO_14
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EVENT_TAMPERIO_15
+ */
+#define DL_TAMPERIO_EVENT_TAMPERIO_15                       DL_LFSS_TAMPERIO_EVENT_TAMPERIO_15
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_0
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_0                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_0
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_1
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_1                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_1
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_2
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_2                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_2
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_3
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_3                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_3
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_4
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_4                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_4
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_5
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_5                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_5
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_6
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_6                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_6
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_7
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_7                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_7
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_8
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_8                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_8
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_9
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_9                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_9
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_10
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_10                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_10
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_11
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_11                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_11
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_12
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_12                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_12
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_13
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_13                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_13
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_14
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_14                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_14
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_15
+ */
+#define DL_TAMPERIO_IIDX_TAMPER_IO_15                       DL_LFSS_TAMPERIO_IIDX_TAMPER_IO_15
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_OUTPUT_SOURCE_TOUT
+ */
+#define DL_TAMPERIO_OUTPUT_SOURCE_TOUT                      DL_LFSS_TAMPERIO_OUTPUT_SOURCE_TOUT
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_OUTPUT_SOURCE_LFCLK
+ */
+#define DL_TAMPERIO_OUTPUT_SOURCE_LFCLK                     DL_LFSS_TAMPERIO_OUTPUT_SOURCE_LFCLK
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_OUTPUT_SOURCE_HEARTBEAT
+ */
+#define DL_TAMPERIO_OUTPUT_SOURCE_HEARTBEAT                 DL_LFSS_TAMPERIO_OUTPUT_SOURCE_HEARTBEAT
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_OUTPUT_SOURCE_TIME_STAMP_EVENT
+ */
+#define DL_TAMPERIO_OUTPUT_SOURCE_TIME_STAMP_EVENT          DL_LFSS_TAMPERIO_OUTPUT_SOURCE_TIME_STAMP_EVENT
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH_NONE
+ */
+#define DL_TAMPERIO_GLITCH_FILTER_WIDTH_NONE                DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH_NONE
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH_30_USEC
+ */
+#define DL_TAMPERIO_GLITCH_FILTER_WIDTH_30_USEC             DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH_30_USEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH_100_USEC
+ */
+#define DL_TAMPERIO_GLITCH_FILTER_WIDTH_100_USEC            DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH_100_USEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH_200_USEC
+ */
+#define DL_TAMPERIO_GLITCH_FILTER_WIDTH_200_USEC            DL_LFSS_TAMPERIO_GLITCH_FILTER_WIDTH_200_USEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY_DISABLE
+ */
+#define DL_TAMPERIO_EDGE_DETECTION_POLARITY_DISABLE            DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY_DISABLE
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY_RISE
+ */
+#define DL_TAMPERIO_EDGE_DETECTION_POLARITY_RISE                DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY_RISE
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY_FALL
+ */
+#define DL_TAMPERIO_EDGE_DETECTION_POLARITY_FALL                DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY_FALL
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY_BOTH
+ */
+#define DL_TAMPERIO_EDGE_DETECTION_POLARITY_BOTH            DL_LFSS_TAMPERIO_EDGE_DETECTION_POLARITY_BOTH
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_MODE_IOMUX
+ */
+#define DL_TAMPERIO_MODE_TAMPER                             DL_LFSS_TAMPERIO_MODE_TAMPER
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TAMPERIO_MODE_IOMUX
+ */
+#define DL_TAMPERIO_MODE_IOMUX                              DL_LFSS_TAMPERIO_MODE_IOMUX
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_INTERVAL_0_125_SEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_INTERVAL_0_125_SEC            DL_LFSS_HEARTBEAT_INTERVAL_0_125_SEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_INTERVAL_0_25_SEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_INTERVAL_0_25_SEC             DL_LFSS_HEARTBEAT_INTERVAL_0_25_SEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_INTERVAL_05_SEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_INTERVAL_05_SEC                DL_LFSS_HEARTBEAT_INTERVAL_05_SEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_INTERVAL_1_SEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_INTERVAL_1_SEC                 DL_LFSS_HEARTBEAT_INTERVAL_1_SEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_INTERVAL_2_SEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_INTERVAL_2_SEC                 DL_LFSS_HEARTBEAT_INTERVAL_2_SEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_INTERVAL_4_SEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_INTERVAL_4_SEC                  DL_LFSS_HEARTBEAT_INTERVAL_4_SEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_INTERVAL_8_SEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_INTERVAL_8_SEC                  DL_LFSS_HEARTBEAT_INTERVAL_8_SEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_INTERVAL_16_SEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_INTERVAL_16_SEC                 DL_LFSS_HEARTBEAT_INTERVAL_16_SEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_PULSE_WIDTH_1_MSEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_PULSE_WIDTH_1_MSEC              DL_LFSS_HEARTBEAT_PULSE_WIDTH_1_MSEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_PULSE_WIDTH_2_MSEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_PULSE_WIDTH_2_MSEC               DL_LFSS_HEARTBEAT_PULSE_WIDTH_2_MSEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_PULSE_WIDTH_4_MSEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_PULSE_WIDTH_4_MSEC               DL_LFSS_HEARTBEAT_PULSE_WIDTH_4_MSEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_PULSE_WIDTH_8_MSEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_PULSE_WIDTH_8_MSEC                     DL_LFSS_HEARTBEAT_PULSE_WIDTH_8_MSEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_PULSE_WIDTH_16_MSEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_PULSE_WIDTH_16_MSEC                    DL_LFSS_HEARTBEAT_PULSE_WIDTH_16_MSEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_PULSE_WIDTH_32_MSEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_PULSE_WIDTH_32_MSEC                    DL_LFSS_HEARTBEAT_PULSE_WIDTH_32_MSEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_PULSE_WIDTH_64_MSEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_PULSE_WIDTH_64_MSEC                    DL_LFSS_HEARTBEAT_PULSE_WIDTH_64_MSEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_PULSE_WIDTH_128_MSEC
+ */
+#define DL_TAMPERIO_HEARTBEAT_PULSE_WIDTH_128_MSEC                   DL_LFSS_HEARTBEAT_PULSE_WIDTH_128_MSEC
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_MODE_DISABLED
+ */
+#define DL_TAMPERIO_HEARTBEAT_MODE_DISABLED                          DL_LFSS_HEARTBEAT_MODE_DISABLED
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_MODE_ALWAYS_ON
+ */
+#define DL_TAMPERIO_HEARTBEAT_MODE_ALWAYS_ON                         DL_LFSS_HEARTBEAT_MODE_ALWAYS_ON
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_MODE_TIME_STAMP
+ */
+#define DL_TAMPERIO_HEARTBEAT_MODE_TIME_STAMP                        DL_LFSS_HEARTBEAT_MODE_TIME_STAMP
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_HEARTBEAT_MODE_POWER_FAIL
+ */
+#define DL_TAMPERIO_HEARTBEAT_MODE_POWER_FAIL               DL_LFSS_HEARTBEAT_MODE_POWER_FAIL
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_enableOutputInversion
+ */
+#define DL_TamperIO_enableOutputInversion                   DL_LFSS_TamperIO_enableOutputInversion
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_isOutputInversionEnabled
+ */
+#define DL_TamperIO_isOutputInversionEnabled                DL_LFSS_TamperIO_isOutputInversionEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_disableOutputInversion
+ */
+#define DL_TamperIO_disableOutputInversion                  DL_LFSS_TamperIO_disableOutputInversion
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_setOutputSource
+ */
+#define DL_TamperIO_setOutputSource                         DL_LFSS_TamperIO_setOutputSource
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getOutputSource
+ */
+#define DL_TamperIO_getOutputSource                         DL_LFSS_TamperIO_getOutputSource
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_setGlitchFilterWidth
+ */
+#define DL_TamperIO_setGlitchFilterWidth                    DL_LFSS_TamperIO_setGlitchFilterWidth
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getGlitchFilterWidth
+ */
+#define DL_TamperIO_getGlitchFilterWidth                    DL_LFSS_TamperIO_getGlitchFilterWidth
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_setEdgeDetectionPolarity
+ */
+#define DL_TamperIO_setEdgeDetectionPolarity                DL_LFSS_TamperIO_setEdgeDetectionPolarity
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getEdgeDetectionPolarity
+ */
+#define DL_TamperIO_getEdgeDetectionPolarity                DL_LFSS_TamperIO_getEdgeDetectionPolarity
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_enableInternalPullUp
+ */
+#define DL_TamperIO_enableInternalPullUp                    DL_LFSS_TamperIO_enableInternalPullUp
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_isInternalPullUpEnabled
+ */
+#define DL_TamperIO_isInternalPullUpEnabled                 DL_LFSS_TamperIO_isInternalPullUpEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_disableInternalPullUp
+ */
+#define DL_TamperIO_disableInternalPullUp                   DL_LFSS_TamperIO_disableInternalPullUp
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_enableInternalPullDown
+ */
+#define DL_TamperIO_enableInternalPullDown                  DL_LFSS_TamperIO_enableInternalPullDown
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_isInternalPullDownEnabled
+ */
+#define DL_TamperIO_isInternalPullDownEnabled               DL_LFSS_TamperIO_isInternalPullDownEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_disableInternalPullDown
+ */
+#define DL_TamperIO_disableInternalPullDown                 DL_LFSS_TamperIO_disableInternalPullDown
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_enableInput
+ */
+#define DL_TamperIO_enableInput                             DL_LFSS_TamperIO_enableInput
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_isInputEnabled
+ */
+#define DL_TamperIO_isInputEnabled                          DL_LFSS_TamperIO_isInputEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_disableInput
+ */
+#define DL_TamperIO_disableInput                            DL_LFSS_TamperIO_disableInput
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_setMode
+ */
+#define DL_TamperIO_setMode                                 DL_LFSS_TamperIO_setMode
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getMode
+ */
+#define DL_TamperIO_getMode                                 DL_LFSS_TamperIO_getMode
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_enableOutput
+ */
+#define DL_TamperIO_enableOutput                            DL_LFSS_TamperIO_enableOutput
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_disableOutput
+ */
+#define DL_TamperIO_disableOutput                           DL_LFSS_TamperIO_disableOutput
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_isOutputEnabled
+ */
+#define DL_TamperIO_isOutputEnabled                         DL_LFSS_TamperIO_isOutputEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_setOutputValue
+ */
+#define DL_TamperIO_setOutputValue                          DL_LFSS_TamperIO_setOutputValue
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getOutputValue
+ */
+#define DL_TamperIO_getOutputValue                          DL_LFSS_TamperIO_getOutputValue
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getInputValue
+ */
+#define DL_TamperIO_getInputValue                           DL_LFSS_TamperIO_getInputValue
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_setHeartBeatInterval
+ */
+#define DL_TamperIO_setHeartBeatInterval                    DL_LFSS_TamperIO_setHeartBeatInterval
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getHeartBeatInterval
+ */
+#define DL_TamperIO_getHeartBeatInterval                    DL_LFSS_TamperIO_getHeartBeatInterval
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_setHeartBeatPulseWidth
+ */
+#define DL_TamperIO_setHeartBeatPulseWidth                  DL_LFSS_TamperIO_setHeartBeatPulseWidth
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getHeartBeatPulseWidth
+ */
+#define DL_TamperIO_getHeartBeatPulseWidth                  DL_LFSS_TamperIO_getHeartBeatPulseWidth
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_setHeartBeatMode
+ */
+#define DL_TamperIO_setHeartBeatMode                        DL_LFSS_TamperIO_setHeartBeatMode
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getHeartBeatMode
+ */
+#define DL_TamperIO_getHeartBeatMode                        DL_LFSS_TamperIO_getHeartBeatMode
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_enableWriteProtectLock
+ */
+#define DL_TamperIO_enableWriteProtectLock                  DL_LFSS_TamperIO_enableWriteProtectLock
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_isWriteProtectLockEnabled
+ */
+#define DL_TamperIO_isWriteProtectLockEnabled               DL_LFSS_TamperIO_isWriteProtectLockEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_disableWriteProtectLock
+ */
+#define DL_TamperIO_disableWriteProtectLock                 DL_LFSS_TamperIO_disableWriteProtectLock
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_enableInterrupt
+ */
+#define DL_TamperIO_enableInterrupt                         DL_LFSS_TamperIO_enableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_enableInterrupt
+ */
+#define DL_TamperIO_disableInterrupt                        DL_LFSS_TamperIO_disableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getEnabledInterrupts
+ */
+#define DL_TamperIO_getEnabledInterrupts                    DL_LFSS_TamperIO_getEnabledInterrupts
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getEnabledInterruptStatus
+ */
+#define DL_TamperIO_getEnabledInterruptStatus               DL_LFSS_TamperIO_getEnabledInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getRawInterruptStatus
+ */
+#define DL_TamperIO_getRawInterruptStatus                   DL_LFSS_TamperIO_getRawInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getPendingInterrupt
+ */
+#define DL_TamperIO_getPendingInterrupt                     DL_LFSS_TamperIO_getPendingInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_clearInterruptStatus
+ */
+#define DL_TamperIO_clearInterruptStatus                    DL_LFSS_TamperIO_clearInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_enableEvent
+ */
+#define DL_TamperIO_enableEvent                             DL_LFSS_TamperIO_enableEvent
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_disableEvent
+ */
+#define DL_TamperIO_disableEvent                            DL_LFSS_TamperIO_disableEvent
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getEnabledEvents
+ */
+#define DL_TamperIO_getEnabledEvents                        DL_LFSS_TamperIO_getEnabledEvents
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getEnabledEventStatus
+ */
+#define DL_TamperIO_getEnabledEventStatus                   DL_LFSS_TamperIO_getEnabledEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getRawEventsStatus
+ */
+#define DL_TamperIO_getRawEventsStatus                      DL_LFSS_TamperIO_getRawEventsStatus
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_clearEventsStatus
+ */
+#define DL_TamperIO_clearEventsStatus                       DL_LFSS_TamperIO_clearEventsStatus
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_setPublisherChanID
+ */
+#define DL_TamperIO_setPublisherChanID                    DL_LFSS_TamperIO_setPublisherChanID
+
+/*!
+ * @brief Redirects to common @ref DL_LFSS_TamperIO_getPublisherChanID
+ */
+#define DL_TamperIO_getPublisherChanID                    DL_LFSS_TamperIO_getPublisherChanID
+
+/* clang-format on */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_TIO__ */
+
+#endif /* ti_dl_dl_tio__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_timer.c
+++ b/mspm0/source/ti/driverlib/dl_timer.c
@@ -1,0 +1,1170 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_timera.h>
+#include <ti/driverlib/dl_timerg.h>
+
+#if defined(__MSPM0_HAS_TIMER_A__) || defined(__MSPM0_HAS_TIMER_G__)
+
+typedef struct {
+    DL_TIMER_CC_INDEX index;
+    uint32_t ccpInput;
+    uint32_t timerConfig;
+    uint32_t ccpInputDir;
+} Timer_Input_Chan_Config;
+
+typedef struct {
+    DL_TIMER_CC_INDEX index;
+} Timer_Input_Pair_Chan_Config;
+
+static void DL_Timer_getInChanConfig(
+    DL_TIMER_INPUT_CHAN chan, Timer_Input_Chan_Config *config);
+static void DL_Timer_getInChanPairConfig(
+    DL_TIMER_INPUT_CHAN chan, Timer_Input_Pair_Chan_Config *config);
+
+void DL_Timer_setClockConfig(
+    GPTIMER_Regs *gptimer, DL_Timer_ClockConfig *config)
+{
+    gptimer->CLKSEL = (uint32_t)(config->clockSel);
+
+    gptimer->CLKDIV = (uint32_t)(config->divideRatio);
+
+    gptimer->COMMONREGS.CPS = (config->prescale);
+}
+
+void DL_Timer_getClockConfig(
+    GPTIMER_Regs *gptimer, DL_Timer_ClockConfig *config)
+{
+    config->clockSel = (DL_TIMER_CLOCK)(gptimer->CLKSEL);
+
+    config->divideRatio = (DL_TIMER_CLOCK_DIVIDE)(gptimer->CLKDIV);
+
+    config->prescale = (uint8_t)(gptimer->COMMONREGS.CPS);
+}
+
+void DL_Timer_initTimerMode(
+    GPTIMER_Regs *gptimer, DL_Timer_TimerConfig *config)
+{
+    DL_Timer_setLoadValue(gptimer, config->period);
+
+    switch (config->timerMode) {
+        /* All four cases below should set counter value to ZERO when enabled */
+        case DL_TIMER_TIMER_MODE_ONE_SHOT_UP:
+        case DL_TIMER_TIMER_MODE_PERIODIC_UP:
+        case DL_TIMER_TIMER_MODE_ONE_SHOT_UP_DOWN:
+        case DL_TIMER_TIMER_MODE_PERIODIC_UP_DOWN:
+            DL_Timer_setCounterValueAfterEnable(
+                gptimer, DL_TIMER_COUNT_AFTER_EN_ZERO);
+            break;
+        /* The two cases below should set counter value to LOAD when enabled */
+        case DL_TIMER_TIMER_MODE_ONE_SHOT:
+        case DL_TIMER_TIMER_MODE_PERIODIC:
+            DL_Timer_setCounterValueAfterEnable(
+                gptimer, DL_TIMER_COUNT_AFTER_EN_LOAD_VAL);
+            break;
+        default:
+            /* Code should not reach this case */
+            break;
+    }
+
+    DL_Timer_setCaptureCompareValue(
+        gptimer, config->counterVal, DL_TIMER_CC_0_INDEX);
+
+    DL_Timer_setCaptureCompareCtl(gptimer, (uint32_t) config->genIntermInt,
+        DL_TIMER_CC_ACOND_TIMCLK, DL_TIMER_CC_0_INDEX);
+
+    gptimer->COUNTERREGS.CTRCTL =
+        ((uint32_t) config->timerMode | (uint32_t) config->startTimer);
+}
+
+void DL_Timer_initCaptureMode(
+    GPTIMER_Regs *gptimer, DL_Timer_CaptureConfig *config)
+{
+    Timer_Input_Chan_Config captConfig;
+
+    DL_Timer_getInChanConfig(config->inputChan, &captConfig);
+
+    DL_Timer_setCaptureCompareInput(gptimer, (uint32_t) config->inputInvMode,
+        captConfig.ccpInput, captConfig.index);
+
+    DL_Timer_setLoadValue(gptimer, config->period);
+
+    switch (config->captureMode) {
+        case DL_TIMER_CAPTURE_MODE_EDGE_TIME:
+            DL_Timer_setCaptureCompareCtl(gptimer, DL_TIMER_CC_MODE_CAPTURE,
+                (DL_TIMER_CC_ZCOND_NONE | DL_TIMER_CC_ACOND_TIMCLK |
+                    DL_TIMER_CC_LCOND_NONE | (uint32_t) config->edgeCaptMode),
+                captConfig.index);
+            break;
+        case DL_TIMER_CAPTURE_MODE_PERIOD_CAPTURE:
+            if (DL_TIMER_CAPTURE_EDGE_DETECTION_MODE_RISING ==
+                config->edgeCaptMode) {
+                DL_Timer_setCaptureCompareCtl(gptimer,
+                    DL_TIMER_CC_MODE_CAPTURE,
+                    (DL_TIMER_CC_ZCOND_NONE | DL_TIMER_CC_ACOND_TIMCLK |
+                        DL_TIMER_CC_LCOND_TRIG_RISE |
+                        (uint32_t) config->edgeCaptMode),
+                    captConfig.index);
+            } else {
+                DL_Timer_setCaptureCompareCtl(gptimer,
+                    DL_TIMER_CC_MODE_CAPTURE,
+                    (DL_TIMER_CC_ZCOND_NONE | DL_TIMER_CC_ACOND_TIMCLK |
+                        DL_TIMER_CC_LCOND_TRIG_FALL |
+                        (uint32_t) config->edgeCaptMode),
+                    captConfig.index);
+            }
+            break;
+        case DL_TIMER_CAPTURE_MODE_PULSE_WIDTH:
+            if (DL_TIMER_CAPTURE_EDGE_DETECTION_MODE_RISING ==
+                config->edgeCaptMode) {
+                DL_Timer_setCaptureCompareCtl(gptimer,
+                    DL_TIMER_CC_MODE_CAPTURE,
+                    (DL_TIMER_CC_ZCOND_NONE | DL_TIMER_CC_ACOND_TIMCLK |
+                        DL_TIMER_CC_LCOND_TRIG_RISE |
+                        DL_TIMER_CC_CCOND_TRIG_FALL),
+                    captConfig.index);
+            } else {
+                DL_Timer_setCaptureCompareCtl(gptimer,
+                    DL_TIMER_CC_MODE_CAPTURE,
+                    (DL_TIMER_CC_ZCOND_NONE | DL_TIMER_CC_ACOND_TIMCLK |
+                        DL_TIMER_CC_LCOND_TRIG_FALL |
+                        DL_TIMER_CC_CCOND_TRIG_RISE),
+                    captConfig.index);
+            }
+            break;
+        default:
+            break;
+    }
+
+    DL_Timer_setCCPDirection(gptimer, captConfig.ccpInputDir);
+
+    switch (config->captureMode) {
+        case DL_TIMER_CAPTURE_MODE_EDGE_TIME_UP:
+        case DL_TIMER_CAPTURE_MODE_PERIOD_CAPTURE_UP:
+        case DL_TIMER_CAPTURE_MODE_PULSE_WIDTH_UP:
+            captConfig.timerConfig =
+                ((uint32_t) captConfig.timerConfig | GPTIMER_CTRCTL_CM_UP);
+            break;
+        default:
+            /* Default timer count is down counting mode. No need to
+              change counting mode */
+            break;
+    }
+
+    DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL,
+        ((uint32_t) captConfig.timerConfig | GPTIMER_CTRCTL_CVAE_LDVAL |
+            GPTIMER_CTRCTL_CM_DOWN | GPTIMER_CTRCTL_REPEAT_REPEAT_1 |
+            (uint32_t) config->startTimer),
+        (GPTIMER_CTRCTL_CZC_MASK | GPTIMER_CTRCTL_CAC_MASK |
+            GPTIMER_CTRCTL_CLC_MASK | GPTIMER_CTRCTL_CVAE_MASK |
+            GPTIMER_CTRCTL_CM_MASK | GPTIMER_CTRCTL_REPEAT_MASK |
+            GPTIMER_CTRCTL_EN_MASK));
+}
+
+void DL_Timer_initCaptureTriggerMode(
+    GPTIMER_Regs *gptimer, DL_Timer_CaptureTriggerConfig *config)
+{
+    DL_Timer_setLoadValue(gptimer, config->period);
+
+    DL_Timer_setCaptureCompareInput(gptimer, DL_TIMER_CC_INPUT_INV_NOINVERT,
+        DL_TIMER_CC_IN_SEL_TRIG, DL_TIMER_CC_0_INDEX);
+
+    switch (config->captureMode) {
+        case DL_TIMER_CAPTURE_MODE_EDGE_TIME:
+            DL_Timer_setCaptureCompareCtl(gptimer, DL_TIMER_CC_MODE_CAPTURE,
+                (DL_TIMER_CC_ZCOND_NONE | DL_TIMER_CC_ACOND_TIMCLK |
+                    DL_TIMER_CC_LCOND_NONE | DL_TIMER_CC_CCOND_TRIG_RISE),
+                DL_TIMER_CC_0_INDEX);
+            break;
+        case DL_TIMER_CAPTURE_MODE_PERIOD_CAPTURE:
+            DL_Timer_setCaptureCompareCtl(gptimer, DL_TIMER_CC_MODE_CAPTURE,
+                (DL_TIMER_CC_ZCOND_NONE | DL_TIMER_CC_ACOND_TIMCLK |
+                    DL_TIMER_CC_LCOND_TRIG_RISE | DL_TIMER_CC_CCOND_TRIG_RISE),
+                DL_TIMER_CC_0_INDEX);
+            break;
+        case DL_TIMER_CAPTURE_MODE_PULSE_WIDTH:
+            DL_Timer_setCaptureCompareCtl(gptimer, DL_TIMER_CC_MODE_CAPTURE,
+                (DL_TIMER_CC_ZCOND_NONE | DL_TIMER_CC_ACOND_TIMCLK |
+                    DL_TIMER_CC_LCOND_TRIG_RISE | DL_TIMER_CC_CCOND_TRIG_FALL),
+                DL_TIMER_CC_0_INDEX);
+            break;
+        default:
+            break;
+    }
+
+    switch (config->captureMode) {
+        case DL_TIMER_CAPTURE_MODE_EDGE_TIME_UP:
+        case DL_TIMER_CAPTURE_MODE_PERIOD_CAPTURE_UP:
+        case DL_TIMER_CAPTURE_MODE_PULSE_WIDTH_UP:
+            DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL,
+                (GPTIMER_CTRCTL_CLC_CCCTL0_LCOND |
+                    GPTIMER_CTRCTL_CAC_CCCTL0_ACOND |
+                    GPTIMER_CTRCTL_CZC_CCCTL0_ZCOND |
+                    GPTIMER_CTRCTL_CVAE_LDVAL | GPTIMER_CTRCTL_CM_UP |
+                    GPTIMER_CTRCTL_REPEAT_REPEAT_1 |
+                    (uint32_t) config->startTimer),
+                (GPTIMER_CTRCTL_CZC_MASK | GPTIMER_CTRCTL_CAC_MASK |
+                    GPTIMER_CTRCTL_CLC_MASK | GPTIMER_CTRCTL_CVAE_MASK |
+                    GPTIMER_CTRCTL_CM_MASK | GPTIMER_CTRCTL_REPEAT_MASK |
+                    GPTIMER_CTRCTL_EN_MASK));
+            break;
+        default:
+            DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL,
+                (GPTIMER_CTRCTL_CLC_CCCTL0_LCOND |
+                    GPTIMER_CTRCTL_CAC_CCCTL0_ACOND |
+                    GPTIMER_CTRCTL_CZC_CCCTL0_ZCOND |
+                    GPTIMER_CTRCTL_CVAE_LDVAL | GPTIMER_CTRCTL_CM_DOWN |
+                    GPTIMER_CTRCTL_REPEAT_REPEAT_1 |
+                    (uint32_t) config->startTimer),
+                (GPTIMER_CTRCTL_CZC_MASK | GPTIMER_CTRCTL_CAC_MASK |
+                    GPTIMER_CTRCTL_CLC_MASK | GPTIMER_CTRCTL_CVAE_MASK |
+                    GPTIMER_CTRCTL_CM_MASK | GPTIMER_CTRCTL_REPEAT_MASK |
+                    GPTIMER_CTRCTL_EN_MASK));
+            break;
+    }
+}
+
+void DL_Timer_initCaptureCombinedMode(
+    GPTIMER_Regs *gptimer, DL_Timer_CaptureCombinedConfig *config)
+{
+    Timer_Input_Chan_Config captConfig;
+    Timer_Input_Pair_Chan_Config captPairConfig;
+
+    DL_Timer_getInChanConfig(config->inputChan, &captConfig);
+    DL_Timer_getInChanPairConfig(config->inputChan, &captPairConfig);
+
+    DL_Timer_setLoadValue(gptimer, config->period);
+
+    DL_Timer_setCaptureCompareInput(gptimer, (uint32_t) config->inputInvMode,
+        captConfig.ccpInput, captConfig.index);
+    DL_Timer_setCaptureCompareInput(gptimer, (uint32_t) config->inputInvMode,
+        GPTIMER_IFCTL_01_ISEL_CCPX_INPUT_PAIR, captPairConfig.index);
+
+    /*
+     * Setting load condition to none due to GPTimer combined capture limitation
+     */
+    DL_Timer_setCaptureCompareCtl(gptimer, DL_TIMER_CC_MODE_CAPTURE,
+        (DL_TIMER_CC_ZCOND_NONE | DL_TIMER_CC_ACOND_TIMCLK |
+            DL_TIMER_CC_LCOND_NONE | DL_TIMER_CC_CCOND_TRIG_FALL),
+        captConfig.index);
+    DL_Timer_setCaptureCompareCtl(gptimer, DL_TIMER_CC_MODE_CAPTURE,
+        (DL_TIMER_CC_ZCOND_NONE | DL_TIMER_CC_ACOND_TIMCLK |
+            DL_TIMER_CC_LCOND_NONE | DL_TIMER_CC_CCOND_TRIG_RISE),
+        captPairConfig.index);
+
+    DL_Timer_setCCPDirection(gptimer, captConfig.ccpInputDir);
+
+    switch (config->captureMode) {
+        case DL_TIMER_CAPTURE_COMBINED_MODE_PULSE_WIDTH_AND_PERIOD_UP:
+            captConfig.timerConfig =
+                ((uint32_t) captConfig.timerConfig | GPTIMER_CTRCTL_CM_UP);
+            break;
+        default:
+            /* Default timer count is down counting mode. No need to
+              change counting mode */
+            break;
+    }
+
+    DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL,
+        ((uint32_t) captConfig.timerConfig | GPTIMER_CTRCTL_CVAE_LDVAL |
+            GPTIMER_CTRCTL_CM_DOWN | GPTIMER_CTRCTL_REPEAT_REPEAT_1 |
+            (uint32_t) config->startTimer),
+        (GPTIMER_CTRCTL_CZC_MASK | GPTIMER_CTRCTL_CAC_MASK |
+            GPTIMER_CTRCTL_CLC_MASK | GPTIMER_CTRCTL_CVAE_MASK |
+            GPTIMER_CTRCTL_CM_MASK | GPTIMER_CTRCTL_REPEAT_MASK |
+            GPTIMER_CTRCTL_EN_MASK));
+}
+
+void DL_Timer_initCompareMode(
+    GPTIMER_Regs *gptimer, DL_Timer_CompareConfig *config)
+{
+    Timer_Input_Chan_Config inChanConfig;
+
+    DL_Timer_getInChanConfig(config->inputChan, &inChanConfig);
+
+    DL_Timer_setCaptureCompareInput(gptimer, (uint32_t) config->inputInvMode,
+        inChanConfig.ccpInput, inChanConfig.index);
+
+    DL_Timer_setLoadValue(gptimer, config->count);
+
+    DL_Timer_setCaptureCompareCtl(gptimer, DL_TIMER_CC_MODE_COMPARE,
+        (DL_TIMER_CC_ZCOND_NONE | (uint32_t) config->edgeDetectMode |
+            DL_TIMER_CC_LCOND_NONE | DL_TIMER_CC_CCOND_NOCAPTURE),
+        inChanConfig.index);
+
+    switch (config->compareMode) {
+        case DL_TIMER_COMPARE_MODE_EDGE_COUNT:
+            DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL,
+                ((uint32_t) inChanConfig.timerConfig |
+                    GPTIMER_CTRCTL_CVAE_LDVAL | GPTIMER_CTRCTL_CM_DOWN |
+                    GPTIMER_CTRCTL_REPEAT_REPEAT_1 |
+                    (uint32_t) config->startTimer),
+                (GPTIMER_CTRCTL_CZC_MASK | GPTIMER_CTRCTL_CAC_MASK |
+                    GPTIMER_CTRCTL_CLC_MASK | GPTIMER_CTRCTL_CVAE_MASK |
+                    GPTIMER_CTRCTL_CM_MASK | GPTIMER_CTRCTL_REPEAT_MASK |
+                    GPTIMER_CTRCTL_EN_MASK));
+            break;
+        case DL_TIMER_COMPARE_MODE_EDGE_COUNT_UP:
+            DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL,
+                ((uint32_t) inChanConfig.timerConfig |
+                    GPTIMER_CTRCTL_CVAE_LDVAL | GPTIMER_CTRCTL_CM_UP |
+                    GPTIMER_CTRCTL_REPEAT_REPEAT_1 |
+                    (uint32_t) config->startTimer),
+                (GPTIMER_CTRCTL_CZC_MASK | GPTIMER_CTRCTL_CAC_MASK |
+                    GPTIMER_CTRCTL_CLC_MASK | GPTIMER_CTRCTL_CVAE_MASK |
+                    GPTIMER_CTRCTL_CM_MASK | GPTIMER_CTRCTL_REPEAT_MASK |
+                    GPTIMER_CTRCTL_EN_MASK));
+            break;
+        case DL_TIMER_COMPARE_MODE_EDGE_COUNT_UP_DOWN:
+            DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL,
+                ((uint32_t) inChanConfig.timerConfig |
+                    GPTIMER_CTRCTL_CVAE_LDVAL | GPTIMER_CTRCTL_CM_UP_DOWN |
+                    GPTIMER_CTRCTL_REPEAT_REPEAT_1 |
+                    (uint32_t) config->startTimer),
+                (GPTIMER_CTRCTL_CZC_MASK | GPTIMER_CTRCTL_CAC_MASK |
+                    GPTIMER_CTRCTL_CLC_MASK | GPTIMER_CTRCTL_CVAE_MASK |
+                    GPTIMER_CTRCTL_CM_MASK | GPTIMER_CTRCTL_REPEAT_MASK |
+                    GPTIMER_CTRCTL_EN_MASK));
+            break;
+        default:
+            /* Code should not reach this case */
+            break;
+    }
+}
+
+void DL_Timer_initCompareTriggerMode(
+    GPTIMER_Regs *gptimer, DL_Timer_CompareTriggerConfig *config)
+{
+    DL_Timer_setCaptureCompareInput(gptimer, DL_TIMER_CC_INPUT_INV_NOINVERT,
+        DL_TIMER_CC_IN_SEL_TRIG, DL_TIMER_CC_0_INDEX);
+
+    DL_Timer_setLoadValue(gptimer, config->count);
+
+    DL_Timer_setCaptureCompareCtl(gptimer, DL_TIMER_CC_MODE_COMPARE,
+        (DL_TIMER_CC_ZCOND_NONE | (uint32_t) config->edgeDetectMode |
+            DL_TIMER_CC_LCOND_NONE | DL_TIMER_CC_CCOND_NOCAPTURE),
+        DL_TIMER_CC_0_INDEX);
+
+    switch (config->compareMode) {
+        case DL_TIMER_COMPARE_MODE_EDGE_COUNT:
+            DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL,
+                (GPTIMER_CTRCTL_CLC_CCCTL0_LCOND |
+                    GPTIMER_CTRCTL_CAC_CCCTL0_ACOND |
+                    GPTIMER_CTRCTL_CZC_CCCTL0_ZCOND |
+                    GPTIMER_CTRCTL_CVAE_LDVAL | GPTIMER_CTRCTL_CM_DOWN |
+                    GPTIMER_CTRCTL_REPEAT_REPEAT_1 |
+                    (uint32_t) config->startTimer),
+                (GPTIMER_CTRCTL_CZC_MASK | GPTIMER_CTRCTL_CAC_MASK |
+                    GPTIMER_CTRCTL_CLC_MASK | GPTIMER_CTRCTL_CVAE_MASK |
+                    GPTIMER_CTRCTL_CM_MASK | GPTIMER_CTRCTL_REPEAT_MASK |
+                    GPTIMER_CTRCTL_EN_MASK));
+            break;
+        case DL_TIMER_COMPARE_MODE_EDGE_COUNT_UP:
+            DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL,
+                (GPTIMER_CTRCTL_CLC_CCCTL0_LCOND |
+                    GPTIMER_CTRCTL_CAC_CCCTL0_ACOND |
+                    GPTIMER_CTRCTL_CZC_CCCTL0_ZCOND |
+                    GPTIMER_CTRCTL_CVAE_LDVAL | GPTIMER_CTRCTL_CM_UP |
+                    GPTIMER_CTRCTL_REPEAT_REPEAT_1 |
+                    (uint32_t) config->startTimer),
+                (GPTIMER_CTRCTL_CZC_MASK | GPTIMER_CTRCTL_CAC_MASK |
+                    GPTIMER_CTRCTL_CLC_MASK | GPTIMER_CTRCTL_CVAE_MASK |
+                    GPTIMER_CTRCTL_CM_MASK | GPTIMER_CTRCTL_REPEAT_MASK |
+                    GPTIMER_CTRCTL_EN_MASK));
+            break;
+        case DL_TIMER_COMPARE_MODE_EDGE_COUNT_UP_DOWN:
+            DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL,
+                (GPTIMER_CTRCTL_CLC_CCCTL0_LCOND |
+                    GPTIMER_CTRCTL_CAC_CCCTL0_ACOND |
+                    GPTIMER_CTRCTL_CZC_CCCTL0_ZCOND |
+                    GPTIMER_CTRCTL_CVAE_LDVAL | GPTIMER_CTRCTL_CM_UP_DOWN |
+                    GPTIMER_CTRCTL_REPEAT_REPEAT_1 |
+                    (uint32_t) config->startTimer),
+                (GPTIMER_CTRCTL_CZC_MASK | GPTIMER_CTRCTL_CAC_MASK |
+                    GPTIMER_CTRCTL_CLC_MASK | GPTIMER_CTRCTL_CVAE_MASK |
+                    GPTIMER_CTRCTL_CM_MASK | GPTIMER_CTRCTL_REPEAT_MASK |
+                    GPTIMER_CTRCTL_EN_MASK));
+            break;
+        default:
+            /* Code should not reach this case */
+            break;
+    }
+}
+
+void DL_Timer_initPWMMode(GPTIMER_Regs *gptimer, DL_Timer_PWMConfig *config)
+{
+    switch (config->pwmMode) {
+        case DL_TIMER_PWM_MODE_EDGE_ALIGN:
+            DL_Timer_setLoadValue(gptimer, (config->period - (uint32_t) 1));
+            DL_Timer_setCaptureCompareAction(gptimer,
+                (DL_TIMER_CC_LACT_CCP_HIGH | DL_TIMER_CC_CDACT_CCP_LOW),
+                DL_TIMER_CC_0_INDEX);
+            DL_Timer_setCaptureCompareAction(gptimer,
+                (DL_TIMER_CC_LACT_CCP_HIGH | DL_TIMER_CC_CDACT_CCP_LOW),
+                DL_TIMER_CC_1_INDEX);
+            break;
+        case DL_TIMER_PWM_MODE_EDGE_ALIGN_UP:
+            DL_Timer_setLoadValue(gptimer, (config->period - (uint32_t) 1));
+            DL_Timer_setCaptureCompareAction(gptimer,
+                (DL_TIMER_CC_ZACT_CCP_HIGH | DL_TIMER_CC_CUACT_CCP_LOW),
+                DL_TIMER_CC_0_INDEX);
+            DL_Timer_setCaptureCompareAction(gptimer,
+                (DL_TIMER_CC_ZACT_CCP_HIGH | DL_TIMER_CC_CUACT_CCP_LOW),
+                DL_TIMER_CC_1_INDEX);
+            DL_Timer_setCounterValueAfterEnable(
+                gptimer, DL_TIMER_COUNT_AFTER_EN_ZERO);
+            break;
+        default:  // DL_TIMER_PWM_MODE_CENTER_ALIGN
+            DL_Timer_setLoadValue(gptimer, (config->period >> 1));
+            DL_Timer_setCaptureCompareAction(gptimer,
+                (DL_TIMER_CC_CUACT_CCP_HIGH | DL_TIMER_CC_CDACT_CCP_LOW),
+                DL_TIMER_CC_0_INDEX);
+            DL_Timer_setCaptureCompareAction(gptimer,
+                (DL_TIMER_CC_CUACT_CCP_HIGH | DL_TIMER_CC_CDACT_CCP_LOW),
+                DL_TIMER_CC_1_INDEX);
+            break;
+    }
+
+    DL_Timer_setCaptureCompareCtl(
+        gptimer, DL_TIMER_CC_MODE_COMPARE, 0, DL_TIMER_CC_0_INDEX);
+
+    DL_Timer_setCaptureCompareCtl(
+        gptimer, DL_TIMER_CC_MODE_COMPARE, 0, DL_TIMER_CC_1_INDEX);
+
+    DL_Timer_setCaptureCompareOutCtl(gptimer, DL_TIMER_CC_OCTL_INIT_VAL_LOW,
+        DL_TIMER_CC_OCTL_INV_OUT_DISABLED, DL_TIMER_CC_OCTL_SRC_FUNCVAL,
+        DL_TIMER_CC_0_INDEX);
+
+    DL_Timer_setCaptureCompareOutCtl(gptimer, DL_TIMER_CC_OCTL_INIT_VAL_LOW,
+        DL_TIMER_CC_OCTL_INV_OUT_DISABLED, DL_TIMER_CC_OCTL_SRC_FUNCVAL,
+        DL_TIMER_CC_1_INDEX);
+
+    DL_Timer_setCaptureCompareInput(gptimer, DL_TIMER_CC_INPUT_INV_NOINVERT,
+        DL_TIMER_CC_IN_SEL_CCPX, DL_TIMER_CC_0_INDEX);
+
+    DL_Timer_setCaptureCompareInput(gptimer, DL_TIMER_CC_INPUT_INV_NOINVERT,
+        DL_TIMER_CC_IN_SEL_CCPX, DL_TIMER_CC_1_INDEX);
+
+    DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL,
+        (GPTIMER_CTRCTL_REPEAT_REPEAT_1 | (uint32_t) config->pwmMode |
+            (uint32_t) config->startTimer),
+        (GPTIMER_CTRCTL_CZC_MASK | GPTIMER_CTRCTL_CAC_MASK |
+            GPTIMER_CTRCTL_CLC_MASK | GPTIMER_CTRCTL_CVAE_MASK |
+            GPTIMER_CTRCTL_CM_MASK | GPTIMER_CTRCTL_REPEAT_MASK |
+            GPTIMER_CTRCTL_EN_MASK));
+}
+
+void DL_Timer_setCaptureCompareValue(
+    GPTIMER_Regs *gptimer, uint32_t value, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.CC_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    *pReg = (value);
+}
+
+uint32_t DL_Timer_getCaptureCompareValue(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.CC_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    return (*pReg & GPTIMER_CC_01_CCVAL_MASK);
+}
+
+void DL_Timer_setCaptureCompareCtl(GPTIMER_Regs *gptimer, uint32_t ccMode,
+    uint32_t ccCondMask, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.CCCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    DL_Common_updateReg(pReg, (ccMode | ccCondMask),
+        (GPTIMER_CCCTL_01_COC_MASK | GPTIMER_CCCTL_01_ZCOND_MASK |
+            GPTIMER_CCCTL_01_LCOND_MASK | GPTIMER_CCCTL_01_ACOND_MASK |
+            GPTIMER_CCCTL_01_CCOND_MASK));
+}
+
+uint32_t DL_Timer_getCaptureCompareCtl(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.CCCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    return (
+        *pReg & (GPTIMER_CCCTL_01_COC_MASK | GPTIMER_CCCTL_01_ZCOND_MASK |
+                    GPTIMER_CCCTL_01_LCOND_MASK | GPTIMER_CCCTL_01_ACOND_MASK |
+                    GPTIMER_CCCTL_01_CCOND_MASK));
+}
+
+void DL_Timer_enableSuppressionOfCompEvent(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.CCCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    *pReg |= (GPTIMER_CCCTL_01_SCERCNEZ_ENABLED);
+}
+
+void DL_Timer_disableSuppressionOfCompEvent(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.CCCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    *pReg &= ~(GPTIMER_CCCTL_01_SCERCNEZ_ENABLED);
+}
+
+void DL_Timer_setCaptCompUpdateMethod(GPTIMER_Regs *gptimer,
+    DL_TIMER_CC_UPDATE_METHOD ccUpdtMode, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.CCCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    DL_Common_updateReg(
+        pReg, (uint32_t) ccUpdtMode, GPTIMER_CCCTL_01_CCUPD_MASK);
+}
+
+DL_TIMER_CC_UPDATE_METHOD DL_Timer_getCaptCompUpdateMethod(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.CCCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    uint32_t ccUpdtMode = *pReg & GPTIMER_CCCTL_01_CCUPD_MASK;
+
+    return ((DL_TIMER_CC_UPDATE_METHOD)(ccUpdtMode));
+}
+
+void DL_Timer_setCaptureCompareOutCtl(GPTIMER_Regs *gptimer, uint32_t ccpIV,
+    uint32_t ccpOInv, uint32_t ccpO, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.OCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    *pReg = (ccpIV | ccpOInv | ccpO);
+}
+
+uint32_t DL_Timer_getCaptureCompareOutCtl(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.OCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    return (*pReg);
+}
+
+void DL_Timer_setCaptureCompareAction(
+    GPTIMER_Regs *gptimer, uint32_t actionsMask, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.CCACT_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    DL_Common_updateReg(pReg, (uint32_t) actionsMask,
+        (GPTIMER_CCACT_01_FEXACT_MASK | GPTIMER_CCACT_01_FENACT_MASK |
+            GPTIMER_CCACT_01_CUACT_MASK | GPTIMER_CCACT_01_CDACT_MASK |
+            GPTIMER_CCACT_01_LACT_MASK | GPTIMER_CCACT_01_ZACT_MASK));
+}
+
+uint32_t DL_Timer_getCaptureCompareAction(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.CCACT_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    return (
+        *pReg & (GPTIMER_CCACT_01_FEXACT_MASK | GPTIMER_CCACT_01_FENACT_MASK |
+                    GPTIMER_CCACT_01_CUACT_MASK | GPTIMER_CCACT_01_CDACT_MASK |
+                    GPTIMER_CCACT_01_LACT_MASK | GPTIMER_CCACT_01_ZACT_MASK));
+}
+
+void DL_Timer_overrideCCPOut(GPTIMER_Regs *gptimer, DL_TIMER_FORCE_OUT out,
+    DL_TIMER_FORCE_CMPL_OUT outComp, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.CCACT_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    DL_Common_updateReg(pReg, ((uint32_t) out | ((uint32_t) outComp)),
+        (GPTIMER_CCACT_01_SWFRCACT_CMPL_MASK |
+            GPTIMER_CCACT_01_SWFRCACT_MASK));
+}
+
+void DL_Timer_setCaptureCompareInput(GPTIMER_Regs *gptimer, uint32_t inv,
+    uint32_t isel, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.IFCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    DL_Common_updateReg(pReg, (inv | isel),
+        (GPTIMER_IFCTL_01_INV_MASK | GPTIMER_IFCTL_01_ISEL_MASK));
+}
+
+uint32_t DL_Timer_getCaptureCompareInput(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.IFCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    return (*pReg & (GPTIMER_IFCTL_01_INV_MASK | GPTIMER_IFCTL_01_ISEL_MASK));
+}
+
+void DL_Timer_setCaptureCompareInputFilter(GPTIMER_Regs *gptimer, uint32_t cpv,
+    uint32_t fp, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.IFCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    DL_Common_updateReg(pReg, (cpv | fp),
+        (GPTIMER_IFCTL_01_CPV_MASK | GPTIMER_IFCTL_01_FP_MASK));
+}
+
+uint32_t DL_Timer_getCaptureCompareInputFilter(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.IFCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    return (*pReg & (GPTIMER_IFCTL_01_CPV_MASK | GPTIMER_IFCTL_01_FP_MASK));
+}
+
+void DL_Timer_enableCaptureCompareInputFilter(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.IFCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    *pReg |= (GPTIMER_IFCTL_01_FE_ENABLED);
+}
+
+void DL_Timer_disableCaptureCompareInputFilter(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.IFCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    *pReg &= ~(GPTIMER_IFCTL_01_FE_ENABLED);
+}
+
+bool DL_Timer_isCaptureCompareInputFilterEnabled(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex)
+{
+    volatile uint32_t *pReg;
+
+    pReg = &gptimer->COUNTERREGS.IFCTL_01[0];
+    pReg += (uint32_t) ccIndex;
+
+    return (GPTIMER_IFCTL_01_FE_ENABLED == (*pReg & GPTIMER_IFCTL_01_FE_MASK));
+}
+
+bool DL_Timer_saveConfiguration(
+    GPTIMER_Regs *gptimer, DL_Timer_backupConfig *ptr)
+{
+    bool saveState = !ptr->backupRdy;
+    if (saveState) {
+        /* Generic Events configuration */
+        ptr->sub0PortConf = gptimer->FSUB_0;
+        ptr->sub1PortConf = gptimer->FSUB_1;
+        ptr->pub0PortConf = gptimer->FPUB_0;
+        ptr->pub1PortConf = gptimer->FPUB_1;
+
+        /* Clock configuration */
+        ptr->clkDivConf   = gptimer->CLKDIV;
+        ptr->clockPscConf = gptimer->COMMONREGS.CPS;
+        ptr->clkSelConf   = gptimer->CLKSEL;
+        ptr->countClkConf = gptimer->COMMONREGS.CCLKCTL;
+
+        /* Interrupt and Event Configuration */
+        ptr->intEvnt0Conf = gptimer->CPU_INT.IMASK;
+        ptr->intEvnt1Conf = gptimer->GEN_EVENT0.IMASK;
+        ptr->intEvnt2Conf = gptimer->GEN_EVENT1.IMASK;
+
+        /* Cross-trigger configuration */
+        ptr->crossTrigCtl  = gptimer->COMMONREGS.CTTRIGCTL;
+        ptr->crossTrigConf = gptimer->COMMONREGS.CTTRIG;
+
+        /* Timer configuration */
+        ptr->cntVal     = gptimer->COUNTERREGS.CTR;
+        ptr->cntCtlConf = gptimer->COUNTERREGS.CTRCTL;
+        ptr->loadVal    = gptimer->COUNTERREGS.LOAD;
+        ptr->tSelConf   = gptimer->COUNTERREGS.TSEL;
+        ptr->ccpDirConf = gptimer->COMMONREGS.CCPD;
+        ptr->outDisConf = gptimer->COMMONREGS.ODIS;
+
+        /* Capture or Compare configuration */
+        ptr->cc0Val     = gptimer->COUNTERREGS.CC_01[0];
+        ptr->cc1Val     = gptimer->COUNTERREGS.CC_01[1];
+        ptr->cc0Ctl     = gptimer->COUNTERREGS.CCCTL_01[0];
+        ptr->cc1Ctl     = gptimer->COUNTERREGS.CCCTL_01[1];
+        ptr->cc0OutCtl  = gptimer->COUNTERREGS.OCTL_01[0];
+        ptr->cc1OutCtl  = gptimer->COUNTERREGS.OCTL_01[1];
+        ptr->cc0ActCtl  = gptimer->COUNTERREGS.CCACT_01[0];
+        ptr->cc1ActCtl  = gptimer->COUNTERREGS.CCACT_01[1];
+        ptr->in0FiltCtl = gptimer->COUNTERREGS.IFCTL_01[0];
+        ptr->in1FiltCtl = gptimer->COUNTERREGS.IFCTL_01[1];
+
+        ptr->backupRdy = true;
+    }
+    return saveState;
+}
+
+bool DL_Timer_restoreConfiguration(
+    GPTIMER_Regs *gptimer, DL_Timer_backupConfig *ptr, bool restoreCounter)
+{
+    bool stateRestored = ptr->backupRdy;
+    if (stateRestored) {
+        ptr->backupRdy = false;
+        /* Generic Events Configuration */
+        gptimer->FSUB_0 = ptr->sub0PortConf;
+        gptimer->FSUB_1 = ptr->sub1PortConf;
+        gptimer->FPUB_0 = ptr->pub0PortConf;
+        gptimer->FPUB_1 = ptr->pub1PortConf;
+
+        /* Clock Configuration */
+        gptimer->CLKSEL = ptr->clkSelConf;
+        gptimer->CLKDIV = ptr->clkDivConf;
+
+        /**
+         *  Since the only difference between TIMG and TIMH is the prescaler
+         * register, restore function will ommit restoring prescaler by
+         * comparing to gptimer pointer to the TIMH0 expected base address
+         * (i.e. 0x40880000U) in MSPM0G devices. MSPM0L devices don't have a
+         * TIMH instances.*/
+        if (((uint32_t) &gptimer) == 0x40880000U) {
+            gptimer->COMMONREGS.CPS = ptr->clockPscConf;
+        } else {
+            // Configuration of prescaler is ommited
+        }
+        gptimer->COMMONREGS.CCLKCTL = ptr->countClkConf;
+
+        /* Timer Configuration */
+        if (true == restoreCounter) {
+            gptimer->COUNTERREGS.CTR = ptr->cntVal;
+        }
+        gptimer->COUNTERREGS.LOAD = ptr->loadVal;
+        gptimer->COUNTERREGS.TSEL = ptr->tSelConf;
+        gptimer->COMMONREGS.CCPD  = ptr->ccpDirConf;
+        gptimer->COMMONREGS.ODIS  = ptr->outDisConf;
+
+        /* Capture or Compare Configuration */
+        gptimer->COUNTERREGS.CC_01[0]    = ptr->cc0Val;
+        gptimer->COUNTERREGS.CC_01[1]    = ptr->cc1Val;
+        gptimer->COUNTERREGS.CCCTL_01[0] = ptr->cc0Ctl;
+        gptimer->COUNTERREGS.CCCTL_01[1] = ptr->cc1Ctl;
+        gptimer->COUNTERREGS.OCTL_01[0]  = ptr->cc0OutCtl;
+        gptimer->COUNTERREGS.OCTL_01[1]  = ptr->cc1OutCtl;
+        gptimer->COUNTERREGS.CCACT_01[0] = ptr->cc0ActCtl;
+        gptimer->COUNTERREGS.CCACT_01[1] = ptr->cc1ActCtl;
+        gptimer->COUNTERREGS.IFCTL_01[0] = ptr->in0FiltCtl;
+        gptimer->COUNTERREGS.IFCTL_01[1] = ptr->in1FiltCtl;
+
+        /* Cross-trigger Configuration */
+        gptimer->COMMONREGS.CTTRIGCTL = ptr->crossTrigCtl;
+        gptimer->COMMONREGS.CTTRIG    = ptr->crossTrigConf;
+
+        /* Interrupt and Event Configuration */
+        gptimer->CPU_INT.IMASK    = ptr->intEvnt0Conf;
+        gptimer->GEN_EVENT0.IMASK = ptr->intEvnt1Conf;
+        gptimer->GEN_EVENT1.IMASK = ptr->intEvnt2Conf;
+
+        /* Restores Timer counter state until the end to prevent unexpected
+         * behavior */
+        gptimer->COUNTERREGS.CTRCTL = ptr->cntCtlConf;
+    }
+    return stateRestored;
+}
+
+#ifdef __MSPM0_HAS_TIMER_A__
+
+void DL_TimerA_initPWMMode(GPTIMER_Regs *gptimer, DL_TimerA_PWMConfig *config)
+{
+    DL_Timer_PWMConfig pwmConfig;
+
+    if (true == config->isTimerWithFourCC) {
+        switch (config->pwmMode) {
+            case DL_TIMER_PWM_MODE_EDGE_ALIGN:
+                DL_Timer_setCaptureCompareAction(gptimer,
+                    (DL_TIMER_CC_LACT_CCP_HIGH | DL_TIMER_CC_CDACT_CCP_LOW),
+                    DL_TIMER_CC_2_INDEX);
+                DL_Timer_setCaptureCompareAction(gptimer,
+                    (DL_TIMER_CC_LACT_CCP_HIGH | DL_TIMER_CC_CDACT_CCP_LOW),
+                    DL_TIMER_CC_3_INDEX);
+                break;
+            case DL_TIMER_PWM_MODE_EDGE_ALIGN_UP:
+                DL_Timer_setCaptureCompareAction(gptimer,
+                    (DL_TIMER_CC_LACT_CCP_LOW | DL_TIMER_CC_CUACT_CCP_HIGH),
+                    DL_TIMER_CC_2_INDEX);
+                DL_Timer_setCaptureCompareAction(gptimer,
+                    (DL_TIMER_CC_LACT_CCP_LOW | DL_TIMER_CC_CUACT_CCP_HIGH),
+                    DL_TIMER_CC_3_INDEX);
+                break;
+            default:  // DL_TIMER_PWM_MODE_CENTER_ALIGN
+                DL_Timer_setCaptureCompareAction(gptimer,
+                    (DL_TIMER_CC_CUACT_CCP_HIGH | DL_TIMER_CC_CDACT_CCP_LOW),
+                    DL_TIMER_CC_2_INDEX);
+                DL_Timer_setCaptureCompareAction(gptimer,
+                    (DL_TIMER_CC_CUACT_CCP_HIGH | DL_TIMER_CC_CDACT_CCP_LOW),
+                    DL_TIMER_CC_3_INDEX);
+                break;
+        }
+
+        DL_Timer_setCaptureCompareCtl(
+            gptimer, DL_TIMER_CC_MODE_COMPARE, 0, DL_TIMER_CC_2_INDEX);
+
+        DL_Timer_setCaptureCompareCtl(
+            gptimer, DL_TIMER_CC_MODE_COMPARE, 0, DL_TIMER_CC_3_INDEX);
+
+        DL_Timer_setCaptureCompareOutCtl(gptimer,
+            DL_TIMER_CC_OCTL_INIT_VAL_LOW, DL_TIMER_CC_OCTL_INV_OUT_DISABLED,
+            DL_TIMER_CC_OCTL_SRC_FUNCVAL, DL_TIMER_CC_2_INDEX);
+
+        DL_Timer_setCaptureCompareOutCtl(gptimer,
+            DL_TIMER_CC_OCTL_INIT_VAL_LOW, DL_TIMER_CC_OCTL_INV_OUT_DISABLED,
+            DL_TIMER_CC_OCTL_SRC_FUNCVAL, DL_TIMER_CC_3_INDEX);
+
+        DL_Timer_setCaptureCompareInput(gptimer,
+            DL_TIMER_CC_INPUT_INV_NOINVERT, DL_TIMER_CC_IN_SEL_CCPX,
+            DL_TIMER_CC_2_INDEX);
+
+        DL_Timer_setCaptureCompareInput(gptimer,
+            DL_TIMER_CC_INPUT_INV_NOINVERT, DL_TIMER_CC_IN_SEL_CCPX,
+            DL_TIMER_CC_3_INDEX);
+    }
+
+    pwmConfig.period     = config->period;
+    pwmConfig.pwmMode    = config->pwmMode;
+    pwmConfig.startTimer = config->startTimer;
+
+    DL_Timer_initPWMMode(gptimer, &pwmConfig);
+}
+
+void DL_Timer_setFaultSourceConfig(GPTIMER_Regs *gptimer, uint32_t source)
+{
+    DL_Common_updateReg(&gptimer->COUNTERREGS.FCTL,
+        (source >> 16) &
+            (GPTIMER_FCTL_FSENAC0_MASK | GPTIMER_FCTL_FSENAC1_MASK |
+                GPTIMER_FCTL_FSENAC2_MASK | GPTIMER_FCTL_FSENEXT0_MASK |
+                GPTIMER_FCTL_FSENEXT1_MASK | GPTIMER_FCTL_FSENEXT2_MASK),
+        (GPTIMER_FCTL_FSENAC0_MASK | GPTIMER_FCTL_FSENAC1_MASK |
+            GPTIMER_FCTL_FSENAC2_MASK | GPTIMER_FCTL_FSENEXT0_MASK |
+            GPTIMER_FCTL_FSENEXT1_MASK | GPTIMER_FCTL_FSENEXT2_MASK));
+
+    DL_Common_updateReg(&gptimer->COMMONREGS.FSCTL, source,
+        (GPTIMER_FSCTL_FAC0EN_MASK | GPTIMER_FSCTL_FAC1EN_MASK |
+            GPTIMER_FSCTL_FAC2EN_MASK | GPTIMER_FSCTL_FEX0EN_MASK |
+            GPTIMER_FSCTL_FEX1EN_MASK | GPTIMER_FSCTL_FEX2EN_MASK));
+}
+
+uint32_t DL_Timer_getFaultSourceConfig(GPTIMER_Regs *gptimer)
+{
+    uint32_t faultMode;
+    uint32_t faultSense;
+
+    faultMode  = gptimer->COMMONREGS.FSCTL;
+    faultSense = gptimer->COUNTERREGS.FCTL;
+
+    return (((faultSense &
+                 (GPTIMER_FCTL_FSENAC0_MASK | GPTIMER_FCTL_FSENAC1_MASK |
+                     GPTIMER_FCTL_FSENAC2_MASK | GPTIMER_FCTL_FSENEXT0_MASK |
+                     GPTIMER_FCTL_FSENEXT1_MASK | GPTIMER_FCTL_FSENEXT2_MASK))
+                << 16) |
+            (faultMode &
+                ((GPTIMER_FSCTL_FAC0EN_MASK | GPTIMER_FSCTL_FAC1EN_MASK |
+                    GPTIMER_FSCTL_FAC2EN_MASK | GPTIMER_FSCTL_FEX0EN_MASK |
+                    GPTIMER_FSCTL_FEX1EN_MASK | GPTIMER_FSCTL_FEX2EN_MASK))));
+}
+
+bool DL_TimerA_saveConfiguration(
+    GPTIMER_Regs *gptimer, DL_TimerA_backupConfig *ptr)
+{
+    bool saveState = !ptr->backupRdy;
+    if (saveState) {
+        /* Generic Events configuration */
+        ptr->sub0PortConf = gptimer->FSUB_0;
+        ptr->sub1PortConf = gptimer->FSUB_1;
+        ptr->pub0PortConf = gptimer->FPUB_0;
+        ptr->pub1PortConf = gptimer->FPUB_1;
+
+        /* Clock configuration */
+        ptr->clkDivConf   = gptimer->CLKDIV;
+        ptr->clockPscConf = gptimer->COMMONREGS.CPS;
+        ptr->clkSelConf   = gptimer->CLKSEL;
+        ptr->countClkConf = gptimer->COMMONREGS.CCLKCTL;
+
+        /* Interrupt and Event Configuration */
+        ptr->intEvnt0Conf = gptimer->CPU_INT.IMASK;
+        ptr->intEvnt1Conf = gptimer->GEN_EVENT0.IMASK;
+        ptr->intEvnt2Conf = gptimer->GEN_EVENT1.IMASK;
+
+        /* Cross-trigger configuration */
+        ptr->crossTrigCtl  = gptimer->COMMONREGS.CTTRIGCTL;
+        ptr->crossTrigConf = gptimer->COMMONREGS.CTTRIG;
+
+        /* Timer configuration */
+        ptr->cntVal     = gptimer->COUNTERREGS.CTR;
+        ptr->cntCtlConf = gptimer->COUNTERREGS.CTRCTL;
+        ptr->loadVal    = gptimer->COUNTERREGS.LOAD;
+        ptr->phaseVal   = gptimer->COUNTERREGS.PL;
+        ptr->tSelConf   = gptimer->COUNTERREGS.TSEL;
+        ptr->ccpDirConf = gptimer->COMMONREGS.CCPD;
+        ptr->outDisConf = gptimer->COMMONREGS.ODIS;
+
+        /* Capture or Compare configuration */
+        ptr->cc0Val     = gptimer->COUNTERREGS.CC_01[0];
+        ptr->cc1Val     = gptimer->COUNTERREGS.CC_01[1];
+        ptr->cc2Val     = gptimer->COUNTERREGS.CC_23[0];
+        ptr->cc3Val     = gptimer->COUNTERREGS.CC_23[1];
+        ptr->cc0Ctl     = gptimer->COUNTERREGS.CCCTL_01[0];
+        ptr->cc1Ctl     = gptimer->COUNTERREGS.CCCTL_01[1];
+        ptr->cc2Ctl     = gptimer->COUNTERREGS.CCCTL_23[0];
+        ptr->cc3Ctl     = gptimer->COUNTERREGS.CCCTL_23[1];
+        ptr->cc0OutCtl  = gptimer->COUNTERREGS.OCTL_01[0];
+        ptr->cc1OutCtl  = gptimer->COUNTERREGS.OCTL_01[1];
+        ptr->cc2OutCtl  = gptimer->COUNTERREGS.OCTL_23[0];
+        ptr->cc3OutCtl  = gptimer->COUNTERREGS.OCTL_23[1];
+        ptr->cc0ActCtl  = gptimer->COUNTERREGS.CCACT_01[0];
+        ptr->cc1ActCtl  = gptimer->COUNTERREGS.CCACT_01[1];
+        ptr->cc2ActCtl  = gptimer->COUNTERREGS.CCACT_23[0];
+        ptr->cc3ActCtl  = gptimer->COUNTERREGS.CCACT_23[1];
+        ptr->in0FiltCtl = gptimer->COUNTERREGS.IFCTL_01[0];
+        ptr->in1FiltCtl = gptimer->COUNTERREGS.IFCTL_01[1];
+        ptr->in2FiltCtl = gptimer->COUNTERREGS.IFCTL_23[0];
+        ptr->in3FiltCtl = gptimer->COUNTERREGS.IFCTL_23[1];
+
+        /* Dead Band Configuration */
+        ptr->dbCtlConf = gptimer->COUNTERREGS.DBCTL;
+
+        /* Repeat Counter Configuration */
+        ptr->rcConf = gptimer->COUNTERREGS.RCLD;
+
+        /* Fault Configuration */
+        ptr->faultSrcHndlConf = gptimer->COUNTERREGS.FCTL;
+        ptr->faultInCtl       = gptimer->COUNTERREGS.FIFCTL;
+        ptr->backupRdy        = true;
+    }
+    return saveState;
+}
+
+bool DL_TimerA_restoreConfiguration(
+    GPTIMER_Regs *gptimer, DL_TimerA_backupConfig *ptr, bool restoreCounter)
+{
+    bool stateRestored = ptr->backupRdy;
+    if (stateRestored) {
+        ptr->backupRdy = false;
+        /* Generic Events Configuration */
+        gptimer->FSUB_0 = ptr->sub0PortConf;
+        gptimer->FSUB_1 = ptr->sub1PortConf;
+        gptimer->FPUB_0 = ptr->pub0PortConf;
+        gptimer->FPUB_1 = ptr->pub1PortConf;
+
+        /* Clock Configuration */
+        gptimer->CLKSEL             = ptr->clkSelConf;
+        gptimer->CLKDIV             = ptr->clkDivConf;
+        gptimer->COMMONREGS.CPS     = ptr->clockPscConf;
+        gptimer->COMMONREGS.CCLKCTL = ptr->countClkConf;
+
+        /* Timer Configuration */
+        if (true == restoreCounter) {
+            gptimer->COUNTERREGS.CTR = ptr->cntVal;
+        }
+        gptimer->COUNTERREGS.LOAD = ptr->loadVal;
+        gptimer->COUNTERREGS.PL   = ptr->phaseVal;
+        gptimer->COUNTERREGS.TSEL = ptr->tSelConf;
+        gptimer->COMMONREGS.CCPD  = ptr->ccpDirConf;
+        gptimer->COMMONREGS.ODIS  = ptr->outDisConf;
+
+        /* Capture or Compare Configuration */
+        gptimer->COUNTERREGS.CC_01[0]    = ptr->cc0Val;
+        gptimer->COUNTERREGS.CC_01[1]    = ptr->cc1Val;
+        gptimer->COUNTERREGS.CC_23[0]    = ptr->cc2Val;
+        gptimer->COUNTERREGS.CC_23[1]    = ptr->cc3Val;
+        gptimer->COUNTERREGS.CCCTL_01[0] = ptr->cc0Ctl;
+        gptimer->COUNTERREGS.CCCTL_01[1] = ptr->cc1Ctl;
+        gptimer->COUNTERREGS.CCCTL_23[0] = ptr->cc2Ctl;
+        gptimer->COUNTERREGS.CCCTL_23[1] = ptr->cc3Ctl;
+        gptimer->COUNTERREGS.OCTL_01[0]  = ptr->cc0OutCtl;
+        gptimer->COUNTERREGS.OCTL_01[1]  = ptr->cc1OutCtl;
+        gptimer->COUNTERREGS.OCTL_23[0]  = ptr->cc2OutCtl;
+        gptimer->COUNTERREGS.OCTL_23[1]  = ptr->cc3OutCtl;
+        gptimer->COUNTERREGS.CCACT_01[0] = ptr->cc0ActCtl;
+        gptimer->COUNTERREGS.CCACT_01[1] = ptr->cc1ActCtl;
+        gptimer->COUNTERREGS.CCACT_23[0] = ptr->cc2ActCtl;
+        gptimer->COUNTERREGS.CCACT_23[1] = ptr->cc3ActCtl;
+        gptimer->COUNTERREGS.IFCTL_01[0] = ptr->in0FiltCtl;
+        gptimer->COUNTERREGS.IFCTL_01[1] = ptr->in1FiltCtl;
+        gptimer->COUNTERREGS.IFCTL_23[0] = ptr->in2FiltCtl;
+        gptimer->COUNTERREGS.IFCTL_23[1] = ptr->in3FiltCtl;
+
+        /* Cross-trigger Configuration */
+        gptimer->COMMONREGS.CTTRIGCTL = ptr->crossTrigCtl;
+        gptimer->COMMONREGS.CTTRIG    = ptr->crossTrigConf;
+
+        /* Dead Band Configuration */
+        gptimer->COUNTERREGS.DBCTL = ptr->dbCtlConf;
+
+        /* Repeat Counter Configuration */
+        ptr->rcConf = gptimer->COUNTERREGS.RCLD;
+
+        /* Fault Configuration */
+        ptr->faultSrcHndlConf = gptimer->COUNTERREGS.FCTL;
+        ptr->faultInCtl       = gptimer->COUNTERREGS.FIFCTL;
+
+        /* Interrupt and Event Configuration */
+        gptimer->CPU_INT.IMASK    = ptr->intEvnt0Conf;
+        gptimer->GEN_EVENT0.IMASK = ptr->intEvnt1Conf;
+        gptimer->GEN_EVENT1.IMASK = ptr->intEvnt2Conf;
+
+        /* Restores Timer counter state until the end to prevent unexpected
+         * behavior */
+        gptimer->COUNTERREGS.CTRCTL = ptr->cntCtlConf;
+    }
+    return stateRestored;
+}
+
+#endif /* __MSPM0_HAS_TIMER_A__ */
+
+static void DL_Timer_getInChanConfig(
+    DL_TIMER_INPUT_CHAN chan, Timer_Input_Chan_Config *config)
+{
+    switch (chan) {
+        case DL_TIMER_INPUT_CHAN_0:
+            config->index    = (DL_TIMER_CC_0_INDEX);
+            config->ccpInput = (DL_TIMER_CC_IN_SEL_CCP0);
+            config->timerConfig =
+                (GPTIMER_CTRCTL_CLC_CCCTL0_LCOND |
+                    GPTIMER_CTRCTL_CAC_CCCTL0_ACOND |
+                    GPTIMER_CTRCTL_CZC_CCCTL0_ZCOND | GPTIMER_CTRCTL_CM_DOWN);
+            config->ccpInputDir = DL_TIMER_CC0_INPUT;
+            break;
+        case DL_TIMER_INPUT_CHAN_1:
+            config->index    = (DL_TIMER_CC_1_INDEX);
+            config->ccpInput = (DL_TIMER_CC_IN_SEL_CCPX);
+            config->timerConfig =
+                (GPTIMER_CTRCTL_CLC_CCCTL1_LCOND |
+                    GPTIMER_CTRCTL_CAC_CCCTL1_ACOND |
+                    GPTIMER_CTRCTL_CZC_CCCTL1_ZCOND | GPTIMER_CTRCTL_CM_DOWN);
+            config->ccpInputDir = (DL_TIMER_CC1_INPUT);
+            break;
+        case DL_TIMER_INPUT_CHAN_2:
+            config->index    = (DL_TIMER_CC_2_INDEX);
+            config->ccpInput = (DL_TIMER_CC_IN_SEL_CCP0);
+            config->timerConfig =
+                (GPTIMER_CTRCTL_CLC_CCCTL2_LCOND |
+                    GPTIMER_CTRCTL_CAC_CCCTL2_ACOND |
+                    GPTIMER_CTRCTL_CZC_CCCTL2_ZCOND | GPTIMER_CTRCTL_CM_DOWN);
+            config->ccpInputDir = (DL_TIMER_CC2_INPUT);
+            break;
+        case DL_TIMER_INPUT_CHAN_3:
+        default:
+            config->index    = (DL_TIMER_CC_3_INDEX);
+            config->ccpInput = (DL_TIMER_CC_IN_SEL_CCPX);
+            config->timerConfig =
+                (GPTIMER_CTRCTL_CLC_CCCTL3_LCOND |
+                    GPTIMER_CTRCTL_CAC_CCCTL3_ACOND |
+                    GPTIMER_CTRCTL_CZC_CCCTL3_ZCOND | GPTIMER_CTRCTL_CM_DOWN);
+            config->ccpInputDir = (DL_TIMER_CC3_INPUT);
+            break;
+    }
+}
+
+static void DL_Timer_getInChanPairConfig(
+    DL_TIMER_INPUT_CHAN chan, Timer_Input_Pair_Chan_Config *config)
+{
+    switch (chan) {
+        case DL_TIMER_INPUT_CHAN_0:
+            config->index = (DL_TIMER_CC_1_INDEX);
+            break;
+        case DL_TIMER_INPUT_CHAN_1:
+            config->index = (DL_TIMER_CC_0_INDEX);
+            break;
+        case DL_TIMER_INPUT_CHAN_2:
+            config->index = (DL_TIMER_CC_3_INDEX);
+            break;
+        case DL_TIMER_INPUT_CHAN_3:
+        default:
+            config->index = (DL_TIMER_CC_2_INDEX);
+            break;
+    }
+}
+
+void DL_Timer_configQEIHallInputMode(GPTIMER_Regs *gptimer)
+{
+    /* Set channels for capture mode */
+    gptimer->COUNTERREGS.CCCTL_01[0] = GPTIMER_CCCTL_01_COC_CAPTURE;
+    gptimer->COUNTERREGS.CCCTL_01[1] = GPTIMER_CCCTL_01_COC_CAPTURE;
+
+    /* Set channels as input */
+    DL_Timer_setCCPDirection(
+        gptimer, (DL_TIMER_CC0_INPUT | DL_TIMER_CC1_INPUT));
+
+    /* Select XOR option for Hall signals */
+    gptimer->COUNTERREGS.IFCTL_01[0] = DL_TIMER_CC_IN_SEL_CCP_XOR;
+    gptimer->COUNTERREGS.IFCTL_01[1] = DL_TIMER_CC_IN_SEL_CCP_XOR;
+}
+
+#endif /* __MSPM0_HAS_TIMER_A__ || __MSPM0_HAS_TIMER_G__ */

--- a/mspm0/source/ti/driverlib/dl_timer.h
+++ b/mspm0/source/ti/driverlib/dl_timer.h
@@ -1,0 +1,4218 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_timer.h
+ *  @brief      Common General Purpose Timer (TIMx) Driver Library
+ *  @defgroup   TIMX Common General Purpose Timer (TIMx)
+ *
+ *  @anchor ti_dl_dl_timer__Overview
+ *  # Overview
+ *  GPTimer module has different variations and have been defined as TimerG
+ *  and TimerA. This file contains APIs which are common between
+ *  different variations.
+ *  <hr>
+ *  @anchor ti_devices_msp_DL_TIMER_Usage
+ *  # Usage
+ *  It is not recommended to include this header file in the application.
+ *  In order to access TimerG and TimerA functionality include
+ *  to appropriate timer header file at the application level. Accessing the
+ *  functionality via the corresponding header file will allow user to
+ *  determine the functionality supported by the each Timer variant.
+ *
+ *  To access TimerG functionality:
+ *  @code
+ *  // Import TIMG definitions
+ *  #include <ti/driverlib/dl_timerg.h>
+ *  @endcode
+ *
+ *  To access TimerA functionality:
+ *  @code
+ *  // Import TIMA definitions
+ *  #include <ti/driverlib/dl_timera.h>
+ *  @endcode
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup TIMX
+ * @{
+ */
+#ifndef ti_dl_dl_timer__include
+#define ti_dl_dl_timer__include
+
+#if defined(ti_dl_dl_timera__include) || defined(ti_dl_dl_timerg__include) || \
+    defined(DOXYGEN__INCLUDE)
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#if defined(__MSPM0_HAS_TIMER_A__) || defined(__MSPM0_HAS_TIMER_G__)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_TIMER_CCx
+ *  @{
+ */
+
+/*!
+ * @brief Selects Output direction for CCP0
+ */
+#define DL_TIMER_CC0_OUTPUT                     (GPTIMER_CCPD_C0CCP0_OUTPUT)
+
+/*!
+ * @brief Selects Input direction for CCP0
+ */
+#define DL_TIMER_CC0_INPUT                      (GPTIMER_CCPD_C0CCP0_INPUT)
+
+/*!
+ * @brief Selects Output direction for CCP1
+ */
+#define DL_TIMER_CC1_OUTPUT                     (GPTIMER_CCPD_C0CCP1_OUTPUT)
+
+/*!
+ * @brief Selects Input direction for CCP1
+ */
+#define DL_TIMER_CC1_INPUT                      (GPTIMER_CCPD_C0CCP1_INPUT)
+
+/*!
+ * @brief Selects Output direction for CCP2
+ */
+#define DL_TIMER_CC2_OUTPUT                     (GPTIMER_CCPD_C0CCP2_OUTPUT)
+
+/*!
+ * @brief Selects Input direction for CCP2
+ */
+#define DL_TIMER_CC2_INPUT                      (GPTIMER_CCPD_C0CCP2_INPUT)
+
+/*!
+ * @brief Selects Output direction for CCP3
+ */
+#define DL_TIMER_CC3_OUTPUT                     (GPTIMER_CCPD_C0CCP3_OUTPUT)
+
+/*!
+ * @brief Selects Input direction for CCP3
+ */
+#define DL_TIMER_CC3_INPUT                      (GPTIMER_CCPD_C0CCP3_INPUT)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_MODE
+ *  @{
+ */
+/*!
+ * @brief Configures CC in Compare mode
+ */
+#define DL_TIMER_CC_MODE_COMPARE                  (GPTIMER_CCCTL_01_COC_COMPARE)
+/*!
+ * @brief Configures CC in Capture mode
+ */
+#define DL_TIMER_CC_MODE_CAPTURE                 (GPTIMER_CCCTL_01_COC_CAPTURE)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_ZCOND
+ *  @{
+ */
+
+/*!
+ * @brief No event generates zero pulse
+ */
+#define DL_TIMER_CC_ZCOND_NONE             (GPTIMER_CCCTL_01_ZCOND_CC_TRIG_NO_EFFECT)
+
+/*!
+ * @brief Rising edge of CCP or trigger assertion edge generates zero pulse
+ */
+#define DL_TIMER_CC_ZCOND_TRIG_RISE        (GPTIMER_CCCTL_01_ZCOND_CC_TRIG_RISE)
+
+/*!
+ * @brief Falling edge of CCP or trigger or de-assertion edge generates zero
+ *        pulse
+ */
+#define DL_TIMER_CC_ZCOND_TRIG_FALL        (GPTIMER_CCCTL_01_ZCOND_CC_TRIG_FALL)
+/*!
+ * @brief Either edge of CCP or trigger change (assertion/de-assertion edge)
+ *        generates zero pulse
+ */
+#define DL_TIMER_CC_ZCOND_TRIG_EDGE        (GPTIMER_CCCTL_01_ZCOND_CC_TRIG_EDGE)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_LCOND
+ *  @{
+ */
+
+/*!
+ * @brief No event generates load pulse
+ */
+#define DL_TIMER_CC_LCOND_NONE            (GPTIMER_CCCTL_01_LCOND_CC_TRIG_NO_EFFECT)
+
+/*!
+ * @brief Rising edge of CCP or trigger assertion edge generates load pulse
+ */
+#define DL_TIMER_CC_LCOND_TRIG_RISE       (GPTIMER_CCCTL_01_LCOND_CC_TRIG_RISE)
+
+/*!
+ * @brief Falling edge of CCP or trigger or de-assertion edge generates load
+ *        pulse
+ */
+#define DL_TIMER_CC_LCOND_TRIG_FALL       (GPTIMER_CCCTL_01_LCOND_CC_TRIG_FALL)
+
+/*!
+ * @brief Either edge of CCP or trigger change (assertion/de-assertion edge)
+ *        generates load pulse
+ */
+#define DL_TIMER_CC_LCOND_TRIG_EDGE       (GPTIMER_CCCTL_01_LCOND_CC_TRIG_EDGE)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_ACOND
+ *  @{
+ */
+
+/*!
+ * @brief Each TIMCLK generates an advance pulse
+ */
+#define DL_TIMER_CC_ACOND_TIMCLK                 (GPTIMER_CCCTL_01_ACOND_TIMCLK)
+
+/*!
+ * @brief Rising edge of CCP or trigger assertion edge generates an advance
+ *        pulse
+ */
+#define DL_TIMER_CC_ACOND_TRIG_RISE       (GPTIMER_CCCTL_01_ACOND_CC_TRIG_RISE)
+
+/*!
+ * @brief Falling edge of CCP or trigger de-assertion edge generates an advance
+ *        pulse
+ */
+#define DL_TIMER_CC_ACOND_TRIG_FALL       (GPTIMER_CCCTL_01_ACOND_CC_TRIG_FALL)
+/*!
+ * @brief Either edge of CCP or trigger change (assertion/de-assertion edge)
+ *        generates an advance pulse.
+ */
+#define DL_TIMER_CC_ACOND_TRIG_EDGE       (GPTIMER_CCCTL_01_ACOND_CC_TRIG_EDGE)
+/*!
+ * @brief CCP High or Trigger assertion generates an advance pulse.
+ */
+#define DL_TIMER_CC_ACOND_TRIG_HIGH       (GPTIMER_CCCTL_01_ACOND_CC_TRIG_HIGH)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_CCOND
+ *  @{
+ */
+
+/*!
+ * @brief None (never captures)
+ */
+#define DL_TIMER_CC_CCOND_NOCAPTURE       (GPTIMER_CCCTL_01_CCOND_NOCAPTURE)
+
+/*!
+ * @brief Rising edge of CCP or trigger assertion edge generates a capture
+ *        pulse
+ */
+#define DL_TIMER_CC_CCOND_TRIG_RISE       (GPTIMER_CCCTL_01_CCOND_CC_TRIG_RISE)
+/*!
+ * @brief Falling edge of CCP or trigger de-assertion edge generates a capture
+ *        pulse
+ */
+#define DL_TIMER_CC_CCOND_TRIG_FALL       (GPTIMER_CCCTL_01_CCOND_CC_TRIG_FALL)
+/*!
+ * @brief Either edge of CCP or trigger change (assertion/de-assertion edge)
+ *        generates a capture pulse
+ */
+#define DL_TIMER_CC_CCOND_TRIG_EDGE       (GPTIMER_CCCTL_01_CCOND_CC_TRIG_EDGE)
+
+/** @}*/
+
+
+/** @addtogroup DL_TIMER_CC_OCTL_INIT_VAL
+ *  @{
+ */
+/*!
+ * @brief CCP is low while output is disabled
+ */
+#define DL_TIMER_CC_OCTL_INIT_VAL_LOW              (GPTIMER_OCTL_01_CCPIV_LOW)
+
+/*!
+ * @brief CCP is high while output is disabled
+ */
+#define DL_TIMER_CC_OCTL_INIT_VAL_HIGH             (GPTIMER_OCTL_01_CCPIV_HIGH)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_OCTL_INV_OUT
+ *  @{
+ */
+/*!
+ * @brief CCP Output inversion is enabled
+ */
+#define DL_TIMER_CC_OCTL_INV_OUT_ENABLED        (GPTIMER_OCTL_01_CCPOINV_INV)
+
+/*!
+ * @brief CCP Output inversion is disabled
+ */
+#define DL_TIMER_CC_OCTL_INV_OUT_DISABLED       (GPTIMER_OCTL_01_CCPOINV_NOINV)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_OCTL_SRC
+ *  @{
+ */
+/*!
+ * @brief Output controlled by function values (e.g. PWM)
+ */
+#define DL_TIMER_CC_OCTL_SRC_FUNCVAL       (GPTIMER_OCTL_01_CCPO_FUNCVAL)
+
+/*!
+ * @brief Output controlled by load event
+ */
+#define DL_TIMER_CC_OCTL_SRC_LOAD          (GPTIMER_OCTL_01_CCPO_LOAD)
+
+/*!
+ * @brief Output controlled by compare value = counter condition.
+ */
+#define DL_TIMER_CC_OCTL_SRC_CMPVAL        (GPTIMER_OCTL_01_CCPO_CMPVAL)
+
+/*!
+ * @brief Output controlled by zero event.
+ */
+#define DL_TIMER_CC_OCTL_SRC_ZERO          (GPTIMER_OCTL_01_CCPO_ZERO)
+
+/*!
+ * @brief Output controlled by capture event.
+ */
+#define DL_TIMER_CC_OCTL_SRC_CAPCOND       (GPTIMER_OCTL_01_CCPO_CAPCOND)
+
+/*!
+ * @brief Output controlled by fault condition.
+ */
+#define DL_TIMER_CC_OCTL_SRC_FAULTCOND       (GPTIMER_OCTL_01_CCPO_FAULTCOND)
+
+/*!
+ * @brief Mirror CCP of first capture and compare register in counter group.
+ */
+#define DL_TIMER_CC_OCTL_SRC_CC0_MIRR_ALL  (GPTIMER_OCTL_01_CCPO_CC0_MIRROR_ALL)
+
+/*!
+ * @brief Mirror CCP of second capture and compare register in counter group.
+ */
+#define DL_TIMER_CC_OCTL_SRC_CC1_MIRR_ALL  (GPTIMER_OCTL_01_CCPO_CC1_MIRROR_ALL)
+
+/*!
+ * @brief Dead band inserted output
+ */
+#define DL_TIMER_CC_OCTL_SRC_DEAD_BAND           (GPTIMER_OCTL_01_CCPO_DEADBAND)
+
+/*!
+ * @brief Counter direction.
+ */
+#define DL_TIMER_CC_OCTL_SRC_CNTDIR                (GPTIMER_OCTL_01_CCPO_CNTDIR)
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_FEXACT
+ *  @{
+ */
+
+/*!
+ * @brief The CCP output value is unaffected by the event.
+ */
+#define DL_TIMER_CC_FEXACT_DISABLED           (GPTIMER_CCACT_01_FEXACT_DISABLED)
+
+/*!
+ * @brief CCP output value is set high.
+ */
+#define DL_TIMER_CC_FEXACT_HIGH               (GPTIMER_CCACT_01_FEXACT_CCP_HIGH)
+
+/*!
+ * @brief CCP output value is set low.
+ */
+#define DL_TIMER_CC_FEXACT_LOW                 (GPTIMER_CCACT_01_FEXACT_CCP_LOW)
+
+/*!
+ * @brief CCP output value is toggled.
+ */
+#define DL_TIMER_CC_FEXACT_TOGGLE           (GPTIMER_CCACT_01_FEXACT_CCP_TOGGLE)
+
+
+/*!
+ * @brief CCP output value is Hi-Z.
+ */
+#define DL_TIMER_CC_FEXACT_HIGHZ           (GPTIMER_CCACT_01_FEXACT_CCP_HIGHZ)
+
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_FENACT
+ *  @{
+ */
+
+/*!
+ * @brief The CCP output value is unaffected by the event.
+ */
+#define DL_TIMER_CC_FENACT_DISABLED           (GPTIMER_CCACT_01_FENACT_DISABLED)
+
+/*!
+ * @brief CCP output value is set high.
+ */
+#define DL_TIMER_CC_FENACT_CCP_HIGH           (GPTIMER_CCACT_01_FENACT_CCP_HIGH)
+
+/*!
+ * @brief CCP output value is set low
+ */
+#define DL_TIMER_CC_FENACT_CCP_LOW             (GPTIMER_CCACT_01_FENACT_CCP_LOW)
+
+/*!
+ * @brief CCP output value is toggled.
+ */
+#define DL_TIMER_CC_FENACT_CCP_TOGGLE      \
+                                            (GPTIMER_CCACT_01_FENACT_CCP_TOGGLE)
+
+/*!
+ * @brief CCP output value is Hi-Z.
+ */
+#define DL_TIMER_CC_FENACT_HIGHZ           (GPTIMER_CCACT_01_FENACT_CCP_HIGHZ)
+
+
+/** @}*/
+
+ /** @addtogroup DL_TIMER_CC_CUACT
+ *  @{
+ */
+/*!
+ * @brief The CCP output value is unaffected by the event
+ */
+#define DL_TIMER_CC_CUACT_DISABLED         (GPTIMER_CCACT_01_CUACT_DISABLED)
+/*!
+ * @brief CCP output value is set high
+ */
+#define DL_TIMER_CC_CUACT_CCP_HIGH         (GPTIMER_CCACT_01_CUACT_CCP_HIGH)
+/*!
+ * @brief CCP output value is set low
+ */
+#define DL_TIMER_CC_CUACT_CCP_LOW          (GPTIMER_CCACT_01_CUACT_CCP_LOW)
+/*!
+ * @brief CCP output value is toggled
+ */
+#define DL_TIMER_CC_CUACT_CCP_TOGGLE       (GPTIMER_CCACT_01_CUACT_CCP_TOGGLE)
+
+/** @}*/
+
+ /** @addtogroup DL_TIMER_CC_CDACT
+ *  @{
+ */
+/*!
+ * @brief The CCP output value is unaffected by the event
+ */
+#define DL_TIMER_CC_CDACT_DISABLED         (GPTIMER_CCACT_01_CDACT_DISABLED)
+/*!
+ * @brief CCP output value is set high
+ */
+#define DL_TIMER_CC_CDACT_CCP_HIGH         (GPTIMER_CCACT_01_CDACT_CCP_HIGH)
+/*!
+ * @brief CCP output value is set low
+ */
+#define DL_TIMER_CC_CDACT_CCP_LOW          (GPTIMER_CCACT_01_CDACT_CCP_LOW)
+/*!
+ * @brief CCP output value is toggled
+ */
+#define DL_TIMER_CC_CDACT_CCP_TOGGLE       (GPTIMER_CCACT_01_CDACT_CCP_TOGGLE)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_LACT
+ *  @{
+ */
+
+/*!
+ * @brief The CCP output value is unaffected by the event
+ */
+
+#define DL_TIMER_CC_LACT_DISABLED         (GPTIMER_CCACT_01_LACT_DISABLED)
+
+/*!
+ * @brief CCP output value is set high
+ */
+#define DL_TIMER_CC_LACT_CCP_HIGH         (GPTIMER_CCACT_01_LACT_CCP_HIGH)
+
+/*!
+ * @brief CCP output value is low
+ */
+#define DL_TIMER_CC_LACT_CCP_LOW          (GPTIMER_CCACT_01_LACT_CCP_LOW)
+
+/*!
+ * @brief CCP output value is toggled
+ */
+#define DL_TIMER_CC_LACT_CCP_TOGGLE       (GPTIMER_CCACT_01_LACT_CCP_TOGGLE)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_ZACT
+ *  @{
+ */
+/*!
+ * @brief The CCP output value is unaffected by the event
+ */
+#define DL_TIMER_CC_ZACT_DISABLED         (GPTIMER_CCACT_01_ZACT_DISABLED)
+
+/*!
+ * @brief CCP output value is high
+ */
+#define DL_TIMER_CC_ZACT_CCP_HIGH         (GPTIMER_CCACT_01_ZACT_CCP_HIGH)
+
+/*!
+ * @brief CCP output value is low
+ */
+#define DL_TIMER_CC_ZACT_CCP_LOW          (GPTIMER_CCACT_01_ZACT_CCP_LOW)
+
+/*!
+ * @brief CCP output value is toggled
+ */
+#define DL_TIMER_CC_ZACT_CCP_TOGGLE       (GPTIMER_CCACT_01_ZACT_CCP_TOGGLE)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_INPUT_INV
+ *  @{
+ */
+
+/*!
+ * @brief CCP input is not inverted
+ */
+#define DL_TIMER_CC_INPUT_INV_NOINVERT (GPTIMER_IFCTL_01_INV_NOINVERT)
+
+/*!
+ * @brief CCP input is inverted
+ */
+#define DL_TIMER_CC_INPUT_INV_INVERT   (GPTIMER_IFCTL_01_INV_INVERT)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_IN_SEL
+ *  @{
+ */
+
+/*!
+ * @brief CCP of the corresponding capture compare unit
+ */
+#define DL_TIMER_CC_IN_SEL_CCPX      (GPTIMER_IFCTL_01_ISEL_CCPX_INPUT)
+
+/*!
+ * @brief Input pair CCPX of the capture compare unit. For CCP0 input
+ *        pair is CCP1 and viceversa.
+ */
+#define DL_TIMER_CC_IN_SEL_CCPX_PAIR  (GPTIMER_IFCTL_01_ISEL_CCPX_INPUT_PAIR)
+
+/*!
+ * @brief CCP0 of the counter
+ */
+#define DL_TIMER_CC_IN_SEL_CCP0      (GPTIMER_IFCTL_01_ISEL_CCP0_INPUT)
+
+/*!
+ * @brief Trigger
+ */
+#define DL_TIMER_CC_IN_SEL_TRIG      (GPTIMER_IFCTL_01_ISEL_TRIG_INPUT)
+
+
+/*!
+ * @brief XOR of CCP inputs as input source
+ */
+#define DL_TIMER_CC_IN_SEL_CCP_XOR      (GPTIMER_IFCTL_01_ISEL_CCP_XOR)
+
+/*!
+ * @brief subscriber 0 event as input source
+ */
+#define DL_TIMER_CC_IN_SEL_FSUB0      (GPTIMER_IFCTL_01_ISEL_CCP_FSUB0)
+
+/*!
+ * @brief subscriber 1 event as input source
+ */
+#define DL_TIMER_CC_IN_SEL_FSUB1      (GPTIMER_IFCTL_01_ISEL_CCP_FSUB1)
+
+/*!
+ * @brief Comparator 0 output
+ */
+#define DL_TIMER_CC_IN_SEL_COMP0      (GPTIMER_IFCTL_01_ISEL_CCP_COMP0)
+
+/*!
+ * @brief Comparator 1 output
+ */
+#define DL_TIMER_CC_IN_SEL_COMP1      (GPTIMER_IFCTL_01_ISEL_CCP_COMP1)
+
+/*!
+ * @brief Comparator 2 output.
+ */
+#define DL_TIMER_CC_IN_SEL_COMP2      (GPTIMER_IFCTL_01_ISEL_CCP_COMP2)
+
+
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_FAULT_SOURCE
+ *  @{
+ */
+
+/*!
+* @brief Disables COMP0 as fault source
+*/
+#define DL_TIMER_FAULT_SOURCE_COMP0_DISABLE                                   \
+        (GPTIMER_FSCTL_FAC0EN_DISABLE | (GPTIMER_FCTL_FSENAC0_LOWCTIVE << 16))
+
+/*!
+* @brief Enables COMP0 as fault source and fault input is active low
+*/
+#define DL_TIMER_FAULT_SOURCE_COMP0_SENSE_LOW                                 \
+        (GPTIMER_FSCTL_FAC0EN_ENABLE | (GPTIMER_FCTL_FSENAC0_LOWCTIVE << 16))
+
+/*!
+* @brief Enables COMP0 as fault source and fault input is active high
+*/
+#define DL_TIMER_FAULT_SOURCE_COMP0_SENSE_HIGH                                \
+        (GPTIMER_FSCTL_FAC0EN_ENABLE | (GPTIMER_FCTL_FSENAC0_HIGHACTIVE << 16))
+
+/*!
+* @brief Disables COMP1 as fault source
+*/
+#define DL_TIMER_FAULT_SOURCE_COMP1_DISABLE                                   \
+        (GPTIMER_FSCTL_FAC1EN_DISABLE | (GPTIMER_FCTL_FSENAC1_LOWCTIVE << 16))
+
+/*!
+* @brief Enables COMP1 as fault source and fault input is active low
+*/
+#define DL_TIMER_FAULT_SOURCE_COMP1_SENSE_LOW                                 \
+        (GPTIMER_FSCTL_FAC1EN_ENABLE | (GPTIMER_FCTL_FSENAC1_LOWCTIVE << 16))
+
+/*!
+* @brief Enables COMP1 as fault source and fault input is active high
+*/
+#define DL_TIMER_FAULT_SOURCE_COMP1_SENSE_HIGH                                \
+        (GPTIMER_FSCTL_FAC1EN_ENABLE | (GPTIMER_FCTL_FSENAC1_HIGHACTIVE << 16))
+
+/*!
+* @brief Disables COMP2 as fault source
+*/
+#define DL_TIMER_FAULT_SOURCE_COMP2_DISABLE                                   \
+        (GPTIMER_FSCTL_FAC2EN_DISABLE | (GPTIMER_FCTL_FSENAC2_LOWCTIVE << 16))
+
+/*!
+* @brief Enables COMP2 as fault source and fault input is active low
+*/
+#define DL_TIMER_FAULT_SOURCE_COMP2_SENSE_LOW                                 \
+        (GPTIMER_FSCTL_FAC2EN_ENABLE | (GPTIMER_FCTL_FSENAC2_LOWCTIVE << 16))
+
+/*!
+* @brief Enables COMP2 as fault source and fault input is active high
+*/
+#define DL_TIMER_FAULT_SOURCE_COMP2_SENSE_HIGH                                \
+        (GPTIMER_FSCTL_FAC2EN_ENABLE | (GPTIMER_FCTL_FSENAC2_HIGHACTIVE << 16))
+
+/*!
+* @brief Disables external fault pin 0 as fault source
+*/
+#define DL_TIMER_FAULT_SOURCE_EXTERNAL_0_DISABLE                              \
+        (GPTIMER_FSCTL_FEX0EN_DISABLE | (GPTIMER_FCTL_FSENEXT0_LOWCTIVE << 16))
+
+/*!
+* @brief Enables external fault pin 0 as fault source and fault input is active
+*        low
+*/
+#define DL_TIMER_FAULT_SOURCE_EXTERNAL_0_SENSE_LOW                            \
+        (GPTIMER_FSCTL_FEX0EN_ENABLE | (GPTIMER_FCTL_FSENEXT0_LOWCTIVE << 16))
+
+/*!
+* @brief Enables external fault pin 0 as fault source and fault input is active
+*        high
+*/
+#define DL_TIMER_FAULT_SOURCE_EXTERNAL_0_SENSE_HIGH                           \
+        (GPTIMER_FSCTL_FEX0EN_ENABLE | (GPTIMER_FCTL_FSENEXT0_HIGHACTIVE << 16))
+
+/*!
+* @brief Disables external fault pin 1 as fault source
+*/
+#define DL_TIMER_FAULT_SOURCE_EXTERNAL_1_DISABLE                              \
+        (GPTIMER_FSCTL_FEX1EN_DISABLE | (GPTIMER_FCTL_FSENEXT1_LOWCTIVE << 16))
+
+/*!
+* @brief Enables external fault pin 1 as fault source and fault input is active
+*        low
+*/
+#define DL_TIMER_FAULT_SOURCE_EXTERNAL_1_SENSE_LOW                            \
+        (GPTIMER_FSCTL_FEX1EN_ENABLE | (GPTIMER_FCTL_FSENEXT1_LOWCTIVE << 16))
+
+/*!
+* @brief Enables external fault pin 1 as fault source and fault input is active
+*        high
+*/
+#define DL_TIMER_FAULT_SOURCE_EXTERNAL_1_SENSE_HIGH                           \
+        (GPTIMER_FSCTL_FEX1EN_ENABLE | (GPTIMER_FCTL_FSENEXT1_HIGHACTIVE << 16))
+
+/*!
+* @brief Disables external fault pin 2 as fault source
+*/
+#define DL_TIMER_FAULT_SOURCE_EXTERNAL_2_DISABLE                              \
+        (GPTIMER_FSCTL_FEX2EN_DISABLE | (GPTIMER_FCTL_FSENEXT2_LOWCTIVE << 16))
+
+/*!
+* @brief Enables external fault pin 2 as fault source and fault input is active
+*        low
+*/
+#define DL_TIMER_FAULT_SOURCE_EXTERNAL_2_SENSE_LOW                            \
+        (GPTIMER_FSCTL_FEX2EN_ENABLE | (GPTIMER_FCTL_FSENEXT2_LOWCTIVE << 16))
+
+/*!
+* @brief Enables external fault pin 2 as fault source and fault input is active
+*        high
+*/
+#define DL_TIMER_FAULT_SOURCE_EXTERNAL_2_SENSE_HIGH                           \
+        (GPTIMER_FSCTL_FEX2EN_ENABLE | (GPTIMER_FCTL_FSENEXT2_HIGHACTIVE << 16))
+
+/** @}*/
+
+
+/** @addtogroup DL_TIMER_FAULT_CONFIG_TFIM
+ *  @{
+ */
+
+/*!
+ * @brief Selected trigger doesn't participate as a fault input.
+ */
+#define DL_TIMER_FAULT_CONFIG_TFIM_DISABLED         (GPTIMER_FCTL_TFIM_DISABLED)
+
+/*!
+ * @brief Selected trigger participates as a fault input.
+ */
+#define DL_TIMER_FAULT_CONFIG_TFIM_ENABLED           (GPTIMER_FCTL_TFIM_ENABLED)
+
+/** @}*/
+
+
+/** @addtogroup DL_TIMER_FAULT_CONFIG_FL
+ *  @{
+ */
+/*!
+ * @brief Overall fault condition is not dependent on the F bit in RIS
+ */
+#define DL_TIMER_FAULT_CONFIG_FL_NO_LATCH  (GPTIMER_FCTL_FL_NO_LATCH)
+
+/*!
+ * @brief Overall fault condition is dependent on the F bit in RIS
+ */
+#define DL_TIMER_FAULT_CONFIG_FL_LATCH_SW_CLR    (GPTIMER_FCTL_FL_LATCH_SW_CLR)
+
+/*!
+ * @brief Fault condition is latched. Fault condition is cleared on a zero event
+ *        if the fault input is 0
+ */
+#define DL_TIMER_FAULT_CONFIG_FL_LATCH_Z_CLR   (GPTIMER_FCTL_FL_LATCH_Z_CLR)
+
+/*!
+ * @brief Fault condition is latched. Fault condition is cleared on a load event
+ *        if the fault input is 0
+ */
+#define DL_TIMER_FAULT_CONFIG_FL_LATCH_LD_CLR    (GPTIMER_FCTL_FL_LATCH_LD_CLR)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_FAULT_CONFIG_FI
+ *  @{
+ */
+
+/*!
+ * @brief Fault condition is independent on all selected fault sources
+ *        coming into the Timer
+ */
+#define DL_TIMER_FAULT_CONFIG_FI_INDEPENDENT  (GPTIMER_FCTL_FI_INDEPENDENT)
+
+/*!
+ * @brief Fault condition is dependent on all selected fault sources
+ *        coming into the Timer
+ */
+#define DL_TIMER_FAULT_CONFIG_FI_DEPENDENT    (GPTIMER_FCTL_FI_DEPENDENT)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_FAULT_CONFIG_FIEN
+ *  @{
+ */
+
+/*!
+ * @brief Disables the input for fault detection from the device pin.
+ */
+#define DL_TIMER_FAULT_CONFIG_FIEN_DISABLED  (GPTIMER_FCTL_FIEN_DISABLED)
+
+/*!
+ * @brief Enables the input for fault detection from the device pin.
+ */
+#define DL_TIMER_FAULT_CONFIG_FIEN_ENABLED   (GPTIMER_FCTL_FIEN_ENABLED)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_FAULT_FILT
+ *  @{
+ */
+/*!
+ * @brief Input bypasses filter
+ */
+#define DL_TIMER_FAULT_FILTER_BYPASS     (GPTIMER_FIFCTL_FILTEN_BYPASS)
+
+/*!
+ * @brief Input filter is enabled
+ */
+#define DL_TIMER_FAULT_FILTER_FILTERED   (GPTIMER_FIFCTL_FILTEN_FILTERED)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_FAULT_FILTER_CPV
+ *  @{
+ */
+
+/*!
+ * @brief Input filter uses a stricter consecutive period count
+ */
+#define DL_TIMER_FAULT_FILTER_CPV_CONSEC_PER  (GPTIMER_FIFCTL_CPV_CONSEC_PER)
+
+/*!
+ * @brief Input filter uses majority voting
+ */
+#define DL_TIMER_FAULT_FILTER_CPV_VOTING      (GPTIMER_FIFCTL_CPV_VOTING)
+
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_FAULT_FILTER_FP
+ *  @{
+ */
+/*!
+ * @brief Sample period for the input filter is set to 3 TIMCLK
+ */
+#define DL_TIMER_FAULT_FILTER_FP_PER_3   (GPTIMER_FIFCTL_FP_PER_3)
+
+/*!
+ * @brief Sample period for the input filter is set to 5 TIMCLK
+ */
+#define DL_TIMER_FAULT_FILTER_FP_PER_5   (GPTIMER_FIFCTL_FP_PER_5)
+
+/*!
+ * @brief Sample period for the input filter is set to 8 TIMCLK
+ */
+#define DL_TIMER_FAULT_FILTER_FP_PER_8   (GPTIMER_FIFCTL_FP_PER_8)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_INPUT_FILT_CPV
+ *  @{
+ */
+
+/*!
+ * @brief Input filter uses a stricter consecutive period count
+ */
+#define DL_TIMER_CC_INPUT_FILT_CPV_CONSEC_PER (GPTIMER_IFCTL_01_CPV_CONSECUTIVE)
+
+/*!
+ * @brief Input filter uses majority voting
+ */
+#define DL_TIMER_CC_INPUT_FILT_CPV_VOTING          (GPTIMER_IFCTL_01_CPV_VOTING)
+
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CC_INPUT_FILT_FP
+ *  @{
+ */
+/*!
+ * @brief Sample period for the input filter is set to 3 TIMCLK
+ */
+#define DL_TIMER_CC_INPUT_FILT_FP_PER_3                 (GPTIMER_IFCTL_01_FP__3)
+
+/*!
+ * @brief Sample period for the input filter is set to 5 TIMCLK
+ */
+#define DL_TIMER_CC_INPUT_FILT_FP_PER_5                 (GPTIMER_IFCTL_01_FP__5)
+
+/*!
+ * @brief Sample period for the input filter is set to 8 TIMCLK
+ */
+#define DL_TIMER_CC_INPUT_FILT_FP_PER_8                 (GPTIMER_IFCTL_01_FP__8)
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_INTERRUPT
+ *  @{
+ */
+
+/*!
+ * @brief Repeat Counter interrupt
+ */
+#define DL_TIMER_INTERRUPT_REPC_EVENT           (GPTIMER_CPU_INT_IMASK_REPC_SET)
+
+/*!
+ * @brief Fault interrupt
+ */
+#define DL_TIMER_INTERRUPT_FAULT_EVENT             (GPTIMER_CPU_INT_IMASK_F_SET)
+
+/*!
+ * @brief Timer zero interrupt
+ */
+#define DL_TIMER_INTERRUPT_ZERO_EVENT                      (GPTIMER_CPU_INT_IMASK_Z_SET)
+
+/*!
+* @brief Timer load interrupt
+*/
+#define DL_TIMER_INTERRUPT_LOAD_EVENT                      (GPTIMER_CPU_INT_IMASK_L_SET)
+
+/*!
+* @brief Timer capture for compare 0 down interrupt
+*/
+#define DL_TIMER_INTERRUPT_CC0_DN_EVENT                 (GPTIMER_CPU_INT_IMASK_CCD0_SET)
+
+/*!
+* @brief Timer capture for compare 1 down interrupt
+*/
+#define DL_TIMER_INTERRUPT_CC1_DN_EVENT                 (GPTIMER_CPU_INT_IMASK_CCD1_SET)
+
+/*!
+* @brief Timer capture for compare 2 down interrupt
+*/
+#define DL_TIMER_INTERRUPT_CC2_DN_EVENT                 (GPTIMER_CPU_INT_IMASK_CCD2_SET)
+
+/*!
+* @brief Timer capture for compare 3 down interrupt
+*/
+#define DL_TIMER_INTERRUPT_CC3_DN_EVENT                 (GPTIMER_CPU_INT_IMASK_CCD3_SET)
+
+/*!
+* @brief Timer capture for compare 4 down interrupt
+*/
+#define DL_TIMER_INTERRUPT_CC4_DN_EVENT                 (GPTIMER_CPU_INT_IMASK_CCD4_SET)
+
+/*!
+* @brief Timer capture for compare 5 down interrupt
+*/
+#define DL_TIMER_INTERRUPT_CC5_DN_EVENT                 (GPTIMER_CPU_INT_IMASK_CCD5_SET)
+
+/*!
+* @brief Timer capture for compare 0 up interrupt
+*/
+#define DL_TIMER_INTERRUPT_CC0_UP_EVENT                 (GPTIMER_CPU_INT_IMASK_CCU0_SET)
+
+/*!
+* @brief Timer capture for compare 1 up interrupt
+*/
+#define DL_TIMER_INTERRUPT_CC1_UP_EVENT                 (GPTIMER_CPU_INT_IMASK_CCU1_SET)
+
+/*!
+* @brief Timer capture for compare 2 up interrupt
+*/
+#define DL_TIMER_INTERRUPT_CC2_UP_EVENT                 (GPTIMER_CPU_INT_IMASK_CCU2_SET)
+
+/*!
+* @brief Timer capture for compare 3 up interrupt
+*/
+#define DL_TIMER_INTERRUPT_CC3_UP_EVENT                 (GPTIMER_CPU_INT_IMASK_CCU3_SET)
+
+/*!
+* @brief Timer capture for compare 4 up interrupt
+*/
+#define DL_TIMER_INTERRUPT_CC4_UP_EVENT                 (GPTIMER_CPU_INT_IMASK_CCU4_SET)
+
+/*!
+* @brief Timer capture for compare 5 up interrupt
+*/
+#define DL_TIMER_INTERRUPT_CC5_UP_EVENT                 (GPTIMER_CPU_INT_IMASK_CCU5_SET)
+
+/*!
+* @brief Timer over flow interrupt
+*/
+#define DL_TIMER_INTERRUPT_OVERFLOW_EVENT                (GPTIMER_CPU_INT_IMASK_TOV_SET)
+
+/*!
+* @brief Timer QEI mode direction change event
+*/
+#define DL_TIMER_INTERRUPT_DC_EVENT                       (GPTIMER_CPU_INT_IMASK_DC_SET)
+
+
+/*!
+* @brief Timer QEI mode transition error
+*/
+#define DL_TIMER_INTERRUPT_QEIERR_EVENT               (GPTIMER_CPU_INT_IMASK_QEIERR_SET)
+
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_EVENT
+ *  @{
+ */
+
+/*!
+ * @brief Repeat Counter event
+ */
+#define DL_TIMER_EVENT_REPC_EVENT            (GPTIMER_GEN_EVENT0_IMASK_REPC_SET)
+
+/*!
+ * @brief Fault event
+ */
+#define DL_TIMER_EVENT_FAULT_EVENT              (GPTIMER_GEN_EVENT0_IMASK_F_SET)
+
+/*!
+ * @brief Timer zero event
+ */
+#define DL_TIMER_EVENT_ZERO_EVENT                          (GPTIMER_GEN_EVENT0_IMASK_Z_SET)
+
+/*!
+* @brief Timer load event
+*/
+#define DL_TIMER_EVENT_LOAD_EVENT                          (GPTIMER_GEN_EVENT0_IMASK_L_SET)
+
+/*!
+* @brief Timer capture for compare 0 down event
+*/
+#define DL_TIMER_EVENT_CC0_DN_EVENT                     (GPTIMER_GEN_EVENT0_IMASK_CCD0_SET)
+
+/*!
+* @brief Timer capture for compare 1 down event
+*/
+#define DL_TIMER_EVENT_CC1_DN_EVENT                     (GPTIMER_GEN_EVENT0_IMASK_CCD1_SET)
+
+/*!
+* @brief Timer capture for compare 2 down interrupt
+*/
+#define DL_TIMER_EVENT_CC2_DN_EVENT                     (GPTIMER_GEN_EVENT0_IMASK_CCD2_SET)
+
+/*!
+* @brief Timer capture for compare 3 down event
+*/
+#define DL_TIMER_EVENT_CC3_DN_EVENT                     (GPTIMER_GEN_EVENT0_IMASK_CCD3_SET)
+
+/*!
+* @brief Timer capture for compare 4 down event
+*/
+#define DL_TIMER_EVENT_CC4_DN_EVENT                     (GPTIMER_GEN_EVENT0_IMASK_CCD4_SET)
+
+/*!
+* @brief Timer capture for compare 5 down event
+*/
+#define DL_TIMER_EVENT_CC5_DN_EVENT                     (GPTIMER_GEN_EVENT0_IMASK_CCD5_SET)
+
+/*!
+* @brief Timer capture for compare 0 up event
+*/
+#define DL_TIMER_EVENT_CC0_UP_EVENT                     (GPTIMER_GEN_EVENT0_IMASK_CCU0_SET)
+
+/*!
+* @brief Timer capture for compare 1 up event
+*/
+#define DL_TIMER_EVENT_CC1_UP_EVENT                     (GPTIMER_GEN_EVENT0_IMASK_CCU1_SET)
+
+/*!
+* @brief Timer capture for compare 2 up event
+*/
+#define DL_TIMER_EVENT_CC2_UP_EVENT                     (GPTIMER_GEN_EVENT0_IMASK_CCU2_SET)
+
+/*!
+* @brief Timer capture for compare 3 up event
+*/
+#define DL_TIMER_EVENT_CC3_UP_EVENT                     (GPTIMER_GEN_EVENT0_IMASK_CCU3_SET)
+
+/*!
+* @brief Timer capture for compare 4 up event
+*/
+#define DL_TIMER_EVENT_CC4_UP_EVENT                     (GPTIMER_GEN_EVENT0_IMASK_CCU4_SET)
+
+/*!
+event
+*/
+#define DL_TIMER_EVENT_CC5_UP_EVENT                     (GPTIMER_GEN_EVENT0_IMASK_CCU5_SET)
+
+/*!
+* @brief Timer over flow event
+*/
+#define DL_TIMER_EVENT_OVERFLOW_EVENT                    (GPTIMER_GEN_EVENT0_IMASK_TOV_SET)
+
+/*!
+* @brief Timer qei mode direction change event
+*/
+#define DL_TIMER_EVENT_DC_EVENT                           (GPTIMER_GEN_EVENT0_IMASK_DC_SET)
+
+
+/*!
+* @brief Timer qei mode transition error
+*/
+#define DL_TIMER_EVENT_QEIERR_EVENT                   (GPTIMER_GEN_EVENT0_IMASK_QEIERR_SET)
+
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CCP0_DIS_OUT_ADV
+ *  @{
+ */
+
+/**
+ *  @brief CCP0 output is forced low when timer is disabled
+ */
+#define DL_TIMER_CCP0_DIS_OUT_ADV_FORCE_LOW (GPTIMER_ODIS_C0CCP0_CCP_OUTPUT_LOW)
+
+/**
+ *  @brief CCP0 output is set by the OCTL when timer is disabled
+ */
+#define DL_TIMER_CCP0_DIS_OUT_ADV_SET_BY_OCTL \
+                                           (GPTIMER_ODIS_C0CCP0_CCP_OUTPUT_OCTL)
+/** @}*/
+
+/** @addtogroup DL_TIMER_CCP1_DIS_OUT_ADV
+ *  @{
+ */
+
+/**
+ *  @brief CCP1 output is forced low when timer is disabled
+ */
+#define DL_TIMER_CCP1_DIS_OUT_ADV_FORCE_LOW (GPTIMER_ODIS_C0CCP1_CCP_OUTPUT_LOW)
+
+/**
+ *  @brief CCP1 output is set by the OCTL when timer is disabled
+ */
+#define DL_TIMER_CCP1_DIS_OUT_ADV_SET_BY_OCTL \
+                                           (GPTIMER_ODIS_C0CCP1_CCP_OUTPUT_OCTL)
+/** @}*/
+
+/** @addtogroup DL_TIMER_CCP2_DIS_OUT_ADV
+ *  @{
+ */
+/**
+ *  @brief CCP2 output is forced low when timer is disabled
+ */
+#define DL_TIMER_CCP2_DIS_OUT_ADV_FORCE_LOW (GPTIMER_ODIS_C0CCP2_CCP_OUTPUT_LOW)
+
+/**
+ *  @brief CCP2 output is set by the OCTL when timer is disabled
+ */
+#define DL_TIMER_CCP2_DIS_OUT_ADV_SET_BY_OCTL \
+                                           (GPTIMER_ODIS_C0CCP2_CCP_OUTPUT_OCTL)
+/** @}*/
+
+/** @addtogroup DL_TIMER_CCP3_DIS_OUT_ADV
+ *  @{
+ */
+
+/**
+ *  @brief CCP3 output is forced low when timer is disabled
+ */
+#define DL_TIMER_CCP3_DIS_OUT_ADV_FORCE_LOW (GPTIMER_ODIS_C0CCP3_CCP_OUTPUT_LOW)
+
+/**
+ *  @brief CCP3 output is set by the OCTL when timer is disabled
+ */
+#define DL_TIMER_CCP3_DIS_OUT_ADV_SET_BY_OCTL \
+                                           (GPTIMER_ODIS_C0CCP3_CCP_OUTPUT_OCTL)
+/** @}*/
+
+/* clang-format on */
+
+/*! @enum DL_TIMER_CLOCK */
+typedef enum {
+    /*! Selects BUSCLK as clock source */
+    DL_TIMER_CLOCK_BUSCLK = GPTIMER_CLKSEL_BUSCLK_SEL_ENABLE,
+    /*! Selects 2X BUSCLK as clock source */
+    DL_TIMER_CLOCK_2X_BUSCLK = GPTIMER_CLKSEL_BUS2XCLK_SEL_ENABLE,
+    /*! Selects MFCLK as clock source */
+    DL_TIMER_CLOCK_MFCLK = GPTIMER_CLKSEL_MFCLK_SEL_ENABLE,
+    /*! Selects LFCLK as clock source */
+    DL_TIMER_CLOCK_LFCLK = GPTIMER_CLKSEL_LFCLK_SEL_ENABLE,
+    /*! Disables selected clock source */
+    DL_TIMER_CLOCK_DISABLE = GPTIMER_CLKSEL_LFCLK_SEL_DISABLE,
+} DL_TIMER_CLOCK;
+
+/*! @enum  DL_TIMER_CLOCK_DIVIDE */
+typedef enum {
+    /*! Timer source clock divide ratio set to 1 */
+    DL_TIMER_CLOCK_DIVIDE_1 = GPTIMER_CLKDIV_RATIO_DIV_BY_1,
+    /*! Timer source clock divide ratio set to 2 */
+    DL_TIMER_CLOCK_DIVIDE_2 = GPTIMER_CLKDIV_RATIO_DIV_BY_2,
+    /*! Timer source clock divide ratio set to 3 */
+    DL_TIMER_CLOCK_DIVIDE_3 = GPTIMER_CLKDIV_RATIO_DIV_BY_3,
+    /*! Timer source clock divide ratio set to 4 */
+    DL_TIMER_CLOCK_DIVIDE_4 = GPTIMER_CLKDIV_RATIO_DIV_BY_4,
+    /*! Timer source clock divide ratio set to 5 */
+    DL_TIMER_CLOCK_DIVIDE_5 = GPTIMER_CLKDIV_RATIO_DIV_BY_5,
+    /*! Timer source clock divide ratio set to 6 */
+    DL_TIMER_CLOCK_DIVIDE_6 = GPTIMER_CLKDIV_RATIO_DIV_BY_6,
+    /*! Timer source clock divide ratio set to 7 */
+    DL_TIMER_CLOCK_DIVIDE_7 = GPTIMER_CLKDIV_RATIO_DIV_BY_7,
+    /*! Timer source clock divide ratio set to 8 */
+    DL_TIMER_CLOCK_DIVIDE_8 = GPTIMER_CLKDIV_RATIO_DIV_BY_8,
+} DL_TIMER_CLOCK_DIVIDE;
+
+/*! @enum  DL_TIMER_CCP_DIS_OUT */
+typedef enum {
+    /*! CCP output source is disabled and driven low before conditional
+     * inversion */
+    DL_TIMER_CCP_DIS_OUT_LOW = GPTIMER_ODIS_C0CCP0_CCP_OUTPUT_LOW,
+    /*! CCP output source is not disabled */
+    DL_TIMER_CCP_DIS_OUT_SET_BY_OCTL = GPTIMER_ODIS_C0CCP0_CCP_OUTPUT_OCTL,
+} DL_TIMER_CCP_DIS_OUT;
+
+/*! @enum  DL_TIMER_CC_INDEX */
+typedef enum {
+    /*! Index associated to Capture Compare 0 */
+    DL_TIMER_CC_0_INDEX = 0,
+    /*! Index associated to Capture Compare 1 */
+    DL_TIMER_CC_1_INDEX = 1,
+    /*! Index associated to Capture Compare 2 */
+    DL_TIMER_CC_2_INDEX = 2,
+    /*! Index associated to Capture Compare 3 */
+    DL_TIMER_CC_3_INDEX = 3,
+
+    /*! Index associated to Capture Compare 4 */
+    DL_TIMER_CC_4_INDEX = 4,
+    /*! Index associated to Capture Compare 5 */
+    DL_TIMER_CC_5_INDEX = 5,
+
+} DL_TIMER_CC_INDEX;
+
+/*! @enum  DL_TIMER_EXT_TRIG_SEL*/
+typedef enum {
+    /*! External trigger 0 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_0 = GPTIMER_TSEL_ETSEL_TRIG0,
+    /*! External trigger 1 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_1 = GPTIMER_TSEL_ETSEL_TRIG1,
+    /*! External trigger 2 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_2 = GPTIMER_TSEL_ETSEL_TRIG2,
+    /*! External trigger 3 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_3 = GPTIMER_TSEL_ETSEL_TRIG3,
+    /*! External trigger 4 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_4 = GPTIMER_TSEL_ETSEL_TRIG4,
+    /*! External trigger 5 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_5 = GPTIMER_TSEL_ETSEL_TRIG5,
+    /*! External trigger 6 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_6 = GPTIMER_TSEL_ETSEL_TRIG6,
+    /*! External trigger 7 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_7 = GPTIMER_TSEL_ETSEL_TRIG7,
+    /*! External trigger 8 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_8 = GPTIMER_TSEL_ETSEL_TRIG8,
+    /*! External trigger 9 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_9 = GPTIMER_TSEL_ETSEL_TRIG9,
+    /*! External trigger 10 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_10 = GPTIMER_TSEL_ETSEL_TRIG10,
+    /*! External trigger 11 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_11 = GPTIMER_TSEL_ETSEL_TRIG11,
+    /*! External trigger 12 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_12 = GPTIMER_TSEL_ETSEL_TRIG12,
+    /*! External trigger 13 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_13 = GPTIMER_TSEL_ETSEL_TRIG13,
+    /*! External trigger 14 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_14 = GPTIMER_TSEL_ETSEL_TRIG14,
+    /*! External trigger 15 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_15 = GPTIMER_TSEL_ETSEL_TRIG15,
+    /*! External event subscriber 0 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_SUB_0 = GPTIMER_TSEL_ETSEL_TRIG_SUB0,
+    /*! External event subscriber 1 */
+    DL_TIMER_EXT_TRIG_SEL_TRIG_SUB_1 = GPTIMER_TSEL_ETSEL_TRIG_SUB1,
+} DL_TIMER_EXT_TRIG_SEL;
+
+/*! @enum  DL_TIMER_TIMER_MODE */
+typedef enum {
+    /*! Configures Timer in one shot mode in DOWN COUNTING mode */
+    DL_TIMER_TIMER_MODE_ONE_SHOT =
+        (GPTIMER_CTRCTL_CM_DOWN | GPTIMER_CTRCTL_REPEAT_REPEAT_0),
+    /*! Configures Timer in periodic mode in DOWN COUNTING mode */
+    DL_TIMER_TIMER_MODE_PERIODIC =
+        (GPTIMER_CTRCTL_CM_DOWN | GPTIMER_CTRCTL_REPEAT_REPEAT_1),
+    /*! Configures Timer in one shot mode in UP COUNTING mode */
+    DL_TIMER_TIMER_MODE_ONE_SHOT_UP =
+        (GPTIMER_CTRCTL_CM_UP | GPTIMER_CTRCTL_REPEAT_REPEAT_0),
+    /*! Configures Timer in periodic mode in UP COUNTING mode */
+    DL_TIMER_TIMER_MODE_PERIODIC_UP =
+        (GPTIMER_CTRCTL_CM_UP | GPTIMER_CTRCTL_REPEAT_REPEAT_1),
+    /*! Configures Timer in one shot mode in UP/DOWN COUNTING mode */
+    DL_TIMER_TIMER_MODE_ONE_SHOT_UP_DOWN =
+        (GPTIMER_CTRCTL_CM_UP_DOWN | GPTIMER_CTRCTL_REPEAT_REPEAT_0),
+    /*! Configures Timer in periodic mode in UP/DOWN COUNTING mode */
+    DL_TIMER_TIMER_MODE_PERIODIC_UP_DOWN =
+        (GPTIMER_CTRCTL_CM_UP_DOWN | GPTIMER_CTRCTL_REPEAT_REPEAT_1),
+} DL_TIMER_TIMER_MODE;
+
+/*! @enum  DL_TIMER_CAPTURE_MODE */
+typedef enum {
+    /*! Configures Timer in edge time capture mode and timer is configured
+     *! in down counting mode */
+    DL_TIMER_CAPTURE_MODE_EDGE_TIME,
+    /*! Configures Timer in period capture mode and timer is configured
+     *! in down counting mode */
+    DL_TIMER_CAPTURE_MODE_PERIOD_CAPTURE,
+    /*! Configures Timer in pulse width capture mode and timer is configured
+     *! in down counting mode */
+    DL_TIMER_CAPTURE_MODE_PULSE_WIDTH,
+    /*! Configures Timer in edge time capture mode and timer is configured
+     *! in up counting mode */
+    DL_TIMER_CAPTURE_MODE_EDGE_TIME_UP,
+    /*! Configures Timer in period capture mode and timer is configured
+     *! in up counting mode */
+    DL_TIMER_CAPTURE_MODE_PERIOD_CAPTURE_UP,
+    /*! Configures Timer in pulse width capture mode and timer is configured
+     *! in up counting mode */
+    DL_TIMER_CAPTURE_MODE_PULSE_WIDTH_UP,
+} DL_TIMER_CAPTURE_MODE;
+
+/*! @enum  DL_TIMER_CAPTURE_COMBINED_MODE */
+typedef enum {
+    /*! Configures Timer in pulse width and period mode and timer is configured
+     *! in down counting mode */
+    DL_TIMER_CAPTURE_COMBINED_MODE_PULSE_WIDTH_AND_PERIOD,
+    /*! Configures Timer in pulse width and period mode and timer is configured
+     *! in up counting mode */
+    DL_TIMER_CAPTURE_COMBINED_MODE_PULSE_WIDTH_AND_PERIOD_UP,
+} DL_TIMER_CAPTURE_COMBINED_MODE;
+
+/*! @enum  DL_TIMER_COMPARE_MODE */
+typedef enum {
+    /*! Configures Timer in edge count mode and timer is configured
+     *! in down counting mode */
+    DL_TIMER_COMPARE_MODE_EDGE_COUNT,
+    /*! Configures Timer in edge count mode and timer is configured
+     *! in up counting mode */
+    DL_TIMER_COMPARE_MODE_EDGE_COUNT_UP,
+    /*! Configures Timer in edge count mode and timer is configured
+     *! in up/down counting mode */
+    DL_TIMER_COMPARE_MODE_EDGE_COUNT_UP_DOWN,
+} DL_TIMER_COMPARE_MODE;
+
+/*! @enum  DL_TIMER_COUNT_MODE */
+typedef enum {
+    /*! Timer counts in DOWN mode */
+    DL_TIMER_COUNT_MODE_DOWN = GPTIMER_CTRCTL_CM_DOWN,
+    /*! Timer counts in UP/DOWN mode */
+    DL_TIMER_COUNT_MODE_UP_DOWN = GPTIMER_CTRCTL_CM_UP_DOWN,
+    /*! Timer counts in UP mode */
+    DL_TIMER_COUNT_MODE_UP = GPTIMER_CTRCTL_CM_UP,
+} DL_TIMER_COUNT_MODE;
+
+/*! @enum  DL_TIMER */
+typedef enum {
+    /*! Start running timer */
+    DL_TIMER_START = GPTIMER_CTRCTL_EN_ENABLED,
+    /*! Don't start running timer */
+    DL_TIMER_STOP = GPTIMER_CTRCTL_EN_DISABLED,
+} DL_TIMER;
+
+/*! @enum DL_TIMER_INTERM_INT */
+typedef enum {
+
+    /*! Enables intermediate interrupt in timer mode */
+    DL_TIMER_INTERM_INT_ENABLED = GPTIMER_CCCTL_01_COC_COMPARE,
+    /*! Disabled intermediate interrupt in timer mode */
+    DL_TIMER_INTERM_INT_DISABLED = GPTIMER_CCCTL_01_COC_CAPTURE,
+
+} DL_TIMER_INTERM_INT;
+
+/*! @enum  DL_TIMER_CAPTURE_EDGE_DETECTION_MODE */
+typedef enum {
+    /*! Selects rising edge detection */
+    DL_TIMER_CAPTURE_EDGE_DETECTION_MODE_RISING =
+        GPTIMER_CCCTL_01_CCOND_CC_TRIG_RISE,
+    /*! Selects falling edge detection */
+    DL_TIMER_CAPTURE_EDGE_DETECTION_MODE_FALLING =
+        GPTIMER_CCCTL_01_CCOND_CC_TRIG_FALL,
+} DL_TIMER_CAPTURE_EDGE_DETECTION_MODE;
+
+/*! @enum  DL_TIMER_COMPARE_EDGE_DETECTION_MODE */
+typedef enum {
+    /*! Selects rising edge detection */
+    DL_TIMER_COMPARE_EDGE_DETECTION_MODE_RISING =
+        GPTIMER_CCCTL_01_ACOND_CC_TRIG_RISE,
+    /*! Selects falling edge detection */
+    DL_TIMER_COMPARE_EDGE_DETECTION_MODE_FALLING =
+        GPTIMER_CCCTL_01_ACOND_CC_TRIG_FALL,
+    /*! Selects both (rising and falling) edge detection */
+    DL_TIMER_COMPARE_EDGE_DETECTION_MODE_EDGE =
+        GPTIMER_CCCTL_01_ACOND_CC_TRIG_EDGE,
+} DL_TIMER_COMPARE_EDGE_DETECTION_MODE;
+
+/*! @enum DL_TIMER_PWM_MODE */
+typedef enum {
+    /*! Configured Timer for PWM in edge align mode */
+    DL_TIMER_PWM_MODE_EDGE_ALIGN = GPTIMER_CTRCTL_CM_DOWN,
+    /*! Configured Timer for PWM in edge align mode */
+    DL_TIMER_PWM_MODE_EDGE_ALIGN_UP = GPTIMER_CTRCTL_CM_UP,
+    /*! Configured Timer for PWM in center align mode */
+    DL_TIMER_PWM_MODE_CENTER_ALIGN = GPTIMER_CTRCTL_CM_UP_DOWN,
+} DL_TIMER_PWM_MODE;
+
+/*! @enum DL_TIMER_DEAD_BAND_MODE */
+typedef enum {
+    /*! Selects dead band insertion mode 0 */
+    DL_TIMER_DEAD_BAND_MODE_0 = GPTIMER_DBCTL_M1_ENABLE_DISABLED,
+    /*! Selects dead band insertion mode 1 */
+    DL_TIMER_DEAD_BAND_MODE_1 = GPTIMER_DBCTL_M1_ENABLE_ENABLED,
+} DL_TIMER_DEAD_BAND_MODE;
+
+/*! @enum DL_TIMER_FAULT_ENTRY_CCP */
+
+typedef enum {
+    /*! The CCP output value is not affected by the event */
+    DL_TIMER_FAULT_ENTRY_CCP_DISABLED = GPTIMER_CCACT_01_FENACT_DISABLED,
+    /*! The CCP output value is set high */
+    DL_TIMER_FAULT_ENTRY_CCP_HIGH = GPTIMER_CCACT_01_FENACT_CCP_HIGH,
+    /*! The CCP output value is set to low  */
+    DL_TIMER_FAULT_ENTRY_CCP_LOW = GPTIMER_CCACT_01_FENACT_CCP_LOW,
+    /*! The CCP output value is toggled*/
+    DL_TIMER_FAULT_ENTRY_CCP_TOGGLE = GPTIMER_CCACT_01_FENACT_CCP_TOGGLE,
+
+    /*! The CCP output value is High-Z*/
+    DL_TIMER_FAULT_ENTRY_CCP_HIGHZ = GPTIMER_CCACT_01_FENACT_CCP_HIGHZ,
+
+} DL_TIMER_FAULT_ENTRY_CCP;
+
+/*! @enum DL_TIMER_FAULT_EXIT_CCP */
+typedef enum {
+    /*! The CCP output value is not affected by the event */
+    DL_TIMER_FAULT_EXIT_CCP_DISABLED = GPTIMER_CCACT_01_FEXACT_DISABLED,
+    /*! The CCP output value is set high */
+    DL_TIMER_FAULT_EXIT_CCP_HIGH = GPTIMER_CCACT_01_FEXACT_CCP_HIGH,
+    /*! The CCP output value is set to low  */
+    DL_TIMER_FAULT_EXIT_CCP_LOW = GPTIMER_CCACT_01_FEXACT_CCP_LOW,
+    /*! The CCP output value is toggled*/
+    DL_TIMER_FAULT_EXIT_CCP_TOGGLE = GPTIMER_CCACT_01_FEXACT_CCP_TOGGLE,
+
+    /*! The CCP output value is High-Z*/
+    DL_TIMER_FAULT_EXIT_CCP_HIGHZ = GPTIMER_CCACT_01_FEXACT_CCP_HIGHZ,
+
+} DL_TIMER_FAULT_EXIT_CCP;
+
+/*! @enum DL_TIMER_FAULT_EXIT_CTR */
+typedef enum {
+    /*! Timer resumes counting upon release of fault condition */
+    DL_TIMER_FAULT_EXIT_CTR_RESUME = GPTIMER_CTRCTL_FRB_RESUME,
+    /*! Timer resumes operation based on counter value after enable
+     *  configuration */
+    DL_TIMER_FAULT_EXIT_CTR_CVAE_ACTION = GPTIMER_CTRCTL_FRB_CVAE_ACTION,
+} DL_TIMER_FAULT_EXIT_CTR;
+
+/*! @enum DL_TIMER_FAULT_ENTRY_CTR */
+typedef enum {
+    /*! Timer counter continues running during fault */
+    DL_TIMER_FAULT_ENTRY_CTR_CONT_COUNT = GPTIMER_CTRCTL_FB_CONT_COUNT,
+    /*! Timer counter continues is suspended during fault */
+    DL_TIMER_FAULT_ENTRY_CTR_SUSP_COUNT = GPTIMER_CTRCTL_FB_SUSP_COUNT,
+} DL_TIMER_FAULT_ENTRY_CTR;
+
+/*! @enum DL_TIMER_CROSS_TRIG_SRC */
+typedef enum {
+    /*! Use FSUB0 for Event manager */
+    DL_TIMER_CROSS_TRIG_SRC_FSUB0 = GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_FSUB0,
+    /*! Use FSUB1 for Event manager */
+    DL_TIMER_CROSS_TRIG_SRC_FSUB1 = GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_FSUB1,
+    /*! Use Zero event  as cross trigger source */
+    DL_TIMER_CROSS_TRIG_SRC_ZERO = GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_Z,
+    /*! Use Load event  as cross trigger source */
+    DL_TIMER_CROSS_TRIG_SRC_LOAD = GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_L,
+    /*! Use Capture Compare Down 0 event  as cross trigger source. */
+    DL_TIMER_CROSS_TRIG_SRC_CCD0 = GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCD0,
+    /*! Use Capture Compare Down 1 event  as cross trigger source. */
+    DL_TIMER_CROSS_TRIG_SRC_CCD1 = GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCD1,
+    /*! Use Capture Compare Down 2 event  as cross trigger source. */
+    DL_TIMER_CROSS_TRIG_SRC_CCD2 = GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCD2,
+    /*! Use Capture Compare Down 3 event  as cross trigger source. */
+    DL_TIMER_CROSS_TRIG_SRC_CCD3 = GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCD3,
+    /*! Use Capture Compare Up 0 event  as cross trigger source. */
+    DL_TIMER_CROSS_TRIG_SRC_CCU0 = GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCU0,
+    /*! Use Capture Compare Up 1 event  as cross trigger source. */
+    DL_TIMER_CROSS_TRIG_SRC_CCU1 = GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCU1,
+    /*! Use Capture Compare Up 2 event  as cross trigger source. */
+    DL_TIMER_CROSS_TRIG_SRC_CCU2 = GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCU2,
+    /*! Use Capture Compare Up 3 event  as cross trigger source. */
+    DL_TIMER_CROSS_TRIG_SRC_CCU3 = GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_CCU3,
+
+} DL_TIMER_CROSS_TRIG_SRC;
+
+/*! @enum DL_TIMER_CROSS_TRIGGER_INPUT */
+typedef enum {
+    /*! Cross Triggering through subscriber ports enabled */
+    DL_TIMER_CROSS_TRIGGER_INPUT_ENABLED = GPTIMER_CTTRIGCTL_EVTCTEN_ENABLE,
+    /*! Cross Triggering through subscriber ports disabled */
+    DL_TIMER_CROSS_TRIGGER_INPUT_DISABLED = GPTIMER_CTTRIGCTL_EVTCTEN_DISABLED,
+} DL_TIMER_CROSS_TRIGGER_INPUT;
+
+/*! @enum DL_TIMER_CROSS_TRIGGER_MODE */
+typedef enum {
+    /*! Cross Triggering Enabled */
+    DL_TIMER_CROSS_TRIGGER_MODE_ENABLED = GPTIMER_CTTRIGCTL_CTEN_ENABLE,
+    /*! Cross Triggering Disabled */
+    DL_TIMER_CROSS_TRIGGER_MODE_DISABLED = GPTIMER_CTTRIGCTL_CTEN_DISABLED,
+} DL_TIMER_CROSS_TRIGGER_MODE;
+
+/*! @enum DL_TIMER_IIDX */
+typedef enum {
+    /*! Timer interrupt index for zero interrupt */
+    DL_TIMER_IIDX_ZERO = GPTIMER_CPU_INT_IIDX_STAT_Z,
+    /*! Timer interrupt index for load interrupt */
+    DL_TIMER_IIDX_LOAD = GPTIMER_CPU_INT_IIDX_STAT_L,
+    /*! Timer interrupt index for compare 0 down interrupt */
+    DL_TIMER_IIDX_CC0_DN = GPTIMER_CPU_INT_IIDX_STAT_CCD0,
+    /*! Timer interrupt index for compare 1 down interrupt */
+    DL_TIMER_IIDX_CC1_DN = GPTIMER_CPU_INT_IIDX_STAT_CCD1,
+    /*! Timer interrupt index for compare 2 down interrupt */
+    DL_TIMER_IIDX_CC2_DN = GPTIMER_CPU_INT_IIDX_STAT_CCD2,
+    /*! Timer interrupt index for compare 3 down interrupt */
+    DL_TIMER_IIDX_CC3_DN = GPTIMER_CPU_INT_IIDX_STAT_CCD3,
+    /*! Timer interrupt index for compare 0 up interrupt */
+    DL_TIMER_IIDX_CC0_UP = GPTIMER_CPU_INT_IIDX_STAT_CCU0,
+    /*! Timer interrupt index for compare 1 up interrupt */
+    DL_TIMER_IIDX_CC1_UP = GPTIMER_CPU_INT_IIDX_STAT_CCU1,
+    /*! Timer interrupt index for compare 2 up interrupt */
+    DL_TIMER_IIDX_CC2_UP = GPTIMER_CPU_INT_IIDX_STAT_CCU2,
+    /*! Timer interrupt index for compare 3 up interrupt */
+    DL_TIMER_IIDX_CC3_UP = GPTIMER_CPU_INT_IIDX_STAT_CCU3,
+
+    /*! Timer interrupt index for compare 4 down interrupt */
+    DL_TIMER_IIDX_CC4_DN = GPTIMER_CPU_INT_IIDX_STAT_CCD4,
+    /*! Timer interrupt index for compare 5 down interrupt */
+    DL_TIMER_IIDX_CC5_DN = GPTIMER_CPU_INT_IIDX_STAT_CCD5,
+    /*! Timer interrupt index for compare 4 up interrupt */
+    DL_TIMER_IIDX_CC4_UP = GPTIMER_CPU_INT_IIDX_STAT_CCU4,
+    /*! Timer interrupt index for compare 5 up interrupt */
+    DL_TIMER_IIDX_CC5_UP = GPTIMER_CPU_INT_IIDX_STAT_CCU5,
+
+    /*! Timer interrupt index for fault interrupt */
+    DL_TIMER_IIDX_FAULT = GPTIMER_CPU_INT_IIDX_STAT_F,
+    /*! Timer interrupt index for timer overflow interrupt */
+    DL_TIMER_IIDX_OVERFLOW = GPTIMER_CPU_INT_IIDX_STAT_TOV,
+    /*! Timer interrupt index for repeat counter
+     * @note <b> This is a Timer A specific interrupt. </b>
+     */
+    DL_TIMER_IIDX_REPEAT_COUNT = GPTIMER_CPU_INT_IIDX_STAT_REPC,
+    /*! Timer interrupt index for direction change interrupt
+     * @note <b> Please refer the Timer TRM to determine TIMG instances which
+     * support this feature. </b> */
+    DL_TIMER_IIDX_DIR_CHANGE = GPTIMER_CPU_INT_IIDX_STAT_DC,
+} DL_TIMER_IIDX;
+
+/*! @enum DL_TIMER_PUBLISHER_INDEX */
+typedef enum {
+    /*! TIMER Publisher index 0 */
+    DL_TIMER_PUBLISHER_INDEX_0 = 0,
+    /*! TIMER Publisher index 1 */
+    DL_TIMER_PUBLISHER_INDEX_1 = 1
+} DL_TIMER_PUBLISHER_INDEX;
+
+/*! @enum DL_TIMER_SUBSCRIBER_INDEX */
+typedef enum {
+    /*! TIMER Subscriber index 0 */
+    DL_TIMER_SUBSCRIBER_INDEX_0 = 0,
+    /*! TIMER Subscriber index 1 */
+    DL_TIMER_SUBSCRIBER_INDEX_1 = 1
+} DL_TIMER_SUBSCRIBER_INDEX;
+
+/*! @enum DL_TIMER_EVENT_ROUTE */
+typedef enum {
+    /*! TIMER event route 1 */
+    DL_TIMER_EVENT_ROUTE_1 = 0,
+    /*! TIMER event route 2 */
+    DL_TIMER_EVENT_ROUTE_2 = 12
+} DL_TIMER_EVENT_ROUTE;
+
+/*! @enum DL_TIMER_INPUT_CHAN */
+typedef enum {
+    /*! Selected timer instance channel 0 as input capture channel */
+    DL_TIMER_INPUT_CHAN_0,
+    /*! Selects timer instance channel 1 as input capture channel */
+    DL_TIMER_INPUT_CHAN_1,
+    /*! Selects timer instance channel 2 as input capture channel.
+     *  Please refer to device DS to determine number of input channels
+     *  by the timer instance */
+    DL_TIMER_INPUT_CHAN_2,
+    /*! Selects timer instance channel 3 as input capture channel.
+     *  Please refer to device DS to determine number of input channels
+     *  by the timer instance */
+    DL_TIMER_INPUT_CHAN_3,
+} DL_TIMER_INPUT_CHAN;
+
+/*! @enum  DL_TIMER_DEBUG_RES */
+typedef enum {
+    /*! Resume counting */
+    DL_TIMER_DEBUG_RES_RESUME = GPTIMER_CTRCTL_DRB_RESUME,
+    /*! Perform the action as specified by the Counter Value After Enable (CVAE)
+     *! field. */
+    DL_TIMER_DEBUG_RES_CVAE_ACTION = GPTIMER_CTRCTL_DRB_CVAE_ACTION,
+} DL_TIMER_DEBUG_RES;
+
+/*! @enum  DL_TIMER_CZC */
+typedef enum {
+    /*! Zero event is controlled by CCCTL0 Zero condition */
+    DL_TIMER_CZC_CCCTL0_ZCOND = GPTIMER_CTRCTL_CZC_CCCTL0_ZCOND,
+    /*! Zero event is controlled by CCCTL1 Zero condition */
+    DL_TIMER_CZC_CCCTL1_ZCOND = GPTIMER_CTRCTL_CZC_CCCTL1_ZCOND,
+    /*! Zero event is controlled by CCCTL2 Zero condition */
+    DL_TIMER_CZC_CCCTL2_ZCOND = GPTIMER_CTRCTL_CZC_CCCTL2_ZCOND,
+    /*! Zero event is controlled by CCCTL3 Zero condition */
+    DL_TIMER_CZC_CCCTL3_ZCOND = GPTIMER_CTRCTL_CZC_CCCTL3_ZCOND,
+    /*! Zero event is controlled by 2-input QEI mode */
+    DL_TIMER_CZC_QEI_2INP = GPTIMER_CTRCTL_CZC_QEI_2INP,
+    /*! Zero event is controlled by 3-input QEI mode */
+    DL_TIMER_CZC_QEI_3INP = GPTIMER_CTRCTL_CZC_QEI_3INP,
+} DL_TIMER_CZC;
+
+/*! @enum  DL_TIMER_CAC */
+typedef enum {
+    /*! Advance event is controlled by CCCTL0 advance condition */
+    DL_TIMER_CAC_CCCTL0_ACOND = GPTIMER_CTRCTL_CAC_CCCTL0_ACOND,
+    /*! Advance event is controlled by CCCTL1 advance condition */
+    DL_TIMER_CAC_CCCTL1_ACOND = GPTIMER_CTRCTL_CAC_CCCTL1_ACOND,
+    /*! Advance event is controlled by CCCTL2 advance condition */
+    DL_TIMER_CAC_CCCTL2_ACOND = GPTIMER_CTRCTL_CAC_CCCTL2_ACOND,
+    /*! Advance event is controlled by CCCTL3 advance condition */
+    DL_TIMER_CAC_CCCTL3_ACOND = GPTIMER_CTRCTL_CAC_CCCTL3_ACOND,
+    /*! Advance event is controlled by 2-input QEI mode */
+    DL_TIMER_CAC_QEI_2INP = GPTIMER_CTRCTL_CAC_QEI_2INP,
+    /*! Advance event is controlled by 3-input QEI mode */
+    DL_TIMER_CAC_QEI_3INP = GPTIMER_CTRCTL_CAC_QEI_3INP,
+} DL_TIMER_CAC;
+
+/*! @enum  DL_TIMER_CLC */
+typedef enum {
+    /*! Load event is controlled by CCCTL0 load condition */
+    DL_TIMER_CLC_CCCTL0_LCOND = GPTIMER_CTRCTL_CLC_CCCTL0_LCOND,
+    /*! Load event is controlled by CCCTL1 load condition */
+    DL_TIMER_CLC_CCCTL1_LCOND = GPTIMER_CTRCTL_CLC_CCCTL1_LCOND,
+    /*! Load event is controlled by CCCTL2 load condition */
+    DL_TIMER_CLC_CCCTL2_LCOND = GPTIMER_CTRCTL_CLC_CCCTL2_LCOND,
+    /*! Load event is controlled by CCCTL3 load condition */
+    DL_TIMER_CLC_CCCTL3_LCOND = GPTIMER_CTRCTL_CLC_CCCTL3_LCOND,
+    /*! Load event is controlled by 2-input QEI mode */
+    DL_TIMER_CLC_QEI_2INP = GPTIMER_CTRCTL_CLC_QEI_2INP,
+    /*! Load event is controlled by 3-input QEI mode */
+    DL_TIMER_CLC_QEI_3INP = GPTIMER_CTRCTL_CLC_QEI_3INP,
+} DL_TIMER_CLC;
+
+/*! @enum  DL_TIMER_COUNT_AFTER_EN */
+typedef enum {
+    /*! The counter is set to the LOAD register value */
+    DL_TIMER_COUNT_AFTER_EN_LOAD_VAL = GPTIMER_CTRCTL_CVAE_LDVAL,
+    /*! The counter value is unchanged from its current value */
+    DL_TIMER_COUNT_AFTER_EN_NO_CHANGE = GPTIMER_CTRCTL_CVAE_NOCHANGE,
+    /*! The counter is set to zero */
+    DL_TIMER_COUNT_AFTER_EN_ZERO = GPTIMER_CTRCTL_CVAE_ZEROVAL,
+
+} DL_TIMER_COUNT_AFTER_EN;
+
+/*! @enum  DL_TIMER_REPEAT_MODE */
+typedef enum {
+    /*! Does not automatically advance following a zero event */
+    DL_TIMER_REPEAT_MODE_DISABLED = GPTIMER_CTRCTL_REPEAT_REPEAT_0,
+    /*! Continues to advance following a zero event */
+    DL_TIMER_REPEAT_MODE_ENABLED = GPTIMER_CTRCTL_REPEAT_REPEAT_1,
+    /*! Continues to advance following a zero event if the debug mode is not in
+     *! effect, or following the release of the debug mode */
+    DL_TIMER_REPEAT_MODE_ENABLED_DEBUG = GPTIMER_CTRCTL_REPEAT_REPEAT_3,
+} DL_TIMER_REPEAT_MODE;
+
+/*! @enum  DL_TIMER_CC_UPDATE_METHOD */
+typedef enum {
+    /*! Value written to the CCACT.SWFRCACT register has immediate effect */
+    DL_TIMER_CC_UPDATE_METHOD_IMMEDIATE = (GPTIMER_CCCTL_01_CCUPD_IMMEDIATELY),
+    /*! Following a zero event. Writes to the CCx_y register are stored in
+     *  Shadow register and transferred to CCx_y in the TIMCLK cycle following
+     *  CTR equals 0 */
+    DL_TIMER_CC_UPDATE_METHOD_ZERO_EVT = (GPTIMER_CCCTL_01_CCUPD_ZERO_EVT),
+    /*! Following a compare (down) event. Writes to the CCx_y register are
+     *  stored in Shadow register and transferred to CCx_y in the TIMCLK cycle
+     *  following CTR equals the CCx_y register value.*/
+    DL_TIMER_CC_UPDATE_METHOD_COMP_DN_EVT =
+        (GPTIMER_CCCTL_01_CCUPD_COMPARE_DOWN_EVT),
+    /*! Following a compare (up) event. Writes to the CCx_y register are stored
+     *  in Shadow register and transferred to CCx_y in the TIMCLK cycle
+     *  following CTR equals the CCx_y register value. */
+    DL_TIMER_CC_UPDATE_METHOD_COMP_UP_EVT =
+        (GPTIMER_CCCTL_01_CCUPD_COMPARE_UP_EVT),
+    /*! Following a zero or load event. Writes to the CCx_y register are stored
+     *  in Shadow register and transferred to CCx_y in the TIMCLK cycle
+     *  following CTR equals 0 or CTR. Equals LDn.  Note this update mechanism
+     *  is defined for use only in configurations using up/down counting.
+     *  This mode is not intended for use in down count configurations */
+    DL_TIMER_CC_UPDATE_METHOD_ZERO_OR_LOAD_EVT =
+        (GPTIMER_CCCTL_01_CCUPD_ZERO_LOAD_EVT),
+    /*! Following a zero event with repeat count also zero.  Writes to the CCx_y
+     *  register are stored in Shadow register and transferred to CCx_y in the
+     *  TIMCLK cycle following CTR equals 0 and if RC equal 0.*/
+    DL_TIMER_CC_UPDATE_METHOD_ZERO_RC_EVT =
+        (GPTIMER_CCCTL_01_CCUPD_ZERO_RC_ZERO_EVT),
+    /*! Following a TRIG pulse, writes to the
+     *! Capture Compare register are stored in shadow register and transferred
+     *! to Capture Compare register in the TIMCLK cycle following timer counter
+     *! equal to zero AND repeaet counter value is 0 */
+    DL_TIMER_CC_UPDATE_METHOD_TRIG_EVT = (GPTIMER_CCCTL_01_CCUPD_TRIG),
+} DL_TIMER_CC_UPDATE_METHOD;
+
+/*! @enum  DL_TIMER_SEC_COMP_DOWN_EVT */
+typedef enum {
+    /*! Selects Capture Compare down event based on Capture Compare register 0
+     *! value */
+    DL_TIMER_SEC_COMP_DOWN_EVT_SEL_CC0 = (GPTIMER_CCCTL_01_CC2SELD_SEL_CCD0),
+    /*! Selects Capture Compare down event based on Capture Compare register 1
+     *! value */
+    DL_TIMER_SEC_COMP_DOWN_EVT_SEL_CC1 = (GPTIMER_CCCTL_01_CC2SELD_SEL_CCD1),
+    /*! Selects Capture Compare down event based on Capture Compare register 2
+     *! value */
+    DL_TIMER_SEC_COMP_DOWN_EVT_SEL_CC2 = (GPTIMER_CCCTL_01_CC2SELD_SEL_CCD2),
+    /*! Selects Capture Compare down event based on Capture Compare register 3
+     *! value */
+    DL_TIMER_SEC_COMP_DOWN_EVT_SEL_CC3 = (GPTIMER_CCCTL_01_CC2SELD_SEL_CCD3),
+    /*! Selects Capture Compare down event based on Capture Compare register 4
+     *! value */
+    DL_TIMER_SEC_COMP_DOWN_EVT_SEL_CC4 = (GPTIMER_CCCTL_01_CC2SELD_SEL_CCD4),
+    /*! Selects Capture Compare down event based on Capture Compare register 5
+     *! value */
+    DL_TIMER_SEC_COMP_DOWN_EVT_SEL_CC5 = (GPTIMER_CCCTL_01_CC2SELD_SEL_CCD5),
+} DL_TIMER_SEC_COMP_DOWN_EVT;
+
+/*! @enum  DL_TIMER_SEC_COMP_UP_EVT */
+typedef enum {
+    /*! Selects Capture Compare up event based on Capture Compare register 0
+     *! value */
+    DL_TIMER_SEC_COMP_UP_EVT_SEL_CC0 = (GPTIMER_CCCTL_01_CC2SELU_SEL_CCU0),
+    /*! Selects Capture Compare up event based on Capture Compare register 1
+     *! value */
+    DL_TIMER_SEC_COMP_UP_EVT_SEL_CC1 = (GPTIMER_CCCTL_01_CC2SELU_SEL_CCU1),
+    /*! Selects Capture Compare up event based on Capture Compare register 2
+     *! value */
+    DL_TIMER_SEC_COMP_UP_EVT_SEL_CC2 = (GPTIMER_CCCTL_01_CC2SELU_SEL_CCU2),
+    /*! Selects Capture Compare up event based on Capture Compare register 3
+     *! value */
+    DL_TIMER_SEC_COMP_UP_EVT_SEL_CC3 = (GPTIMER_CCCTL_01_CC2SELU_SEL_CCU3),
+    /*! Selects Capture Compare up event based on Capture Compare register 4
+     *! value */
+    DL_TIMER_SEC_COMP_UP_EVT_SEL_CC4 = (GPTIMER_CCCTL_01_CC2SELU_SEL_CCU4),
+    /*! Selects Capture Compare up event based on Capture Compare register 5
+     *! value */
+    DL_TIMER_SEC_COMP_UP_EVT_SEL_CC5 = (GPTIMER_CCCTL_01_CC2SELU_SEL_CCU5),
+} DL_TIMER_SEC_COMP_UP_EVT;
+
+/*! @enum  DL_TIMER_SEC_COMP_UP_ACT_SEL */
+typedef enum {
+    /*! Second comparator output action is disabled. */
+    DL_TIMER_SEC_COMP_UP_ACT_SEL_DISABLE = GPTIMER_CCACT_01_CC2UACT_DISABLED,
+    /*! Timer channel is set high when the second comparator up counting event
+     * is detected */
+    DL_TIMER_SEC_COMP_UP_ACT_SEL_HIGH = GPTIMER_CCACT_01_CC2UACT_CCP_HIGH,
+    /*! Timer channel is set low when the second comparator up counting event
+     * is detected */
+    DL_TIMER_SEC_COMP_UP_ACT_SEL_LOW = GPTIMER_CCACT_01_CC2UACT_CCP_LOW,
+    /*! Timer channel is toggles when the second comparator up counting event
+     * is detected */
+    DL_TIMER_SEC_COMP_UP_ACT_SEL_TOGGLE = GPTIMER_CCACT_01_CC2UACT_CCP_TOGGLE,
+} DL_TIMER_SEC_COMP_UP_ACT_SEL;
+
+/*! @enum  DL_TIMER_SEC_COMP_DOWN_ACT_SEL */
+typedef enum {
+    /*! Second comparator output action is disabled. */
+    DL_TIMER_SEC_COMP_DOWN_ACT_SEL_DISABLE = GPTIMER_CCACT_01_CC2DACT_DISABLED,
+    /*! Timer channel is set high when the second comparator down counting event
+     * is detected */
+    DL_TIMER_SEC_COMP_DOWN_ACT_SEL_HIGH = GPTIMER_CCACT_01_CC2DACT_CCP_HIGH,
+    /*! Timer channel is set low when the second comparator down counting event
+     * is detected */
+    DL_TIMER_SEC_COMP_DOWN_ACT_SEL_LOW = GPTIMER_CCACT_01_CC2DACT_CCP_LOW,
+    /*! Timer channel is toggles when the second comparator down counting event
+     * is detected */
+    DL_TIMER_SEC_COMP_DOWN_ACT_SEL_TOGGLE =
+        GPTIMER_CCACT_01_CC2DACT_CCP_TOGGLE,
+} DL_TIMER_SEC_COMP_DOWN_ACT_SEL;
+
+/*! @enum  DL_TIMER_SUPP_COMP_EVT_RC */
+typedef enum {
+    /*! Capture compare up and down events are always generated from the counter
+     *! when their conditions are genreated */
+    DL_TIMER_SUPP_COMP_EVT_RC_DISABLED = (GPTIMER_CCCTL_01_SCERCNEZ_DISABLED),
+    /*! Capture compare up and down events are generated from the counter when
+     *! their conditions are genreated and the repeat counter value is 0 */
+    DL_TIMER_SUPP_COMP_EVT_RC_ENABLED = (GPTIMER_CCCTL_01_SCERCNEZ_ENABLED),
+} DL_TIMER_SUPP_COMP_EVT_RC;
+
+/*! @enum  DL_TIMER_FORCE_OUT */
+typedef enum {
+    /*! The CCP output value is unaffected */
+    DL_TIMER_FORCE_OUT_DISABLED = (GPTIMER_CCACT_01_SWFRCACT_DISABLED),
+    /*! Output value is set high */
+    DL_TIMER_FORCE_OUT_HIGH = (GPTIMER_CCACT_01_SWFRCACT_CCP_HIGH),
+    /*! Output value is set low */
+    DL_TIMER_FORCE_OUT_LOW = (GPTIMER_CCACT_01_SWFRCACT_CCP_LOW),
+
+} DL_TIMER_FORCE_OUT;
+
+/*! @enum  DL_TIMER_FORCE_CMPL_OUT */
+typedef enum {
+    /*! The complementary CCP output value is unaffected */
+    DL_TIMER_FORCE_CMPL_OUT_DISABLED =
+        (GPTIMER_CCACT_01_SWFRCACT_CMPL_DISABLED),
+    /*! Complementary CCP output is set high */
+    DL_TIMER_FORCE_CMPL_OUT_HIGH = (GPTIMER_CCACT_01_SWFRCACT_CMPL_CCP_HIGH),
+    /*! Complementary CCP output is set low */
+    DL_TIMER_FORCE_CMPL_OUT_LOW = (GPTIMER_CCACT_01_SWFRCACT_CMPL_CCP_LOW),
+
+} DL_TIMER_FORCE_CMPL_OUT;
+
+/*! @enum  DL_TIMER_CORE_HALT */
+typedef enum {
+    /*! Timer will halt immediately, even if the resultant state will result in
+        corruption if the system is restarted */
+    DL_TIMER_CORE_HALT_IMMEDIATE =
+        (GPTIMER_PDBGCTL_FREE_STOP | GPTIMER_PDBGCTL_SOFT_IMMEDIATE),
+    /*! Timer blocks the debug freeze until it has reached a boundary where it
+        can resume without corruption */
+    DL_TIMER_CORE_HALT_DELAYED =
+        (GPTIMER_PDBGCTL_FREE_STOP | GPTIMER_PDBGCTL_SOFT_DELAYED),
+    /*! Timer ignores the state of the Core Halted input */
+    DL_TIMER_CORE_HALT_FREE_RUN =
+        (GPTIMER_PDBGCTL_FREE_RUN | GPTIMER_PDBGCTL_SOFT_DELAYED),
+} DL_TIMER_CORE_HALT;
+
+/*!
+ *  @brief  Configuration struct for @ref DL_Timer_setClockConfig.
+ */
+typedef struct {
+    /*! Selects timer module clock source @ref DL_TIMER_CLOCK*/
+    DL_TIMER_CLOCK clockSel;
+    /*! Selects the timer module clock divide ratio
+    @ref DL_TIMER_CLOCK_DIVIDE */
+    DL_TIMER_CLOCK_DIVIDE divideRatio;
+    /*! Selects the timer module clock prescaler. Valid range 0-255 */
+    uint8_t prescale;
+} DL_Timer_ClockConfig;
+
+/*!
+ *  @brief  Configuration struct for @ref DL_Timer_initTimerMode.
+ */
+typedef struct {
+    /*! One shot or Periodic mode configuration. One of
+     * @ref DL_TIMER_TIMER_MODE */
+    DL_TIMER_TIMER_MODE timerMode;
+    /*! Actual period will be period_actual=(period +1)T_TIMCLK
+     * where T_TIMCLK is the period of the timer source clock. */
+    uint32_t period;
+    /*! Start timer after configuration @ref DL_TIMER */
+    DL_TIMER startTimer;
+    /*! Generate intermediate counter interrupt
+     * @ref DL_TIMER_INTERM_INT*/
+    DL_TIMER_INTERM_INT genIntermInt;
+    /*! Counter value when intermediate interrupt should be generated. This
+     * member must be set to 0 when
+     * @ref genIntermInt == DL_TIMER_INTERM_INT_DISABLED */
+    uint16_t counterVal;
+} DL_Timer_TimerConfig;
+
+/*!
+ * @brief Configuration struct for @ref DL_Timer_initCaptureMode.
+ */
+typedef struct {
+    /*! Selects capture mode. One of @ref DL_TIMER_CAPTURE_MODE */
+    DL_TIMER_CAPTURE_MODE captureMode;
+    /*! Specifies the capture period. period_actual=(period +1)T_TIMCLK
+     * where T_TIMCLK is the period of the timer source clock. */
+    uint32_t period;
+    /*! Start timer after configuration @ref DL_TIMER */
+    DL_TIMER startTimer;
+    /*! Specifies the edge detection mode. One of
+        @ref DL_TIMER_CAPTURE_EDGE_DETECTION_MODE*/
+    DL_TIMER_CAPTURE_EDGE_DETECTION_MODE edgeCaptMode;
+    /*! Selects input channel used for capture mode */
+    DL_TIMER_INPUT_CHAN inputChan;
+    /*! Specifies if input should be inverted. One of
+     *  @ref DL_TIMER_CC_INPUT_INV */
+    uint32_t inputInvMode;
+} DL_Timer_CaptureConfig;
+
+/*!
+ * @brief Configuration struct for @ref DL_Timer_initCaptureTriggerMode.
+ */
+typedef struct {
+    /*! Selects capture mode. One of @ref DL_TIMER_CAPTURE_MODE */
+    DL_TIMER_CAPTURE_MODE captureMode;
+    /*! Specifies the capture period. period_actual=(period +1) * T_TIMCLK
+     * where T_TIMCLK is the period of the timer source clock. */
+    uint16_t period;
+    /*! Start timer after configuration. One of @ref DL_TIMER */
+    DL_TIMER startTimer;
+} DL_Timer_CaptureTriggerConfig;
+
+/*!
+ * @brief Configuration struct for @ref DL_Timer_initCaptureCombinedMode.
+ */
+typedef struct {
+    /*! Selects capture mode. One of @ref DL_TIMER_CAPTURE_COMBINED_MODE */
+    DL_TIMER_CAPTURE_COMBINED_MODE captureMode;
+    /*! Specifies the capture period. period_actual=(period +1)T_TIMCLK
+     * where T_TIMCLK is the period of the timer source clock. */
+    uint32_t period;
+    /*! Start timer after configuration @ref DL_TIMER */
+    DL_TIMER startTimer;
+    /*! Selects input channel used for capture mode. One of @ref DL_TIMER_INPUT_CHAN */
+    DL_TIMER_INPUT_CHAN inputChan;
+    /*! Specifies if input should be inverted. One of
+     *  @ref DL_TIMER_CC_INPUT_INV */
+    uint32_t inputInvMode;
+} DL_Timer_CaptureCombinedConfig;
+
+/*!
+ * @brief Configuration struct for @ref DL_Timer_initCompareMode.
+ */
+typedef struct {
+    /*! Selects capture mode. One of @ref DL_TIMER_COMPARE_MODE */
+    DL_TIMER_COMPARE_MODE compareMode;
+    /*! Specifies the intial count value. In edge count mode this value will
+     *  decrease everytime the configured edge detection mode is detected.
+     *  The counter will be reset to this value after the reaching zero.
+     *  Valid range [0-65535]. */
+    uint16_t count;
+    /*! Specifies the edge detection mode. One of
+        @ref DL_TIMER_CAPTURE_EDGE_DETECTION_MODE*/
+    DL_TIMER_COMPARE_EDGE_DETECTION_MODE edgeDetectMode;
+    /*! Selects input channel used for compare mode. One of @ref DL_TIMER_INPUT_CHAN */
+    DL_TIMER_INPUT_CHAN inputChan;
+    /*! Specifies if input should be inverted. One of
+     *  @ref DL_TIMER_CC_INPUT_INV */
+    uint32_t inputInvMode;
+    /*! Start timer after configuration. One of @ref DL_TIMER */
+    DL_TIMER startTimer;
+} DL_Timer_CompareConfig;
+
+/*!
+ * @brief Configuration struct for @ref DL_Timer_initCompareTriggerMode.
+ */
+typedef struct {
+    /*! Selects capture mode. One of @ref DL_TIMER_COMPARE_MODE */
+    DL_TIMER_COMPARE_MODE compareMode;
+    /*! Specifies the intial count value. In edge count mode this value will
+     *  decrease everytime the configured edge detection mode is detected.
+     *  The counter will be reset to this value after the reaching zero.
+     *  Valid range [0-65535]. */
+    uint16_t count;
+    /*! Specifies the edge detection mode. One of
+        @ref DL_TIMER_CAPTURE_EDGE_DETECTION_MODE*/
+    DL_TIMER_COMPARE_EDGE_DETECTION_MODE edgeDetectMode;
+    /*! Start timer after configuration. One of @ref DL_TIMER */
+    DL_TIMER startTimer;
+} DL_Timer_CompareTriggerConfig;
+
+/**
+ * @brief Configuration struct for @ref DL_Timer_initPWMMode.
+ */
+typedef struct {
+    /*! Specifies the pwm period. The actual value configured to LOAD register
+     *  depends on the pwmMode selected. When
+     *  pwmMode = DL_TIMER_PWM_MODE_EDGE_ALIGN, LOAD = (period -1). When
+     *  pwmMode = DL_TIMER_PWM_MODE_CENTER_ALIGN, LOAD = (period / 2).
+     *  Actual PWM freq = (Timer_freq/(prescaler * divideRatio * period))
+     */
+    uint32_t period;
+    /*! Specifies the PWM Mode. One of @ref DL_TIMER_PWM_MODE */
+    DL_TIMER_PWM_MODE pwmMode;
+    /*! Start timer after configuration @ref DL_TIMER */
+    DL_TIMER startTimer;
+} DL_Timer_PWMConfig;
+
+/**
+ * @brief Configuration structure to backup Timer peripheral state before
+ *        entering STOP or STANDBY mode. Not required after PG 1.0 silicon.
+ *        Used by @ref DL_Timer_saveConfiguration and
+ *        @ref DL_Timer_restoreConfiguration
+ */
+typedef struct {
+    /*! Timer subscriber 0 channel ID. Value between 0 - 15. */
+    uint32_t sub0PortConf;
+    /*! Timer subscriber 1 channel ID. Value between 0 - 15. */
+    uint32_t sub1PortConf;
+    /*! Timer publisher 0 channel ID. Value between 0 - 15. */
+    uint32_t pub0PortConf;
+    /*! Timer publisher 1 channel ID. Value between 0 - 15. */
+    uint32_t pub1PortConf;
+    /*! Timer clockDivider configuration.*/
+    uint32_t clkDivConf;
+    /*! Timer clock prescaler configuration.*/
+    uint32_t clockPscConf;
+    /*! Timer Clock Source Select configuration.*/
+    uint32_t clkSelConf;
+    /*! Timer Clock configuration.*/
+    uint32_t countClkConf;
+    /*! Timer interrupt configuration for EVENT0.*/
+    uint32_t intEvnt0Conf;
+    /*! Timer interrupt configuration for EVENT1.*/
+    uint32_t intEvnt1Conf;
+    /*! Timer interrupt configuration for EVENT2.*/
+    uint32_t intEvnt2Conf;
+    /*! Timer CCP Direction configuration.*/
+    uint32_t ccpDirConf;
+    /*! Timer CCP Output forced low configuration.*/
+    uint32_t outDisConf;
+    /*! Timer Cross Timer Trigger Control configuration.*/
+    uint32_t crossTrigCtl;
+    /*! Timer Cross Trigger Configuration */
+    uint32_t tSelConf;
+    /*! Timer Cross Timer Trigger*/
+    uint32_t crossTrigConf;
+    /*! Timer counter value. Timer counter value is stored but user can
+     *  specify if counter is restore via restoreCounter argument in
+     *  @ref DL_Timer_restoreConfiguration */
+    uint32_t cntVal;
+    /*! Timer counter control configuration */
+    uint32_t cntCtlConf;
+    /*! Timer load value */
+    uint32_t loadVal;
+    /*! Timer Capture or Compare 0 value */
+    uint32_t cc0Val;
+    /*! Timer Capture or Compare 1 value */
+    uint32_t cc1Val;
+    /*! Timer Capture or Compare Control Register 0 */
+    uint32_t cc0Ctl;
+    /*! Timer Capture or Compare Control Register 1 */
+    uint32_t cc1Ctl;
+    /*! Timer Capture or Compare Output Control Register 0 */
+    uint32_t cc0OutCtl;
+    /*! Timer Capture or Compare Output Control Register 1 */
+    uint32_t cc1OutCtl;
+    /*! Timer Capture or Compare Signal Generator Action Control Register 0 */
+    uint32_t cc0ActCtl;
+    /*! Timer Capture or Compare Signal Generator Action Control Register 1 */
+    uint32_t cc1ActCtl;
+    /*! Timer Capture or Compare Input Filter and Inversion Control
+     *  Register 0 */
+    uint32_t in0FiltCtl;
+    /*! Timer Capture or Compare Input Filter and Inversion Control
+     *  Register 1 */
+    uint32_t in1FiltCtl;
+    /*! Boolean flag indicating whether or not a valid configuration structure
+     *  exists. Should not be modified by the user. */
+    bool backupRdy;
+} DL_Timer_backupConfig;
+
+/*! @enum DL_TIMER_QEI_MODE */
+typedef enum {
+    /*! Set QEI to 2 input mode: PHA->CCP0, PHB->CCP1. */
+    DL_TIMER_QEI_MODE_2_INPUT =
+        (GPTIMER_CTRCTL_CLC_QEI_2INP | GPTIMER_CTRCTL_CAC_QEI_2INP |
+            GPTIMER_CTRCTL_CZC_QEI_2INP),
+    /*! Set QEI to 3 input mode: PHA->CCP0, PHB->CCP1, Index input signal->IDX. */
+    DL_TIMER_QEI_MODE_3_INPUT =
+        (GPTIMER_CTRCTL_CLC_QEI_3INP | GPTIMER_CTRCTL_CAC_QEI_3INP |
+            GPTIMER_CTRCTL_CZC_QEI_3INP),
+} DL_TIMER_QEI_MODE;
+
+/*! @enum DL_TIMER_QEI_DIRECTION */
+typedef enum {
+    /*! Encoder counter going down */
+    DL_TIMER_QEI_DIR_DOWN = GPTIMER_QDIR_DIR_DOWN,
+    /*! Encoder counter going up */
+    DL_TIMER_QEI_DIR_UP = GPTIMER_QDIR_DIR_UP,
+} DL_TIMER_QEI_DIRECTION;
+
+/**
+ * @brief Enables power on timer module
+ *
+ * @param gptimer              Pointer to the register overlay for the
+ *                             peripheral
+ */
+__STATIC_INLINE void DL_Timer_enablePower(GPTIMER_Regs *gptimer)
+{
+    gptimer->GPRCM.PWREN =
+        (GPTIMER_PWREN_KEY_UNLOCK_W | GPTIMER_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power on timer module
+ *
+ * @param gptimer              Pointer to the register overlay for the
+ *                             peripheral
+ */
+__STATIC_INLINE void DL_Timer_disablePower(GPTIMER_Regs *gptimer)
+{
+    gptimer->GPRCM.PWREN =
+        (GPTIMER_PWREN_KEY_UNLOCK_W | GPTIMER_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief Returns if power on timer module is enabled
+ *
+ * @param gptimer              Pointer to the register overlay for the
+ *                             peripheral
+ *
+ * @return true if power is enabled
+ * @return false if power is disabled
+ */
+__STATIC_INLINE bool DL_Timer_isPowerEnabled(GPTIMER_Regs *gptimer)
+{
+    return ((gptimer->GPRCM.PWREN & GPTIMER_PWREN_ENABLE_MASK) ==
+            GPTIMER_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Resets timer peripheral
+ *
+ * @param gptimer              Pointer to the register overlay for the
+ *                             peripheral
+ */
+__STATIC_INLINE void DL_Timer_reset(GPTIMER_Regs *gptimer)
+{
+    gptimer->GPRCM.RSTCTL =
+        (GPTIMER_RSTCTL_KEY_UNLOCK_W | GPTIMER_RSTCTL_RESETSTKYCLR_CLR |
+            GPTIMER_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief Returns if timer peripheral has been reset
+ *
+ * @param gptimer              Pointer to the register overlay for the
+ *                             peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ */
+__STATIC_INLINE bool DL_Timer_isReset(GPTIMER_Regs *gptimer)
+{
+    return ((gptimer->GPRCM.STAT & GPTIMER_STAT_RESETSTKY_MASK) ==
+            GPTIMER_STAT_RESETSTKY_RESET);
+}
+
+/**
+ *  @brief      Sets CCP Direction
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccpConfig      Direction configuration for CCP as input or
+ *                             output. Bitwise OR  of @ref DL_TIMER_CCx
+ */
+__STATIC_INLINE void DL_Timer_setCCPDirection(
+    GPTIMER_Regs *gptimer, uint32_t ccpConfig)
+{
+    gptimer->COMMONREGS.CCPD = (ccpConfig);
+}
+
+/**
+ *  @brief      Gets CCP Direction
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     Bitwise OR of CCP Direction configuration @ref DL_TIMER_CCx
+ */
+__STATIC_INLINE uint32_t DL_Timer_getCCPDirection(GPTIMER_Regs *gptimer)
+{
+    return (gptimer->COMMONREGS.CCPD);
+}
+
+/**
+ *  @brief      Forces the output of the timer low via the ODIS register.
+ *              This can be useful during shutdown or configuring the timer.
+ *              The output pin still passes through the inversion (INV) bit.
+ *              See figure "Output connection for TIMG" in Technical
+ *              Reference Manual (TRM) for diagram.
+ *              DL_Timer_overrideCCPOut() can be used for for similar
+ *              functionality, where independent overrride settings for the
+ *              output and complementary output channels can be configured.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccp0Config     Output Configuration for CCP0. One of @ref
+ *                             DL_TIMER_CCP_DIS_OUT
+ *  @param[in]  ccp1Config     Output Configuration for CCP1. One of @ref
+ *                             DL_TIMER_CCP_DIS_OUT
+ */
+__STATIC_INLINE void DL_Timer_setCCPOutputDisabled(GPTIMER_Regs *gptimer,
+    DL_TIMER_CCP_DIS_OUT ccp0Config, DL_TIMER_CCP_DIS_OUT ccp1Config)
+{
+    DL_Common_updateReg(&gptimer->COMMONREGS.ODIS,
+        (((uint32_t) ccp0Config) |
+            ((uint32_t) ccp1Config << GPTIMER_ODIS_C0CCP1_OFS)),
+        (GPTIMER_ODIS_C0CCP0_MASK | GPTIMER_ODIS_C0CCP1_MASK));
+}
+
+/**
+ *  @brief      Sets CCP Output configuration for timer instances with more than
+ *  two CCP channels via the ODIS register. The output pin still passes through
+ *  the inversion (INV) bit.
+ *
+ *  @note Refer to device datasheet to determine if timer instance supports
+ *  this feature. Only Timer instance which supports more than two CCP channels
+ *  should use this API.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccpOdisConfig  Output Configuration for CCP channels. Bitwise OR
+ *                             @ref DL_TIMER_CCP0_DIS_OUT_ADV,
+ *                             @ref DL_TIMER_CCP1_DIS_OUT_ADV,
+ *                             @ref DL_TIMER_CCP2_DIS_OUT_ADV,
+ *                             @ref DL_TIMER_CCP3_DIS_OUT_ADV
+ */
+__STATIC_INLINE void DL_Timer_setCCPOutputDisabledAdv(
+    GPTIMER_Regs *gptimer, uint32_t ccpOdisConfig)
+{
+    DL_Common_updateReg(&gptimer->COMMONREGS.ODIS, (ccpOdisConfig),
+        (GPTIMER_ODIS_C0CCP0_MASK | GPTIMER_ODIS_C0CCP1_MASK |
+            GPTIMER_ODIS_C0CCP2_MASK | GPTIMER_ODIS_C0CCP3_MASK));
+}
+
+/**
+ *  @brief      Configure timer source clock
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  config         Pointer to the clock configuration struct
+ *                             @ref DL_Timer_ClockConfig.
+ */
+void DL_Timer_setClockConfig(
+    GPTIMER_Regs *gptimer, DL_Timer_ClockConfig *config);
+
+/**
+ *  @brief      Get  timer source clock configuration
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  config         Pointer to the clock configuration struct
+ *                             @ref DL_Timer_ClockConfig.
+ */
+void DL_Timer_getClockConfig(
+    GPTIMER_Regs *gptimer, DL_Timer_ClockConfig *config);
+
+/**
+ *  @brief      Enable timer clock
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ */
+__STATIC_INLINE void DL_Timer_enableClock(GPTIMER_Regs *gptimer)
+{
+    gptimer->COMMONREGS.CCLKCTL = (GPTIMER_CCLKCTL_CLKEN_ENABLED);
+}
+
+/**
+ *  @brief      Disable timer clock
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ */
+__STATIC_INLINE void DL_Timer_disableClock(GPTIMER_Regs *gptimer)
+{
+    gptimer->COMMONREGS.CCLKCTL = (GPTIMER_CCLKCTL_CLKEN_DISABLED);
+}
+
+/**
+ *  @brief      Returns if timer clock is disabled
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return true if clock is enabled
+ *  @return false if clock is disabled
+ */
+__STATIC_INLINE bool DL_Timer_isClockEnabled(GPTIMER_Regs *gptimer)
+{
+    return ((gptimer->COMMONREGS.CCLKCTL & GPTIMER_CCLKCTL_CLKEN_MASK) ==
+            GPTIMER_CCLKCTL_CLKEN_ENABLED);
+}
+
+/**
+ *  @brief      Configure Cross Timer Trigger
+ *
+ *  @param[in]  gptimer           Pointer to the register overlay for the
+ *                                peripheral
+ *  @param[in]  ctSource          Selects cross trigger source.
+ *                                @ref DL_TIMER_CROSS_TRIG_SRC
+ *
+ *  @param[in]  enInTrigCond      Cofigures Input Trigger Conditions to the
+ *                                Timer module as a condition for Cross Triggers *                                @ref DL_TIMER_CROSS_TRIGGER_INPUT
+ *
+ * @param[in]  enCrossTrig        Configures Timer Cross trigger
+ *                                @ref DL_TIMER_CROSS_TRIGGER_MODE
+ *
+ */
+__STATIC_INLINE void DL_Timer_configCrossTrigger(GPTIMER_Regs *gptimer,
+    DL_TIMER_CROSS_TRIG_SRC ctSource,
+    DL_TIMER_CROSS_TRIGGER_INPUT enInTrigCond,
+    DL_TIMER_CROSS_TRIGGER_MODE enCrossTrig)
+{
+    gptimer->COMMONREGS.CTTRIGCTL =
+        (uint32_t)((uint32_t) ctSource | (uint32_t) enInTrigCond |
+                   (uint32_t) enCrossTrig);
+}
+
+/**
+ *  @brief      Configure Cross Timer Trigger source
+ *
+ *  @param[in]  gptimer           Pointer to the register overlay for the
+ *                                peripheral
+  *  @param[in]  ctSource          Selects cross trigger source.
+ *                                @ref DL_TIMER_CROSS_TRIG_SRC
+ *
+ */
+__STATIC_INLINE void DL_Timer_configCrossTriggerSrc(
+    GPTIMER_Regs *gptimer, DL_TIMER_CROSS_TRIG_SRC ctSource)
+{
+    DL_Common_updateReg(&gptimer->COMMONREGS.CTTRIGCTL, (uint32_t) ctSource,
+        GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_MASK);
+}
+
+/**
+ *  @brief      Enables/DIsables Input Trigger condition for Cross Timer Trigger
+ *
+ *  @param[in]  gptimer           Pointer to the register overlay for the
+ *                                peripheral
+ *
+ *  @param[in]  enInTrigCond      Cofigures Input Trigger Conditions to the
+ *                                Timer module as a condition for Cross Triggers
+ *                                @ref DL_TIMER_CROSS_TRIGGER_INPUT
+ *
+ */
+__STATIC_INLINE void DL_Timer_configCrossTriggerInputCond(
+    GPTIMER_Regs *gptimer, DL_TIMER_CROSS_TRIGGER_INPUT enInTrigCond)
+{
+    DL_Common_updateReg(&gptimer->COMMONREGS.CTTRIGCTL,
+        (uint32_t) enInTrigCond, GPTIMER_CTTRIGCTL_EVTCTEN_MASK);
+}
+
+/**
+ *  @brief      Enable/Disable Cross Timer Trigger
+ *
+ *  @param[in]  gptimer           Pointer to the register overlay for the
+ *                                peripheral
+ * @param[in]  enCrossTrig        Configures Timer Cross trigger
+ *                                @ref DL_TIMER_CROSS_TRIGGER_MODE
+ *
+ */
+__STATIC_INLINE void DL_Timer_configCrossTriggerEnable(
+    GPTIMER_Regs *gptimer, DL_TIMER_CROSS_TRIGGER_MODE enCrossTrig)
+{
+    DL_Common_updateReg(&gptimer->COMMONREGS.CTTRIGCTL, (uint32_t) enCrossTrig,
+        GPTIMER_CTTRIGCTL_CTEN_MASK);
+}
+
+/**
+ *  @brief      Get Cross Timer Trigger configuration
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return Bitwise OR of @ref DL_TIMER_CROSS_TRIG_SRC,
+ *          @ref DL_TIMER_CROSS_TRIGGER_INPUT, @ref DL_TIMER_CROSS_TRIGGER_MODE,
+ *
+ */
+__STATIC_INLINE uint32_t DL_Timer_getCrossTriggerConfig(GPTIMER_Regs *gptimer)
+{
+    return (gptimer->COMMONREGS.CTTRIGCTL);
+}
+
+/**
+ *  @brief      Get Cross Timer Trigger source
+ *
+ *  @param[in]  gptimer           Pointer to the register overlay for the
+ *                                peripheral
+ *
+ *  @return One of @ref DL_TIMER_CROSS_TRIG_SRC
+ *
+ */
+__STATIC_INLINE DL_TIMER_CROSS_TRIG_SRC DL_Timer_getCrossTriggerSrc(
+    GPTIMER_Regs *gptimer)
+{
+    uint32_t ctSource =
+        gptimer->COMMONREGS.CTTRIGCTL & GPTIMER_CTTRIGCTL_EVTCTTRIGSEL_MASK;
+
+    return (DL_TIMER_CROSS_TRIG_SRC)(ctSource);
+}
+
+/**
+ *  @brief      Get Input Trigger condition for Cross Timer Trigger
+ *
+ *  @param[in]  gptimer           Pointer to the register overlay for the
+ *                                peripheral
+ *
+ *  @return One of @ref DL_TIMER_CROSS_TRIGGER_INPUT
+ *
+ */
+__STATIC_INLINE DL_TIMER_CROSS_TRIGGER_INPUT DL_Timer_getCrossTriggerInputCond(
+    GPTIMER_Regs *gptimer)
+{
+    uint32_t triggerCondition =
+        gptimer->COMMONREGS.CTTRIGCTL & GPTIMER_CTTRIGCTL_EVTCTEN_MASK;
+
+    return (DL_TIMER_CROSS_TRIGGER_INPUT)(triggerCondition);
+}
+
+/**
+ *  @brief      Checks if Cross Timer Trigger is enabled or disabled
+ *
+ *  @param[in]  gptimer           Pointer to the register overlay for the
+ *                                peripheral
+ *
+ *  @return One of @ref DL_TIMER_CROSS_TRIGGER_MODE
+ *
+ */
+__STATIC_INLINE DL_TIMER_CROSS_TRIGGER_MODE DL_Timer_getCrossTriggerEnable(
+    GPTIMER_Regs *gptimer)
+{
+    uint32_t mode =
+        gptimer->COMMONREGS.CTTRIGCTL & GPTIMER_CTTRIGCTL_CTEN_MASK;
+
+    return (DL_TIMER_CROSS_TRIGGER_MODE)(mode);
+}
+
+/**
+ *  @brief      Generates a synchronized trigger condition across all trigger
+ *              enabled Timer instances
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ */
+__STATIC_INLINE void DL_Timer_generateCrossTrigger(GPTIMER_Regs *gptimer)
+{
+    gptimer->COMMONREGS.CTTRIG = GPTIMER_CTTRIG_TRIG_GENERATE;
+}
+
+/**
+ *  @brief      Enable shadow to activate load of buffered registers and
+ *              register fields.
+ *
+ *  @note Please refer to the device datasheet to determine shadow features
+ *        avaialable per timer instance.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ */
+__STATIC_INLINE void DL_Timer_enableShadowFeatures(GPTIMER_Regs *gptimer)
+{
+    gptimer->COMMONREGS.GCTL |= GPTIMER_GCTL_SHDWLDEN_ENABLE;
+}
+
+/**
+ *  @brief      Disable shadow to activate load of buffered registers and
+ *              register fields.
+ *
+ *  @note Please refer to the device datasheet to determine shadow features
+ *        avaialable per timer instance.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ */
+__STATIC_INLINE void DL_Timer_disableShadowFeatures(GPTIMER_Regs *gptimer)
+{
+    gptimer->COMMONREGS.GCTL &= ~(GPTIMER_GCTL_SHDWLDEN_ENABLE);
+}
+
+/**
+ *  @brief      Sets timer LOAD register value
+ *
+ *  @param[in]  gptimer      Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in]  value        Value to be loaded to timer LOAD
+ *                           register. Refer to the device datasheet to
+ *                           determine the bit width of the counter for
+ *                           the selected Timer instance.
+ *
+ */
+__STATIC_INLINE void DL_Timer_setLoadValue(
+    GPTIMER_Regs *gptimer, uint32_t value)
+{
+    gptimer->COUNTERREGS.LOAD = value;
+}
+
+/**
+ *  @brief      Gets the timer LOAD register value
+ *
+ *  @param[in]  gptimer      Pointer to the register overlay for the
+ *                           peripheral
+ *
+ *  @return     Returns the timer's LOAD register value.
+ *
+ */
+__STATIC_INLINE uint32_t DL_Timer_getLoadValue(GPTIMER_Regs *gptimer)
+{
+    return (gptimer->COUNTERREGS.LOAD & GPTIMER_LOAD_LD_MAXIMUM);
+}
+
+/**
+ *  @brief      Gets the current counter value of the timer
+ *
+ *  @param[in]  gptimer      Pointer to the register overlay for the
+ *                           peripheral
+ *
+ *  @return     Returns the timer counter value
+ */
+__STATIC_INLINE uint32_t DL_Timer_getTimerCount(GPTIMER_Regs *gptimer)
+{
+    return (gptimer->COUNTERREGS.CTR & GPTIMER_CTR_CCTR_MASK);
+}
+
+/**
+ *  @brief      Set timer counter value
+ *
+ *  @note       <b>Warning</b> setting the counter value directly while the
+ *              timer's counter is running can lead to unpredictable behavior.
+ *              This function should only be used when the timer's counter
+ *              isn't running. If you need to change the counter value while
+ *              it is running then use DL_Timer_setLoadValue(). For TimerH use
+ *              DL_TimerH_setLoadValue() instead. These functions will
+ *              update the LOAD register which will safely copy its
+ *              value to the counter register.
+ *
+ *  @param[in]  gptimer      Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in]  value        Value to set the timer counter value to
+ *
+ */
+__STATIC_INLINE void DL_Timer_setTimerCount(
+    GPTIMER_Regs *gptimer, uint32_t value)
+{
+    gptimer->COUNTERREGS.CTR = value;
+}
+
+/**
+ *  @brief     Enable suppression of load and zero events
+ *
+ *  @note Refer to device datasheet to determine if timer instance supports
+ *  this feature. Only Timer instance which supports Repeat Counter supports
+ *  this feature.
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *
+ */
+__STATIC_INLINE void DL_Timer_enableLZEventSuppression(GPTIMER_Regs *gptimer)
+{
+    gptimer->COUNTERREGS.CTRCTL |= (GPTIMER_CTRCTL_SLZERCNEZ_ENABLED);
+}
+
+/**
+ *  @brief     Disable suppression of load and zero events
+ *
+ *  @note Refer to device datasheet to determine if timer instance supports
+ *  this feature. Only Timer instances which supports Repeat Counter supports
+ *  this feature.
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *
+ */
+__STATIC_INLINE void DL_Timer_disableLZEventSuppression(GPTIMER_Regs *gptimer)
+{
+    gptimer->COUNTERREGS.CTRCTL &= ~(GPTIMER_CTRCTL_SLZERCNEZ_ENABLED);
+}
+
+/**
+ *  @brief     Checks if suppression of load and zero events is enabled
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @return Returns the status ofsuppression of load and zero events
+ *
+ *  @retval     true  suppression of load and zero events is enabled
+ *  @retval     false suppression of load and zero events is disabled
+ *
+ */
+__STATIC_INLINE bool DL_Timer_isLZEventSuppressionEnabled(
+    GPTIMER_Regs *gptimer)
+{
+    return (GPTIMER_CTRCTL_SLZERCNEZ_ENABLED ==
+            (gptimer->COUNTERREGS.CTRCTL & GPTIMER_CTRCTL_SLZERCNEZ_MASK));
+}
+
+/**
+ *  @brief     Configures timer behavior during debug release/exit
+ *
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in]  debResB       Specifies timer behavior upon
+ *                              relase/exit of debug mode.
+ *                              @ref DL_TIMER_DEBUG_RES
+ *
+ */
+__STATIC_INLINE void DL_Timer_setDebugReleaseBehavior(
+    GPTIMER_Regs *gptimer, DL_TIMER_DEBUG_RES debResB)
+{
+    DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL, (uint32_t) debResB,
+        GPTIMER_CTRCTL_DRB_MASK);
+}
+
+/**
+ *  @brief     Get timer resume behavior after relase/exit of debug mode.
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @return @ref DL_TIMER_DEBUG_RES
+ *
+ */
+__STATIC_INLINE DL_TIMER_DEBUG_RES DL_Timer_getDebugReleaseBehavior(
+    GPTIMER_Regs *gptimer)
+{
+    uint32_t debResB = gptimer->COUNTERREGS.CTRCTL & GPTIMER_CTRCTL_DRB_MASK;
+
+    return ((DL_TIMER_DEBUG_RES)(debResB));
+}
+
+/**
+ *  @brief     Configure timer counter control operation
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in]  zeroCtl         Specifies event which zeroes the counter value.
+ *                              @ref DL_TIMER_CZC
+ *  @param[in]  advCtl          Specifies event which increments or
+ *                              decrements the counter value.
+ *                              @ref DL_TIMER_CAC
+ *  @param[in]  loadCtl         Specifies event which sets counter value
+ *                              with LD register value.
+ *                              @ref DL_TIMER_CLC
+ */
+__STATIC_INLINE void DL_Timer_setCounterControl(GPTIMER_Regs *gptimer,
+    DL_TIMER_CZC zeroCtl, DL_TIMER_CAC advCtl, DL_TIMER_CLC loadCtl)
+{
+    DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL,
+        ((uint32_t) zeroCtl | (uint32_t) advCtl | (uint32_t) loadCtl),
+        (GPTIMER_CTRCTL_CZC_MASK | GPTIMER_CTRCTL_CAC_MASK |
+            GPTIMER_CTRCTL_CLC_MASK));
+}
+
+/**
+ *  @brief     Get timer counter zero control operation
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @return @ref DL_TIMER_CZC
+ */
+__STATIC_INLINE DL_TIMER_CZC DL_Timer_getCounterZeroControl(
+    GPTIMER_Regs *gptimer)
+{
+    uint32_t zeroCtl = gptimer->COUNTERREGS.CTRCTL & GPTIMER_CTRCTL_CZC_MASK;
+
+    return ((DL_TIMER_CZC)(zeroCtl));
+}
+
+/**
+ *  @brief     Get timer counter advance control operation
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @return @ref DL_TIMER_CAC
+ */
+__STATIC_INLINE DL_TIMER_CAC DL_Timer_getCounterAdvanceControl(
+    GPTIMER_Regs *gptimer)
+{
+    uint32_t advCtl = gptimer->COUNTERREGS.CTRCTL & GPTIMER_CTRCTL_CAC_MASK;
+
+    return ((DL_TIMER_CAC)(advCtl));
+}
+
+/**
+ *  @brief     Get timer counter load control operation
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @return @ref DL_TIMER_CLC
+ */
+__STATIC_INLINE DL_TIMER_CLC DL_Timer_getCounterLoadControl(
+    GPTIMER_Regs *gptimer)
+{
+    uint32_t loadCtl = gptimer->COUNTERREGS.CTRCTL & GPTIMER_CTRCTL_CLC_MASK;
+
+    return ((DL_TIMER_CLC)(loadCtl));
+}
+
+/**
+ *  @brief     Configure timer counter couting mode
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in]  countMode       Specifies timer counter couting mode.
+ *                              @ref DL_TIMER_COUNT_MODE
+ */
+__STATIC_INLINE void DL_Timer_setCounterMode(
+    GPTIMER_Regs *gptimer, DL_TIMER_COUNT_MODE countMode)
+{
+    DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL, ((uint32_t) countMode),
+        (GPTIMER_CTRCTL_CM_MASK));
+}
+
+/**
+ *  @brief     Get timer counter couting mode
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *
+ *  @return @ref DL_TIMER_COUNT_MODE
+ */
+__STATIC_INLINE DL_TIMER_COUNT_MODE DL_Timer_getCounterMode(
+    GPTIMER_Regs *gptimer)
+{
+    uint32_t cmMode = (gptimer->COUNTERREGS.CTRCTL & GPTIMER_CTRCTL_CM_MASK);
+    return ((DL_TIMER_COUNT_MODE) cmMode);
+}
+
+/**
+ *  @brief      Configures counter value after enable
+ *
+ *  @param[in]  gptimer      Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in]  cvae         Speficies counter value after enable.
+ *                           @ref DL_TIMER_COUNT_AFTER_EN
+ *
+ */
+__STATIC_INLINE void DL_Timer_setCounterValueAfterEnable(
+    GPTIMER_Regs *gptimer, DL_TIMER_COUNT_AFTER_EN cvae)
+{
+    DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL, (uint32_t) cvae,
+        GPTIMER_CTRCTL_CVAE_MASK);
+}
+
+/**
+ *  @brief      Returns counter value after enable cofiguration
+ *
+ *  @param[in]  gptimer      Pointer to the register overlay for the
+ *                           peripheral
+ *  @return  @ref DL_TIMER_COUNT_AFTER_EN
+ *
+ */
+__STATIC_INLINE DL_TIMER_COUNT_AFTER_EN DL_Timer_getCounterValueAfterEnable(
+    GPTIMER_Regs *gptimer)
+{
+    uint32_t cvae = gptimer->COUNTERREGS.CTRCTL & GPTIMER_CTRCTL_CVAE_MASK;
+
+    return ((DL_TIMER_COUNT_AFTER_EN)(cvae));
+}
+
+/**
+ *  @brief     Configure timer repeat counter mode
+ *
+ *  @note Refer to device datasheet to determine if timer instance supports
+ *  this feature. Only Timer instances which supports repeat counter supports
+ *  this feature.
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in]  repeatMode      Specifies timer repeat counter mode
+ *                              @ref DL_TIMER_REPEAT_MODE
+ */
+__STATIC_INLINE void DL_Timer_setCounterRepeatMode(
+    GPTIMER_Regs *gptimer, DL_TIMER_REPEAT_MODE repeatMode)
+{
+    DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL, (uint32_t) repeatMode,
+        GPTIMER_CTRCTL_REPEAT_MASK);
+}
+
+/**
+ *  @brief     Get timer repeat counter mode
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @return @ref DL_TIMER_REPEAT_MODE
+ */
+__STATIC_INLINE DL_TIMER_REPEAT_MODE DL_Timer_getCounterRepeatMode(
+    GPTIMER_Regs *gptimer)
+{
+    uint32_t repeatMode =
+        gptimer->COUNTERREGS.CTRCTL & GPTIMER_CTRCTL_REPEAT_MASK;
+
+    return ((DL_TIMER_REPEAT_MODE)(repeatMode));
+}
+
+/**
+ *  @brief      Configure timer in one shot or periodic timer mode
+ *  Initializes all the common configurable options for the TIMx peripheral when
+ *  used in Timer mode. Any other custom configuration can be done after calling
+ *  this API.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  config         Pointer to the mode configuration struct
+ *                             @ref DL_Timer_TimerConfig.
+ *
+ */
+void DL_Timer_initTimerMode(
+    GPTIMER_Regs *gptimer, DL_Timer_TimerConfig *config);
+
+/**
+ *  @brief      Configure timer in edge count, period capture, edge time or
+ *              pulse-width capture mode
+ *  Initializes all the common configurable options for the TIMx peripheral when
+ *  used in Capture mode. Any other custom configuration can be done after
+ *  calling this API.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  config         Pointer to the mode configuration struct
+ *                             @ref DL_Timer_CaptureConfig.
+ *
+ */
+void DL_Timer_initCaptureMode(
+    GPTIMER_Regs *gptimer, DL_Timer_CaptureConfig *config);
+
+/**
+ *  @brief      Configure timer in edge count, period capture, edge time or
+ *              pulse-width capture mode using the trigger as input source
+ *  Initializes all the common configurable options for the TIMx peripheral when
+ *  used in Capture mode. Any other custom configuration can be done after
+ *  calling this API.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  config         Pointer to the mode configuration struct
+ *                             @ref DL_Timer_CaptureTriggerConfig.
+ *
+ */
+void DL_Timer_initCaptureTriggerMode(
+    GPTIMER_Regs *gptimer, DL_Timer_CaptureTriggerConfig *config);
+
+/**
+ *  @brief      Configure timer in combined pulse-width and period capture
+ *  Initializes all the common configurable options for the TIMx peripheral when
+ *  used in Capture mode. Any other custom configuration can be done after
+ *  calling this API.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  config         Pointer to the mode configuration struct
+ *                             @ref DL_Timer_CaptureCombinedConfig.
+ *
+ */
+void DL_Timer_initCaptureCombinedMode(
+    GPTIMER_Regs *gptimer, DL_Timer_CaptureCombinedConfig *config);
+
+/**
+ *  @brief      Configure timer in edge count compare mode
+ *  Initializes all the common configurable options for the TIMx peripheral when
+ *  used in Compare mode. Any other custom configuration can be done after
+ *  calling this API.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  config         Pointer to the mode configuration struct
+ *                             @ref DL_Timer_CompareConfig.
+ *
+ */
+void DL_Timer_initCompareMode(
+    GPTIMER_Regs *gptimer, DL_Timer_CompareConfig *config);
+
+/**
+ *  @brief      Configure timer in edge count compare mode using the trigger as
+ *              input source
+ *  Initializes all the common configurable options for the TIMx peripheral when
+ *  used in Compare mode. Any other custom configuration can be done after
+ *  calling this API.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  config         Pointer to the mode configuration struct
+ *                             @ref DL_Timer_CompareTriggerConfig.
+ *
+ */
+void DL_Timer_initCompareTriggerMode(
+    GPTIMER_Regs *gptimer, DL_Timer_CompareTriggerConfig *config);
+
+/**
+ * @brief Configure timer in Pulse Width Modulation Mode
+ *  Initializes all the common configurable options for the TIMx peripheral when
+ *  used in PWM mode. Any other custom configuration can be done after calling
+ *  this API.
+ *
+ * @param gptimer              Pointer to the register overlay for the
+ *                             peripheral
+ * @param config               Pointer to the mode configuration struct
+ *                             @ref DL_Timer_PWMConfig.
+ */
+void DL_Timer_initPWMMode(GPTIMER_Regs *gptimer, DL_Timer_PWMConfig *config);
+
+/**
+ *  @brief      Reset register controlling counter operation
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ */
+__STATIC_INLINE void DL_Timer_resetCounterMode(GPTIMER_Regs *gptimer)
+{
+    gptimer->COUNTERREGS.CTRCTL = GPTIMER_CTRCTL_EN_DISABLED;
+}
+
+/**
+ *  @brief      Sets Timer Capture Compare Value
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  value          Value to write to capture compare register
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ */
+void DL_Timer_setCaptureCompareValue(
+    GPTIMER_Regs *gptimer, uint32_t value, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief      Get Timer Capture Compare value
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ *  @return     The current capture compare value
+ *
+ *
+ */
+uint32_t DL_Timer_getCaptureCompareValue(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief Sets Capture Compare Control configuration
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccMode         Specifies whether the CC register is used as a
+ *                             capture register or a compare register
+ *                             @ref DL_TIMER_CC_MODE
+ *  @param[in]  ccCondMask     Specifies zero, load, advance and capture
+ *                             conditions. Bitwise OR of @ref DL_TIMER_CC_ZCOND,
+ *                             @ref DL_TIMER_CC_LCOND, @ref DL_TIMER_CC_ACOND,
+ *                             @ref DL_TIMER_CC_CCOND
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ */
+void DL_Timer_setCaptureCompareCtl(GPTIMER_Regs *gptimer, uint32_t ccMode,
+    uint32_t ccCondMask, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief   Gets Capture Compare Control configuration
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ *  @return Bitwise OR of @ref DL_TIMER_CC_MODE, @ref DL_TIMER_CC_ZCOND,
+ *          @ref DL_TIMER_CC_LCOND, @ref DL_TIMER_CC_ACOND,
+ *          @ref DL_TIMER_CC_CCOND
+ *
+ */
+uint32_t DL_Timer_getCaptureCompareCtl(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief Configures source for second capture compare down event
+ *
+ *  @param[in] gptimer       Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in] secCompDn     Specifies second capture compare down event
+ *                           source. @ref DL_TIMER_SEC_COMP_DOWN_EVT
+ *  @param[in] ccIndex       Index associated to capture compare register
+ *                           @ref DL_TIMER_CC_INDEX.
+ *
+ */
+void DL_Timer_setSecondCompSrcDn(GPTIMER_Regs *gptimer,
+    DL_TIMER_SEC_COMP_DOWN_EVT secCompDn, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief Gets source for second capture compare down event
+ *
+ *  @param[in] gptimer       Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in]  ccIndex      Index associated to capture compare register
+ *                           @ref DL_TIMER_CC_INDEX.
+ *  @return @ref DL_TIMER_SEC_COMP_DOWN_EVT
+ */
+DL_TIMER_SEC_COMP_DOWN_EVT DL_Timer_getSecondCompSrcDn(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief Configures source for second capture compare up event
+ *
+ *  @param[in] gptimer       Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in] secCompUp     Specifies second capture compare up event
+ *                           source. @ref DL_TIMER_SEC_COMP_UP_EVT
+ *  @param[in] ccIndex       Index associated to capture compare register
+ *                           @ref DL_TIMER_CC_INDEX.
+ *
+ */
+void DL_Timer_setSecondCompSrcUp(GPTIMER_Regs *gptimer,
+    DL_TIMER_SEC_COMP_UP_EVT secCompUp, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief Gets source for second capture compare down event
+ *
+ *  @param[in] gptimer       Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in]  ccIndex      Index associated to capture compare register
+ *                           @ref DL_TIMER_CC_INDEX.
+ *  @return @ref DL_TIMER_SEC_COMP_UP_EVT
+ */
+DL_TIMER_SEC_COMP_UP_EVT DL_Timer_getSecondCompSrcUp(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief Enables suppression of compare event if repeat counter is not equal to
+ *         zero
+ *
+ *  @param[in] gptimer       Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in]  ccIndex      Index associated to capture compare register
+ *                           @ref DL_TIMER_CC_INDEX.
+ */
+void DL_Timer_enableSuppressionOfCompEvent(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief Disables suppression of compare event if repeat counter is not equal
+ *         to zero
+ *
+ *  @param[in] gptimer       Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in]  ccIndex      Index associated to capture compare register
+ *                           @ref DL_TIMER_CC_INDEX.
+ */
+void DL_Timer_disableSuppressionOfCompEvent(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief Configures capture compare shadow register update method
+ *
+ *  @param[in] gptimer       Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in] ccUpdtMode    Specifies capture compare shadow register update
+ *                           method. @ref DL_TIMER_CC_UPDATE_METHOD
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ */
+void DL_Timer_setCaptCompUpdateMethod(GPTIMER_Regs *gptimer,
+    DL_TIMER_CC_UPDATE_METHOD ccUpdtMode, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief Gets capture compare shadow register update method
+ *
+ *  @param[in] gptimer       Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in]  ccIndex      Index associated to capture compare register
+ *                           @ref DL_TIMER_CC_INDEX.
+ * @return @ref DL_TIMER_CC_UPDATE_METHOD
+ */
+DL_TIMER_CC_UPDATE_METHOD DL_Timer_getCaptCompUpdateMethod(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief     Sets Capture Compare Output Control
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccpIV          Specifies the logical value put on the CCP
+ *                             output while the output is disabled
+ *                             @ref DL_TIMER_CC_OCTL_INIT_VAL
+ *  @param[in]  ccpOInv        Specifies if the he output as selected by ccpo is
+ *                             inverted. @ref DL_TIMER_CC_OCTL_INV_OUT
+ *  @param[in]  ccpO           CCP Output Source @ref DL_TIMER_CC_OCTL_SRC
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ */
+void DL_Timer_setCaptureCompareOutCtl(GPTIMER_Regs *gptimer, uint32_t ccpIV,
+    uint32_t ccpOInv, uint32_t ccpO, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief    Gets Capture Compare Output Control
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ *  @return Bitwise OR of @ref DL_TIMER_CC_OCTL_INIT_VAL,
+ *          @ref DL_TIMER_CC_OCTL_INV_OUT, @ref DL_TIMER_CC_OCTL_SRC
+ *
+ */
+uint32_t DL_Timer_getCaptureCompareOutCtl(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief     Sets actions of the signal generator
+ *
+ *  @param[in] gptimer       Pointer to the register overlay for the
+ *                           peripheral
+ *  @param[in] actionsMask   Bit mask of signal generator actions. Bitwise OR of
+ *                           @ref DL_TIMER_CC_FEXACT, @ref DL_TIMER_CC_FENACT,
+ *                           @ref DL_TIMER_CC_CUACT, @ref DL_TIMER_CC_CDACT,
+ *                           @ref DL_TIMER_CC_LACT, @ref DL_TIMER_CC_ZACT,
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ */
+void DL_Timer_setCaptureCompareAction(
+    GPTIMER_Regs *gptimer, uint32_t actionsMask, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief    Gets actions of the signal generator
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ *  @return Bitwise OR of @ref DL_TIMER_CC_FEXACT, @ref DL_TIMER_CC_FENACT,
+ *          @ref DL_TIMER_CC_CUACT, @ref DL_TIMER_CC_CDACT,
+ *          @ref DL_TIMER_CC_LACT, @ref DL_TIMER_CC_ZACT.
+ *
+ */
+uint32_t DL_Timer_getCaptureCompareAction(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief    Set second comparator down counting timer channel output action
+ *
+ *  The timer channel output will be set to selected
+ *  @ref DL_TIMER_SEC_COMP_DOWN_ACT_SEL when the timer counter reaches the
+ *  configured capture compare value configure by
+ *  @sa DL_Timer_setSecondCompSrcDn
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  secCompDnAct   One of @ref DL_TIMER_SEC_COMP_DOWN_ACT_SEL.
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ */
+void DL_Timer_setSecondCompActionDn(GPTIMER_Regs *gptimer,
+    DL_TIMER_SEC_COMP_DOWN_ACT_SEL secCompDnAct, DL_TIMER_CC_INDEX ccIndex);
+/**
+ *  @brief    Gets second comparator down counting timer channel output action
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ *  @return @ref DL_TIMER_SEC_COMP_DOWN_ACT_SEL
+ *
+ */
+DL_TIMER_SEC_COMP_DOWN_ACT_SEL DL_Timer_getSecondCompActionDn(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief    Sets second comparator up counting timer channel output action
+ *
+ *  The timer channel output will be set to selected
+ *  @ref DL_TIMER_SEC_COMP_UP_ACT_SEL when the timer counter reaches the
+ *  configured capture compare value configure by
+ *  @sa DL_Timer_setSecondCompSrcUp
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  secCompUpAct   One of @ref DL_TIMER_SEC_COMP_UP_ACT_SEL.
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ */
+void DL_Timer_setSecondCompActionUp(GPTIMER_Regs *gptimer,
+    DL_TIMER_SEC_COMP_UP_ACT_SEL secCompUpAct, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief    Gets second comparator up counting timer channel output action
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ *  @return @ref DL_TIMER_SEC_COMP_UP_ACT_SEL
+ *
+ */
+DL_TIMER_SEC_COMP_UP_ACT_SEL DL_Timer_getSecondCompActionUp(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief Overrides the timer CCP output
+ *
+ *  @param[in]  gptimer       Pointer to the register overlay for the
+ *                            peripheral
+ *  @param[in]  out           Specifies the CCP output state.
+ *                            @ref DL_TIMER_FORCE_OUT
+ *  @param[in]  outComp       If timer insatance supports complementary output,
+ *                            it allows to override complementary out also.
+ *                            If timer instance doesn't support complementary
+ *                            output, this parameter is ignored.
+ *                            @ref DL_TIMER_FORCE_CMPL_OUT
+ *  @param[in]  ccIndex       Index associated to capture compare register
+ *                            @ref DL_TIMER_CC_INDEX.
+ */
+void DL_Timer_overrideCCPOut(GPTIMER_Regs *gptimer, DL_TIMER_FORCE_OUT out,
+    DL_TIMER_FORCE_CMPL_OUT outComp, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief     Sets Capture Compare Input
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  inv            Specifies whether the selected input is
+ *                             inverted. @ref DL_TIMER_CC_INPUT_INV
+ *  @param[in]  isel           Selects the input source to the filter
+ *                             input. @ref DL_TIMER_CC_IN_SEL
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ */
+void DL_Timer_setCaptureCompareInput(GPTIMER_Regs *gptimer, uint32_t inv,
+    uint32_t isel, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief    Gets Capture Compare Input
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ *  @return Bitwise OR of @ref DL_TIMER_CC_INPUT_FILT_CPV,
+ *          @ref DL_TIMER_CC_INPUT_FILT_FP
+ *
+ */
+uint32_t DL_Timer_getCaptureCompareInput(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief     Sets Capture Compare Input Filter
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  cpv            Specifies fitering mode.
+ *                             @ref DL_TIMER_CC_INPUT_FILT_CPV
+ *  @param[in]  fp             Specifies the filter period.
+ *                             @ref DL_TIMER_CC_INPUT_FILT_FP
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ */
+void DL_Timer_setCaptureCompareInputFilter(GPTIMER_Regs *gptimer, uint32_t cpv,
+    uint32_t fp, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief    Gets Capture Compare Input Filter
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *
+ *  @return Bitwise OR of @ref DL_TIMER_CC_INPUT_FILT_CPV,
+ *          @ref DL_TIMER_CC_INPUT_FILT_FP
+ *
+ */
+uint32_t DL_Timer_getCaptureCompareInputFilter(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief Enables the capture compare input filter
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ */
+void DL_Timer_enableCaptureCompareInputFilter(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief Disables the capture compare input filter
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ */
+void DL_Timer_disableCaptureCompareInputFilter(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief Checks if the capture compare input filter is enabled
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ *  @return Returns the status of capture compare input filter
+ *
+ *  @retval     true  capture compare input filter is enabled
+ *  @retval     false capture compare input filter is disabled
+ */
+bool DL_Timer_isCaptureCompareInputFilterEnabled(
+    GPTIMER_Regs *gptimer, DL_TIMER_CC_INDEX ccIndex);
+
+/**
+ *  @brief     Sets dead band fall and raise delay
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  falldelay      The number of TIMCLK periods inserted between
+ *                             the fall of CCPi and the rise of CCPBo. Valid
+ *                             range [0- 4095]
+ *  @param[in]  risedelay      The number of TIMCLK periods inserted
+ *                             between the fall of CCPi and the rise of CCPAo.
+ *                             Valid range [0- 4095].
+ *  @param[in]  mode           Specifies the dead band insertion mode. One of
+ *                             @ref DL_TIMER_DEAD_BAND_MODE
+ *
+ */
+__STATIC_INLINE void DL_Timer_setDeadBand(GPTIMER_Regs *gptimer,
+    uint16_t falldelay, uint16_t risedelay, uint32_t mode)
+{
+    gptimer->COUNTERREGS.DBCTL =
+        (((uint32_t) falldelay << GPTIMER_DBCTL_FALLDELAY_OFS) |
+            (uint32_t) risedelay | mode);
+}
+
+/**
+ *  @brief    Gets dead band fall delay
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return Dead Band Fall delay in TIMCLK
+ */
+__STATIC_INLINE uint16_t DL_Timer_getDeadBandFallDelay(GPTIMER_Regs *gptimer)
+{
+    uint32_t temp =
+        (gptimer->COUNTERREGS.DBCTL & GPTIMER_DBCTL_FALLDELAY_MASK) >>
+        GPTIMER_DBCTL_FALLDELAY_OFS;
+
+    return ((uint16_t) temp);
+}
+
+/**
+ *  @brief    Gets dead band rise delay
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return Dead Band Rise delay in TIMCLK
+ */
+__STATIC_INLINE uint16_t DL_Timer_getDeadBandRiseDelay(GPTIMER_Regs *gptimer)
+{
+    return (uint16_t)(
+        (gptimer->COUNTERREGS.DBCTL) & (GPTIMER_DBCTL_RISEDELAY_MASK));
+}
+
+/**
+ *  @brief     Set External Trigger Event
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  trigSel        External Trigger Select
+ *                             @ref DL_TIMER_EXT_TRIG_SEL
+ *
+ */
+__STATIC_INLINE void DL_Timer_setExternalTriggerEvent(
+    GPTIMER_Regs *gptimer, DL_TIMER_EXT_TRIG_SEL trigSel)
+{
+    DL_Common_updateReg(&gptimer->COUNTERREGS.TSEL, (uint32_t) trigSel,
+        GPTIMER_TSEL_ETSEL_MASK);
+}
+
+/**
+ *  @brief    Gets External Trigger Event
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return @ref DL_TIMER_EXT_TRIG_SEL
+ *
+ */
+__STATIC_INLINE DL_TIMER_EXT_TRIG_SEL DL_Timer_getExternalTriggerEvent(
+    GPTIMER_Regs *gptimer)
+{
+    uint32_t trigSel = gptimer->COUNTERREGS.TSEL & GPTIMER_TSEL_ETSEL_MASK;
+
+    return (DL_TIMER_EXT_TRIG_SEL)(trigSel);
+}
+
+/**
+ *  @brief     Enables external trigger
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ */
+__STATIC_INLINE void DL_Timer_enableExternalTrigger(GPTIMER_Regs *gptimer)
+{
+    gptimer->COUNTERREGS.TSEL |= (GPTIMER_TSEL_TE_ENABLED);
+}
+
+/**
+ *  @brief     Disables external trigger
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ */
+__STATIC_INLINE void DL_Timer_disableExternalTrigger(GPTIMER_Regs *gptimer)
+{
+    gptimer->COUNTERREGS.TSEL &= ~(GPTIMER_TSEL_TE_ENABLED);
+}
+
+/**
+ *  @brief     Checks if  external trigger is enabled
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return Returns the status of external trigger
+ *
+ *  @retval     true  external trigger is enabled
+ *  @retval     false external trigger is disabled
+ */
+__STATIC_INLINE bool DL_Timer_isExternalTriggerEnabled(GPTIMER_Regs *gptimer)
+{
+    return ((gptimer->COUNTERREGS.TSEL & GPTIMER_TSEL_TE_MASK) ==
+            GPTIMER_TSEL_TE_ENABLED);
+}
+
+/**
+ *  @brief     Sets repeat counter value. Repeat counter feature is used to
+ *             reduce interupt overhead.
+ *  @note      <b>This feature is not supported by all TimerA instances.</b>
+ *             Please refer to the "TIMx Configurations" table in the
+ *             device specific datasheet to determine TimerA instances which
+ *             support "Repeat Counter" configuration.
+ *
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in]  repeatCount     Specifies repeat counter value
+ *
+ */
+__STATIC_INLINE void DL_Timer_setRepeatCounter(
+    GPTIMER_Regs *gptimer, uint8_t repeatCount)
+{
+    gptimer->COUNTERREGS.RCLD = (repeatCount);
+}
+
+/**
+ *  @brief     Gets repeat counter value.
+ *  @note      <b>This feature is not supported by all TimerA instances.</b>
+ *             Please refer to the "TIMx Configurations" table in the
+ *             device specific datasheet to determine TimerA instances which
+ *             support "Repeat Counter" configuration.
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *
+ *  @return Repeat counter value.
+ *
+ */
+__STATIC_INLINE uint8_t DL_Timer_getRepeatCounter(GPTIMER_Regs *gptimer)
+{
+    return ((uint8_t)(gptimer->COUNTERREGS.RC & GPTIMER_RC_RC_MASK));
+}
+
+/**
+ *  @brief     Enables phase load
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *
+ */
+__STATIC_INLINE void DL_Timer_enablePhaseLoad(GPTIMER_Regs *gptimer)
+{
+    gptimer->COUNTERREGS.CTRCTL |= (GPTIMER_CTRCTL_PLEN_ENABLED);
+}
+
+/**
+ *  @brief     Disables phase load
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *
+ *
+ */
+__STATIC_INLINE void DL_Timer_disablePhaseLoad(GPTIMER_Regs *gptimer)
+{
+    gptimer->COUNTERREGS.CTRCTL &= ~(GPTIMER_CTRCTL_PLEN_ENABLED);
+}
+
+/**
+ *  @brief     Checks if phase load enabled
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @return Returns the status of phase load
+ *
+ *  @retval     true  phase load is enabled
+ *  @retval     false phase load is disabled
+ *
+ */
+__STATIC_INLINE bool DL_Timer_isPhaseLoadEnabled(GPTIMER_Regs *gptimer)
+{
+    return (GPTIMER_CTRCTL_PLEN_ENABLED ==
+            (gptimer->COUNTERREGS.CTRCTL & GPTIMER_CTRCTL_PLEN_MASK));
+}
+
+/**
+ *  @brief     Sets phase load value
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in]  value           Phase load value
+ *
+ */
+__STATIC_INLINE void DL_Timer_setPhaseLoadValue(
+    GPTIMER_Regs *gptimer, uint16_t value)
+{
+    gptimer->COUNTERREGS.PL = (value);
+}
+
+/**
+ *  @brief     Gets phase load value
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *
+ *  @return Phase load value
+ */
+__STATIC_INLINE uint16_t DL_Timer_getPhaseLoadValue(GPTIMER_Regs *gptimer)
+{
+    return ((uint16_t)(gptimer->COUNTERREGS.PL & GPTIMER_PL_PHASE_MASK));
+}
+
+/**
+ *  @brief      Starts Timer Counter
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ */
+__STATIC_INLINE void DL_Timer_startCounter(GPTIMER_Regs *gptimer)
+{
+    gptimer->COUNTERREGS.CTRCTL |= (GPTIMER_CTRCTL_EN_ENABLED);
+}
+
+/**
+ *  @brief      Stops Timer Counter
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ */
+__STATIC_INLINE void DL_Timer_stopCounter(GPTIMER_Regs *gptimer)
+{
+    gptimer->COUNTERREGS.CTRCTL &= ~(GPTIMER_CTRCTL_EN_ENABLED);
+}
+
+/**
+ *  @brief      Check if timer is actively running
+ *
+ *  @param[in]  gptimer      Pointer to the register overlay for the
+ *                            peripheral
+ *
+ *  @return     Returns the running status of the Timer
+ *
+ *  @retval     true  Timer is running
+ *  @retval     false Timer is not running
+ */
+__STATIC_INLINE bool DL_Timer_isRunning(GPTIMER_Regs *gptimer)
+{
+    return ((gptimer->COUNTERREGS.CTRCTL & GPTIMER_CTRCTL_EN_MASK) ==
+            GPTIMER_CTRCTL_EN_ENABLED);
+}
+
+/**
+ *  @brief      Configure Quadrature Encoder Interface (QEI)
+ *
+ *  @post User should call @ref DL_Timer_setLoadValue and
+ *  @ref DL_Timer_startCounter to complete the QEI Configuration.
+ *  Refer to Timer TRM for more details.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  mode           Choose QEI input mode. One of @ref DL_TIMER_QEI_MODE
+ *  @param[in]  invert         Control whether selected input is inverted.
+ *                             One of @ref DL_TIMER_CC_INPUT_INV
+ *  @param[in]  ccIndex        Index associated to capture compare register
+ *                             @ref DL_TIMER_CC_INDEX.
+ */
+__STATIC_INLINE void DL_Timer_configQEI(GPTIMER_Regs *gptimer,
+    DL_TIMER_QEI_MODE mode, uint32_t invert, DL_TIMER_CC_INDEX ccIndex)
+{
+    gptimer->COUNTERREGS.CCCTL_01[ccIndex] =
+        GPTIMER_CCCTL_01_CCOND_CC_TRIG_RISE | GPTIMER_CCCTL_01_COC_CAPTURE;
+    gptimer->COUNTERREGS.IFCTL_01[ccIndex] =
+        GPTIMER_IFCTL_01_ISEL_CCPX_INPUT | invert;
+    gptimer->COUNTERREGS.CTRCTL =
+        (uint32_t) mode | GPTIMER_CTRCTL_CVAE_NOCHANGE |
+        GPTIMER_CTRCTL_CM_UP_DOWN | GPTIMER_CTRCTL_REPEAT_REPEAT_1;
+}
+
+/**
+ *  @brief      Configure Hall Input Mode
+ *
+ *  @note Refer to device datasheet to determine if timer instance supports
+ *  this feature. Only TIMGx instances with QEI support should use this API.
+ *
+ *  @post User should call @ref DL_Timer_setLoadValue and
+ *  @ref DL_Timer_startCounter to complete the Hall Input Mode Configuration.
+ *  Refer to Timer TRM for more details.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ */
+void DL_Timer_configQEIHallInputMode(GPTIMER_Regs *gptimer);
+
+/**
+ *  @brief      Get direction of Quadrature Encoder Interface (QEI) count
+ *
+ *  @param[in]  gptimer  Pointer to the register overlay for the
+ *                       peripheral
+ *  @retval     One of @ref DL_TIMER_QEI_DIRECTION values
+ */
+__STATIC_INLINE DL_TIMER_QEI_DIRECTION DL_Timer_getQEIDirection(
+    GPTIMER_Regs *gptimer)
+{
+    uint32_t qeiDirection = gptimer->COUNTERREGS.QDIR & GPTIMER_QDIR_DIR_MASK;
+
+    return (DL_TIMER_QEI_DIRECTION)(qeiDirection);
+}
+
+/**
+  *  @brief     Sets Fault Configuration
+  *
+  *  @param[in]  gptimer        Pointer to the register overlay for the
+  *                             peripheral
+  *  @param[in]  faultConfMask  Specifies faults configuration. Bitwise OR of
+  *                             @ref DL_TIMER_FAULT_CONFIG_TFIM,
+  *                             @ref DL_TIMER_FAULT_CONFIG_FL,
+  *                             @ref DL_TIMER_FAULT_CONFIG_FI,
+  *                             @ref DL_TIMER_FAULT_CONFIG_FIEN
+  *
+  */
+__STATIC_INLINE void DL_Timer_setFaultConfig(
+    GPTIMER_Regs *gptimer, uint32_t faultConfMask)
+{
+    DL_Common_updateReg(&gptimer->COUNTERREGS.FCTL, faultConfMask,
+        (GPTIMER_FCTL_TFIM_MASK | GPTIMER_FCTL_FL_MASK | GPTIMER_FCTL_FI_MASK |
+            GPTIMER_FCTL_FIEN_MASK));
+}
+
+/**
+  *  @brief     Gets Fault Configuration
+  *
+  *  @param[in]  gptimer        Pointer to the register overlay for the
+  *                             peripheral
+  *
+  *  @return Bitwise OR value of @ref DL_TIMER_FAULT_CONFIG_TFIM,
+  *          @ref DL_TIMER_FAULT_CONFIG_FL, @ref DL_TIMER_FAULT_CONFIG_FI,
+  *          @ref DL_TIMER_FAULT_CONFIG_FIEN
+  *
+  */
+__STATIC_INLINE uint32_t DL_Timer_getFaultConfig(GPTIMER_Regs *gptimer)
+{
+    return (gptimer->COUNTERREGS.FCTL &
+            (GPTIMER_FCTL_FIEN_MASK | GPTIMER_FCTL_FI_MASK |
+                GPTIMER_FCTL_FL_MASK | GPTIMER_FCTL_TFIM_MASK));
+}
+
+/**
+  *  @brief Enables fault input detection
+  *
+  *  @param[in] gptimer   Pointer to the register overlay for the
+  *                       peripheral
+  */
+__STATIC_INLINE void DL_Timer_enableFaultInput(GPTIMER_Regs *gptimer)
+{
+    gptimer->COUNTERREGS.FCTL |= (GPTIMER_FCTL_FIEN_ENABLED);
+}
+
+/**
+  *  @brief Disables fault input detection
+  *
+  *  @param[in] gptimer   Pointer to the register overlay for the
+  *                       peripheral
+  */
+__STATIC_INLINE void DL_Timer_disableFaultInput(GPTIMER_Regs *gptimer)
+{
+    gptimer->COUNTERREGS.FCTL &= ~(GPTIMER_FCTL_FIEN_ENABLED);
+}
+
+/**
+  *  @brief Specifies if fault input is enabled
+  *
+  *  @param[in] gptimer   Pointer to the register overlay for the
+  *                       peripheral
+  *  @return  true  Fault input is enabled
+  *  @return  false Fault input is disabled
+  */
+__STATIC_INLINE bool DL_Timer_isFaultInputEnabled(GPTIMER_Regs *gptimer)
+{
+    return (GPTIMER_FCTL_FIEN_ENABLED ==
+            (gptimer->COUNTERREGS.FCTL & GPTIMER_FCTL_FIEN_MASK));
+}
+
+/**
+ *  @brief Enables source clock fault detection
+ *
+ *  @param[in] gptimer Pointer to the register overlay for the
+ *                     peripheral
+ */
+__STATIC_INLINE void DL_Timer_enableClockFaultDetection(GPTIMER_Regs *gptimer)
+{
+    gptimer->COMMONREGS.FSCTL |= (GPTIMER_FSCTL_FCEN_DISABLE);
+}
+
+/**
+ *  @brief Disables source clock fault detection
+ *
+ *  @param[in] gptimer Pointer to the register overlay for the
+ *                     peripheral
+ */
+__STATIC_INLINE void DL_Timer_disableClockFaultDetection(GPTIMER_Regs *gptimer)
+{
+    gptimer->COMMONREGS.FSCTL &= ~(GPTIMER_FSCTL_FCEN_DISABLE);
+}
+
+/**
+ *  @brief Specifies if source clock fault detection is enabled
+ *
+ *  @param[in] gptimer Pointer to the register overlay for the
+ *                    peripheral
+ *  @return true if source clock fault detection is enabled
+ *  @return false if source clock fault detection is disabled
+ */
+__STATIC_INLINE bool DL_Timer_isClockFaultDetectionEnabled(
+    GPTIMER_Regs *gptimer)
+{
+    return (GPTIMER_FSCTL_FCEN_ENABLE ==
+            (gptimer->COMMONREGS.FSCTL & GPTIMER_FSCTL_FCEN_MASK));
+}
+
+/**
+  *  @brief Configures the fault source and and fault input mode
+  *
+  *  @param[in] gptimer Pointer to the register overlay for the
+  *                     peripheral
+  *  @param[in] source  Selects fault source and and fault input mode. One of
+  *                     @ref DL_TIMER_FAULT_SOURCE.
+  *
+  */
+void DL_Timer_setFaultSourceConfig(GPTIMER_Regs *gptimer, uint32_t source);
+
+/**
+  *  @brief
+  *
+  *  @param[in] gptimer Pointer to the register overlay for the
+  *                     peripheral
+  *  @return The fault source and and fault input mode. One of
+  *          @ref DL_TIMER_FAULT_SOURCE.
+  */
+uint32_t DL_Timer_getFaultSourceConfig(GPTIMER_Regs *gptimer);
+
+/**
+  *  @brief     Set Fault Input Filtering Configuration
+  *
+  *  @param[in]  gptimer        Pointer to the register overlay for the
+  *                             peripheral
+  *  @param[in]  filten         Specifies input is filter mode
+  *                             @ref DL_TIMER_FAULT_FILT
+  *  @param[in]  cpv            Specifies input filter type
+  *                             @ref DL_TIMER_FAULT_FILTER_CPV
+  *  @param[in]  fp             Specifies sample period for the input filter
+  *                             @ref DL_TIMER_FAULT_FILTER_FP
+  *
+  */
+__STATIC_INLINE void DL_Timer_setFaultInputFilterConfig(
+    GPTIMER_Regs *gptimer, uint32_t filten, uint32_t cpv, uint32_t fp)
+{
+    gptimer->COUNTERREGS.FIFCTL = (filten | cpv | fp);
+}
+
+/**
+  *  @brief     Get Fault Input Filtering Configuration
+  *
+  *  @param[in]  gptimer        Pointer to the register overlay for the
+  *                             peripheral
+  *  @return Bitwise OR of @ref DL_TIMER_FAULT_FILT,
+  *          @ref DL_TIMER_FAULT_FILTER_CPV and  @ref DL_TIMER_FAULT_FILTER_FP
+  *
+  */
+__STATIC_INLINE uint32_t DL_Timer_getFaultInputFilterConfig(
+    GPTIMER_Regs *gptimer)
+{
+    return (gptimer->COUNTERREGS.FIFCTL);
+}
+
+/**
+ *  @brief     Configures output behavior upon fault entry and exit
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in]  faultEntry      Specifies the fault entry behavior.
+ *                              One of @ref DL_TIMER_FAULT_ENTRY_CCP
+ *  @param[in]  faultExit       Specifies the fault exit behavior.
+ *                              One of @ref DL_TIMER_FAULT_EXIT_CCP
+ *  @param[in]  ccIndex         Index associated to capture compare register
+ *                              @ref DL_TIMER_CC_INDEX.
+ *
+ */
+__STATIC_INLINE void DL_Timer_configFaultOutputAction(GPTIMER_Regs *gptimer,
+    DL_TIMER_FAULT_ENTRY_CCP faultEntry, DL_TIMER_FAULT_EXIT_CCP faultExit,
+    DL_TIMER_CC_INDEX ccIndex)
+{
+    DL_Common_updateReg(&gptimer->COUNTERREGS.CCACT_01[ccIndex],
+        ((uint32_t) faultEntry | (uint32_t) faultExit),
+        (GPTIMER_CCACT_01_FEXACT_MASK | GPTIMER_CCACT_01_FENACT_MASK));
+}
+
+/**
+ *  @brief     Configures timer counter behavior upon fault entry and exit
+ *
+ *  @param[in]  gptimer         Pointer to the register overlay for the
+ *                              peripheral
+ *  @param[in]  faultEntry      Specifies the fault entry behavior.
+ *                              One of @ref DL_TIMER_FAULT_ENTRY_CTR
+ *  @param[in]  faultExit       Specifies the fault exit behavior.
+ *                              One of @ref DL_TIMER_FAULT_EXIT_CTR
+ *
+ */
+__STATIC_INLINE void DL_Timer_configFaultCounter(GPTIMER_Regs *gptimer,
+    DL_TIMER_FAULT_ENTRY_CTR faultEntry, DL_TIMER_FAULT_EXIT_CTR faultExit)
+{
+    DL_Common_updateReg(&gptimer->COUNTERREGS.CTRCTL,
+        ((uint32_t) faultEntry | (uint32_t) faultExit),
+        (GPTIMER_CTRCTL_FRB_MASK | GPTIMER_CTRCTL_FB_MASK));
+}
+
+/**
+ *  @brief      Enable timer interrupts
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_TIMER_INTERRUPT.
+ */
+__STATIC_INLINE void DL_Timer_enableInterrupt(
+    GPTIMER_Regs *gptimer, uint32_t interruptMask)
+{
+    gptimer->CPU_INT.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disable timer interrupts
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_TIMER_INTERRUPT.
+ */
+__STATIC_INLINE void DL_Timer_disableInterrupt(
+    GPTIMER_Regs *gptimer, uint32_t interruptMask)
+{
+    gptimer->CPU_INT.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief      Check which timer interrupts are enabled
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_TIMER_INTERRUPT.
+ *
+ *  @return     Which of the requested timer interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_TIMER_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_Timer_getEnabledInterrupts(
+    GPTIMER_Regs *gptimer, uint32_t interruptMask)
+{
+    return (gptimer->CPU_INT.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled timer interrupts
+ *
+ *  Checks if any of the timer interrupts that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_TIMER_INTERRUPT.
+ *
+ *  @return     Which of the requested timer interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_TIMER_INTERRUPT values
+ *
+ *  @sa         DL_Timer_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_Timer_getEnabledInterruptStatus(
+    GPTIMER_Regs *gptimer, uint32_t interruptMask)
+{
+    return (gptimer->CPU_INT.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any timer interrupt
+ *
+ *  Checks if any of the timer interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_TIMER_INTERRUPT.
+ *
+ *  @return     Which of the requested timer interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_TIMER_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_Timer_getRawInterruptStatus(
+    GPTIMER_Regs *gptimer, uint32_t interruptMask)
+{
+    return (gptimer->CPU_INT.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending timer interrupt
+ *
+ *  Checks if any of the timer interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     The highest priority pending timer interrupt. One of
+ *              @ref DL_TIMER_IIDX
+ */
+__STATIC_INLINE DL_TIMER_IIDX DL_Timer_getPendingInterrupt(
+    GPTIMER_Regs *gptimer)
+{
+    return ((DL_TIMER_IIDX) gptimer->CPU_INT.IIDX);
+}
+
+/**
+ *  @brief      Clear pending timer interrupts
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_TIMER_INTERRUPT.
+ */
+__STATIC_INLINE void DL_Timer_clearInterruptStatus(
+    GPTIMER_Regs *gptimer, uint32_t interruptMask)
+{
+    gptimer->CPU_INT.ICLR = interruptMask;
+}
+
+/**
+ *  @brief Sets the event publisher channel id
+ *
+ *  @param[in]  gptimer Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  index   Specifies the register event index to be configured
+ *  @param[in]  chanID  Channel ID number. Valid range 0-15. If ChanID == 0
+ *                      publisher is disconnected.
+ */
+__STATIC_INLINE void DL_Timer_setPublisherChanID(
+    GPTIMER_Regs *gptimer, DL_TIMER_PUBLISHER_INDEX index, uint8_t chanID)
+{
+    volatile uint32_t *pReg = &gptimer->FPUB_0;
+
+    *(pReg + (uint32_t) index) = (chanID & GPTIMER_FPUB_0_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event publisher channel id
+ *
+ *  @param[in]  gptimer Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  index  Specifies the register event index to be configured
+ *
+ *  @return     Event publisher channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_Timer_getPublisherChanID(
+    GPTIMER_Regs *gptimer, DL_TIMER_PUBLISHER_INDEX index)
+{
+    volatile uint32_t *pReg = &gptimer->FPUB_0;
+
+    return (
+        (uint8_t)(*(pReg + (uint32_t) index) & GPTIMER_FPUB_0_CHANID_MASK));
+}
+
+/**
+ *  @brief Sets the event subscriber channel id
+ *
+ *  @param[in]  gptimer Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  index   Specifies the register event index to be configured
+ *  @param[in]  chanID  Channel ID number. Valid range 0-15. If ChanID == 0
+ *                      subscriber is disconnected.
+ */
+__STATIC_INLINE void DL_Timer_setSubscriberChanID(
+    GPTIMER_Regs *gptimer, DL_TIMER_SUBSCRIBER_INDEX index, uint8_t chanID)
+{
+    volatile uint32_t *pReg = &gptimer->FSUB_0;
+
+    *(pReg + (uint32_t) index) = (chanID & GPTIMER_FSUB_0_CHANID_MAXIMUM);
+}
+
+/**
+ *  @brief Gets the event subscriber channel id
+ *
+ *  @param[in]  gptimer Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  index  Specifies the register event index to be configured
+ *
+ *  @return     Event subscriber channel ID
+ *
+ */
+__STATIC_INLINE uint8_t DL_Timer_getSubscriberChanID(
+    GPTIMER_Regs *gptimer, DL_TIMER_SUBSCRIBER_INDEX index)
+{
+    volatile uint32_t *pReg = &gptimer->FSUB_0;
+
+    return (
+        (uint8_t)(*(pReg + (uint32_t) index) & GPTIMER_FSUB_0_CHANID_MASK));
+}
+
+/**
+ *  @brief      Enable timer event
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  index          Specifies the register event index to be
+ *                             configured
+ *  @param[in]  eventMask      Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_TIMER_EVENT.
+ */
+__STATIC_INLINE void DL_Timer_enableEvent(
+    GPTIMER_Regs *gptimer, DL_TIMER_EVENT_ROUTE index, uint32_t eventMask)
+{
+    volatile uint32_t *pReg = (volatile uint32_t *) &gptimer->GEN_EVENT0.IMASK;
+
+    *(pReg + (uint32_t) index) |= (eventMask);
+}
+
+/**
+ *  @brief      Disable timer event
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  index          Specifies the register event index to be
+ *                             configured
+ *  @param[in]  eventMask      Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_TIMER_EVENT.
+ */
+__STATIC_INLINE void DL_Timer_disableEvent(
+    GPTIMER_Regs *gptimer, DL_TIMER_EVENT_ROUTE index, uint32_t eventMask)
+{
+    volatile uint32_t *pReg = (volatile uint32_t *) &gptimer->GEN_EVENT0.IMASK;
+
+    *(pReg + (uint32_t) index) &= ~(eventMask);
+}
+
+/**
+ *  @brief      Check which timer events are enabled
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  index          Specifies the register event index to be
+ *                             configured
+ *  @param[in]  eventMask      Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_TIMER_EVENT.
+ *
+ *  @return     Which of the requested timer interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_TIMER_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_Timer_getEnabledEvents(
+    GPTIMER_Regs *gptimer, DL_TIMER_EVENT_ROUTE index, uint32_t eventMask)
+{
+    volatile uint32_t *pReg = (volatile uint32_t *) &gptimer->GEN_EVENT0.IMASK;
+
+    return ((*(pReg + (uint32_t) index) & eventMask));
+}
+
+/**
+ *  @brief      Check event flag of enabled timer event
+ *
+ *  Checks if any of the timer events that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  index          Specifies the register event index to be
+ *                             configured
+ *  @param[in]  eventMask      Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_TIMER_EVENT.
+ *
+ *  @return     Which of the requested timer interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_TIMER_EVENT values
+ *
+ *  @sa         DL_Timer_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_Timer_getEnabledEventStatus(
+    GPTIMER_Regs *gptimer, DL_TIMER_EVENT_ROUTE index, uint32_t eventMask)
+{
+    const volatile uint32_t *pReg =
+        (const volatile uint32_t *) &gptimer->GEN_EVENT0.MIS;
+
+    return ((*(pReg + (uint32_t) index) & eventMask));
+}
+
+/**
+ *  @brief      Check interrupt flag of any timer event
+ *
+ *  Checks if any events are pending. Events do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  index          Specifies the register event index to be
+ *                             configured
+ *  @param[in]  eventMask      Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_TIMER_EVENT.
+ *
+ *  @return     Which of the requested timer interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_TIMER_EVENT values
+ */
+__STATIC_INLINE uint32_t DL_Timer_getRawEventsStatus(
+    GPTIMER_Regs *gptimer, DL_TIMER_EVENT_ROUTE index, uint32_t eventMask)
+{
+    const volatile uint32_t *pReg =
+        (const volatile uint32_t *) &gptimer->GEN_EVENT0.RIS;
+
+    return ((*(pReg + (uint32_t) index) & eventMask));
+}
+
+/**
+ *  @brief      Clear pending timer events
+ *
+ *  @param[in]  gptimer        Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  index          Specifies the register event index to be
+ *                             configured
+ *  @param[in]  eventMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_TIMER_EVENT.
+ */
+__STATIC_INLINE void DL_Timer_clearEventsStatus(
+    GPTIMER_Regs *gptimer, DL_TIMER_EVENT_ROUTE index, uint32_t eventMask)
+{
+    volatile uint32_t *pReg = (volatile uint32_t *) &gptimer->GEN_EVENT0.ICLR;
+
+    *(pReg + (uint32_t) index) |= (eventMask);
+}
+
+/**
+ *  @brief      Saves Timer configuration before entering STOP or STANDBY mode.
+ *              Only necessary for PG 1.0 silicon. Timer must be in IDLE state
+ *              before calling this API. Timer can be put IDLE state by calling
+ *              DL_TimerG_stopCounter or DL_TimerH_stopCounter.
+ *
+ *  @param[in]  gptimer  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr      Configuration backup setup structure. See
+ *                       @ref DL_Timer_backupConfig.
+ *
+ *  @retval     FALSE if a configuration already exists in ptr (will not be
+ *              overwritten). TRUE if a configuration was successfully saved
+ *
+ */
+bool DL_Timer_saveConfiguration(
+    GPTIMER_Regs *gptimer, DL_Timer_backupConfig *ptr);
+
+/**
+ *  @brief      Restore Timer configuration after leaving STOP or STANDBY mode.
+ *              Only necessary for PG 1.0 silicon.
+ *
+ *  @param[in]  gptimer  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr      Configuration backup setup structure. See
+ *                       @ref DL_Timer_backupConfig.
+ *  @param[in]  restoreCounter If true timer counter value is also
+ *                             restored (e.g. resume counts of edge counts).
+ *                             If false timer counter is not restored.
+ *
+ *  @retval     FALSE if a configuration does not exist in ptr (will not be
+ *              loaded). TRUE if a configuration successfully loaded
+ *
+ */
+bool DL_Timer_restoreConfiguration(
+    GPTIMER_Regs *gptimer, DL_Timer_backupConfig *ptr, bool restoreCounter);
+
+/**
+ *  @brief      Configures timer behavior when the core is halted.
+ *
+ *  @param[in]  gptimer  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  haltMode Timer halt behavvior. One of @ref DL_TIMER_CORE_HALT.
+ *
+ */
+__STATIC_INLINE void DL_Timer_setCoreHaltBehavior(
+    GPTIMER_Regs *gptimer, DL_TIMER_CORE_HALT haltMode)
+{
+    gptimer->PDBGCTL = ((uint32_t) haltMode & (GPTIMER_PDBGCTL_FREE_MASK |
+                                                  GPTIMER_PDBGCTL_SOFT_MASK));
+}
+
+/**
+ *  @brief      Get timer behavior when the core is halted.
+ *
+ *  @param[in]  gptimer  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Timer bahvior when core is halted. One of
+ *              @ref DL_TIMER_CORE_HALT
+ *
+ */
+__STATIC_INLINE DL_TIMER_CORE_HALT DL_Timer_getCoreHaltBehavior(
+    GPTIMER_Regs *gptimer)
+{
+    uint32_t haltMode = (gptimer->PDBGCTL & (GPTIMER_PDBGCTL_FREE_MASK |
+                                                GPTIMER_PDBGCTL_SOFT_MASK));
+
+    return (DL_TIMER_CORE_HALT)(haltMode);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_TIMER_A__ || __MSPM0_HAS_TIMER_G__ */
+
+#else
+#warning \
+    "TI highly recommends accessing timer with dl_timera and dl_timerg only."
+#endif /* ti_dl_dl_timera__include ti_dl_dl_timerg__include*/
+
+#endif /* ti_dl_dl_timer__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_timera.h
+++ b/mspm0/source/ti/driverlib/dl_timera.h
@@ -1,0 +1,1755 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_timera.h
+ *  @brief      General Purpose Timer Advance (TIMA) Driver Library
+ *  @defgroup   TIMA General Purpose Timer Advance (TIMA)
+ *
+ *  @anchor ti_dl_dl_timera__Overview
+ *  # Overview
+ *
+ *   The TimerA Driver Library allows you to configure the Advanced Timer
+ *   (TIMA) module in output compare, input capture, PWM output, one-shot and
+ *   periodic modes. For detailed TIMA features please refer to the Device
+ *   Technical Reference Manual (TRM).
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup TIMA
+ * @{
+ */
+#ifndef ti_dl_dl_timera__include
+#define ti_dl_dl_timera__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/driverlib/dl_timer.h>
+
+#ifdef __MSPM0_HAS_TIMER_A__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Configuration struct for @ref DL_TimerA_initPWMMode.
+ */
+typedef struct {
+    /*! Specifies the pwm period. */
+    uint32_t period;
+    /*! Specifies the PWM Mode. One of @ref DL_TIMER_PWM_MODE */
+    DL_TIMER_PWM_MODE pwmMode;
+    /*! Specifies if this is a counter with four capture compare registers.
+        Please refer to the device datasheet to determine if Timer instance
+        supports four capture compare registers */
+    bool isTimerWithFourCC;
+    /*! Start timer after configuration @ref DL_TIMER */
+    DL_TIMER startTimer;
+} DL_TimerA_PWMConfig;
+
+/**
+ * @brief Configuration structure to backup Timer A peripheral state before
+ *        entering STOP or STANDBY mode. Not required after PG 1.0 silicon.
+ *        Used by @ref DL_TimerA_saveConfiguration and
+ *        @ref DL_TimerA_restoreConfiguration
+ */
+typedef struct {
+    /*! Timer A subscriber 0 channel ID. Value between 0 - 15. */
+    uint32_t sub0PortConf;
+    /*! Timer A subscriber 1 channel ID. Value between 0 - 15. */
+    uint32_t sub1PortConf;
+    /*! Timer A publisher 0 channel ID. Value between 0 - 15. */
+    uint32_t pub0PortConf;
+    /*! Timer A publisher 1 channel ID. Value between 0 - 15. */
+    uint32_t pub1PortConf;
+    /*! Timer A clockDivider configuration.*/
+    uint32_t clkDivConf;
+    /*! Timer A clock prescaler configuration.*/
+    uint32_t clockPscConf;
+    /*! Timer A Clock Source Select configuration.*/
+    uint32_t clkSelConf;
+    /*! Timer A Clock configuration.*/
+    uint32_t countClkConf;
+    /*! Timer A interrupt configuration for EVENT0.*/
+    uint32_t intEvnt0Conf;
+    /*! Timer A interrupt configuration for EVENT1.*/
+    uint32_t intEvnt1Conf;
+    /*! Timer A interrupt configuration for EVENT2.*/
+    uint32_t intEvnt2Conf;
+    /*! Timer A CCP Direction configuration.*/
+    uint32_t ccpDirConf;
+    /*! Timer A CCP Output forced low configuration.*/
+    uint32_t outDisConf;
+    /*! Timer A Cross Timer Trigger Control configuration.*/
+    uint32_t crossTrigCtl;
+    /*! Timer A Cross Timer Trigger Mask*/
+    uint32_t crossTrifMsk;
+    /*! Timer A Cross Trigger Configuration */
+    uint32_t tSelConf;
+    /*! Timer A Cross Timer Trigger*/
+    uint32_t crossTrigConf;
+    /*! Timer A counter value. Timer counter value is stored but user can
+     *  specify if counter is restore via restoreCounter argument in
+     *  @ref DL_TimerA_restoreConfiguration */
+    uint32_t cntVal;
+    /*! Timer A counter control configuration */
+    uint32_t cntCtlConf;
+    /*! Timer A load value */
+    uint32_t loadVal;
+    /*! Timer A Capture or Compare 0 value */
+    uint32_t cc0Val;
+    /*! Timer A Capture or Compare 1 value */
+    uint32_t cc1Val;
+    /*! Timer A Capture or Compare 2 value */
+    uint32_t cc2Val;
+    /*! Timer A Capture or Compare 3 value */
+    uint32_t cc3Val;
+    /*! Timer A Capture or Compare Control Register 0 */
+    uint32_t cc0Ctl;
+    /*! Timer A Capture or Compare Control Register 1 */
+    uint32_t cc1Ctl;
+    /*! Timer A Capture or Compare Control Register 2 */
+    uint32_t cc2Ctl;
+    /*! Timer A Capture or Compare Control Register 3 */
+    uint32_t cc3Ctl;
+    /*! Timer A Capture or Compare Output Control Register 0 */
+    uint32_t cc0OutCtl;
+    /*! Timer A Capture or Compare Output Control Register 1 */
+    uint32_t cc1OutCtl;
+    /*! Timer A Capture or Compare Output Control Register 2 */
+    uint32_t cc2OutCtl;
+    /*! Timer A Capture or Compare Output Control Register 3 */
+    uint32_t cc3OutCtl;
+    /*! Timer A Capture or Compare Signal Generator Action Control Register 0 */
+    uint32_t cc0ActCtl;
+    /*! Timer A Capture or Compare Signal Generator Action Control Register 1 */
+    uint32_t cc1ActCtl;
+    /*! Timer A Capture or Compare Signal Generator Action Control Register 2 */
+    uint32_t cc2ActCtl;
+    /*! Timer A Capture or Compare Signal Generator Action Control Register 3 */
+    uint32_t cc3ActCtl;
+    /*! Timer A Capture or Compare Input Filter and Inversion Control
+     *  Register 0 */
+    uint32_t in0FiltCtl;
+    /*! Timer A Capture or Compare Input Filter and Inversion Control
+     *  Register 1 */
+    uint32_t in1FiltCtl;
+    /*! Timer A Capture or Compare Input Filter and Inversion Control
+     *  Register 2 */
+    uint32_t in2FiltCtl;
+    /*! Timer A Capture or Compare Input Filter and Inversion Control
+     *  Register 3 */
+    uint32_t in3FiltCtl;
+    /*! Timer A Phase Load Value */
+    uint32_t phaseVal;
+    /*! Timer A Dead Band Control Configuration */
+    uint32_t dbCtlConf;
+    /*! Timer A Repeat Counter Configuration */
+    uint32_t rcConf;
+    /*! Timer A Fault Source and Handling Configuration */
+    uint32_t faultSrcHndlConf;
+    /*! Timer A Fault Source Input Filtering Configuration */
+    uint32_t faultInCtl;
+    /*! Timer A Fault Cross Trigger Input Selection Configuration */
+    uint32_t faultCrossTrigCtl;
+    /*! Boolean flag indicating whether or not a valid configuration structure
+     *  exists. Should not be modified by the user. */
+    bool backupRdy;
+} DL_TimerA_backupConfig;
+
+/* clang-format off */
+
+/** @addtogroup DL_TIMERA_CAPTURE_COMPARE_INDEX
+ *  @{
+ */
+
+/**
+ * @brief  Index associated to Capture Compare 0
+ */
+#define DL_TIMERA_CAPTURE_COMPARE_0_INDEX       DL_TIMER_CC_0_INDEX
+
+/**
+ * @brief  Index associated to Capture Compare 1
+ */
+#define DL_TIMERA_CAPTURE_COMPARE_1_INDEX       DL_TIMER_CC_1_INDEX
+
+/**
+ * @brief  Index associated to Capture Compare 2
+ * @note   <b>This option is not supported by all device TimerA modules </b>
+ *         please refer to the "TIMx Configurations" table in the
+ *         device specific datasheet to determine Timer instances which
+ *         support "4 CC Channel" configuration.
+ */
+#define DL_TIMERA_CAPTURE_COMPARE_2_INDEX       DL_TIMER_CC_2_INDEX
+
+/**
+ * @brief  Index associated to Capture Compare 3
+ * @note   <b>This option is not supported by all device TimerA modules </b>
+ *         please refer to the "TIMx Configurations" table in the
+ *         device specific datasheet to determine Timer instances which
+ *         support "4 CC Channel" configuration.
+ */
+#define DL_TIMERA_CAPTURE_COMPARE_3_INDEX       DL_TIMER_CC_3_INDEX
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_CCx
+ *  @{
+ */
+/*!
+ * @brief Selects Output direction for CCP0
+ */
+#define DL_TIMERA_CC2_OUTPUT                     (GPTIMER_CCPD_C0CCP2_OUTPUT)
+
+/*!
+ * @brief Selects Input direction for CCP0
+ */
+#define DL_TIMERA_CC2_INPUT                      (GPTIMER_CCPD_C0CCP2_INPUT)
+
+/*!
+ * @brief Selects Output direction for CCP1
+ */
+#define DL_TIMERA_CC3_OUTPUT                     (GPTIMER_CCPD_C0CCP3_OUTPUT)
+
+/*!
+ * @brief Selects Input direction for CCP1
+ */
+#define DL_TIMERA_CC3_INPUT                      (GPTIMER_CCPD_C0CCP3_INPUT)
+
+/** @}*/
+
+/** @addtogroup DL_TIMERA_INTERRUPT
+ *  @{
+ */
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_INTERRUPT_ZERO_EVENT
+ */
+#define DL_TIMERA_INTERRUPT_ZERO_EVENT           (DL_TIMER_INTERRUPT_ZERO_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_LOAD_EVENT
+*/
+#define DL_TIMERA_INTERRUPT_LOAD_EVENT           (DL_TIMER_INTERRUPT_LOAD_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC0_DN_EVENT
+*/
+#define DL_TIMERA_INTERRUPT_CC0_DN_EVENT       (DL_TIMER_INTERRUPT_CC0_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC1_DN_EVENT
+*/
+#define DL_TIMERA_INTERRUPT_CC1_DN_EVENT       (DL_TIMER_INTERRUPT_CC1_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC0_UP_EVENT
+*/
+#define DL_TIMERA_INTERRUPT_CC0_UP_EVENT       (DL_TIMER_INTERRUPT_CC0_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC1_UP_EVENT
+*/
+#define DL_TIMERA_INTERRUPT_CC1_UP_EVENT       (DL_TIMER_INTERRUPT_CC1_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_OVERFLOW_EVENT
+*/
+#define DL_TIMERA_INTERRUPT_OVERFLOW_EVENT   (DL_TIMER_INTERRUPT_OVERFLOW_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC2_DN_EVENT
+*/
+#define DL_TIMERA_INTERRUPT_CC2_DN_EVENT       (DL_TIMER_INTERRUPT_CC2_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC3_DN_EVENT
+*/
+#define DL_TIMERA_INTERRUPT_CC3_DN_EVENT       (DL_TIMER_INTERRUPT_CC3_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC2_UP_EVENT
+*/
+#define DL_TIMERA_INTERRUPT_CC2_UP_EVENT      (DL_TIMER_INTERRUPT_CC2_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC3_UP_EVENT
+*/
+#define DL_TIMERA_INTERRUPT_CC3_UP_EVENT      (DL_TIMER_INTERRUPT_CC3_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC4_DN_EVENT
+* @note <b> This is a Timer A specific interrupt. </b>
+*/
+#define DL_TIMERA_INTERRUPT_CC4_DN_EVENT       (DL_TIMER_INTERRUPT_CC4_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC5_DN_EVENT
+* @note <b> This is a Timer A specific interrupt. </b>
+*/
+#define DL_TIMERA_INTERRUPT_CC5_DN_EVENT       (DL_TIMER_INTERRUPT_CC5_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC4_UP_EVENT
+* @note <b> This is a Timer A specific interrupt. </b>
+*/
+#define DL_TIMERA_INTERRUPT_CC4_UP_EVENT       (DL_TIMER_INTERRUPT_CC4_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC5_UP_EVENT
+* @note <b> This is a Timer A specific interrupt. </b>
+*/
+#define DL_TIMERA_INTERRUPT_CC5_UP_EVENT       (DL_TIMER_INTERRUPT_CC5_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_REPC_EVENT
+* @note <b> This is a Timer A specific interrupt. </b>
+*/
+#define DL_TIMERA_INTERRUPT_REPC_EVENT           (DL_TIMER_INTERRUPT_REPC_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_FAULT_EVENT
+* @note <b> This is a Timer A specific interrupt. </b>
+*/
+#define DL_TIMERA_INTERRUPT_FAULT_EVENT         (DL_TIMER_INTERRUPT_FAULT_EVENT)
+
+/** @}*/
+
+/** @addtogroup DL_TIMERA_EVENT
+ *  @{
+ */
+/*!
+ * @brief Redirects to common @ref DL_TIMER_EVENT_ZERO_EVENT
+ */
+#define DL_TIMERA_EVENT_ZERO_EVENT                   (DL_TIMER_EVENT_ZERO_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_LOAD_EVENT
+*/
+#define DL_TIMERA_EVENT_LOAD_EVENT                   (DL_TIMER_EVENT_LOAD_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC0_DN_EVENT
+*/
+#define DL_TIMERA_EVENT_CC0_DN_EVENT               (DL_TIMER_EVENT_CC0_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC1_DN_EVENT
+*/
+#define DL_TIMERA_EVENT_CC1_DN_EVENT               (DL_TIMER_EVENT_CC1_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC0_UP_EVENT
+*/
+#define DL_TIMERA_EVENT_CC0_UP_EVENT               (DL_TIMER_EVENT_CC0_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC1_UP_EVENT
+*/
+#define DL_TIMERA_EVENT_CC1_UP_EVENT               (DL_TIMER_EVENT_CC1_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_OVERFLOW_EVENT
+*/
+#define DL_TIMERA_EVENT_OVERFLOW_EVENT           (DL_TIMER_EVENT_OVERFLOW_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC2_DN_EVENT
+*/
+#define DL_TIMERA_EVENT_CC2_DN_EVENT               (DL_TIMER_EVENT_CC2_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC3_DN_EVENT
+*/
+#define DL_TIMERA_EVENT_CC3_DN_EVENT               (DL_TIMER_EVENT_CC3_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC2_UP_EVENT
+*/
+#define DL_TIMERA_EVENT_CC2_UP_EVENT               (DL_TIMER_EVENT_CC2_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC3_UP_EVENT
+*/
+#define DL_TIMERA_EVENT_CC3_UP_EVENT               (DL_TIMER_EVENT_CC3_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC4_DN_EVENT
+* @note <b> This is a Timer A specific interrupt. </b>
+*/
+#define DL_TIMERA_EVENT_CC4_DN_EVENT               (DL_TIMER_EVENT_CC4_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC5_DN_EVENT
+* @note <b> This is a Timer A specific interrupt. </b>
+*/
+#define DL_TIMERA_EVENT_CC5_DN_EVENT               (DL_TIMER_EVENT_CC5_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC4_UP_EVENT
+* @note <b> This is a Timer A specific interrupt. </b>
+*/
+#define DL_TIMERA_EVENT_CC4_UP_EVENT               (DL_TIMER_EVENT_CC4_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC5_UP_EVENT
+* @note <b> This is a Timer A specific interrupt. </b>
+*/
+#define DL_TIMERA_EVENT_CC5_UP_EVENT               (DL_TIMER_EVENT_CC5_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_REPC_EVENT
+* @note <b> This is a Timer A specific interrupt. </b>
+*/
+#define DL_TIMERA_EVENT_REPC_EVENT                   (DL_TIMER_EVENT_REPC_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_FAULT_EVENT
+* @note <b> This is a Timer A specific interrupt. </b>
+*/
+#define DL_TIMERA_EVENT_FAULT_EVENT                 (DL_TIMER_EVENT_FAULT_EVENT)
+
+/** @}*/
+
+/** @addtogroup DL_TIMERA_CCP0_DIS_OUT_ADV
+ *  @{
+ */
+
+/**
+  * @brief Redirects to common @ref DL_TIMER_CCP0_DIS_OUT_ADV_FORCE_LOW
+  */
+#define DL_TIMERA_CCP0_DIS_OUT_ADV_FORCE_LOW \
+                                             DL_TIMER_CCP0_DIS_OUT_ADV_FORCE_LOW
+
+/**
+  * @brief Redirects to common @ref DL_TIMER_CCP0_DIS_OUT_ADV_SET_BY_OCTL
+  */
+#define DL_TIMERA_CCP0_DIS_OUT_ADV_SET_BY_OCTL \
+                                           DL_TIMER_CCP0_DIS_OUT_ADV_SET_BY_OCTL
+
+/** @}*/
+
+/** @addtogroup DL_TIMERA_CCP1_DIS_OUT_ADV
+ *  @{
+ */
+
+/**
+  * @brief Redirects to common @ref DL_TIMER_CCP1_DIS_OUT_ADV_FORCE_LOW
+  */
+#define DL_TIMERA_CCP1_DIS_OUT_ADV_FORCE_LOW \
+                                             DL_TIMER_CCP1_DIS_OUT_ADV_FORCE_LOW
+
+/**
+  * @brief Redirects to common @ref DL_TIMER_CCP1_DIS_OUT_ADV_SET_BY_OCTL
+  */
+#define DL_TIMERA_CCP1_DIS_OUT_ADV_SET_BY_OCTL \
+                                           DL_TIMER_CCP1_DIS_OUT_ADV_SET_BY_OCTL
+/** @}*/
+
+/** @addtogroup DL_TIMERA_CCP2_DIS_OUT_ADV
+ *  @{
+ */
+/**
+  * @brief Redirects to common @ref DL_TIMER_CCP2_DIS_OUT_ADV_FORCE_LOW
+  */
+#define DL_TIMERA_CCP2_DIS_OUT_ADV_FORCE_LOW \
+                                             DL_TIMER_CCP2_DIS_OUT_ADV_FORCE_LOW
+
+/**
+  * @brief Redirects to common @ref DL_TIMER_CCP2_DIS_OUT_ADV_SET_BY_OCTL
+  */
+#define DL_TIMERA_CCP2_DIS_OUT_ADV_SET_BY_OCTL \
+                                           DL_TIMER_CCP2_DIS_OUT_ADV_SET_BY_OCTL
+/** @}*/
+
+/** @addtogroup DL_TIMERA_CCP3_DIS_OUT_ADV
+ *  @{
+ */
+
+/**
+  * @brief Redirects to common @ref DL_TIMER_CCP3_DIS_OUT_ADV_FORCE_LOW
+  */
+#define DL_TIMERA_CCP3_DIS_OUT_ADV_FORCE_LOW \
+                                             DL_TIMER_CCP3_DIS_OUT_ADV_FORCE_LOW
+
+/**
+  * @brief Redirects to common @ref DL_TIMER_CCP3_DIS_OUT_ADV_SET_BY_OCTL
+  */
+#define DL_TIMERA_CCP3_DIS_OUT_ADV_SET_BY_OCTL \
+                                           DL_TIMER_CCP3_DIS_OUT_ADV_SET_BY_OCTL
+/** @}*/
+
+/** @addtogroup DL_TIMERA_IIDX
+ *  @{
+ */
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_ZERO
+ */
+#define DL_TIMERA_IIDX_ZERO                                   DL_TIMER_IIDX_ZERO
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_LOAD
+ */
+#define DL_TIMERA_IIDX_LOAD                                   DL_TIMER_IIDX_LOAD
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_CC0_DN
+ */
+#define DL_TIMERA_IIDX_CC0_DN                               DL_TIMER_IIDX_CC0_DN
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_CC1_DN
+ */
+#define DL_TIMERA_IIDX_CC1_DN                               DL_TIMER_IIDX_CC1_DN
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_CC2_DN
+ */
+#define DL_TIMERA_IIDX_CC2_DN                               DL_TIMER_IIDX_CC2_DN
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_CC3_DN
+ */
+#define DL_TIMERA_IIDX_CC3_DN                               DL_TIMER_IIDX_CC3_DN
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_CC0_UP
+ */
+#define DL_TIMERA_IIDX_CC0_UP                               DL_TIMER_IIDX_CC0_UP
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_CC1_UP
+ */
+#define DL_TIMERA_IIDX_CC1_UP                               DL_TIMER_IIDX_CC1_UP
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_CC2_UP
+ */
+#define DL_TIMERA_IIDX_CC2_UP                               DL_TIMER_IIDX_CC2_UP
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_CC3_UP
+ */
+#define DL_TIMERA_IIDX_CC3_UP                               DL_TIMER_IIDX_CC3_UP
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_CC4_DN
+ */
+#define DL_TIMERA_IIDX_CC4_DN                               DL_TIMER_IIDX_CC4_DN
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_CC5_DN
+ */
+#define DL_TIMERA_IIDX_CC5_DN                               DL_TIMER_IIDX_CC5_DN
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_CC4_UP
+ */
+#define DL_TIMERA_IIDX_CC4_UP                               DL_TIMER_IIDX_CC4_UP
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_CC5_UP
+ */
+#define DL_TIMERA_IIDX_CC5_UP                               DL_TIMER_IIDX_CC5_UP
+
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_FAULT
+ */
+#define DL_TIMERA_IIDX_FAULT                                 DL_TIMER_IIDX_FAULT
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_OVERFLOW
+ */
+#define DL_TIMERA_IIDX_OVERFLOW                           DL_TIMER_IIDX_OVERFLOW
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_REPEAT_COUNT
+ */
+#define DL_TIMERA_IIDX_REPEAT_COUNT                   DL_TIMER_IIDX_REPEAT_COUNT
+
+/** @}*/
+
+/** @addtogroup DL_TIMERA_FAULT_SOURCE
+ *  @{
+ */
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_COMP0_DISABLE
+ */
+#define DL_TIMERA_FAULT_SOURCE_COMP0_DISABLE \
+                                             DL_TIMER_FAULT_SOURCE_COMP0_DISABLE
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_COMP0_SENSE_LOW
+ */
+#define DL_TIMERA_FAULT_SOURCE_COMP0_SENSE_LOW \
+                                           DL_TIMER_FAULT_SOURCE_COMP0_SENSE_LOW
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_COMP0_SENSE_HIGH
+ */
+#define DL_TIMERA_FAULT_SOURCE_COMP0_SENSE_HIGH \
+                                          DL_TIMER_FAULT_SOURCE_COMP0_SENSE_HIGH
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_COMP1_DISABLE
+*/
+#define DL_TIMERA_FAULT_SOURCE_COMP1_DISABLE \
+                                             DL_TIMER_FAULT_SOURCE_COMP1_DISABLE
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_COMP1_SENSE_LOW
+ */
+#define DL_TIMERA_FAULT_SOURCE_COMP1_SENSE_LOW \
+                                           DL_TIMER_FAULT_SOURCE_COMP1_SENSE_LOW
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_COMP1_SENSE_HIGH
+ */
+#define DL_TIMERA_FAULT_SOURCE_COMP1_SENSE_HIGH \
+                                          DL_TIMER_FAULT_SOURCE_COMP1_SENSE_HIGH
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_COMP2_DISABLE
+ */
+#define DL_TIMERA_FAULT_SOURCE_COMP2_DISABLE \
+                                             DL_TIMER_FAULT_SOURCE_COMP2_DISABLE
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_COMP2_SENSE_LOW
+ */
+#define DL_TIMERA_FAULT_SOURCE_COMP2_SENSE_LOW \
+                                           DL_TIMER_FAULT_SOURCE_COMP2_SENSE_LOW
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_COMP2_SENSE_HIGH
+ */
+#define DL_TIMERA_FAULT_SOURCE_COMP2_SENSE_HIGH \
+                                          DL_TIMER_FAULT_SOURCE_COMP2_SENSE_HIGH
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_EXTERNAL_0_DISABLE
+ */
+#define DL_TIMERA_FAULT_SOURCE_EXTERNAL_0_DISABLE \
+                                        DL_TIMER_FAULT_SOURCE_EXTERNAL_0_DISABLE
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_EXTERNAL_0_SENSE_LOW
+ */
+#define DL_TIMERA_FAULT_SOURCE_EXTERNAL_0_SENSE_LOW \
+                                      DL_TIMER_FAULT_SOURCE_EXTERNAL_0_SENSE_LOW
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_EXTERNAL_0_SENSE_HIGH
+ */
+#define DL_TIMERA_FAULT_SOURCE_EXTERNAL_0_SENSE_HIGH \
+                                     DL_TIMER_FAULT_SOURCE_EXTERNAL_0_SENSE_HIGH
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_EXTERNAL_1_DISABLE
+ */
+#define DL_TIMERA_FAULT_SOURCE_EXTERNAL_1_DISABLE \
+                                        DL_TIMER_FAULT_SOURCE_EXTERNAL_1_DISABLE
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_EXTERNAL_1_SENSE_LOW
+ */
+#define DL_TIMERA_FAULT_SOURCE_EXTERNAL_1_SENSE_LOW \
+                                      DL_TIMER_FAULT_SOURCE_EXTERNAL_1_SENSE_LOW
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_EXTERNAL_1_SENSE_HIGH
+ */
+#define DL_TIMERA_FAULT_SOURCE_EXTERNAL_1_SENSE_HIGH \
+                                     DL_TIMER_FAULT_SOURCE_EXTERNAL_1_SENSE_HIGH
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_EXTERNAL_2_DISABLE
+ */
+#define DL_TIMERA_FAULT_SOURCE_EXTERNAL_2_DISABLE \
+                                        DL_TIMER_FAULT_SOURCE_EXTERNAL_2_DISABLE
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_EXTERNAL_2_SENSE_LOW
+ */
+#define DL_TIMERA_FAULT_SOURCE_EXTERNAL_2_SENSE_LOW \
+                                      DL_TIMER_FAULT_SOURCE_EXTERNAL_2_SENSE_LOW
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_SOURCE_EXTERNAL_2_SENSE_HIGH
+ */
+#define DL_TIMERA_FAULT_SOURCE_EXTERNAL_2_SENSE_HIGH \
+                                     DL_TIMER_FAULT_SOURCE_EXTERNAL_2_SENSE_HIGH
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_FAULT_ENTRY_CCP
+ *  @{
+ */
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_ENTRY_CCP_DISABLED
+ */
+#define DL_TIMERA_FAULT_ENTRY_CCP_DISABLED     DL_TIMER_FAULT_ENTRY_CCP_DISABLED
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_ENTRY_CCP_HIGH
+ */
+#define DL_TIMERA_FAULT_ENTRY_CCP_HIGH             DL_TIMER_FAULT_ENTRY_CCP_HIGH
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_ENTRY_CCP_LOW
+ */
+#define DL_TIMERA_FAULT_ENTRY_CCP_LOW               DL_TIMER_FAULT_ENTRY_CCP_LOW
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_ENTRY_CCP_TOGGLE
+ */
+#define DL_TIMERA_FAULT_ENTRY_CCP_TOGGLE         DL_TIMER_FAULT_ENTRY_CCP_TOGGLE
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_ENTRY_CCP_HIGHZ
+ */
+#define DL_TIMERA_FAULT_ENTRY_CCP_HIGHZ           DL_TIMER_FAULT_ENTRY_CCP_HIGHZ
+
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_FAULT_EXIT_CCP
+ *  @{
+ */
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_EXIT_CCP_DISABLED
+ */
+#define DL_TIMERA_FAULT_EXIT_CCP_DISABLED       DL_TIMER_FAULT_EXIT_CCP_DISABLED
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_EXIT_CCP_HIGH
+ */
+#define DL_TIMERA_FAULT_EXIT_CCP_HIGH               DL_TIMER_FAULT_EXIT_CCP_HIGH
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_EXIT_CCP_LOW
+ */
+#define DL_TIMERA_FAULT_EXIT_CCP_LOW                 DL_TIMER_FAULT_EXIT_CCP_LOW
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_EXIT_CCP_TOGGLE
+ */
+#define DL_TIMERA_FAULT_EXIT_CCP_TOGGLE           DL_TIMER_FAULT_EXIT_CCP_TOGGLE
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_EXIT_CCP_HIGHZ
+ */
+#define DL_TIMERA_FAULT_EXIT_CCP_HIGHZ             DL_TIMER_FAULT_EXIT_CCP_HIGHZ
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_FAULT_EXIT_CTR
+ *  @{
+ */
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_EXIT_CTR_RESUME
+ */
+#define DL_TIMERA_FAULT_EXIT_CTR_RESUME           DL_TIMER_FAULT_EXIT_CTR_RESUME
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_EXIT_CTR_CVAE_ACTION
+ */
+#define DL_TIMERA_FAULT_EXIT_CTR_CVAE_ACTION DL_TIMER_FAULT_EXIT_CTR_CVAE_ACTION
+
+/** @}*/
+
+/** @addtogroup DL_TIMER_FAULT_ENTRY_CTR
+ *  @{
+ */
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_ENTRY_CTR_CONT_COUNT
+ */
+#define DL_TIMERA_FAULT_ENTRY_CTR_CONT_COUNT DL_TIMER_FAULT_ENTRY_CTR_CONT_COUNT
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_ENTRY_CTR_SUSP_COUNT
+ */
+#define DL_TIMERA_FAULT_ENTRY_CTR_SUSP_COUNT DL_TIMER_FAULT_ENTRY_CTR_SUSP_COUNT
+
+/** @}*/
+
+/** @addtogroup DL_TIMERA_FAULT_CONFIG_TFIM
+ *  @{
+ */
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_CONFIG_TFIM_DISABLED
+ */
+#define DL_TIMERA_FAULT_CONFIG_TFIM_DISABLED \
+                                             DL_TIMER_FAULT_CONFIG_TFIM_DISABLED
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_CONFIG_TFIM_ENABLED
+ */
+#define DL_TIMERA_FAULT_CONFIG_TFIM_ENABLED   DL_TIMER_FAULT_CONFIG_TFIM_ENABLED
+
+/** @}*/
+
+
+/** @addtogroup DL_TIMERA_FAULT_CONFIG_FL
+ *  @{
+ */
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_CONFIG_FL_NO_LATCH
+ */
+#define DL_TIMERA_FAULT_CONFIG_FL_NO_LATCH     DL_TIMER_FAULT_CONFIG_FL_NO_LATCH
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_CONFIG_FL_NO_LATCH
+ */
+#define DL_TIMERA_FAULT_CONFIG_FL_LATCH_SW_CLR \
+                                           DL_TIMER_FAULT_CONFIG_FL_LATCH_SW_CLR
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_CONFIG_FL_LATCH_Z_CLR
+ */
+#define DL_TIMERA_FAULT_CONFIG_FL_LATCH_Z_CLR \
+                                            DL_TIMER_FAULT_CONFIG_FL_LATCH_Z_CLR
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_CONFIG_FL_LATCH_LD_CLR
+ */
+#define DL_TIMERA_FAULT_CONFIG_FL_LATCH_LD_CLR \
+                                           DL_TIMER_FAULT_CONFIG_FL_LATCH_LD_CLR
+
+/** @}*/
+
+
+/** @addtogroup DL_TIMERA_FAULT_CONFIG_FI
+ *  @{
+ */
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_CONFIG_FI_INDEPENDENT
+ */
+#define DL_TIMERA_FAULT_CONFIG_FI_INDEPENDENT \
+                                            DL_TIMER_FAULT_CONFIG_FI_INDEPENDENT
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_CONFIG_FI_DEPENDENT
+ */
+#define DL_TIMERA_FAULT_CONFIG_FI_DEPENDENT   DL_TIMER_FAULT_CONFIG_FI_DEPENDENT
+
+/** @}*/
+
+/** @addtogroup DL_TIMERA_FAULT_CONFIG_FIEN
+ *  @{
+ */
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_CONFIG_FIEN_DISABLED
+ */
+#define DL_TIMERA_FAULT_CONFIG_FIEN_DISABLED DL_TIMER_FAULT_CONFIG_FIEN_DISABLED
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_CONFIG_FIEN_ENABLED
+ */
+#define DL_TIMERA_FAULT_CONFIG_FIEN_ENABLED   DL_TIMER_FAULT_CONFIG_FIEN_ENABLED
+
+/** @}*/
+
+/** @addtogroup DL_TIMERA_FAULT_FILT
+ *  @{
+ */
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_FILTER_BYPASS
+ */
+#define DL_TIMERA_FAULT_FILTER_BYPASS               DL_TIMER_FAULT_FILTER_BYPASS
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_FILTER_FILTERED
+ */
+#define DL_TIMERA_FAULT_FILTER_FILTERED           DL_TIMER_FAULT_FILTER_FILTERED
+
+/** @}*/
+
+/** @addtogroup DL_TIMERA_FAULT_FILTER_CPV
+ *  @{
+ */
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_FILTER_CPV_CONSEC_PER
+ */
+#define DL_TIMERA_FAULT_FILTER_CPV_CONSEC_PER \
+                                            DL_TIMER_FAULT_FILTER_CPV_CONSEC_PER
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_FILTER_CPV_VOTING
+ */
+#define DL_TIMERA_FAULT_FILTER_CPV_VOTING       DL_TIMER_FAULT_FILTER_CPV_VOTING
+
+
+/** @}*/
+
+/** @addtogroup DL_TIMERA_FAULT_FILTER_FP
+ *  @{
+ */
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_FILTER_FP_PER_3
+ */
+#define DL_TIMERA_FAULT_FILTER_FP_PER_3           DL_TIMER_FAULT_FILTER_FP_PER_3
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_FILTER_FP_PER_5
+ */
+#define DL_TIMERA_FAULT_FILTER_FP_PER_5           DL_TIMER_FAULT_FILTER_FP_PER_5
+
+/*!
+ * @brief Redirects to common @ref DL_TIMER_FAULT_FILTER_FP_PER_8
+ */
+#define DL_TIMERA_FAULT_FILTER_FP_PER_8           DL_TIMER_FAULT_FILTER_FP_PER_8
+
+/** @}*/
+
+/** @addtogroup DL_TIMERA_PUBLISHER_INDEX
+ *  @{
+ */
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_PUBLISHER_INDEX_0
+ */
+#define DL_TIMERA_PUBLISHER_INDEX_0                   DL_TIMER_PUBLISHER_INDEX_0
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_PUBLISHER_INDEX_1
+ */
+#define DL_TIMERA_PUBLISHER_INDEX_1                   DL_TIMER_PUBLISHER_INDEX_1
+
+/** @}*/
+
+/** @addtogroup DL_TIMERA_SUBSCRIBER_INDEX
+ *  @{
+ */
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_SUBSCRIBER_INDEX_0
+ */
+#define DL_TIMERA_SUBSCRIBER_INDEX_0                 DL_TIMER_SUBSCRIBER_INDEX_0
+/**
+ * @brief Redirects to common @ref DL_TIMER_SUBSCRIBER_INDEX_1
+ */
+#define DL_TIMERA_SUBSCRIBER_INDEX_1                 DL_TIMER_SUBSCRIBER_INDEX_1
+
+/** @}*/
+
+/** @addtogroup DL_TIMERA_EVENT_ROUTE
+ *  @{
+ */
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_EVENT_ROUTE_1
+ */
+#define DL_TIMERA_EVENT_ROUTE_1                           DL_TIMER_EVENT_ROUTE_1
+/**
+ * @brief Redirects to common @ref DL_TIMER_EVENT_ROUTE_2
+ */
+#define DL_TIMERA_EVENT_ROUTE_2                           DL_TIMER_EVENT_ROUTE_2
+
+/** @}*/
+
+/**
+ * @brief Redirects to common @ref DL_Timer_ClockConfig
+ *
+ */
+typedef DL_Timer_ClockConfig                              DL_TimerA_ClockConfig;
+
+/**
+ * @brief Redirects to common @ref DL_Timer_TimerConfig
+ *
+ */
+typedef DL_Timer_TimerConfig                              DL_TimerA_TimerConfig;
+
+/**
+ * @brief Redirects to common @ref DL_Timer_CaptureConfig
+ *
+ */
+typedef DL_Timer_CaptureConfig                         DL_TimerA_CaptureConfig;
+
+/**
+ * @brief Redirects to common @ref DL_Timer_CaptureTriggerConfig
+ *
+ */
+typedef DL_Timer_CaptureTriggerConfig            DL_TimerA_CaptureTriggerConfig;
+
+/**
+ * @brief Redirects to common @ref DL_Timer_CaptureCombinedConfig
+ *
+ */
+typedef DL_Timer_CaptureCombinedConfig          DL_TimerA_CaptureCombinedConfig;
+
+/**
+ * @brief Redirects to common @ref DL_Timer_CompareConfig
+ *
+ */
+typedef DL_Timer_CompareConfig                          DL_TimerA_CompareConfig;
+
+/**
+ * @brief Redirects to common @ref DL_Timer_CompareTriggerConfig
+ *
+ */
+typedef DL_Timer_CompareTriggerConfig            DL_TimerA_CompareTriggerConfig;
+/**
+ * @brief Redirects to common @ref DL_Timer_enablePower
+ */
+#define DL_TimerA_enablePower                               DL_Timer_enablePower
+
+/**
+ * @brief Redirects to common @ref DL_Timer_disablePower
+ */
+#define DL_TimerA_disablePower                             DL_Timer_disablePower
+
+/**
+ * @brief Redirects to common @ref DL_Timer_isPowerEnabled
+ */
+#define DL_TimerA_isPowerEnabled                         DL_Timer_isPowerEnabled
+
+/**
+ * @brief Redirects to common @ref DL_Timer_reset
+ */
+#define DL_TimerA_reset                                           DL_Timer_reset
+
+/**
+ * @brief Redirects to common @ref DL_Timer_isReset
+ */
+#define DL_TimerA_isReset                                       DL_Timer_isReset
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCCPDirection
+ */
+#define DL_TimerA_setCCPDirection                       DL_Timer_setCCPDirection
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCCPDirection
+ */
+#define DL_TimerA_getCCPDirection                       DL_Timer_getCCPDirection
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCCPOutputDisabled
+ */
+#define DL_TimerA_setCCPOutputDisabled             DL_Timer_setCCPOutputDisabled
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCCPOutputDisabledAdv
+ */
+#define DL_TimerA_setCCPOutputDisabledAdv       DL_Timer_setCCPOutputDisabledAdv
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setClockConfig
+ */
+#define DL_TimerA_setClockConfig                         DL_Timer_setClockConfig
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getClockConfig
+ */
+#define DL_TimerA_getClockConfig                         DL_Timer_getClockConfig
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getClockConfig
+ */
+#define DL_TimerA_enableClock                               DL_Timer_enableClock
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getClockConfig
+ */
+#define DL_TimerA_disableClock                             DL_Timer_disableClock
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_isClockEnabled
+ */
+#define DL_TimerA_isClockEnabled                         DL_Timer_isClockEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_configCrossTrigger
+ */
+#define DL_TimerA_configCrossTrigger                 DL_Timer_configCrossTrigger
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_configCrossTriggerSrc
+ */
+#define DL_TimerA_configCrossTriggerSrc           DL_Timer_configCrossTriggerSrc
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_configCrossTriggerInputCond
+ */
+#define DL_TimerA_configCrossTriggerInputCond \
+                                            DL_Timer_configCrossTriggerInputCond
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_configCrossTriggerEnable
+ */
+#define DL_TimerA_configCrossTriggerEnable     DL_Timer_configCrossTriggerEnable
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCrossTriggerConfig
+ */
+#define DL_TimerA_getCrossTriggerConfig           DL_Timer_getCrossTriggerConfig
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCrossTriggerSrc
+ */
+#define DL_TimerA_getCrossTriggerSrc                 DL_Timer_getCrossTriggerSrc
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCrossTriggerInputCond
+ */
+#define DL_TimerA_getCrossTriggerInputCond     DL_Timer_getCrossTriggerInputCond
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCrossTriggerEnable
+ */
+#define DL_TimerA_getCrossTriggerEnable           DL_Timer_getCrossTriggerEnable
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableShadowFeatures
+ */
+#define DL_TimerA_enableShadowFeatures             DL_Timer_enableShadowFeatures
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disableShadowFeatures
+ */
+#define DL_TimerA_disableShadowFeatures           DL_Timer_disableShadowFeatures
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_generateCrossTrigger
+ */
+#define DL_TimerA_generateCrossTrigger             DL_Timer_generateCrossTrigger
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setLoadValue
+ */
+#define DL_TimerA_setLoadValue                             DL_Timer_setLoadValue
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getLoadValue
+ */
+#define DL_TimerA_getLoadValue                             DL_Timer_getLoadValue
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getTimerCount
+ */
+#define DL_TimerA_getTimerCount                           DL_Timer_getTimerCount
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setTimerCount
+ */
+#define DL_TimerA_setTimerCount                           DL_Timer_setTimerCount
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableLZEventSuppression
+ */
+#define DL_TimerA_enableLZEventSuppression                     DL_Timer_enableLZEventSuppression
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disableLZEventSuppression
+ */
+#define DL_TimerA_disableLZEventSuppression                   DL_Timer_disableLZEventSuppression
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_isLZEventSuppressionEnabled
+ */
+#define DL_TimerA_isLZEventSuppressionEnabled               DL_Timer_isLZEventSuppressionEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setDebugReleaseBehavior
+ */
+#define DL_TimerA_setDebugReleaseBehavior       DL_Timer_setDebugReleaseBehavior
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getDebugReleaseBehavior
+ */
+#define DL_TimerA_getDebugReleaseBehavior       DL_Timer_getDebugReleaseBehavior
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCounterControl
+ */
+#define DL_TimerA_setCounterControl                   DL_Timer_setCounterControl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCounterZeroControl
+ */
+#define DL_TimerA_getCounterZeroControl           DL_Timer_getCounterZeroControl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCounterAdvanceControl
+ */
+#define DL_TimerA_getCounterAdvanceControl     DL_Timer_getCounterAdvanceControl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCounterLoadControl
+ */
+#define DL_TimerA_getCounterLoadControl           DL_Timer_getCounterLoadControl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCounterMode
+ */
+#define DL_TimerA_setCounterMode                         DL_Timer_setCounterMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCounterMode
+ */
+#define DL_TimerA_getCounterMode                         DL_Timer_getCounterMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCounterValueAfterEnable
+ */
+#define DL_TimerA_setCounterValueAfterEnable DL_Timer_setCounterValueAfterEnable
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCounterValueAfterEnable
+ */
+#define DL_TimerA_getCounterValueAfterEnable DL_Timer_getCounterValueAfterEnable
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCounterRepeatMode
+ */
+#define DL_TimerA_setCounterRepeatMode             DL_Timer_setCounterRepeatMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCounterRepeatMode
+ */
+#define DL_TimerA_getCounterRepeatMode             DL_Timer_getCounterRepeatMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_initTimerMode
+ */
+#define DL_TimerA_initTimerMode                           DL_Timer_initTimerMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_initCaptureMode
+ */
+#define DL_TimerA_initCaptureMode                       DL_Timer_initCaptureMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_initCaptureTriggerMode
+ */
+#define DL_TimerA_initCaptureTriggerMode         DL_Timer_initCaptureTriggerMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_initCaptureCombinedMode
+ */
+#define DL_TimerA_initCaptureCombinedMode       DL_Timer_initCaptureCombinedMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_initCompareMode
+ */
+#define DL_TimerA_initCompareMode                       DL_Timer_initCompareMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_initCompareTriggerMode
+ */
+#define DL_TimerA_initCompareTriggerMode         DL_Timer_initCompareTriggerMode
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_resetCounterMode
+ */
+#define DL_TimerA_resetCounterMode                     DL_Timer_resetCounterMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptureCompareValue
+ */
+#define DL_TimerA_setCaptureCompareValue         DL_Timer_setCaptureCompareValue
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptureCompareValue
+ */
+#define DL_TimerA_getCaptureCompareValue         DL_Timer_getCaptureCompareValue
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptureCompareCtl
+ */
+#define DL_TimerA_setCaptureCompareCtl             DL_Timer_setCaptureCompareCtl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptureCompareCtl
+ */
+#define DL_TimerA_getCaptureCompareCtl             DL_Timer_getCaptureCompareCtl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setSecondCompSrcDn
+ */
+#define DL_TimerA_setSecondCompSrcDn                 DL_Timer_setSecondCompSrcDn
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getSecondCompSrcDn
+ */
+#define DL_TimerA_getSecondCompSrcDn                 DL_Timer_GetSecondCompSrcDn
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setSecondCompSrcUp
+ */
+#define DL_TimerA_setSecondCompSrcUp                 DL_Timer_setSecondCompSrcUp
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getSecondCompSrcUp
+ */
+#define DL_TimerA_getSecondCompSrcUp                 DL_Timer_GetSecondCompSrcUp
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptCompUpdateMethod
+ */
+#define DL_TimerA_setCaptCompUpdateMethod          DL_Timer_setCaptCompUpdateMethod
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptCompUpdateMethod
+ */
+#define DL_TimerA_getCaptCompUpdateMethod          DL_Timer_getCaptCompUpdateMethod
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableSuppressionOfCompEvent
+ */
+#define DL_TimerA_enableSuppressionOfCompEvent                 DL_Timer_enableSuppressionOfCompEvent
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disableSuppressionOfCompEvent
+ */
+#define DL_Timer_disableSuppressionOfCompEvent                DL_Timer_disableSuppressionOfCompEvent
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptureCompareOutCtl
+ */
+#define DL_TimerA_setCaptureCompareOutCtl       DL_Timer_setCaptureCompareOutCtl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptureCompareOutCtl
+ */
+#define DL_TimerA_getCaptureCompareOutCtl       DL_Timer_getCaptureCompareOutCtl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptureCompareAction
+ */
+#define DL_TimerA_setCaptureCompareAction       DL_Timer_setCaptureCompareAction
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptureCompareAction
+ */
+#define DL_TimerA_getCaptureCompareAction       DL_Timer_getCaptureCompareAction
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setSecondCompActionDn
+ */
+#define DL_TimerA_setSecondCompActionDn           DL_Timer_setSecondCompActionDn
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getSecondCompActionDn
+ */
+#define DL_TimerA_getSecondCompActionDn           DL_Timer_getSecondCompActionDn
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setSecondCompActionUp
+ */
+#define DL_TimerA_setSecondCompActionUp           DL_Timer_setSecondCompActionUp
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getSecondCompActionUp
+ */
+#define DL_TimerA_getSecondCompActionUp           DL_Timer_getSecondCompActionUp
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptureCompareInput
+ */
+#define DL_TimerA_setCaptureCompareInput \
+                                           DL_Timer_setCaptureCompareInput
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptureCompareInput
+ */
+#define DL_TimerA_getCaptureCompareInput \
+                                           DL_Timer_getCaptureCompareInput
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptureCompareInputFilter
+ */
+#define DL_TimerA_setCaptureCompareInputFilter \
+                                           DL_Timer_setCaptureCompareInputFilter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptureCompareInputFilter
+ */
+#define DL_TimerA_getCaptureCompareInputFilter \
+                                           DL_Timer_getCaptureCompareInputFilter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableCaptureCompareInputFilter
+ */
+#define DL_TimerA_enableCaptureCompareInputFilter \
+                                        DL_Timer_enableCaptureCompareInputFilter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disableCaptureCompareInputFilter
+ */
+#define DL_TimerA_disableCaptureCompareInputFilter \
+                                       DL_Timer_disableCaptureCompareInputFilter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_isCaptureCompareInputFilterEnabled
+ */
+#define DL_TimerA_isCaptureCompareInputFilterEnabled \
+                                     DL_Timer_isCaptureCompareInputFilterEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setExternalTriggerEvent
+ */
+#define DL_TimerA_setExternalTriggerEvent       DL_Timer_setExternalTriggerEvent
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getExternalTriggerEvent
+ */
+#define DL_TimerA_getExternalTriggerEvent       DL_Timer_getExternalTriggerEvent
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableExternalTrigger
+ */
+#define DL_TimerA_enableExternalTrigger           DL_Timer_enableExternalTrigger
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disableExternalTrigger
+ */
+#define DL_TimerA_disableExternalTrigger         DL_Timer_disableExternalTrigger
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_isExternalTriggerEnabled
+ */
+#define DL_TimerA_isExternalTriggerEnabled     DL_Timer_isExternalTriggerEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_startCounter
+ */
+#define DL_TimerA_startCounter                             DL_Timer_startCounter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_stopCounter
+ */
+#define DL_TimerA_stopCounter                               DL_Timer_stopCounter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_isRunning
+ */
+#define DL_TimerA_isRunning                                   DL_Timer_isRunning
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableInterrupt
+ */
+#define DL_TimerA_enableInterrupt                       DL_Timer_enableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disableInterrupt
+ */
+#define DL_TimerA_disableInterrupt                     DL_Timer_disableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getEnabledInterrupts
+ */
+#define DL_TimerA_getEnabledInterrupts             DL_Timer_getEnabledInterrupts
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getEnabledInterruptStatus
+ */
+#define DL_TimerA_getEnabledInterruptStatus   DL_Timer_getEnabledInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getRawInterruptStatus
+ */
+#define DL_TimerA_getRawInterruptStatus           DL_Timer_getRawInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getPendingInterrupt
+ */
+#define DL_TimerA_getPendingInterrupt               DL_Timer_getPendingInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_clearInterruptStatus
+ */
+#define DL_TimerA_clearInterruptStatus             DL_Timer_clearInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setDeadBand
+ */
+#define DL_TimerA_setDeadBand                               DL_Timer_setDeadBand
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getDeadBandFallDelay
+ */
+#define DL_TimerA_getDeadBandFallDelay             DL_Timer_getDeadBandFallDelay
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getDeadBandRiseDelay
+ */
+#define DL_TimerA_getDeadBandRiseDelay             DL_Timer_getDeadBandRiseDelay
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setRepeatCounter
+ */
+#define DL_TimerA_setRepeatCounter                     DL_Timer_setRepeatCounter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getRepeatCounter
+ */
+#define DL_TimerA_getRepeatCounter                     DL_Timer_getRepeatCounter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enablePhaseLoad
+ */
+#define DL_TimerA_enablePhaseLoad                       DL_Timer_enablePhaseLoad
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disablePhaseLoad
+ */
+#define DL_TimerA_disablePhaseLoad                     DL_Timer_disablePhaseLoad
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_isPhaseLoadEnabled
+ */
+#define DL_TimerA_isPhaseLoadEnabled                 DL_Timer_isPhaseLoadEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setPhaseLoadValue
+ */
+#define DL_TimerA_setPhaseLoadValue                   DL_Timer_setPhaseLoadValue
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getPhaseLoadValue
+ */
+#define DL_TimerA_getPhaseLoadValue                   DL_Timer_getPhaseLoadValue
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setPublisherChanID
+ */
+#define DL_TimerA_setPublisherChanID                 DL_Timer_setPublisherChanID
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getPublisherChanID
+ */
+#define DL_TimerA_getPublisherChanID                 DL_Timer_getPublisherChanID
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setSubscriberChanID
+ */
+#define DL_TimerA_setSubscriberChanID               DL_Timer_setSubscriberChanID
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getSubscriberChanID
+ */
+#define DL_TimerA_getSubscriberChanID               DL_Timer_getSubscriberChanID
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableEvent
+ */
+#define DL_TimerA_enableEvent                               DL_Timer_enableEvent
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disableEvent
+ */
+#define DL_TimerA_disableEvent                             DL_Timer_disableEvent
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getEnabledEvents
+ */
+#define DL_TimerA_getEnabledEvents                     DL_Timer_getEnabledEvents
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getEnabledEventStatus
+ */
+#define DL_TimerA_getEnabledEventStatus           DL_Timer_getEnabledEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getRawEventsStatus
+ */
+#define DL_TimerA_getRawEventsStatus                 DL_Timer_getRawEventsStatus
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_clearInterruptStatus
+ */
+#define DL_TimerA_clearInterruptStatus             DL_Timer_clearInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setFaultConfig
+ */
+#define DL_TimerA_setFaultConfig                         DL_Timer_setFaultConfig
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getFaultConfig
+ */
+#define DL_TimerA_getFaultConfig                         DL_Timer_getFaultConfig
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableFaultInput
+ */
+#define DL_TimerA_enableFaultInput                     DL_Timer_enableFaultInput
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disableFaultInput
+ */
+#define DL_TimerA_disableFaultInput                   DL_Timer_disableFaultInput
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_isFaultInputEnabled
+ */
+#define DL_TimerA_isFaultInputEnabled               DL_Timer_isFaultInputEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableClockFaultDetection
+ */
+#define DL_TimerA_enableClockFaultDetection   DL_Timer_enableClockFaultDetection
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disableClockFaultDetection
+ */
+#define DL_TimerA_disableClockFaultDetection \
+                                             DL_Timer_disableClockFaultDetection
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_isClockFaultDetectionEnabled
+ */
+#define DL_TimerA_isClockFaultDetectionEnabled \
+                                           DL_Timer_isClockFaultDetectionEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setFaultSourceConfig
+ */
+#define DL_TimerA_setFaultSourceConfig             DL_Timer_setFaultSourceConfig
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getFaultSourceConfig
+ */
+#define DL_TimerA_getFaultSourceConfig             DL_Timer_getFaultSourceConfig
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setFaultInputFilterConfig
+ */
+#define DL_TimerA_setFaultInputFilterConfig   DL_Timer_setFaultInputFilterConfig
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getFaultInputFilterConfig
+ */
+#define DL_TimerA_getFaultInputFilterConfig   DL_Timer_getFaultInputFilterConfig
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_configFaultOutputAction
+ */
+#define DL_TimerA_configFaultOutputAction       DL_Timer_configFaultOutputAction
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_configFaultCounter
+ */
+#define DL_TimerA_configFaultCounter                 DL_Timer_configFaultCounter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCoreHaltBehavior
+ */
+#define DL_TimerA_setCoreHaltBehavior               DL_Timer_setCoreHaltBehavior
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCoreHaltBehavior
+ */
+#define DL_TimerA_getHaltBehavior                   DL_Timer_getCoreHaltBehavior
+
+/* clang-format on */
+
+/**
+ * @brief Configure timer in Pulse Width Modulation (PWM) Mode
+ *  Initializes all the common configurable options for the TIMA peripheral when
+ *  used in PWM mode. Any other custom configuration can be done after calling
+ *  this API.
+ *
+ * @param gptimer              Pointer to the register overlay for the
+ *                             peripheral
+ * @param config               Pointer to the mode configuration struct
+ *                             @ref DL_TimerA_PWMConfig.
+ */
+void DL_TimerA_initPWMMode(GPTIMER_Regs *gptimer, DL_TimerA_PWMConfig *config);
+
+/**
+ *  @brief      Saves TimerA configuration before entering STOP or STANDBY mode.
+ *              Only necessary for PG 1.0 silicon. Timer must be in IDLE state
+ *              before calling this API. Timer can be put IDLE state by calling
+ *              @ref DL_TimerA_stopCounter.
+ *
+ *  @param[in]  gptimer  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr      Configuration backup setup structure. See
+ *                       @ref DL_TimerA_backupConfig.
+ *
+ *  @retval     FALSE if a configuration already exists in ptr (will not be
+ *              overwritten). TRUE if a configuration was successfully saved
+ *
+ */
+bool DL_TimerA_saveConfiguration(
+    GPTIMER_Regs *gptimer, DL_TimerA_backupConfig *ptr);
+
+/**
+ *  @brief      Restore TimerA configuration after leaving a STOP or STANDBY
+ *              mode. Only necessary for PG 1.0 silicon.
+ *
+ *  @param[in]  gptimer  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr      Configuration backup setup structure. See
+ *                       @ref DL_TimerA_backupConfig.
+ *  @param[in]  restoreCounter If true timer counter value is also
+ *                             restored (e.g. resume counts of edge counts).
+ *                             If false timer counter is not restored.
+ *
+ *  @retval     FALSE if a configuration does not exist in ptr (will not be
+ *              loaded). TRUE if a configuration successfully loaded
+ *
+ */
+bool DL_TimerA_restoreConfiguration(
+    GPTIMER_Regs *gptimer, DL_TimerA_backupConfig *ptr, bool restoreCounter);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_TIMER_A__ */
+
+#endif /* ti_dl_dl_timera__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_timerg.h
+++ b/mspm0/source/ti/driverlib/dl_timerg.h
@@ -1,0 +1,973 @@
+/*
+* Copyright (c) 2020, Texas Instruments Incorporated
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* *  Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+* *  Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* *  Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+* CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+* PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+* OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+* OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/*!****************************************************************************
+*  @file       dl_timerg.h
+*  @brief      General Purpose Timer G (TIMG) Driver Library
+*  @defgroup   TIMG General Purpose Timer G (TIMG)
+*
+*  @anchor ti_dl_dl_timerg__Overview
+*  # Overview
+*
+*   The TimerG Driver Library allows you to configure the General Purpose Timer
+*   (TIMG) module in output compare, input capture, PWM output, one-shot and
+*   periodic modes. For detailed TIMG features please refer to the Device
+*   Technical Reference Manual (TRM)
+*
+*  <hr>
+******************************************************************************
+*/
+/** @addtogroup TIMG
+ * @{
+ */
+#ifndef ti_dl_dl_timerg__include
+#define ti_dl_dl_timerg__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/driverlib/dl_timer.h>
+
+#ifdef __MSPM0_HAS_TIMER_G__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/**
+ * @brief Redirects to common @ref DL_Timer_backupConfig
+ *
+ */
+typedef DL_Timer_backupConfig                           DL_TimerG_backupConfig;
+
+
+/**
+ * @brief Redirects to common @ref DL_Timer_ClockConfig
+ *
+ */
+typedef DL_Timer_ClockConfig                             DL_TimerG_ClockConfig;
+
+/**
+ * @brief Redirects to common @ref DL_Timer_TimerConfig
+ *
+ */
+typedef DL_Timer_TimerConfig                             DL_TimerG_TimerConfig;
+
+/**
+ * @brief Redirects to common @ref DL_Timer_CaptureConfig
+ *
+ */
+typedef DL_Timer_CaptureConfig                         DL_TimerG_CaptureConfig;
+
+/**
+ * @brief Redirects to common @ref DL_Timer_CaptureTriggerConfig
+ *
+ */
+typedef DL_Timer_CaptureTriggerConfig            DL_TimerG_CaptureTriggerConfig;
+
+/**
+ * @brief Redirects to common @ref DL_Timer_CaptureCombinedConfig
+ *
+ */
+typedef DL_Timer_CaptureCombinedConfig          DL_TimerG_CaptureCombinedConfig;
+
+/**
+ * @brief Redirects to common @ref DL_Timer_CompareConfig
+ *
+ */
+typedef DL_Timer_CompareConfig                          DL_TimerG_CompareConfig;
+
+/**
+ * @brief Redirects to common @ref DL_Timer_CompareTriggerConfig
+ *
+ */
+typedef DL_Timer_CompareTriggerConfig            DL_TimerG_CompareTriggerConfig;
+
+/**
+ * @brief Redirects to common @ref DL_Timer_PWMConfig
+ *
+ */
+typedef DL_Timer_PWMConfig                                  DL_TimerG_PWMConfig;
+
+/** @addtogroup DL_TIMERG_CAPTURE_COMPARE_INDEX
+ *  @{
+ */
+/**
+ * @brief  Index associated to Capture Compare 0
+ */
+#define DL_TIMERG_CAPTURE_COMPARE_0_INDEX       DL_TIMER_CC_0_INDEX
+
+/**
+ * @brief  Index associated to Capture Compare 1
+ */
+#define DL_TIMERG_CAPTURE_COMPARE_1_INDEX       DL_TIMER_CC_1_INDEX
+
+/** @}*/
+
+/** @addtogroup DL_TIMERG_INTERRUPT
+ *  @{
+ */
+/*!
+ * @brief Redirects to common @ref DL_TIMER_INTERRUPT_ZERO_EVENT
+ */
+#define DL_TIMERG_INTERRUPT_ZERO_EVENT           (DL_TIMER_INTERRUPT_ZERO_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_LOAD_EVENT
+*/
+#define DL_TIMERG_INTERRUPT_LOAD_EVENT           (DL_TIMER_INTERRUPT_LOAD_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC0_DN_EVENT
+*/
+#define DL_TIMERG_INTERRUPT_CC0_DN_EVENT       (DL_TIMER_INTERRUPT_CC0_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC1_DN_EVENT
+*/
+#define DL_TIMERG_INTERRUPT_CC1_DN_EVENT       (DL_TIMER_INTERRUPT_CC1_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC0_UP_EVENT
+*/
+#define DL_TIMERG_INTERRUPT_CC0_UP_EVENT       (DL_TIMER_INTERRUPT_CC0_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC1_UP_EVENT
+*/
+#define DL_TIMERG_INTERRUPT_CC1_UP_EVENT       (DL_TIMER_INTERRUPT_CC1_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC2_DN_EVENT
+* @note <b> This interrupt is only available on some TimerG variants with
+*       4 external CCP Channels. Please refer to "TIMx
+*       Configurations" table in the device specific datasheet.</b>
+*/
+#define DL_TIMERG_INTERRUPT_CC2_DN_EVENT       (DL_TIMER_INTERRUPT_CC2_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC3_DN_EVENT
+* @note <b> This interrupt is only available on some TimerG variants with
+*       4 external CCP Channels. Please refer to "TIMx
+*       Configurations" table in the device specific datasheet.</b>
+*/
+#define DL_TIMERG_INTERRUPT_CC3_DN_EVENT       (DL_TIMER_INTERRUPT_CC3_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC2_UP_EVENT
+* @note <b> This interrupt is only available on some TimerG variants with
+*       4 external CCP Channels. Please refer to "TIMx
+*       Configurations" table in the device specific datasheet.</b>
+*/
+#define DL_TIMERG_INTERRUPT_CC2_UP_EVENT       (DL_TIMER_INTERRUPT_CC2_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_CC3_UP_EVENT
+* @note <b> This interrupt is only available on some TimerG variants with
+*       4 external CCP Channels. Please refer to "TIMx
+*       Configurations" table in the device specific datasheet.</b>
+*/
+#define DL_TIMERG_INTERRUPT_CC3_UP_EVENT       (DL_TIMER_INTERRUPT_CC3_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_OVERFLOW_EVENT
+*/
+#define DL_TIMERG_INTERRUPT_OVERFLOW_EVENT   (DL_TIMER_INTERRUPT_OVERFLOW_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_DC_EVENT
+* @note <b> This interrupt is only available on some TimerG variants with
+*       Quadrature Encoding Input (QEI). Please refer to "TIMx
+*       Configurations" table in the device specific datasheet.</b>
+*/
+#define DL_TIMERG_INTERRUPT_DC_EVENT               (DL_TIMER_INTERRUPT_DC_EVENT)
+
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_INTERRUPT_QEIERR_EVENT
+* @note <b> This interrupt is only available on some TimerG variants with
+*       Quadrature Encoding Input (QEI). Please refer to "TIMx
+*       Configurations" table in the device specific datasheet.</b>
+*/
+#define DL_TIMERG_INTERRUPT_QEI_ERR_EVENT      (DL_TIMER_INTERRUPT_QEIERR_EVENT)
+
+
+/** @}*/
+
+/** @addtogroup DL_TIMERG_EVENT
+ *  @{
+ */
+/*!
+ * @brief Redirects to common @ref DL_TIMER_EVENT_ZERO_EVENT
+ */
+#define DL_TIMERG_EVENT_ZERO_EVENT                   (DL_TIMER_EVENT_ZERO_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_LOAD_EVENT
+*/
+#define DL_TIMERG_EVENT_LOAD_EVENT                   (DL_TIMER_EVENT_LOAD_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC0_DN_EVENT
+*/
+#define DL_TIMERG_EVENT_CC0_DN_EVENT               (DL_TIMER_EVENT_CC0_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC1_DN_EVENT
+*/
+#define DL_TIMERG_EVENT_CC1_DN_EVENT               (DL_TIMER_EVENT_CC1_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC0_UP_EVENT
+*/
+#define DL_TIMERG_EVENT_CC0_UP_EVENT               (DL_TIMER_EVENT_CC0_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC1_UP_EVENT
+*/
+#define DL_TIMERG_EVENT_CC1_UP_EVENT               (DL_TIMER_EVENT_CC1_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC2_DN_EVENT
+* @note <b> This event is only available on some TimerG variants with
+*       4 external CCP Channels. Please refer to "TIMx
+*       Configurations" table in the device specific datasheet.</b>
+*/
+#define DL_TIMERG_EVENT_CC2_DN_EVENT               (DL_TIMER_EVENT_CC2_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC3_DN_EVENT
+* @note <b> This event is only available on some TimerG variants with
+*       4 external CCP Channels. Please refer to "TIMx
+*       Configurations" table in the device specific datasheet.</b>
+*/
+#define DL_TIMERG_EVENT_CC3_DN_EVENT               (DL_TIMER_EVENT_CC3_DN_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC2_UP_EVENT
+* @note <b> This event is only available on some TimerG variants with
+*       4 external CCP Channels. Please refer to "TIMx
+*       Configurations" table in the device specific datasheet.</b>
+*/
+#define DL_TIMERG_EVENT_CC2_UP_EVENT               (DL_TIMER_EVENT_CC2_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_CC3_UP_EVENT
+* @note <b> This event is only available on some TimerG variants with
+*       4 external CCP Channels. Please refer to "TIMx
+*       Configurations" table in the device specific datasheet.</b>
+*/
+#define DL_TIMERG_EVENT_CC3_UP_EVENT               (DL_TIMER_EVENT_CC3_UP_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_OVERFLOW_EVENT
+*/
+#define DL_TIMERG_EVENT_OVERFLOW_EVENT           (DL_TIMER_EVENT_OVERFLOW_EVENT)
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_DC_EVENT
+* @note <b> This interrupt is only available on some TimerG variants with
+*       Quadrature Encoding Input (QEI). Please refer to "TIMx
+*       Configurations" table in the device specific datasheet.</b>
+*/
+#define DL_TIMERG_EVENT_DC_EVENT                       (DL_TIMER_EVENT_DC_EVENT)
+
+
+/*!
+* @brief Redirects to common @ref DL_TIMER_EVENT_QEIERR_EVENT
+* @note <b> This interrupt is only available on some TimerG variants with
+*       Quadrature Encoding Input (QEI). Please refer to "TIMx
+*       Configurations" table in the device specific datasheet.</b>
+*/
+#define DL_TIMERG_EVENT_QEIERR_EVENT               (DL_TIMER_EVENT_QEIERR_EVENT)
+
+
+/** @}*/
+
+/** @addtogroup DL_TIMERG_IIDX
+ *  @{
+ */
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_ZERO
+ */
+#define DL_TIMERG_IIDX_ZERO                                   DL_TIMER_IIDX_ZERO
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_ZERO
+ */
+#define DL_TIMERG_IIDX_LOAD                                   DL_TIMER_IIDX_LOAD
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_ZERO
+ */
+#define DL_TIMERG_IIDX_CC0_DN                               DL_TIMER_IIDX_CC0_DN
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_ZERO
+ */
+#define DL_TIMERG_IIDX_CC1_DN                               DL_TIMER_IIDX_CC1_DN
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_ZERO
+ */
+#define DL_TIMERG_IIDX_CC0_UP                               DL_TIMER_IIDX_CC0_UP
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_ZERO
+ */
+#define DL_TIMERG_IIDX_CC1_UP                               DL_TIMER_IIDX_CC1_UP
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_IIDX_ZERO
+ */
+#define DL_TIMERG_IIDX_OVERFLOW                           DL_TIMER_IIDX_OVERFLOW
+
+/**
+  * @brief Redirects to common @ref DL_TIMER_IIDX_ZERO
+  * @note <b> This is only available on some instances of TimerG. Consult the
+  *       TRM to determin instances with support this functionality.</b>
+  */
+#define DL_TIMERG_IIDX_DIR_CHANGE                       DL_TIMER_IIDX_DIR_CHANGE
+
+
+/*!
+* @brief QEI incorrect transition state error
+* @note <b> This interrupt is only available on some TimerG variants with
+*       Quadrature Encoding Input (QEI). Please refer to "TIMx
+*       Configurations" table in the device specific datasheet.</b>
+*/
+#define DL_TIMERG_IIDX_QEIERR                           DL_TIMER_IDX_STAT_QEIERR
+
+/** @}*/
+
+/** @addtogroup DL_TIMERG_PUBLISHER_INDEX
+ *  @{
+ */
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_PUBLISHER_INDEX_0
+ */
+#define DL_TIMERG_PUBLISHER_INDEX_0                   DL_TIMER_PUBLISHER_INDEX_0
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_PUBLISHER_INDEX_1
+ */
+#define DL_TIMERG_PUBLISHER_INDEX_1                   DL_TIMER_PUBLISHER_INDEX_1
+
+/** @}*/
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_QEI_DIRECTION
+ */
+#define DL_TIMERG_QEI_DIRECTION                       DL_TIMER_QEI_DIRECTION
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_QEI_MODE
+ */
+#define DL_TIMERG_QEI_MODE                       DL_TIMER_QEI_MODE
+
+/** @addtogroup DL_TIMERG_SUBSCRIBER_INDEX
+ *  @{
+ */
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_SUBSCRIBER_INDEX_0
+ */
+#define DL_TIMERG_SUBSCRIBER_INDEX_0                 DL_TIMER_SUBSCRIBER_INDEX_0
+/**
+ * @brief Redirects to common @ref DL_TIMER_SUBSCRIBER_INDEX_1
+ */
+#define DL_TIMERG_SUBSCRIBER_INDEX_1                 DL_TIMER_SUBSCRIBER_INDEX_1
+
+/** @}*/
+
+/** @addtogroup DL_TIMERG_EVENT_ROUTE
+ *  @{
+ */
+
+/**
+ * @brief Redirects to common @ref DL_TIMER_EVENT_ROUTE_1
+ */
+#define DL_TIMERG_EVENT_ROUTE_1                           DL_TIMER_EVENT_ROUTE_1
+/**
+ * @brief Redirects to common @ref DL_TIMER_EVENT_ROUTE_2
+ */
+#define DL_TIMERG_EVENT_ROUTE_2                           DL_TIMER_EVENT_ROUTE_2
+
+/** @}*/
+
+/**
+ * @brief Redirects to common @ref DL_Timer_enablePower
+ */
+#define DL_TimerG_enablePower                               DL_Timer_enablePower
+
+/**
+ * @brief Redirects to common @ref DL_Timer_disablePower
+ */
+#define DL_TimerG_disablePower                             DL_Timer_disablePower
+
+/**
+ * @brief Redirects to common @ref DL_Timer_isPowerEnabled
+ */
+#define DL_TimerG_isPowerEnabled                         DL_Timer_isPowerEnabled
+
+/**
+ * @brief Redirects to common @ref DL_Timer_reset
+ */
+#define DL_TimerG_reset                                           DL_Timer_reset
+
+/**
+ * @brief Redirects to common @ref DL_Timer_isReset
+ */
+#define DL_TimerG_isReset                                       DL_Timer_isReset
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCCPDirection
+ */
+#define DL_TimerG_setCCPDirection                       DL_Timer_setCCPDirection
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCCPDirection
+ */
+#define DL_TimerG_getCCPDirection                       DL_Timer_getCCPDirection
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCCPOutputDisabled
+ */
+#define DL_TimerG_setCCPOutputDisabled             DL_Timer_setCCPOutputDisabled
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setClockConfig
+ */
+#define DL_TimerG_setClockConfig                         DL_Timer_setClockConfig
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getQEIDirection
+ */
+#define DL_TimerG_getQEIDirection                       DL_Timer_getQEIDirection
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getClockConfig
+ */
+#define DL_TimerG_getClockConfig                         DL_Timer_getClockConfig
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getClockConfig
+ */
+#define DL_TimerG_enableClock                               DL_Timer_enableClock
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getClockConfig
+ */
+#define DL_TimerG_disableClock                             DL_Timer_disableClock
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_isClockEnabled
+ */
+#define DL_TimerG_isClockEnabled                         DL_Timer_isClockEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_configCrossTrigger
+ */
+#define DL_TimerG_configCrossTrigger                 DL_Timer_configCrossTrigger
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_configCrossTriggerSrc
+ */
+#define DL_TimerG_configCrossTriggerSrc           DL_Timer_configCrossTriggerSrc
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_configCrossTriggerInputCond
+ */
+#define DL_TimerG_configCrossTriggerInputCond \
+                                            DL_Timer_configCrossTriggerInputCond
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_configCrossTriggerEnable
+ */
+#define DL_TimerG_configCrossTriggerEnable     DL_Timer_configCrossTriggerEnable
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCrossTriggerConfig
+ */
+#define DL_TimerG_getCrossTriggerConfig           DL_Timer_getCrossTriggerConfig
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCrossTriggerSrc
+ */
+#define DL_TimerG_getCrossTriggerSrc                 DL_Timer_getCrossTriggerSrc
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCrossTriggerInputCond
+ */
+#define DL_TimerG_getCrossTriggerInputCond     DL_Timer_getCrossTriggerInputCond
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCrossTriggerEnable
+ */
+#define DL_TimerG_getCrossTriggerEnable           DL_Timer_getCrossTriggerEnable
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_generateCrossTrigger
+ */
+#define DL_TimerG_generateCrossTrigger             DL_Timer_generateCrossTrigger
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setLoadValue
+ */
+#define DL_TimerG_setLoadValue                           DL_Timer_setLoadValue
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getLoadValue
+ */
+#define DL_TimerG_getLoadValue                           DL_Timer_getLoadValue
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getTimerCount
+ */
+#define DL_TimerG_getTimerCount                           DL_Timer_getTimerCount
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setTimerCount
+ */
+#define DL_TimerG_setTimerCount                           DL_Timer_setTimerCount
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setDebugReleaseBehavior
+ */
+#define DL_TimerG_setDebugReleaseBehavior       DL_Timer_setDebugReleaseBehavior
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getDebugReleaseBehavior
+ */
+#define DL_TimerG_getDebugReleaseBehavior       DL_Timer_getDebugReleaseBehavior
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCounterControl
+ */
+#define DL_TimerG_setCounterControl                   DL_Timer_setCounterControl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCounterZeroControl
+ */
+#define DL_TimerG_getCounterZeroControl           DL_Timer_getCounterZeroControl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCounterAdvanceControl
+ */
+#define DL_TimerG_getCounterAdvanceControl     DL_Timer_getCounterAdvanceControl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCounterLoadControl
+ */
+#define DL_TimerG_getCounterLoadControl           DL_Timer_getCounterLoadControl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCounterMode
+ */
+#define DL_TimerG_setCounterMode                         DL_Timer_setCounterMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCounterMode
+ */
+#define DL_TimerG_getCounterMode                         DL_Timer_getCounterMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCounterValueAfterEnable
+ */
+#define DL_TimerG_setCounterValueAfterEnable DL_Timer_setCounterValueAfterEnable
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCounterValueAfterEnable
+ */
+#define DL_TimerG_getCounterValueAfterEnable DL_Timer_getCounterValueAfterEnable
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCounterRepeatMode
+ */
+#define DL_TimerG_setCounterRepeatMode             DL_Timer_setCounterRepeatMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCounterRepeatMode
+ */
+#define DL_TimerG_getCounterRepeatMode             DL_Timer_getCounterRepeatMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_initTimerMode
+ */
+#define DL_TimerG_initTimerMode                           DL_Timer_initTimerMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_initCaptureMode
+ */
+#define DL_TimerG_initCaptureMode                       DL_Timer_initCaptureMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_initCaptureTriggerMode
+ */
+#define DL_TimerG_initCaptureTriggerMode         DL_Timer_initCaptureTriggerMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_initCaptureCombinedMode
+ */
+#define DL_TimerG_initCaptureCombinedMode       DL_Timer_initCaptureCombinedMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_initCompareMode
+ */
+#define DL_TimerG_initCompareMode                       DL_Timer_initCompareMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_initCompareTriggerMode
+ */
+#define DL_TimerG_initCompareTriggerMode         DL_Timer_initCompareTriggerMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_initPWMMode
+ */
+#define DL_TimerG_initPWMMode                               DL_Timer_initPWMMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_resetCounterMode
+ */
+#define DL_TimerG_resetCounterMode                     DL_Timer_resetCounterMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptureCompareValue
+ */
+#define DL_TimerG_setCaptureCompareValue         DL_Timer_setCaptureCompareValue
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptureCompareValue
+ */
+#define DL_TimerG_getCaptureCompareValue         DL_Timer_getCaptureCompareValue
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptureCompareCtl
+ */
+#define DL_TimerG_setCaptureCompareCtl             DL_Timer_setCaptureCompareCtl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptureCompareCtl
+ */
+#define DL_TimerG_getCaptureCompareCtl             DL_Timer_getCaptureCompareCtl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptCompUpdateMethod
+ */
+#define DL_TimerG_getCaptCompUpdateMethod       DL_Timer_getCaptCompUpdateMethod
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptCompUpdateMethod
+ */
+#define DL_TimerG_setCaptCompUpdateMethod       DL_Timer_setCaptCompUpdateMethod
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableShadowFeatures
+ */
+#define DL_TimerG_enableShadowFeatures             DL_Timer_enableShadowFeatures
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setSecondCompSrcDn
+ */
+#define DL_TimerG_setSecondCompSrcDn                 DL_Timer_setSecondCompSrcDn
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getSecondCompSrcDn
+ */
+#define DL_TimerG_getSecondCompSrcDn                 DL_Timer_GetSecondCompSrcDn
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setSecondCompSrcUp
+ */
+#define DL_TimerG_setSecondCompSrcUp                 DL_Timer_setSecondCompSrcUp
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getSecondCompSrcUp
+ */
+#define DL_TimerG_getSecondCompSrcUp                 DL_Timer_GetSecondCompSrcUp
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptureCompareOutCtl
+ */
+#define DL_TimerG_setCaptureCompareOutCtl       DL_Timer_setCaptureCompareOutCtl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptureCompareOutCtl
+ */
+#define DL_TimerG_getCaptureCompareOutCtl       DL_Timer_getCaptureCompareOutCtl
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptureCompareAction
+ */
+#define DL_TimerG_setCaptureCompareAction       DL_Timer_setCaptureCompareAction
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptureCompareAction
+ */
+#define DL_TimerG_getCaptureCompareAction       DL_Timer_getCaptureCompareAction
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setSecondCompActionDn
+ */
+#define DL_TimerG_setSecondCompActionDn           DL_Timer_setSecondCompActionDn
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getSecondCompActionDn
+ */
+#define DL_TimerG_getSecondCompActionDn           DL_Timer_getSecondCompActionDn
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setSecondCompActionUp
+ */
+#define DL_TimerG_setSecondCompActionUp           DL_Timer_setSecondCompActionUp
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getSecondCompActionUp
+ */
+#define DL_TimerG_getSecondCompActionUp           DL_Timer_getSecondCompActionUp
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptureCompareInput
+ */
+#define DL_TimerG_setCaptureCompareInput \
+                                           DL_Timer_setCaptureCompareInput
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptureCompareInput
+ */
+#define DL_TimerG_getCaptureCompareInput \
+                                           DL_Timer_getCaptureCompareInput
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCaptureCompareInputFilter
+ */
+#define DL_TimerG_setCaptureCompareInputFilter \
+                                           DL_Timer_setCaptureCompareInputFilter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCaptureCompareInputFilter
+ */
+#define DL_TimerG_getCaptureCompareInputFilter \
+                                           DL_Timer_getCaptureCompareInputFilter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableCaptureCompareInputFilter
+ */
+#define DL_TimerG_enableCaptureCompareInputFilter \
+                                        DL_Timer_enableCaptureCompareInputFilter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disableCaptureCompareInputFilter
+ */
+#define DL_TimerG_disableCaptureCompareInputFilter \
+                                       DL_Timer_disableCaptureCompareInputFilter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_isCaptureCompareInputFilterEnabled
+ */
+#define DL_TimerG_isCaptureCompareInputFilterEnabled \
+                                     DL_Timer_isCaptureCompareInputFilterEnabled
+
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setExternalTriggerEvent
+ */
+#define DL_TimerG_setExternalTriggerEvent       DL_Timer_setExternalTriggerEvent
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getExternalTriggerEvent
+ */
+#define DL_TimerG_getExternalTriggerEvent       DL_Timer_getExternalTriggerEvent
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableExternalTrigger
+ */
+#define DL_TimerG_enableExternalTrigger           DL_Timer_enableExternalTrigger
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disableExternalTrigger
+ */
+#define DL_TimerG_disableExternalTrigger         DL_Timer_disableExternalTrigger
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_isExternalTriggerEnabled
+ */
+#define DL_TimerG_isExternalTriggerEnabled     DL_Timer_isExternalTriggerEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_startCounter
+ */
+#define DL_TimerG_startCounter                             DL_Timer_startCounter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_stopCounter
+ */
+#define DL_TimerG_stopCounter                               DL_Timer_stopCounter
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_isRunning
+ */
+#define DL_TimerG_isRunning                                   DL_Timer_isRunning
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableInterrupt
+ */
+#define DL_TimerG_enableInterrupt                       DL_Timer_enableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disableInterrupt
+ */
+#define DL_TimerG_disableInterrupt                     DL_Timer_disableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getEnabledInterrupts
+ */
+#define DL_TimerG_getEnabledInterrupts             DL_Timer_getEnabledInterrupts
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getEnabledInterruptStatus
+ */
+#define DL_TimerG_getEnabledInterruptStatus   DL_Timer_getEnabledInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getRawInterruptStatus
+ */
+#define DL_TimerG_getRawInterruptStatus           DL_Timer_getRawInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getPendingInterrupt
+ */
+#define DL_TimerG_getPendingInterrupt               DL_Timer_getPendingInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_clearInterruptStatus
+ */
+#define DL_TimerG_clearInterruptStatus             DL_Timer_clearInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_configQEI
+ */
+#define DL_TimerG_configQEI                                   DL_Timer_configQEI
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_configQEIHallInputMode
+ */
+#define DL_TimerG_configQEIHallInputMode         DL_Timer_configQEIHallInputMode
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setPublisherChanID
+ */
+#define DL_TimerG_setPublisherChanID                 DL_Timer_setPublisherChanID
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getPublisherChanID
+ */
+#define DL_TimerG_getPublisherChanID                 DL_Timer_getPublisherChanID
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setSubscriberChanID
+ */
+#define DL_TimerG_setSubscriberChanID               DL_Timer_setSubscriberChanID
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getSubscriberChanID
+ */
+#define DL_TimerG_getSubscriberChanID               DL_Timer_getSubscriberChanID
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_enableEvent
+ */
+#define DL_TimerG_enableEvent                               DL_Timer_enableEvent
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_disableEvent
+ */
+#define DL_TimerG_disableEvent                             DL_Timer_disableEvent
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getEnabledEvents
+ */
+#define DL_TimerG_getEnabledEvents                     DL_Timer_getEnabledEvents
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getEnabledEventStatus
+ */
+#define DL_TimerG_getEnabledEventStatus           DL_Timer_getEnabledEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getRawEventsStatus
+ */
+#define DL_TimerG_getRawEventsStatus                 DL_Timer_getRawEventsStatus
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_clearInterruptStatus
+ */
+#define DL_TimerG_clearInterruptStatus             DL_Timer_clearInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_saveConfiguration
+ */
+#define DL_TimerG_saveConfiguration                   DL_Timer_saveConfiguration
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_restoreConfiguration
+ */
+#define DL_TimerG_restoreConfiguration             DL_Timer_restoreConfiguration
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_setCoreHaltBehavior
+ */
+#define DL_TimerG_setCoreHaltBehavior               DL_Timer_setCoreHaltBehavior
+
+/*!
+ * @brief Redirects to common @ref DL_Timer_getCoreHaltBehavior
+ */
+#define DL_TimerG_getHaltBehavior                   DL_Timer_getCoreHaltBehavior
+
+/* clang-format on */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_TIMER_G__ */
+
+#endif /* ti_dl_dl_timerg__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_trng.c
+++ b/mspm0/source/ti/driverlib/dl_trng.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_trng.h>
+
+#ifdef __MSPM0_HAS_TRNG__
+
+bool DL_TRNG_saveConfiguration(TRNG_Regs *trng, DL_TRNG_backupConfig *ptr)
+{
+    bool stateSaved = !ptr->backupRdy;
+    if (stateSaved) {
+        ptr->controlWord   = trng->CTL;
+        ptr->clockDivider  = trng->CLKDIVIDE;
+        ptr->interruptMask = trng->CPU_INT.IMASK;
+        ptr->backupRdy     = true;
+    }
+    return stateSaved;
+}
+
+bool DL_TRNG_restoreConfiguration(TRNG_Regs *trng, DL_TRNG_backupConfig *ptr)
+{
+    bool stateRestored = ptr->backupRdy;
+    if (stateRestored) {
+        DL_Common_updateReg(
+            &trng->CTL, ptr->controlWord, TRNG_CTL_DECIM_RATE_MASK);
+        trng->CLKDIVIDE     = ptr->clockDivider;
+        trng->CPU_INT.IMASK = ptr->interruptMask;
+
+        /* If TRNG was originally in OFF state, then send PWROFF command */
+        if (((ptr->controlWord & TRNG_STAT_FSM_STATE_MASK) >>
+                TRNG_STAT_FSM_STATE_OFS) == (uint32_t) DL_TRNG_STATE_OFF) {
+            DL_TRNG_sendCommand(trng, DL_TRNG_CMD_PWROFF);
+        }
+
+        ptr->backupRdy = false;
+    }
+    return stateRestored;
+}
+
+#endif /* __MSPM0_HAS_TRNG__ */

--- a/mspm0/source/ti/driverlib/dl_trng.h
+++ b/mspm0/source/ti/driverlib/dl_trng.h
@@ -1,0 +1,652 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_trng.h
+ *  @brief      True Random Number Generator (TRNG) Driver Library
+ *  @defgroup   TRNG True Random Number Generator (TRNG)
+ *
+ *  @anchor ti_dl_dl_m0p_trng_Overview
+ *  # Overview
+ *
+ *  The True Random Number Generator Driver Library allows full configuration of
+ *  the MSPM0 TRNG module.
+ *  The true random number generator (TRNG) block is an entropy source which
+ *  can be used to generate random bit sequences.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup TRNG
+ * @{
+ */
+#ifndef ti_dl_dl_trng__include
+#define ti_dl_dl_trng__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_TRNG__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_TRNG_INTERRUPT
+ *  @{
+ */
+
+/*!
+* @brief TRNG interrupt definition for health test failed
+*/
+#define DL_TRNG_INTERRUPT_HEALTH_FAIL_EVENT   (TRNG_IMASK_IRQ_HEALTH_FAIL_MASK)
+
+/*!
+* @brief TRNG interrupt definition for commafnd done
+*/
+#define DL_TRNG_INTERRUPT_CMD_DONE_EVENT         (TRNG_IMASK_IRQ_CMD_DONE_MASK)
+
+/*!
+* @brief TRNG interrupt definition for command fail
+*/
+#define DL_TRNG_INTERRUPT_CMD_FAIL_EVENT         (TRNG_IMASK_IRQ_CMD_FAIL_MASK)
+
+/*!
+* @brief TRNG interrupt definition for capture ready
+*/
+#define DL_TRNG_INTERRUPT_CAPTURE_RDY_EVENT  (TRNG_IMASK_IRQ_CAPTURED_RDY_MASK)
+/** @}*/
+
+/** @addtogroup DL_TRNG_HEALTH_TEST_SUCCESS
+ *  @{
+ */
+
+/*!
+* @brief TRNG Digital health test success value
+*/
+#define DL_TRNG_DIGITAL_HEALTH_TEST_SUCCESS                              (0xFF)
+
+/*!
+* @brief TRNG Analog health test success value
+*/
+#define DL_TRNG_ANALOG_HEALTH_TEST_SUCCESS                                (0x1)
+/** @}*/
+
+/* clang-format on */
+
+/*! @enum DL_TRNG_IIDX */
+typedef enum {
+    /*! TRNG interrupt index for health fail */
+    DL_TRNG_IIDX_HEALTH_FAIL = TRNG_IIDX_STAT_IRQ_HEALTH_FAIL,
+    /*! TRNG interrupt index for command done */
+    DL_TRNG_IIDX_CMD_DONE = TRNG_IIDX_STAT_IRQ_CMD_DONE,
+    /*! TRNG interrupt index for command fail */
+    DL_TRNG_IIDX_CMD_FAIL = TRNG_IIDX_STAT_IRQ_CMD_FAIL,
+    /*! TRNG interrupt index indicating the capture buffer is ready */
+    DL_TRNG_IIDX_CAPTURED_READY = TRNG_IIDX_STAT_IRQ_CAPTURED_RDY,
+} DL_TRNG_IIDX;
+
+/*! @enum DL_TRNG_DECIMATION_RATE */
+typedef enum {
+    /*! Decimation by 1 (no decimation) */
+    DL_TRNG_DECIMATION_RATE_1 = 0x0,
+    /*! Decimation rate 2 -- take every other sample */
+    DL_TRNG_DECIMATION_RATE_2 = 0x1,
+    /*! Decimation rate 3 -- take every third sample */
+    DL_TRNG_DECIMATION_RATE_3 = 0x2,
+    /*! Decimation rate 4 -- take every fourth sample */
+    DL_TRNG_DECIMATION_RATE_4 = 0x3,
+    /*! Decimation rate 5 -- take every fifth sample */
+    DL_TRNG_DECIMATION_RATE_5 = 0x4,
+    /*! Decimation rate 6 -- take every sixth sample */
+    DL_TRNG_DECIMATION_RATE_6 = 0x5,
+    /*! Decimation rate 7 -- take every seventh sample */
+    DL_TRNG_DECIMATION_RATE_7 = 0x6,
+    /*! Decimation rate 8 -- take every eighth sample */
+    DL_TRNG_DECIMATION_RATE_8 = 0x7,
+} DL_TRNG_DECIMATION_RATE;
+
+/*! @enum DL_TRNG_CMD */
+typedef enum {
+    /*! TRNG command to power off analog blocks and digital blocks are gated */
+    DL_TRNG_CMD_PWROFF = TRNG_CTL_CMD_PWR_OFF,
+    /*! TRNG command to execute digital power-on self-tests */
+    DL_TRNG_CMD_TEST_DIG = TRNG_CTL_CMD_PWRUP_DIG,
+    /*! TRNG command to execute digital power-on self-tests */
+    DL_TRNG_CMD_TEST_ANA = TRNG_CTL_CMD_PWRUP_ANA,
+    /*! TRNG command to go into normal operating mode */
+    DL_TRNG_CMD_NORM_FUNC = TRNG_CTL_CMD_NORM_FUNC,
+} DL_TRNG_CMD;
+
+/*! @enum DL_TRNG_CLOCK_DIVIDE */
+typedef enum {
+    /*! Clock divide by 1 */
+    DL_TRNG_CLOCK_DIVIDE_1 = TRNG_CLKDIVIDE_RATIO_DIV_BY_1,
+    /*! Clock divide by 2 */
+    DL_TRNG_CLOCK_DIVIDE_2 = TRNG_CLKDIVIDE_RATIO_DIV_BY_2,
+    /*! Clock divide by 4 */
+    DL_TRNG_CLOCK_DIVIDE_4 = TRNG_CLKDIVIDE_RATIO_DIV_BY_4,
+    /*! Clock divide by 6 */
+    DL_TRNG_CLOCK_DIVIDE_6 = TRNG_CLKDIVIDE_RATIO_DIV_BY_6,
+    /*! Clock divide by 8 */
+    DL_TRNG_CLOCK_DIVIDE_8 = TRNG_CLKDIVIDE_RATIO_DIV_BY_8,
+} DL_TRNG_CLOCK_DIVIDE;
+
+/*! @enum DL_TRNG_STATE */
+typedef enum {
+    /*! Current state of the TRNG is OFF */
+    DL_TRNG_STATE_OFF = 0x0,
+    /*! Current state of the TRNG is PWRUP_ES */
+    DL_TRNG_STATE_PWRUP_ES = 0x1,
+    /*! Current state of the TRNG is NORM_FUNC */
+    DL_TRNG_STATE_NORM_FUNC = 0x3,
+    /*! Current state of the TRNG is TEST_DIG */
+    DL_TRNG_STATE_TEST_DIG = 0x7,
+    /*! Current state of the TRNG is TEST_ANA */
+    DL_TRNG_STATE_TEST_ANA = 0xB,
+    /*! Current state of the TRNG is ERROR */
+    DL_TRNG_STATE_ERROR = 0xA,
+    /*! Current state of the TRNG is PWRDOWN_ES */
+    DL_TRNG_STATE_PWRDOWN = 0x2,
+} DL_TRNG_STATE;
+
+/**
+ * @brief Configuration structure to backup TRNG peripheral state before
+ *        going to STOP/STANDBY mode. Not required after PG 1.0 silicon. Used
+ *        by @ref DL_TRNG_saveConfiguration
+ */
+typedef struct {
+    /*! TRNG control word. Combination of @ref DL_TRNG_DECIMATION_RATE and
+     *  @ref DL_TRNG_CMD */
+    uint32_t controlWord;
+    /*! TRNG clock divider. Must be one of @ref DL_TRNG_CLOCK_DIVIDE */
+    uint32_t clockDivider;
+    /*! TRNG interrupt status. Must be one of @ref DL_TRNG_IIDX */
+    uint32_t interruptMask;
+    /*! Boolean flag indicating whether or not a valid configuration structure
+       exists. Should not be modified by the user. */
+    bool backupRdy;
+} DL_TRNG_backupConfig;
+
+/**
+ * @brief Enables power on TRNG module
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_TRNG_enablePower(TRNG_Regs *trng)
+{
+    trng->GPRCM.PWREN = TRNG_PWREN_KEY_UNLOCK_W | TRNG_PWREN_ENABLE_ENABLE;
+}
+
+/**
+ * @brief Disable power on TRNG module
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_TRNG_disablePower(TRNG_Regs *trng)
+{
+    trng->GPRCM.PWREN = TRNG_PWREN_KEY_UNLOCK_W | TRNG_PWREN_ENABLE_DISABLE;
+}
+
+/**
+ * @brief Get the clock divider on the TRNG module
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ *
+ * @return      Clock divider value for the TRNG module
+ */
+__STATIC_INLINE DL_TRNG_CLOCK_DIVIDE DL_TRNG_getClockDivider(TRNG_Regs *trng)
+{
+    return (DL_TRNG_CLOCK_DIVIDE) trng->CLKDIVIDE;
+}
+
+/**
+ * @brief Set the clock divider on the TRNG module
+ *
+ * @param trng          Pointer to the register overlay for the peripheral
+ *
+ * @param clockDivider  Clock divider value for the TRNG module.
+ *                      One of @ref DL_TRNG_CLOCK_DIVIDE
+ */
+__STATIC_INLINE void DL_TRNG_setClockDivider(
+    TRNG_Regs *trng, DL_TRNG_CLOCK_DIVIDE clockDivider)
+{
+    trng->CLKDIVIDE = (uint32_t) clockDivider;
+}
+
+/**
+ * @brief Resets the TRNG module
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_TRNG_reset(TRNG_Regs *trng)
+{
+    trng->GPRCM.RSTCTL =
+        TRNG_RSTCTL_RESETASSERT_ASSERT | TRNG_RSTCTL_KEY_UNLOCK_W;
+}
+
+/**
+ * @brief Returns if TRNG peripheral was reset
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ */
+__STATIC_INLINE bool DL_TRNG_isReset(TRNG_Regs *trng)
+{
+    return (trng->GPRCM.STAT & TRNG_GPRCM_STAT_RESETSTKY_MASK) ==
+           TRNG_GPRCM_STAT_RESETSTKY_RESET;
+}
+
+/**
+ * @brief Returns if the data capture is ready
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ *
+ * @return true if the data capture is ready
+ * @return false if the data capture is not ready
+ */
+__STATIC_INLINE bool DL_TRNG_isCaptureReady(TRNG_Regs *trng)
+{
+    return ((trng->CPU_INT.RIS & TRNG_RIS_IRQ_CAPTURED_RDY_MASK)) ==
+           TRNG_RIS_IRQ_CAPTURED_RDY_SET;
+}
+
+/**
+ * @brief Returns if the issued TRNG command is done
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ *
+ * @return true if the issued command is done
+ * @return false if the issued command is not done
+ */
+__STATIC_INLINE bool DL_TRNG_isCommandDone(TRNG_Regs *trng)
+{
+    return ((trng->CPU_INT.RIS & TRNG_RIS_IRQ_CMD_DONE_MASK)) ==
+           TRNG_RIS_IRQ_CMD_DONE_SET;
+}
+
+/**
+ * @brief Returns if the issued TRNG command failed
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ *
+ * @return true if the issued command failed
+ * @return false if the issued command failed
+ */
+__STATIC_INLINE bool DL_TRNG_isCommandFail(TRNG_Regs *trng)
+{
+    return ((trng->CPU_INT.RIS & TRNG_RIS_IRQ_CMD_FAIL_MASK)) ==
+           TRNG_RIS_IRQ_CMD_FAIL_SET;
+}
+
+/**
+ * @brief Returns if a health test failed
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ *
+ * @return true if a health test is failed
+ * @return false if a health test did not fail
+ */
+__STATIC_INLINE bool DL_TRNG_isHealthTestFail(TRNG_Regs *trng)
+{
+    return ((trng->CPU_INT.RIS & TRNG_RIS_IRQ_HEALTH_FAIL_MASK)) ==
+           TRNG_RIS_IRQ_HEALTH_FAIL_SET;
+}
+
+/**
+ * @brief Set the decimation rate
+ *
+ * @param trng            Pointer to the register overlay for the peripheral
+ *
+ * @param decimationRate  Decimation rate to set.
+ *                        One of @ref DL_TRNG_DECIMATION_RATE
+ */
+__STATIC_INLINE void DL_TRNG_setDecimationRate(
+    TRNG_Regs *trng, DL_TRNG_DECIMATION_RATE decimationRate)
+{
+    DL_Common_updateReg(&trng->CTL,
+        ((uint32_t) decimationRate << TRNG_CTL_DECIM_RATE_OFS),
+        TRNG_CTL_DECIM_RATE_MASK);
+}
+
+/**
+ *  @brief      Get the decimation rate
+ *
+ *  @param[in]  trng  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The decimation rate of the TRNG module
+ *
+ *  @retval     One of @ref DL_TRNG_DECIMATION_RATE
+ */
+__STATIC_INLINE DL_TRNG_DECIMATION_RATE DL_TRNG_getDecimationRate(
+    TRNG_Regs *trng)
+{
+    uint32_t decimationRate =
+        ((trng->CTL & TRNG_CTL_DECIM_RATE_MASK) >> TRNG_CTL_DECIM_RATE_OFS);
+
+    return (DL_TRNG_DECIMATION_RATE)(decimationRate);
+}
+
+/**
+ * @brief Get the digital health test results
+ *
+ * The test sequence includes eight tests, and each test reports its status in
+ * an individual result bit. As each test passes, the corresponding bit is set.
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ *
+ * @return The results of the digital health tests
+ *
+ * @retval DL_TRNG_DIGITAL_HEALTH_TEST_SUCCESS if all tests passed,
+ *         otherwise a bitmask of which tests passed
+ */
+__STATIC_INLINE uint8_t DL_TRNG_getDigitalHealthTestResults(TRNG_Regs *trng)
+{
+    return (uint8_t)(trng->TEST_RESULTS & TRNG_TEST_RESULTS_DIG_TEST_MASK);
+}
+
+/**
+ * @brief Get the analog health test results
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ *
+ * @return The results of the analog health test
+ *
+ * @retval DL_TRNG_ANALOG_HEALTH_TEST_SUCCESS if success
+ * @retval 0 if test failed
+ */
+__STATIC_INLINE uint8_t DL_TRNG_getAnalogHealthTestResults(TRNG_Regs *trng)
+{
+    return (uint8_t)((trng->TEST_RESULTS & TRNG_TEST_RESULTS_ANA_TEST_MASK) >>
+                     TRNG_TEST_RESULTS_ANA_TEST_OFS);
+}
+
+/**
+ * @brief Get the current state of the TRNG front end FSM
+ *
+ * This API should be called twice since two reads of the state are required as
+ * there is a chance of metastability when reading this register.
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ *
+ * @return The current state of the TRNG
+ *
+ * @retval One of @ref DL_TRNG_STATE
+ */
+__STATIC_INLINE uint32_t DL_TRNG_getCurrentState(TRNG_Regs *trng)
+{
+    return ((trng->STAT & TRNG_STAT_FSM_STATE_MASK)) >>
+           TRNG_STAT_FSM_STATE_OFS;
+}
+
+/**
+ * @brief Get the last accepted command that was issued to the TRNG
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ *
+ * @return The last issued accepted command
+ *
+ * @retval One of @ref DL_TRNG_CMD
+ */
+__STATIC_INLINE uint32_t DL_TRNG_getIssuedCommand(TRNG_Regs *trng)
+{
+    return ((trng->STAT & TRNG_STAT_ISSUED_CMD_MASK)) >>
+           TRNG_STAT_ISSUED_CMD_OFS;
+}
+
+/**
+ * @brief Indicates if the repetition counter test caused the most recent
+ *        failure
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ *
+ * @return The status of the repetition test
+ *
+ * @retval true if the repetition test failed
+ * @retval false if the repetition test did not fail
+ */
+__STATIC_INLINE bool DL_TRNG_isRepetitionTestFail(TRNG_Regs *trng)
+{
+    return ((trng->STAT & TRNG_STAT_REP_FAIL_MASK)) == TRNG_STAT_REP_FAIL_MASK;
+}
+
+/**
+ * @brief Indicates if the Adaptive Proportion Test (1,2,3, or 4-bit counters)
+ *        caused the most recent failure
+ *
+ * @param trng  Pointer to the register overlay for the peripheral
+ *
+ * @return The status of the Adaptive Proportion Test
+ *
+ * @retval true if the repetition test failed
+ * @retval false if the repetition test did not fail
+ */
+__STATIC_INLINE bool DL_TRNG_isAdaptiveTestFail(TRNG_Regs *trng)
+{
+    return ((trng->STAT & TRNG_STAT_ADAP_FAIL_MASK)) ==
+           TRNG_STAT_ADAP_FAIL_MASK;
+}
+
+/**
+ *  @brief      Enable TRNG interrupt
+ *
+ *  @param[in]  trng  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_TRNG_INTERRUPT.
+ */
+__STATIC_INLINE void DL_TRNG_enableInterrupt(
+    TRNG_Regs *trng, uint32_t interruptMask)
+{
+    trng->CPU_INT.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disable TRNG interrupt
+ *
+ *  @param[in]  trng  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_TRNG_INTERRUPT.
+ */
+__STATIC_INLINE void DL_TRNG_disableInterrupt(
+    TRNG_Regs *trng, uint32_t interruptMask)
+{
+    trng->CPU_INT.IMASK &= ~interruptMask;
+}
+
+/**
+ *  @brief      Check which TRNG interrupts are enabled
+ *
+ *  @param[in]  trng           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_TRNG_IIDX.
+ *
+ *  @return     Which of the requested TRNG interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_TRNG_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_TRNG_getEnabledInterrupts(
+    TRNG_Regs *trng, uint32_t interruptMask)
+{
+    return trng->CPU_INT.IMASK & interruptMask;
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled TRNG interrupt
+ *
+ *  Checks if the TRNG interrupt that was previously enabled is pending.
+ *
+ *  @param[in]  trng           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_TRNG_INTERRUPT.
+ *
+ *  @return     If the enabled TRNG interrupt is pending
+ *
+ *  @sa         DL_TRNG_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_TRNG_getEnabledInterruptStatus(
+    TRNG_Regs *trng, uint32_t interruptMask)
+{
+    return (trng->CPU_INT.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any TRNG interrupt
+ *
+ *  Checks if the TRNG interrupt is pending. Interrupt does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  trng           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_TRNG_INTERRUPT.
+ *
+ *  @return     If the trng interrupt is pending
+ */
+__STATIC_INLINE uint32_t DL_TRNG_getRawInterruptStatus(
+    TRNG_Regs *trng, uint32_t interruptMask)
+{
+    return trng->CPU_INT.RIS & interruptMask;
+}
+
+/**
+ *  @brief      Get highest priority pending TRNG interrupt
+ *
+ *  Checks if any of the TRNG interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  trng  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The highest priority pending TRNG interrupt
+ *
+ *  @retval     One of @ref DL_TRNG_IIDX
+ */
+__STATIC_INLINE DL_TRNG_IIDX DL_TRNG_getPendingInterrupt(TRNG_Regs *trng)
+{
+    return (DL_TRNG_IIDX) trng->CPU_INT.IIDX;
+}
+
+/**
+ *  @brief      Clear pending TRNG interrupt
+ *
+ *  @param[in]  trng           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_TRNG_INTERRUPT.
+ */
+__STATIC_INLINE void DL_TRNG_clearInterruptStatus(
+    TRNG_Regs *trng, uint32_t interruptMask)
+{
+    trng->CPU_INT.ICLR = interruptMask;
+}
+
+/**
+ *  @brief      Update control register's command bits to send a TRNG command
+ *
+ *  @param[in]  trng  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  cmd   Command to update the control register with
+ */
+__STATIC_INLINE void DL_TRNG_sendCommand(TRNG_Regs *trng, DL_TRNG_CMD cmd)
+{
+    DL_Common_updateReg(&trng->CTL, (uint32_t) cmd, TRNG_CTL_CMD_MASK);
+}
+
+/**
+ *  @brief      Get word capture from TRNG
+ *
+ *  Gets the captured data from the decimation block.
+ *
+ *  @param[in]  trng  Pointer to the register overlay for the peripheral
+ *
+ *  @retval     TRNG capture value
+ *
+ *  @pre The IRQ_CAPTURED_RDY IRQ should be asserted first, indicating that
+ *  random bits are available for read-out.
+ *
+ *  @sa         DL_TRNG_isCaptureReady
+ */
+__STATIC_INLINE uint32_t DL_TRNG_getCapture(TRNG_Regs *trng)
+{
+    return trng->DATA_CAPTURE;
+}
+
+/**
+ *  @brief      Save TRNG configuration before entering a power loss state.
+ *              Only necessary for PG 1.0 silicon.
+ *
+ *  @param[in]  trng  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr   Configuration backup setup structure. See
+ *                    @ref DL_TRNG_backupConfig.
+ *
+ *  @retval     FALSE if a configuration already exists in ptr (will not be
+ *              overwritten). TRUE if a configuration was successfully saved
+ */
+bool DL_TRNG_saveConfiguration(TRNG_Regs *trng, DL_TRNG_backupConfig *ptr);
+
+/**
+ *  @brief      Restore TRNG configuration after leaving a power loss state.
+ *              Upon restoration, if the TRNG was not originally in OFF state,
+ *              then the TRNG will be set to the normal operating mode.
+ *              Only necessary for PG 1.0 silicon.
+ *
+ *  @param[in]  trng  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr   Configuration backup setup structure. See
+ *                    @ref DL_TRNG_backupConfig.
+ *
+ *  @retval     FALSE if a configuration does not exist in ptr (will not be
+ *              loaded). TRUE if a configuration successfully loaded
+ */
+bool DL_TRNG_restoreConfiguration(TRNG_Regs *trng, DL_TRNG_backupConfig *ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_TRNG__ */
+
+#endif /* ti_dl_dl_trng__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_uart.c
+++ b/mspm0/source/ti/driverlib/dl_uart.c
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_uart_extend.h>
+#include <ti/driverlib/dl_uart_main.h>
+
+#if defined(__MSPM0_HAS_UART_MAIN__) || defined(__MSPM0_HAS_UART_EXTD__)
+
+void DL_UART_init(UART_Regs *uart, DL_UART_Config *config)
+{
+    DL_UART_disable(uart);
+
+    DL_Common_updateReg(&uart->CTL0,
+        (uint32_t) config->mode | (uint32_t) config->direction |
+            (uint32_t) config->flowControl,
+        UART_CTL0_RXE_MASK | UART_CTL0_TXE_MASK | UART_CTL0_MODE_MASK |
+            UART_CTL0_RTSEN_MASK | UART_CTL0_CTSEN_MASK | UART_CTL0_FEN_MASK);
+
+    DL_Common_updateReg(&uart->LCRH,
+        (uint32_t) config->parity | (uint32_t) config->wordLength |
+            (uint32_t) config->stopBits,
+        UART_LCRH_PEN_ENABLE | UART_LCRH_EPS_MASK | UART_LCRH_SPS_MASK |
+            UART_LCRH_WLEN_MASK | UART_LCRH_STP2_MASK);
+}
+
+void DL_UART_setClockConfig(UART_Regs *uart, DL_UART_ClockConfig *config)
+{
+    uart->CLKSEL = (uint32_t) config->clockSel;
+
+    uart->CLKDIV = (uint32_t) config->divideRatio;
+}
+
+void DL_UART_getClockConfig(UART_Regs *uart, DL_UART_ClockConfig *config)
+{
+    config->clockSel = (DL_UART_CLOCK) uart->CLKSEL;
+
+    config->divideRatio = (DL_UART_CLOCK_DIVIDE_RATIO) uart->CLKDIV;
+}
+
+void DL_UART_configBaudRate(
+    UART_Regs *uart, uint32_t clockFreq, uint32_t baudRate)
+{
+    uint32_t divisor;
+
+    /*
+     *  The baud rate divisor, brd, is calculated with the following formula:
+     *  brd = ibrd.fbrd = clockOutput / (OVS * baudRate)
+     *  where ibrd is the integer part, fbrd is the fractional part.
+     *  Since fbrd is 6 bits, multiply brd by 64:
+     *       64 * brd = (clockOutput * 64) / (16 * baudRate)
+     *                = (clockOutput * 4) / baudRate
+     *    add 1/2 to round the least significant bit of fbrd:
+     *        64 * brd + 1/2 = (clockOutput * 8 / (2 * baudRate) + 1/2
+     *        divisor = 64*brd+1/2  = [(clockOutput * 8)/ baudRate + 1] / 2
+     *
+     *  The lower 6 bits is fbrd, upper part is ibrd
+     *  Note: If ibrd is 0, FBRD will be ignored and no data will be
+     *  transferred.
+     */
+
+    /*  Calculate baud rate divisor based on OVS: */
+    if ((baudRate * (uint32_t) 8) > clockFreq) {
+        DL_UART_setOversampling(uart, DL_UART_OVERSAMPLING_RATE_3X);
+        divisor = ((clockFreq * (uint32_t) 64) / (baudRate * (uint32_t) 3)) +
+                  ((uint32_t) 1 / (uint32_t) 2);
+
+    } else if ((baudRate * (uint32_t) 16) > clockFreq) {
+        DL_UART_setOversampling(uart, DL_UART_OVERSAMPLING_RATE_8X);
+        baudRate = baudRate / (uint32_t) 2;
+        divisor  = (((clockFreq * (uint32_t) 8) / baudRate) + (uint32_t) 1) /
+                  (uint32_t) 2;
+
+    } else {
+        DL_UART_setOversampling(uart, DL_UART_OVERSAMPLING_RATE_16X);
+        divisor = (((clockFreq * (uint32_t) 8) / baudRate) + (uint32_t) 1) /
+                  (uint32_t) 2;
+    }
+
+    /* Set the integer and fractional parts of the baud rate divisor */
+    DL_UART_setBaudRateDivisor(
+        uart, divisor >> (uint32_t) 6, divisor & (uint32_t) 0x3F);
+}
+
+// TODO: Verify parameters and units
+/**
+ *  @brief      Set the IrDA configurations
+ *
+ *  Calculates the baud rate divisor given the clock output of the UART clock
+ *  source and the target baud rate. This API also enables IrDA mode.
+ *
+ *  @param[in]  uart         Pointer to the register overlay for the peripheral
+ *  @param[in]  polarity     The receive input polarity.
+ *                           One of @DL_UART_IRDA_POLARITY.
+ *  @param[in]  pulseLength  The length of the IrDA transmit pulse.
+ *  @param[in]  irdaClk      The clock used for the transmit pulse.
+ *                           One of @DL_UART_IRDA_CLOCK.
+ */
+void DL_UART_configIrDAMode(UART_Regs *uart, DL_UART_IRDA_POLARITY polarity,
+    uint32_t pulseLength, DL_UART_IRDA_CLOCK irdaClk)
+{
+    DL_Common_updateReg(&uart->IRCTL,
+        (uint32_t) polarity | UART_IRCTL_IREN_ENABLE,
+        UART_IRCTL_IRRXPL_MASK | UART_IRCTL_IREN_MASK);
+
+    DL_UART_setIrDAPulseLength(uart, pulseLength, irdaClk);
+}
+
+void DL_UART_setIrDAPulseLength(
+    UART_Regs *uart, uint32_t pulseLength, DL_UART_IRDA_CLOCK irdaClk)
+{
+    uint32_t IRTXPL;
+
+    if (pulseLength == DL_UART_PULSE_WIDTH_3_16_BIT_PERIOD) {
+        // Set IRTXCLK = 0 = BITCLK16 and IRTXPL = 5
+        DL_Common_updateReg(&uart->IRCTL, 0x14,
+            UART_IRCTL_IRTXCLK_MASK | UART_IRCTL_IRTXPL_MASK);
+    } else {
+        IRTXPL =
+            pulseLength * (uint32_t) 2 * (uint32_t) irdaClk - (uint32_t) 1;
+
+        DL_Common_updateReg(&uart->IRCTL, IRTXPL,
+            UART_IRCTL_IRTXCLK_MASK | UART_IRCTL_IRTXPL_MASK);
+    }
+}
+
+uint8_t DL_UART_receiveDataBlocking(UART_Regs *uart)
+{
+    while (DL_UART_isRXFIFOEmpty(uart)) {
+    };
+
+    return DL_UART_receiveData(uart);
+}
+
+void DL_UART_transmitDataBlocking(UART_Regs *uart, uint8_t data)
+{
+    while (DL_UART_isTXFIFOFull(uart)) {
+    };
+    DL_UART_transmitData(uart, data);
+}
+
+bool DL_UART_receiveDataCheck(UART_Regs *uart, uint8_t *buffer)
+{
+    bool status;
+    if (DL_UART_isRXFIFOEmpty(uart)) {
+        status = false;
+    } else {
+        *buffer = DL_UART_receiveData(uart);
+        status  = true;
+    }
+
+    return status;
+}
+
+bool DL_UART_transmitDataCheck(UART_Regs *uart, uint8_t data)
+{
+    bool status;
+    if (DL_UART_isTXFIFOFull(uart)) {
+        status = false;
+    } else {
+        DL_UART_transmitData(uart, data);
+        status = true;
+    }
+
+    return status;
+}
+
+uint32_t DL_UART_drainRXFIFO(
+    UART_Regs *uart, uint8_t *buffer, uint32_t maxCount)
+{
+    uint32_t i;
+    for (i = 0; i < maxCount; i++) {
+        if (!DL_UART_isRXFIFOEmpty(uart)) {
+            buffer[i] = DL_UART_receiveData(uart);
+        } else {
+            break;
+        }
+    }
+
+    return i;
+}
+
+uint32_t DL_UART_fillTXFIFO(UART_Regs *uart, uint8_t *buffer, uint32_t count)
+{
+    uint32_t i;
+    for (i = 0; i < count; i++) {
+        if (!DL_UART_isTXFIFOFull(uart)) {
+            DL_UART_transmitData(uart, buffer[i]);
+        } else {
+            break;
+        }
+    }
+
+    return i;
+}
+#ifdef __MSPM0_HAS_UART_MAIN__
+
+bool DL_UART_Main_saveConfiguration(
+    UART_Regs *uart, DL_UART_Main_backupConfig *ptr)
+{
+    bool stateSaved = !ptr->backupRdy;
+    if (stateSaved) {
+        ptr->controlWord                  = uart->CTL0;
+        ptr->clockSel                     = uart->CLKSEL;
+        ptr->divideRatio                  = uart->CLKDIV;
+        ptr->interruptFifoLevelSelectWord = uart->IFLS;
+        ptr->ibrd                         = uart->IBRD;
+        ptr->fbrd                         = uart->FBRD;
+        ptr->lineControlRegisterWord      = uart->LCRH;
+        ptr->glitchFilterControlWord      = uart->GFCTL;
+        ptr->interruptMask0               = uart->CPU_INT.IMASK;
+        ptr->interruptMask1               = uart->DMA_TRIG_RX.IMASK;
+        ptr->interruptMask2               = uart->DMA_TRIG_TX.IMASK;
+        ptr->backupRdy                    = true;
+    }
+    return stateSaved;
+}
+
+bool DL_UART_Main_restoreConfiguration(
+    UART_Regs *uart, DL_UART_Main_backupConfig *ptr)
+{
+    bool stateRestored = ptr->backupRdy;
+    if (stateRestored) {
+        /* Set CTL0.ENABLE=0 during initialization */
+        uart->CTL0              = ptr->controlWord & ~(UART_CTL0_ENABLE_MASK);
+        uart->CLKSEL            = ptr->clockSel;
+        uart->CLKDIV            = ptr->divideRatio;
+        uart->IFLS              = ptr->interruptFifoLevelSelectWord;
+        uart->IBRD              = ptr->ibrd;
+        uart->FBRD              = ptr->fbrd;
+        uart->LCRH              = ptr->lineControlRegisterWord;
+        uart->GFCTL             = ptr->glitchFilterControlWord;
+        uart->CPU_INT.IMASK     = ptr->interruptMask0;
+        uart->DMA_TRIG_RX.IMASK = ptr->interruptMask1;
+        uart->DMA_TRIG_TX.IMASK = ptr->interruptMask2;
+
+        /* Re-enable UART if it was originally enabled */
+        if ((ptr->controlWord & UART_CTL0_ENABLE_MASK) ==
+            UART_CTL0_ENABLE_MASK) {
+            DL_UART_enable(uart);
+        }
+        ptr->backupRdy = false;
+    }
+    return stateRestored;
+}
+
+#endif /* __MSPM0_HAS_UART_MAIN__ */
+
+#ifdef __MSPM0_HAS_UART_EXTD__
+
+bool DL_UART_Extend_saveConfiguration(
+    UART_Regs *uart, DL_UART_Extend_backupConfig *ptr)
+{
+    bool stateSaved = !ptr->backupRdy;
+    if (stateSaved) {
+        ptr->controlWord                  = uart->CTL0;
+        ptr->clockSel                     = uart->CLKSEL;
+        ptr->divideRatio                  = uart->CLKDIV;
+        ptr->interruptFifoLevelSelectWord = uart->IFLS;
+        ptr->ibrd                         = uart->IBRD;
+        ptr->fbrd                         = uart->FBRD;
+        ptr->lineControlRegisterWord      = uart->LCRH;
+        ptr->glitchFilterControlWord      = uart->GFCTL;
+        ptr->linControlWord               = uart->LINCTL;
+        ptr->irdaControlWord              = uart->IRCTL;
+        ptr->addressMask                  = uart->AMASK;
+        ptr->address                      = uart->ADDR;
+        ptr->interruptMask0               = uart->CPU_INT.IMASK;
+        ptr->interruptMask1               = uart->DMA_TRIG_RX.IMASK;
+        ptr->interruptMask2               = uart->DMA_TRIG_TX.IMASK;
+        ptr->backupRdy                    = true;
+    }
+    return stateSaved;
+}
+
+bool DL_UART_Extend_restoreConfiguration(
+    UART_Regs *uart, DL_UART_Extend_backupConfig *ptr)
+{
+    bool stateRestored = ptr->backupRdy;
+    if (stateRestored) {
+        /* Set CTL0.ENABLE=0 during initialization */
+        uart->CTL0              = ptr->controlWord & ~(UART_CTL0_ENABLE_MASK);
+        uart->CLKSEL            = ptr->clockSel;
+        uart->CLKDIV            = ptr->divideRatio;
+        uart->IFLS              = ptr->interruptFifoLevelSelectWord;
+        uart->IBRD              = ptr->ibrd;
+        uart->FBRD              = ptr->fbrd;
+        uart->LCRH              = ptr->lineControlRegisterWord;
+        uart->GFCTL             = ptr->glitchFilterControlWord;
+        uart->LCRH              = ptr->lineControlRegisterWord;
+        uart->IRCTL             = ptr->irdaControlWord;
+        uart->AMASK             = ptr->addressMask;
+        uart->ADDR              = ptr->address;
+        uart->CPU_INT.IMASK     = ptr->interruptMask0;
+        uart->DMA_TRIG_RX.IMASK = ptr->interruptMask1;
+        uart->DMA_TRIG_TX.IMASK = ptr->interruptMask2;
+
+        /* Re-enable UART if it was originally enabled */
+        if ((ptr->controlWord & UART_CTL0_ENABLE_MASK) ==
+            UART_CTL0_ENABLE_MASK) {
+            DL_UART_enable(uart);
+        }
+        ptr->backupRdy = false;
+    }
+    return stateRestored;
+}
+
+#endif /* __MSPM0_HAS_UART_EXTD__ */
+
+#endif /* __MSPM0_HAS_UART_MAIN__ || __MSPM0_HAS_UART_EXTD__ */

--- a/mspm0/source/ti/driverlib/dl_uart.h
+++ b/mspm0/source/ti/driverlib/dl_uart.h
@@ -1,0 +1,3489 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_uart.h
+ *  @brief      UART Driver Library
+ *  @defgroup   UART Universal Asynchronous Receiver-Transmitter (UART)
+ *
+ *  @anchor ti_dl_dl_uart_Overview
+ *  # Overview
+ *
+ *  The Universal Asynchronous Receiver-Transmitter Driver Library allows
+ *  full configuration of the MSPM0 UART module.
+ *  This module provides common functionality for UART-Main and UART-Extend, but
+ *  developers should use the corresponding dl_uart_extend or dl_uart_main APIs
+ *  directly.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup UART
+ * @{
+ */
+#ifndef ti_dl_dl_uart__include
+#define ti_dl_dl_uart__include
+
+#if defined(ti_dl_dl_uart_main__include) || \
+    defined(ti_dl_dl_uart_extend__include) || defined(DOXYGEN__INCLUDE)
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#if defined(__MSPM0_HAS_UART_MAIN__) || defined(__MSPM0_HAS_UART_EXTD__)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_UART_INTERRUPT
+ *  @{
+ */
+/*!
+ * @brief DMA done on transmit interrupt
+ */
+#define DL_UART_INTERRUPT_DMA_DONE_TX   (UART_CPU_INT_IMASK_DMA_DONE_TX_SET)
+
+/*!
+ * @brief DMA done on receive interrupt
+ */
+#define DL_UART_INTERRUPT_DMA_DONE_RX   (UART_CPU_INT_IMASK_DMA_DONE_RX_SET)
+
+/*!
+ * @brief Clear to send interrupt
+ */
+#define DL_UART_INTERRUPT_CTS_DONE              (UART_CPU_INT_IMASK_CTS_SET)
+
+/*!
+ * @brief 9-bit mode address match interrupt
+ */
+#define DL_UART_INTERRUPT_ADDRESS_MATCH  (UART_CPU_INT_IMASK_ADDR_MATCH_SET)
+
+/*!
+ * @brief LINC0 match interrupt
+ */
+#define DL_UART_INTERRUPT_LINC0_MATCH         (UART_CPU_INT_IMASK_LINC0_SET)
+
+/*!
+ * @brief End of transmission interrupt
+ */
+#define DL_UART_INTERRUPT_EOT_DONE              (UART_CPU_INT_IMASK_EOT_SET)
+
+/*!
+ * @brief UART transmit interrupt
+ */
+#define DL_UART_INTERRUPT_TX                  (UART_CPU_INT_IMASK_TXINT_SET)
+
+/*!
+ * @brief UART receive interrupt
+ */
+#define DL_UART_INTERRUPT_RX                  (UART_CPU_INT_IMASK_RXINT_SET)
+
+/*!
+ * @brief LIN hardware counter overflow interrupt
+ */
+#define DL_UART_INTERRUPT_LIN_COUNTER_OVERFLOW                                \
+                                             (UART_CPU_INT_IMASK_LINOVF_SET)
+
+/*!
+ * @brief LIN rising edge LINC1 interrupt
+ */
+#define DL_UART_INTERRUPT_LIN_RISING_EDGE                                     \
+                                              (UART_CPU_INT_IMASK_LINC1_SET)
+
+/*!
+ * @brief LIN falling edge LINC0 interrupt
+ */
+#define DL_UART_INTERRUPT_LIN_FALLING_EDGE                                    \
+                                              (UART_CPU_INT_IMASK_LINC0_SET)
+
+/*!
+ * @brief Positive Edge on UARTxRXD interrupt
+ */
+#define DL_UART_INTERRUPT_RXD_POS_EDGE         (UART_CPU_INT_IMASK_RXPE_SET)
+
+/*!
+ * @brief Negative Edge on UARTxRXD interrupt
+ */
+#define DL_UART_INTERRUPT_RXD_NEG_EDGE         (UART_CPU_INT_IMASK_RXNE_SET)
+
+/*!
+ * @brief Overrun error interrupt
+ */
+#define DL_UART_INTERRUPT_OVERRUN_ERROR      (UART_CPU_INT_IMASK_OVRERR_SET)
+
+/*!
+ * @brief Break error interrupt
+ */
+#define DL_UART_INTERRUPT_BREAK_ERROR        (UART_CPU_INT_IMASK_BRKERR_SET)
+
+/*!
+ * @brief Parity error interrupt
+ */
+#define DL_UART_INTERRUPT_PARITY_ERROR       (UART_CPU_INT_IMASK_PARERR_SET)
+
+/*!
+ * @brief Framing error interrupt
+ */
+#define DL_UART_INTERRUPT_FRAMING_ERROR      (UART_CPU_INT_IMASK_FRMERR_SET)
+
+/*!
+ * @brief Receive timeout interrupt
+ */
+#define DL_UART_INTERRUPT_RX_TIMEOUT_ERROR    (UART_CPU_INT_IMASK_RTOUT_SET)
+
+
+/*!
+ * @brief Noise error interrupt
+ */
+#define DL_UART_INTERRUPT_NOISE_ERROR          (UART_CPU_INT_IMASK_NERR_SET)
+
+
+/** @}*/
+
+/*! @enum DL_UART_IIDX */
+typedef enum {
+    /*! UART interrupt index for DMA done on transmit */
+    DL_UART_IIDX_DMA_DONE_TX = UART_CPU_INT_IIDX_STAT_DMA_DONE_TX,
+    /*! UART interrupt index for DMA done on receive */
+    DL_UART_IIDX_DMA_DONE_RX = UART_CPU_INT_IIDX_STAT_DMA_DONE_RX,
+    /*! UART interrupt index for clear to send */
+    DL_UART_IIDX_CTS_DONE = UART_CPU_INT_IIDX_STAT_CTS,
+    /*! UART interrupt index for 9-bit mode address match */
+    DL_UART_IIDX_ADDRESS_MATCH = UART_CPU_INT_IIDX_STAT_MODE_9B,
+    /*! UART interrupt index for end of transmission */
+    DL_UART_IIDX_EOT_DONE = UART_CPU_INT_IIDX_STAT_EOT,
+    /*! UART interrupt index for UART transmit */
+    DL_UART_IIDX_TX = UART_CPU_INT_IIDX_STAT_TXIFG,
+    /*! UART interrupt index for UART receive */
+    DL_UART_IIDX_RX = UART_CPU_INT_IIDX_STAT_RXIFG,
+    /*! UART interrupt index for LIN hardware counter overflow */
+    DL_UART_IIDX_LIN_COUNTER_OVERFLOW = UART_CPU_INT_IIDX_STAT_LINOVF,
+    /*! UART interrupt index for LIN rising edge LINC1 */
+    DL_UART_IIDX_LIN_RISING_EDGE = UART_CPU_INT_IIDX_STAT_LINC1,
+    /*! UART interrupt index for LIN falling edge LINC0 */
+    DL_UART_IIDX_LIN_FALLING_EDGE = UART_CPU_INT_IIDX_STAT_LINC0,
+    /*! UART interrupt index for positive edge on UARTxRXD */
+    DL_UART_IIDX_RXD_POS_EDGE = UART_CPU_INT_IIDX_STAT_RXPE,
+    /*! UART interrupt index for negative edge on UARTxRXD */
+    DL_UART_IIDX_RXD_NEG_EDGE = UART_CPU_INT_IIDX_STAT_RXNE,
+    /*! UART interrupt index for overrun error */
+    DL_UART_IIDX_OVERRUN_ERROR = UART_CPU_INT_IIDX_STAT_OEFG,
+    /*! UART interrupt index for break error */
+    DL_UART_IIDX_BREAK_ERROR = UART_CPU_INT_IIDX_STAT_BEFG,
+    /*! UART interrupt index for parity error */
+    DL_UART_IIDX_PARITY_ERROR = UART_CPU_INT_IIDX_STAT_PEFG,
+    /*! UART interrupt index for framing error */
+    DL_UART_IIDX_FRAMING_ERROR = UART_CPU_INT_IIDX_STAT_FEFG,
+    /*! UART interrupt index for receive timeout */
+    DL_UART_IIDX_RX_TIMEOUT_ERROR = UART_CPU_INT_IIDX_STAT_RTFG,
+
+
+    /*! UART interrupt index for noise error */
+    DL_UART_IIDX_NOISE_ERROR = UART_CPU_INT_IIDX_STAT_NERR_EVT,
+
+
+    /*! UART interrupt index for no interrupt */
+    DL_UART_IIDX_NO_INTERRUPT = UART_CPU_INT_IIDX_STAT_NO_INTR
+} DL_UART_IIDX;
+
+/*! @enum DL_UART_DMA_IIDX_RX */
+typedef enum {
+    /*! UART interrupt index for enabling UART receive as DMA trigger */
+    DL_UART_DMA_IIDX_RX_TRIGGER = UART_DMA_TRIG_RX_IIDX_STAT_RXIFG,
+    /*! UART interrupt index for enabling UART receive timeout as DMA trigger */
+    DL_UART_DMA_IIDX_RX_TIMEOUT_TRIGGER = UART_DMA_TRIG_RX_IIDX_STAT_RTFG
+} DL_UART_DMA_IIDX_RX;
+
+/*! @enum DL_UART_DMA_IIDX_TX */
+typedef enum {
+    /*! UART interrupt index for enabling UART transmit as DMA trigger */
+    DL_UART_DMA_IIDX_TX_TRIGGER = UART_DMA_TRIG_TX_IIDX_STAT_TXIFG
+} DL_UART_DMA_IIDX_TX;
+
+/** @addtogroup DL_UART_DMA_INTERRUPT_RX
+ *  @{
+ */
+/*!
+ * @brief UART interrupt for enabling UART receive as DMA trigger
+ */
+#define DL_UART_DMA_INTERRUPT_RX              (UART_DMA_TRIG_RX_IMASK_RXINT_SET)
+
+/*!
+ * @brief UART interrupt for enabling UART receive timeout as DMA trigger
+ */
+#define DL_UART_DMA_INTERRUPT_RX_TIMEOUT      (UART_DMA_TRIG_RX_IMASK_RTOUT_SET)
+
+/** @}*/
+
+/*!
+ * @brief UART interrupt for enabling UART transmit as DMA trigger
+ */
+#define DL_UART_DMA_INTERRUPT_TX              (UART_DMA_TRIG_TX_IMASK_TXINT_SET)
+
+/** @addtogroup DL_UART_ERROR
+ *  @{
+ */
+/*!
+ * @brief Overrun error ocurred
+ */
+#define DL_UART_ERROR_OVERRUN                          (UART_RXDATA_OVRERR_SET)
+
+/*!
+ * @brief Break error ocurred
+ */
+#define DL_UART_ERROR_BREAK                            (UART_RXDATA_BRKERR_SET)
+
+/*!
+ * @brief Parity error ocurred
+ */
+#define DL_UART_ERROR_PARITY                           (UART_RXDATA_PARERR_SET)
+
+/*!
+ * @brief Framing error ocurred
+ */
+#define DL_UART_ERROR_FRAMING                          (UART_RXDATA_FRMERR_SET)
+
+/** @}*/
+
+/*! @enum DL_UART_PULSE_WIDTH */
+typedef enum {
+    /*! Pulses shorter then 5ns length are filtered */
+    DL_UART_PULSE_WIDTH_5_NS = UART_GFCTL_AGFSEL_AGLIT_5,
+    /*! Pulses shorter then 10ns length are filtered */
+    DL_UART_PULSE_WIDTH_10_NS = UART_GFCTL_AGFSEL_AGLIT_10,
+    /*! Pulses shorter then 25ns length are filtered */
+    DL_UART_PULSE_WIDTH_25_NS = UART_GFCTL_AGFSEL_AGLIT_25,
+    /*! Pulses shorter then 50ns length are filtered */
+    DL_UART_PULSE_WIDTH_50_NS = UART_GFCTL_AGFSEL_AGLIT_50
+} DL_UART_PULSE_WIDTH;
+
+/*! @enum DL_UART_OVERSAMPLING_RATE */
+typedef enum {
+    /*! Set oversampling rate to 16x */
+    DL_UART_OVERSAMPLING_RATE_16X = UART_CTL0_HSE_OVS16,
+    /*! Set oversampling rate to 8x */
+    DL_UART_OVERSAMPLING_RATE_8X = UART_CTL0_HSE_OVS8,
+    /*! Set oversampling rate to 3x.
+     * IrDA, Manchester and DALI are not supported when 3x oversampling is
+     * enabled. */
+    DL_UART_OVERSAMPLING_RATE_3X = UART_CTL0_HSE_OVS3
+} DL_UART_OVERSAMPLING_RATE;
+
+/*! @enum DL_UART_PARITY */
+typedef enum {
+    /*! Enable even parity generation, checks for an even number of 1s */
+    DL_UART_PARITY_EVEN = (UART_LCRH_PEN_ENABLE | UART_LCRH_EPS_EVEN),
+    /*! Enable odd parity generation, checks for an odd number of 1s */
+    DL_UART_PARITY_ODD = (UART_LCRH_PEN_ENABLE | UART_LCRH_EPS_ODD),
+    /*! Enable stick parity with a parity bit of '1'
+     * When enabled, a permanent '1' is set as parity when transmitting and
+     * checked as '1' when receiving data. */
+    DL_UART_PARITY_STICK_ONE = (UART_LCRH_PEN_ENABLE | UART_LCRH_SPS_ENABLE | UART_LCRH_EPS_ODD),
+    /*! Enable stick parity with a parity bit of '0'
+     * When enabled, a permanent '0' is set as parity when transmitting and
+     * checked as '0' when receiving data. */
+    DL_UART_PARITY_STICK_ZERO = (UART_LCRH_PEN_ENABLE | UART_LCRH_SPS_ENABLE | UART_LCRH_EPS_EVEN),
+    /*! Disable parity checking and generation */
+    DL_UART_PARITY_NONE = UART_LCRH_PEN_DISABLE
+} DL_UART_PARITY;
+
+/*! @enum DL_UART_WORD_LENGTH */
+typedef enum {
+    /*! Word length is 5 bits */
+    DL_UART_WORD_LENGTH_5_BITS = UART_LCRH_WLEN_DATABIT5,
+    /*! Word length is 6 bits */
+    DL_UART_WORD_LENGTH_6_BITS = UART_LCRH_WLEN_DATABIT6,
+    /*! Word length is 7 bits */
+    DL_UART_WORD_LENGTH_7_BITS = UART_LCRH_WLEN_DATABIT7,
+    /*! Word length is 8 bits */
+    DL_UART_WORD_LENGTH_8_BITS = UART_LCRH_WLEN_DATABIT8
+} DL_UART_WORD_LENGTH;
+
+/*! @enum DL_UART_MODE */
+typedef enum {
+    /*! Normal operation */
+    DL_UART_MODE_NORMAL = UART_CTL0_MODE_UART,
+    /*! Operate in RS485 mode */
+    DL_UART_MODE_RS485 = UART_CTL0_MODE_RS485,
+    /*! Operate in Idle Line mode */
+    DL_UART_MODE_IDLE_LINE = UART_CTL0_MODE_IDLELINE,
+    /*! Operate in 9 Bit Address mode */
+    DL_UART_MODE_ADDR_9_BIT = UART_CTL0_MODE_ADDR9BIT,
+    /*! Operate in ISO7816 Smart Card Support mode */
+    DL_UART_MODE_SMART_CARD = UART_CTL0_MODE_SMART,
+    /*! Operate in DALI mode */
+    DL_UART_MODE_DALI = UART_CTL0_MODE_DALI
+} DL_UART_MODE;
+
+/*! @enum DL_UART_DIRECTION */
+typedef enum {
+    /*! Enable UART transmitter */
+    DL_UART_DIRECTION_TX = UART_CTL0_TXE_ENABLE,
+    /*! Enable UART receiver */
+    DL_UART_DIRECTION_RX = UART_CTL0_RXE_ENABLE,
+    /*! Enable UART transmitter and receiver */
+    DL_UART_DIRECTION_TX_RX = (UART_CTL0_RXE_ENABLE | UART_CTL0_TXE_ENABLE),
+    /*! Disable UART transmitter and receiver */
+    DL_UART_DIRECTION_NONE = (UART_CTL0_RXE_DISABLE | UART_CTL0_TXE_DISABLE)
+} DL_UART_DIRECTION;
+
+/*! @enum DL_UART_CLOCK */
+typedef enum {
+    /*! Selects BUSCLK as the clock source */
+    DL_UART_CLOCK_BUSCLK = UART_CLKSEL_BUSCLK_SEL_ENABLE,
+    /*! Selects MFCLK as the clock source */
+    DL_UART_CLOCK_MFCLK = UART_CLKSEL_MFCLK_SEL_ENABLE,
+    /*! Selects LFCLK as the clock source */
+    DL_UART_CLOCK_LFCLK = UART_CLKSEL_LFCLK_SEL_ENABLE
+} DL_UART_CLOCK;
+
+/*! @enum DL_UART_FLOW_CONTROL */
+typedef enum {
+    /*! Enable request to send */
+    DL_UART_FLOW_CONTROL_RTS = UART_CTL0_RTSEN_ENABLE,
+    /*! Enable clear to send */
+    DL_UART_FLOW_CONTROL_CTS = UART_CTL0_CTSEN_ENABLE,
+    /*! Enable request to send and clear to send */
+    DL_UART_FLOW_CONTROL_RTS_CTS = (UART_CTL0_RTSEN_ENABLE | UART_CTL0_CTSEN_ENABLE),
+    /*! Disable flow control */
+    DL_UART_FLOW_CONTROL_NONE = (UART_CTL0_CTSEN_DISABLE | UART_CTL0_RTSEN_DISABLE)
+} DL_UART_FLOW_CONTROL;
+
+/*! @enum DL_UART_RTS */
+typedef enum {
+    /*! RTS is asserted indicating data in RX FIFO is below threshold */
+    DL_UART_RTS_ASSERT = UART_CTL0_RTS_SET,
+    /*! RTS is deasserted indicating data in RX FIFO is at or above threshold */
+    DL_UART_RTS_DEASSERT = UART_CTL0_RTS_CLR
+} DL_UART_RTS;
+
+/*! @enum DL_UART_STOP_BITS */
+typedef enum {
+    /*! One stop bit is transmitted at the end of the frame */
+    DL_UART_STOP_BITS_ONE = UART_LCRH_STP2_DISABLE,
+    /*! Two stop bits are transmitted at the end of the frame */
+    DL_UART_STOP_BITS_TWO = UART_LCRH_STP2_ENABLE
+} DL_UART_STOP_BITS;
+
+/*! @enum DL_UART_TXD_OUT */
+typedef enum {
+    /*! TXD pin is low */
+    DL_UART_TXD_OUT_LOW = UART_CTL0_TXD_OUT_LOW,
+    /*! TXD pin is high */
+    DL_UART_TXD_OUT_HIGH = UART_CTL0_TXD_OUT_HIGH
+} DL_UART_TXD_OUT;
+
+/*! @enum DL_UART_TX_FIFO_LEVEL */
+typedef enum {
+    /*! Interrupt triggers when FIFO <= 3/4 empty */
+    DL_UART_TX_FIFO_LEVEL_3_4_EMPTY = UART_IFLS_TXIFLSEL_LVL_3_4,
+    /*! Interrupt triggers when FIFO <= 1/2 empty */
+    DL_UART_TX_FIFO_LEVEL_1_2_EMPTY = UART_IFLS_TXIFLSEL_LVL_1_2,
+    /*! Interrupt triggers when FIFO <= 1/4 empty */
+    DL_UART_TX_FIFO_LEVEL_1_4_EMPTY = UART_IFLS_TXIFLSEL_LVL_1_4,
+    /*! Interrupt triggers when FIFO is empty */
+    DL_UART_TX_FIFO_LEVEL_EMPTY = UART_IFLS_TXIFLSEL_LVL_EMPTY,
+    /*! Interrupt triggers when FIFO >= 1 entry */
+    DL_UART_TX_FIFO_LEVEL_ONE_ENTRY = UART_IFLS_TXIFLSEL_LVL_1
+} DL_UART_TX_FIFO_LEVEL;
+
+/*! @enum DL_UART_RX_FIFO_LEVEL */
+typedef enum {
+    /*! Interrupt triggers when FIFO >= 1 entry available. Required for
+     *! DMA trigger */
+    DL_UART_RX_FIFO_LEVEL_ONE_ENTRY = UART_IFLS_RXIFLSEL_LVL_1,
+    /*! Interrupt triggers when FIFO is full */
+    DL_UART_RX_FIFO_LEVEL_FULL = UART_IFLS_RXIFLSEL_LVL_FULL,
+    /*! Interrupt triggers when FIFO >= 3/4 full */
+    DL_UART_RX_FIFO_LEVEL_3_4_FULL = UART_IFLS_RXIFLSEL_LVL_3_4,
+    /*! Interrupt triggers when FIFO >= 1/2 full */
+    DL_UART_RX_FIFO_LEVEL_1_2_FULL = UART_IFLS_RXIFLSEL_LVL_1_2,
+    /*! Interrupt triggers when FIFO >= 1/4 full */
+    DL_UART_RX_FIFO_LEVEL_1_4_FULL = UART_IFLS_RXIFLSEL_LVL_1_4,
+} DL_UART_RX_FIFO_LEVEL;
+
+/*! @enum DL_UART_IRDA_CLOCK */
+typedef enum {
+    /*! IrDA encode data is based on the Baud Rate clock */
+    DL_UART_IRDA_CLOCK_BAUD_RATE = UART_IRCTL_IRTXCLK_BRCLK,
+    /*! IrDA encode data is based on the Functional clock */
+    DL_UART_IRDA_CLOCK_FUNCTIONAL = UART_IRCTL_IRTXCLK_BITCLK
+} DL_UART_IRDA_CLOCK;
+
+/*! @enum DL_UART_IRDA_POLARITY */
+typedef enum {
+    /*! IrDA transceiver delivers a low pulse when a light pulse is seen */
+    DL_UART_IRDA_POLARITY_LOW = UART_IRCTL_IRRXPL_LOW,
+    /*! IrDA transceiver delivers a high pulse when a light pulse is seen */
+    DL_UART_IRDA_POLARITY_HIGH = UART_IRCTL_IRRXPL_HIGH
+} DL_UART_IRDA_POLARITY;
+
+/*!
+ * @brief Sets the IrDA pulse width to 3/16 bit period when using the BITCLK16
+ */
+#define DL_UART_PULSE_WIDTH_3_16_BIT_PERIOD           ((uint32_t) 0x00000000U)
+
+/*! @enum DL_UART_CLOCK_DIVIDE_RATIO */
+typedef enum {
+    /*! UART source clock divide ratio set to 1 */
+    DL_UART_CLOCK_DIVIDE_RATIO_1 = UART_CLKDIV_RATIO_DIV_BY_1,
+    /*! UART source clock divide ratio set to 2 */
+    DL_UART_CLOCK_DIVIDE_RATIO_2 = UART_CLKDIV_RATIO_DIV_BY_2,
+    /*! UART source clock divide ratio set to 3 */
+    DL_UART_CLOCK_DIVIDE_RATIO_3 = UART_CLKDIV_RATIO_DIV_BY_3,
+    /*! UART source clock divide ratio set to 4 */
+    DL_UART_CLOCK_DIVIDE_RATIO_4 = UART_CLKDIV_RATIO_DIV_BY_4,
+    /*! UART source clock divide ratio set to 5 */
+    DL_UART_CLOCK_DIVIDE_RATIO_5 = UART_CLKDIV_RATIO_DIV_BY_5,
+    /*! UART source clock divide ratio set to 6 */
+    DL_UART_CLOCK_DIVIDE_RATIO_6 = UART_CLKDIV_RATIO_DIV_BY_6,
+    /*! UART source clock divide ratio set to 7 */
+    DL_UART_CLOCK_DIVIDE_RATIO_7 = UART_CLKDIV_RATIO_DIV_BY_7,
+    /*! UART source clock divide ratio set to 8 */
+    DL_UART_CLOCK_DIVIDE_RATIO_8 = UART_CLKDIV_RATIO_DIV_BY_8
+} DL_UART_CLOCK_DIVIDE_RATIO;
+
+/*! @enum DL_UART_CLOCK_DIVIDE2_RATIO */
+typedef enum {
+    /*! UART source clock divide 2 ratio set to 1 */
+    DL_UART_CLOCK_DIVIDE2_RATIO_1 = UART_CLKDIV2_RATIO_DIV_BY_1,
+    /*! UART source clock divide 2 ratio set to 2 */
+    DL_UART_CLOCK_DIVIDE2_RATIO_2 = UART_CLKDIV2_RATIO_DIV_BY_2,
+    /*! UART source clock divide 2 ratio set to 3 */
+    DL_UART_CLOCK_DIVIDE2_RATIO_3 = UART_CLKDIV2_RATIO_DIV_BY_3,
+    /*! UART source clock divide 2 ratio set to 4 */
+    DL_UART_CLOCK_DIVIDE2_RATIO_4 = UART_CLKDIV2_RATIO_DIV_BY_4,
+    /*! UART source clock divide 2 ratio set to 5 */
+    DL_UART_CLOCK_DIVIDE2_RATIO_5 = UART_CLKDIV2_RATIO_DIV_BY_5,
+    /*! UART source clock divide 2 ratio set to 6 */
+    DL_UART_CLOCK_DIVIDE2_RATIO_6 = UART_CLKDIV2_RATIO_DIV_BY_6,
+    /*! UART source clock divide 2 ratio set to 7 */
+    DL_UART_CLOCK_DIVIDE2_RATIO_7 = UART_CLKDIV2_RATIO_DIV_BY_7,
+    /*! UART source clock divide 2 ratio set to 8 */
+    DL_UART_CLOCK_DIVIDE2_RATIO_8 = UART_CLKDIV2_RATIO_DIV_BY_8
+} DL_UART_CLOCK_DIVIDE2_RATIO;
+
+/* clang-format on */
+
+/*!
+ *  @brief  Configuration struct for @ref DL_UART_init
+ */
+typedef struct {
+    /*! The communication mode and protocol used. One of @ref DL_UART_MODE */
+    DL_UART_MODE mode;
+
+    /*! The communication direction. One of @ref DL_UART_DIRECTION. */
+    DL_UART_DIRECTION direction;
+
+    /*! The flow control configuration. One of @ref DL_UART_FLOW_CONTROL */
+    DL_UART_FLOW_CONTROL flowControl;
+
+    /*! The parity configuration. One of @ref DL_UART_PARITY */
+    DL_UART_PARITY parity;
+
+    /*! The size of the data transfer. One of @ref DL_UART_WORD_LENGTH */
+    DL_UART_WORD_LENGTH wordLength;
+
+    /*! One of @ref DL_UART_STOP_BITS  */
+    DL_UART_STOP_BITS stopBits;
+
+} DL_UART_Config;
+
+/*!
+ *  @brief  Configuration struct for @ref DL_UART_setClockConfig.
+ */
+typedef struct {
+    /*! Selects uart module clock source @ref DL_UART_CLOCK */
+    DL_UART_CLOCK clockSel;
+
+    /*! Selects the divide ratio. One of @ref DL_UART_CLOCK_DIVIDE_RATIO */
+    DL_UART_CLOCK_DIVIDE_RATIO divideRatio;
+
+} DL_UART_ClockConfig;
+
+#ifdef __MSPM0_HAS_UART_MAIN__
+
+/**
+ * @brief Configuration structure to backup UART Main peripheral state before
+ *        going to STOP/STANDBY mode. Used by
+ *        @ref DL_UART_Main_saveConfiguration and
+ *        @ref DL_UART_Main_restoreConfiguration
+ */
+typedef struct {
+    /*! Combination of basic UART control configurations that are
+     *  compressed to a single word as they are stored in the UART
+     *  registers. See @ref DL_UART_init for how the peripheral control word
+     *  is created. */
+    uint32_t controlWord;
+
+    /*! UART module clock source. One of  @ref DL_UART_CLOCK */
+    uint32_t clockSel;
+
+    /*! UART clock divider. One of @ref DL_UART_CLOCK_DIVIDE_RATIO */
+    uint32_t divideRatio;
+
+    /*! Combination of UART interrupt FIFO level select configurations that are
+     *  compressed to a single word as they are stored in the UART
+     * registers. */
+    uint32_t interruptFifoLevelSelectWord;
+
+    /*! UART integer baud rate divisor. Value between 0 - 65535. */
+    uint32_t ibrd;
+
+    /*! UART fractional baud rate divisor. Value between 0 - 63. */
+    uint32_t fbrd;
+
+    /*! Combination of UART Line Control Register configurations that are
+     *  compressed to a single word as they are stored in the UART
+     *  registers. See @ref DL_UART_init for how the peripheral control word
+     *  is created. */
+    uint32_t lineControlRegisterWord;
+
+    /*! Combination of UART glitch filter configurations that are
+     *  compressed to a single word as they are stored in the UART
+     *  registers. */
+    uint32_t glitchFilterControlWord;
+
+    /*! UART interrupt mask for EVENT0.
+     * Bitwise OR of @ref DL_UART_INTERRUPT */
+    uint32_t interruptMask0;
+
+    /*! UART interrupt mask for EVENT1.
+     * Bitwise OR of @ref DL_UART_DMA_INTERRUPT_RX */
+    uint32_t interruptMask1;
+
+    /*! UART interrupt mask for EVENT2.
+     * Bitwise OR of @ref DL_UART_DMA_INTERRUPT_TX */
+    uint32_t interruptMask2;
+
+    /*! Boolean flag indicating whether or not a valid configuration structure
+     *  exists. Should not be modified by the user. */
+    bool backupRdy;
+} DL_UART_Main_backupConfig;
+
+#endif /* __MSPM0_HAS_UART_MAIN__ */
+
+#ifdef __MSPM0_HAS_UART_EXTD__
+
+/**
+ * @brief Configuration structure to backup UART Extend peripheral state before
+ *        going to STOP/STANDBY mode. Used by
+ *        @ref DL_UART_Extend_saveConfiguration and
+ *        @ref DL_UART_Extend_restoreConfiguration
+ */
+typedef struct {
+    /*! Combination of basic UART control configurations that are
+     *  compressed to a single word as they are stored in the UART
+     *  registers. See @ref DL_UART_init for how the peripheral control word
+     *  is created. */
+    uint32_t controlWord;
+
+    /*! UART module clock source. One of  @ref DL_UART_CLOCK */
+    uint32_t clockSel;
+
+    /*! UART clock divider. One of @ref DL_UART_CLOCK_DIVIDE_RATIO */
+    uint32_t divideRatio;
+
+    /*! Combination of UART Line Control Register configurations that are
+     *  compressed to a single word as they are stored in the UART
+     *  registers. See @ref DL_UART_init for how the peripheral control word
+     *  is created. */
+    uint32_t lineControlRegisterWord;
+
+    /*! Combination of UART interrupt FIFO level select configurations that are
+     *  compressed to a single word as they are stored in the UART
+     * registers. */
+    uint32_t interruptFifoLevelSelectWord;
+
+    /*! UART integer baud rate divisor. Value between 0 - 65535. */
+    uint32_t ibrd;
+
+    /*! UART fractional baud rate divisor. Value between 0 - 63. */
+    uint32_t fbrd;
+
+    /*! Combination of UART glitch filter configurations that are
+     *  compressed to a single word as they are stored in the UART
+     *  registers. */
+    uint32_t glitchFilterControlWord;
+
+    /*! Combination of UART LIN basic configurations that are
+     *  compressed to a single word as they are stored in the UART
+     *  registers. */
+    uint32_t linControlWord;
+
+    /*! Combination of UART IrDA basic configurations that are
+     *  compressed to a single word as they are stored in the UART
+     *  registers. */
+    uint32_t irdaControlWord;
+
+    /*! UART address mask for 9-bit or Idle mode. */
+    uint32_t addressMask;
+
+    /*! UART address that should be matched for 9-bit or Idle mode. */
+    uint32_t address;
+
+    /*! UART interrupt status for EVENT0.
+     * Bitwise OR of @ref DL_UART_INTERRUPT */
+    uint32_t interruptMask0;
+
+    /*! UART interrupt status for EVENT1.
+     * Bitwise OR of @ref DL_UART_DMA_INTERRUPT_RX */
+    uint32_t interruptMask1;
+
+    /*! UART interrupt status for EVENT2.
+     * Bitwise OR of @ref DL_UART_DMA_INTERRUPT_TX */
+    uint32_t interruptMask2;
+
+    /*! Boolean flag indicating whether or not a valid configuration structure
+     *  exists. Should not be modified by the user. */
+    bool backupRdy;
+} DL_UART_Extend_backupConfig;
+
+#endif /* __MSPM0_HAS_UART_EXTD__ */
+
+/**
+ *  @brief      Initialize the UART peripheral
+ *
+ *  Initializes all the common configurable options for the UART peripheral. Any
+ *  other custom configuration can be done after calling this API. The UART is
+ *  not enabled in this API.
+ *
+ *  @param[in]  uart    Pointer to the register overlay for the peripheral
+ *  @param[in]  config  Configuration for UART peripheral
+ */
+void DL_UART_init(UART_Regs *uart, DL_UART_Config *config);
+
+/**
+ * @brief Enables power on UART module
+ *
+ * @param uart        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_enablePower(UART_Regs *uart)
+{
+    uart->GPRCM.PWREN = (UART_PWREN_KEY_UNLOCK_W | UART_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power on uart module
+ *
+ * @param uart        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disablePower(UART_Regs *uart)
+{
+    uart->GPRCM.PWREN = (UART_PWREN_KEY_UNLOCK_W | UART_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief Returns if  power on uart module
+ *
+ * @param uart        Pointer to the register overlay for the peripheral
+ *
+ * @return true if power is enabled
+ * @return false if power is disabled
+ */
+__STATIC_INLINE bool DL_UART_isPowerEnabled(UART_Regs *uart)
+{
+    return ((uart->GPRCM.PWREN & UART_PWREN_ENABLE_MASK) ==
+            UART_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Resets uart peripheral
+ *
+ * @param uart        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_reset(UART_Regs *uart)
+{
+    uart->GPRCM.RSTCTL =
+        (UART_RSTCTL_KEY_UNLOCK_W | UART_RSTCTL_RESETSTKYCLR_CLR |
+            UART_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief Returns if uart peripheral was reset
+ *
+ * @param uart        Pointer to the register overlay for the peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_UART_isReset(UART_Regs *uart)
+{
+    return ((uart->GPRCM.STAT & UART_GPRCM_STAT_RESETSTKY_MASK) ==
+            UART_GPRCM_STAT_RESETSTKY_RESET);
+}
+
+/**
+ *  @brief      Enable the UART peripheral
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_enable(UART_Regs *uart)
+{
+    uart->CTL0 |= UART_CTL0_ENABLE_ENABLE;
+}
+
+/**
+ *  @brief      Checks if the UART peripheral is enabled
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the enabled status of the UART
+ *
+ *  @retval     true  The UART peripheral is enabled
+ *  @retval     false The UART peripheral is disabled
+
+ */
+__STATIC_INLINE bool DL_UART_isEnabled(UART_Regs *uart)
+{
+    return ((uart->CTL0 & UART_CTL0_ENABLE_MASK) == UART_CTL0_ENABLE_ENABLE);
+}
+
+/**
+ *  @brief      Disable the UART peripheral
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disable(UART_Regs *uart)
+{
+    uart->CTL0 &= ~(UART_CTL0_ENABLE_MASK);
+}
+
+/**
+ *  @brief      Configure UART source clock
+ *
+ *  @param[in]  uart    Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  config  Pointer to the clock configuration struct
+ *                       @ref DL_UART_ClockConfig.
+ */
+void DL_UART_setClockConfig(UART_Regs *uart, DL_UART_ClockConfig *config);
+
+/**
+ *  @brief      Get UART source clock configuration
+ *
+ *  @param[in]  uart    Pointer to the register overlay for the
+ *                      peripheral
+ *  @param[in]  config  Pointer to the clock configuration struct
+ *                      @ref DL_UART_ClockConfig.
+ */
+void DL_UART_getClockConfig(UART_Regs *uart, DL_UART_ClockConfig *config);
+
+/**
+ *  @brief      Configure the baud rate
+ *
+ *  Given the target baud rate and the frequency of the UART clock source, this
+ *  API determines and sets the recommended oversampling setting, and then
+ *  calculates and sets the required baud rate divisors.
+ *
+ * The oversampling rate that will be set is the highest possible oversampling
+ * rate given the target baud rate and UART clock frequency.
+ *
+ * If the user wishes to avoid having the CPU calculate the baud rate divisors
+ * or not use the recommended calculated values, the user can call
+ * @ref DL_UART_setOversampling and @ref DL_UART_setBaudRateDivisor directly.
+ *
+ *  @param[in]  uart       Pointer to the register overlay for the peripheral
+ *  @param[in]  clockFreq  The clock frequency in Hz of the UART clock source
+ *  @param[in]  baudRate   The target baud rate
+ *
+ * @sa          DL_UART_setOversampling
+ * @sa          DL_UART_setBaudRateDivisor
+ */
+void DL_UART_configBaudRate(
+    UART_Regs *uart, uint32_t clockFreq, uint32_t baudRate);
+
+/**
+ *  @brief      Set the oversampling rate
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *  @param[in]  rate  The oversampling rate to use.
+ *                    One of @ref DL_UART_OVERSAMPLING_RATE
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ */
+__STATIC_INLINE void DL_UART_setOversampling(
+    UART_Regs *uart, DL_UART_OVERSAMPLING_RATE rate)
+{
+    DL_Common_updateReg(&uart->CTL0, (uint32_t) rate, UART_CTL0_HSE_MASK);
+}
+
+/**
+ *  @brief      Get the oversampling rate
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current oversampling rate
+ *
+ *  @retval     One of @ref DL_UART_OVERSAMPLING_RATE
+ *
+ */
+__STATIC_INLINE DL_UART_OVERSAMPLING_RATE DL_UART_getOversampling(
+    UART_Regs *uart)
+{
+    uint32_t rate = uart->CTL0 & UART_CTL0_HSE_MASK;
+
+    return (DL_UART_OVERSAMPLING_RATE)(rate);
+}
+
+/**
+ *  @brief      Enable loopback mode
+ *
+ *  Enables the loopback mode. When enabled, the UARTxTXD path is fed through
+ *  the UARTxRXD path.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ */
+__STATIC_INLINE void DL_UART_enableLoopbackMode(UART_Regs *uart)
+{
+    uart->CTL0 |= UART_CTL0_LBE_ENABLE;
+}
+
+/**
+ *  @brief      Check if loopback mode is enabled
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of loopback mode
+ *
+ *  @retval     true  Loopback mode is enabled
+ *  @retval     false Loopback mode is disabled
+ */
+__STATIC_INLINE bool DL_UART_isLoopbackModeEnabled(UART_Regs *uart)
+{
+    return ((uart->CTL0 & UART_CTL0_LBE_MASK) == UART_CTL0_LBE_ENABLE);
+}
+
+/**
+ *  @brief      Disable loopback mode
+ *
+ *  Disables the loopback mode. When disabled, the UARTxTXD path is not fed through
+ *  the UARTxRXD path.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ */
+__STATIC_INLINE void DL_UART_disableLoopbackMode(UART_Regs *uart)
+{
+    uart->CTL0 &= ~(UART_CTL0_LBE_MASK);
+}
+
+/**
+ *  @brief      Set the direction of the UART communication
+ *
+ *  If the UART is disabled in the middle of a transmit or receive, it
+ *  completes the current character before stopping.
+ *
+ *  @param[in]  uart       Pointer to the register overlay for the peripheral
+ *  @param[in]  direction  Direction to set UART communication to.
+ *                         One of @ref DL_UART_DIRECTION.
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ *
+ */
+__STATIC_INLINE void DL_UART_setDirection(
+    UART_Regs *uart, DL_UART_DIRECTION direction)
+{
+    DL_Common_updateReg(&uart->CTL0, (uint32_t) direction,
+        UART_CTL0_TXE_MASK | UART_CTL0_RXE_MASK);
+}
+
+/**
+ *  @brief      Get the direction of the UART communication
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The direction of UART communication.
+ *
+ *  @retval     One of @ref DL_UART_DIRECTION
+ */
+__STATIC_INLINE DL_UART_DIRECTION DL_UART_getDirection(UART_Regs *uart)
+{
+    uint32_t direction =
+        uart->CTL0 & (UART_CTL0_TXE_MASK | UART_CTL0_RXE_MASK);
+
+    return (DL_UART_DIRECTION)(direction);
+}
+
+/**
+ *  @brief      Enable majority voting control
+ *
+ *  When enabled, the three center bits are used to determine received sample
+ *  value. The value corresponding to at least two of the three samples is
+ *  considered to be the received value.In case of error (i.e. all 3 bits are
+ *  not the same), noise error is detected and bits RIS.NERR and register
+ *  RXDATA.NERR are set.
+ *
+ *  When enabled with oversampling of 16, samples 7, 8, and 9 are
+ *  majority voted to decide the sampled bit value.
+ *
+ *  When enabled with oversampling of 8, samples 3, 4, and 5 are majority
+ *  voted to decide the sampled bit value. The value corresponding to at least 2
+ *  of the 3 samples is considered to be the received value.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ *
+ *  @sa          DL_UART_setOversampling
+ */
+__STATIC_INLINE void DL_UART_enableMajorityVoting(UART_Regs *uart)
+{
+    uart->CTL0 |= UART_CTL0_MAJVOTE_ENABLE;
+}
+
+/**
+ *  @brief      Check if majority voting is enabled
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of majority control feature
+ *
+ *  @retval     true  Majority voting is enabled
+ *  @retval     false Majority voting is disabled
+ */
+__STATIC_INLINE bool DL_UART_isMajorityVotingEnabled(UART_Regs *uart)
+{
+    return ((uart->CTL0 & UART_CTL0_MAJVOTE_MASK) == UART_CTL0_MAJVOTE_ENABLE);
+}
+
+/**
+ *  @brief      Disable majority voting control
+ *
+ *  When disabled, only a single sample of the received bit of is taken.
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ */
+__STATIC_INLINE void DL_UART_disableMajorityVoting(UART_Regs *uart)
+{
+    uart->CTL0 &= ~(UART_CTL0_MAJVOTE_MASK);
+}
+
+/**
+ *  @brief      Enable most significant bit (MSB) first
+ *
+ *  When enabled, the most significant bit (MSB) is sent first in the protocol
+ *  packet. This bit has effect on both the way the protocol byte is
+ *  transmitted and received.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ */
+__STATIC_INLINE void DL_UART_enableMSBFirst(UART_Regs *uart)
+{
+    uart->CTL0 |= UART_CTL0_MSBFIRST_ENABLE;
+}
+
+/**
+ *  @brief      Check if most significant bit (MSB) first is enabled
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of majority control feature
+ *
+ *  @retval     true  MSB first is enabled
+ *  @retval     false MSB first is disabled
+ */
+__STATIC_INLINE bool DL_UART_isMSBFirstEnabled(UART_Regs *uart)
+{
+    return (
+        (uart->CTL0 & UART_CTL0_MSBFIRST_MASK) == UART_CTL0_MSBFIRST_ENABLE);
+}
+
+/**
+ *  @brief      Disable most significant bit (MSB) first
+ *
+ *  When disabled, the least significant bit (LSB) is sent first in the protocol
+ *  packet. This bit has effect on both the way the protocol byte is
+ *  transmitted and received.
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ */
+__STATIC_INLINE void DL_UART_disableMSBFirst(UART_Regs *uart)
+{
+    uart->CTL0 &= ~(UART_CTL0_MSBFIRST_MASK);
+}
+
+/**
+ *  @brief      Enable control of the TXD pin
+ *
+ *  When enabled, the TXD pin can be controlled by the TXD_OUT bit. The UART
+ *  transmit section must first be disabled.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ *
+ *  @sa          DL_UART_setDirection
+ *  @sa          DL_UART_setTXDPin
+ */
+__STATIC_INLINE void DL_UART_enableTransmitPinManualControl(UART_Regs *uart)
+{
+    uart->CTL0 |= UART_CTL0_TXD_OUT_EN_ENABLE;
+}
+
+/**
+ *  @brief      Check if control of the TXD pin is enabled
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of control of the TXD pin
+ *
+ *  @retval     true  Control of the TXD pin is enabled
+ *  @retval     false Control of the TXD pin is disabled
+ */
+__STATIC_INLINE bool DL_UART_isTransmitPinManualControlEnabled(UART_Regs *uart)
+{
+    return ((uart->CTL0 & UART_CTL0_TXD_OUT_EN_MASK) ==
+            UART_CTL0_TXD_OUT_EN_ENABLE);
+}
+
+/**
+ *  @brief      Disable control of the TXD pin
+ *
+ *  When disabled, the TXD pin can not be controlled by the TXD_OUT bit
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ */
+__STATIC_INLINE void DL_UART_disableTransmitPinManualControl(UART_Regs *uart)
+{
+    uart->CTL0 &= ~(UART_CTL0_TXD_OUT_EN_MASK);
+}
+
+/**
+ *  @brief      Set the output of the TXD pin
+ *
+ *  Control the output transmit data pin only when TXD_OUT_EN is enabled and
+ *  TXE is disabled.
+ *
+ *  The TXD pin is set to manual control if it hadn't been
+ *  previously set.
+ *
+ *  @param[in]  uart       Pointer to the register overlay for the peripheral
+ *  @param[in]  txdOutVal  Value to set the TXD pin output to.
+ *                         One of @ref DL_UART_TXD_OUT
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ *
+ *  @sa          DL_UART_disableTransmit
+ *  @sa          DL_UART_enableTransmitPinManualControl
+ */
+__STATIC_INLINE void DL_UART_setTransmitPinManualOutput(
+    UART_Regs *uart, DL_UART_TXD_OUT txdOutVal)
+{
+    DL_Common_updateReg(&uart->CTL0,
+        UART_CTL0_TXD_OUT_EN_ENABLE | (uint32_t) txdOutVal,
+        UART_CTL0_TXD_OUT_EN_MASK | UART_CTL0_TXD_OUT_MASK);
+}
+
+/**
+ *  @brief      Get the output value of the TXD pin
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The value of the TXD pin
+ *
+ *  @retval     One of @ref DL_UART_TXD_OUT
+ */
+__STATIC_INLINE DL_UART_TXD_OUT DL_UART_getTransmitPinManualOutput(
+    UART_Regs *uart)
+{
+    uint32_t txdOutVal = uart->CTL0 & UART_CTL0_TXD_OUT_MASK;
+
+    return (DL_UART_TXD_OUT)(txdOutVal);
+}
+
+/**
+ *  @brief      Enable Manchester encoding
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_enableManchesterEncoding(UART_Regs *uart)
+{
+    uart->CTL0 |= UART_CTL0_MENC_ENABLE;
+}
+
+/**
+ *  @brief      Disable Manchester encoding
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disableManchesterEncoding(UART_Regs *uart)
+{
+    uart->CTL0 &= ~(UART_CTL0_MENC_MASK);
+}
+
+/**
+ *  @brief      Check if Manchester encoding is enabled
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of Manchester encode
+ *
+ *  @retval     true  Manchester encoding is enabled
+ *  @retval     false Manchester encoding is disabled
+ */
+__STATIC_INLINE bool DL_UART_isManchesterEncodingEnabled(UART_Regs *uart)
+{
+    return ((uart->CTL0 & UART_CTL0_MENC_MASK) == UART_CTL0_MENC_ENABLE);
+}
+
+/**
+ *  @brief      Set the communication mode/protocol to use
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *  @param[in]  mode  Value to set the UART communication protocol to.
+ *                     One of @ref DL_UART_MODE
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ */
+__STATIC_INLINE void DL_UART_setCommunicationMode(
+    UART_Regs *uart, DL_UART_MODE mode)
+{
+    DL_Common_updateReg(&uart->CTL0, (uint32_t) mode, UART_CTL0_MODE_MASK);
+}
+
+/**
+ *  @brief      Get the communication mode/protocol being used
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The communication mode/protocol being used by the UART
+ *
+ *  @retval     One of @ref DL_UART_MODE
+ */
+__STATIC_INLINE DL_UART_MODE DL_UART_getCommunicationMode(UART_Regs *uart)
+{
+    uint32_t mode = uart->CTL0 & UART_CTL0_MODE_MASK;
+
+    return (DL_UART_MODE)(mode);
+}
+
+/**
+ *  @brief      Set the flow control configuration
+ *
+ *  @param[in]  uart    Pointer to the register overlay for the peripheral
+ *  @param[in]  config  The flow control configuration to use.
+ *                      One of @ref DL_UART_FLOW_CONTROL.
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ */
+__STATIC_INLINE void DL_UART_setFlowControl(
+    UART_Regs *uart, DL_UART_FLOW_CONTROL config)
+{
+    DL_Common_updateReg(&uart->CTL0, (uint32_t) config,
+        UART_CTL0_RTSEN_MASK | UART_CTL0_CTSEN_MASK);
+}
+
+/**
+ *  @brief      Check the flow control configuration
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the
+ *                    peripheral
+ *
+ *  @return     The flow control configuration
+ *
+ *  @retval     One of @ref DL_UART_FLOW_CONTROL values
+ */
+__STATIC_INLINE DL_UART_FLOW_CONTROL DL_UART_getFlowControl(UART_Regs *uart)
+{
+    uint32_t config =
+        uart->CTL0 & (UART_CTL0_RTSEN_MASK | UART_CTL0_CTSEN_MASK);
+
+    return (DL_UART_FLOW_CONTROL)(config);
+}
+
+/**
+ *  @brief      Set the request to send output signal
+ *
+ *  The RTS output signal indicates the state of the RX FIFO, and is
+ *  linked to the programmable receive FIFO threshold levels. When RTS flow
+ *  control is enabled, the RTS signal is asserted (low) when the data in the
+ *  RX FIFO is less than the threshold level. When the RX FIFO threshold level
+ *  is reached, the RTS signal is deasserted (high). The RTS signal is
+ *  reasserted (low) when data has been read out  of the RX FIFO so it is less
+ *  than the threshold.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *  @param[in]  val   The RTS output signal. One of @ref DL_UART_RTS
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ *
+ *  @sa         DL_UART_setTXFIFOThreshold
+ */
+__STATIC_INLINE void DL_UART_setRTSOutput(UART_Regs *uart, DL_UART_RTS val)
+{
+    DL_Common_updateReg(&uart->CTL0, (uint32_t) val, UART_CTL0_RTS_MASK);
+}
+
+/**
+ *  @brief      Get the request to send output signal
+ *
+ *  The RTS output signal indicates the state of the RX FIFO, and is
+ *  linked to the programmable receive FIFO threshold levels. When RTS flow
+ *  control is enabled, the RTS signal is asserted (low) when the data in the
+ *  RX FIFO is less than the threshold level. When the RX FIFO threshold level
+ *  is reached, the RTS signal is deasserted (high). The RTS signal is
+ *  reasserted (low) when data has been read out  of the RX FIFO so it is less
+ *  than the threshold.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The RTS signal status
+ *
+ *  @retval     One of @ref DL_UART_RTS
+ *
+ *  @sa         DL_UART_setTXFIFOThreshold
+ */
+__STATIC_INLINE DL_UART_RTS DL_UART_getRTSOutput(UART_Regs *uart)
+{
+    uint32_t val = uart->CTL0 & UART_CTL0_RTS_MASK;
+
+    return (DL_UART_RTS)(val);
+}
+
+/**
+ *  @brief      Enable FIFOs
+ *
+ *  Enables the transmit and receive FIFO buffers.
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ *
+ *  @sa         DL_UART_init
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ */
+__STATIC_INLINE void DL_UART_enableFIFOs(UART_Regs *uart)
+{
+    uart->CTL0 |= UART_CTL0_FEN_ENABLE;
+}
+
+/**
+ *  @brief      Disable FIFOs
+ *
+ *  Disables the transmit and receive FIFO buffers. The receiver will now
+ *  only hold 1-byte of data.
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ *
+ *  @pre  If the UART has already been enabled, then it must be made ready for
+ *        configuration by first calling @ref DL_UART_changeConfig
+ *  @post If @ref DL_UART_changeConfig was called, then the UART must be
+ *        re-enabled by calling @ref DL_UART_enable
+ */
+__STATIC_INLINE void DL_UART_disableFIFOs(UART_Regs *uart)
+{
+    uart->CTL0 &= ~(UART_CTL0_FEN_MASK);
+}
+
+/**
+ *  @brief      Check if FIFOs are enabled
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of the FIFOs
+ *
+ *  @retval     true  FIFOs are enabled
+ *  @retval     false FIFOs are disabled
+ */
+__STATIC_INLINE bool DL_UART_isFIFOsEnabled(UART_Regs *uart)
+{
+    return ((uart->CTL0 & UART_CTL0_FEN_MASK) == UART_CTL0_FEN_ENABLE);
+}
+
+/**
+ *  @brief      Enable send break (for LIN protocol)
+ *
+ *  When enabled, a low level is continually output on the TXD signal after completing
+ *  transmission of the current character. For the proper execution of the
+ *  break command, software must set this bit for at least two frames (character periods).
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_enableLINSendBreak(UART_Regs *uart)
+{
+    uart->LCRH |= UART_LCRH_BRK_ENABLE;
+}
+
+/**
+ *  @brief      Disable send break
+ *
+ *  When disabled, a low level is not continually output on the TXD signal
+ *  after completing transmission of the current character.
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disableLINSendBreak(UART_Regs *uart)
+{
+    uart->LCRH &= ~(UART_LCRH_BRK_MASK);
+}
+
+/**
+ *  @brief      Check if send break is enabled
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of send break
+ *
+ *  @retval     true  Send break is enabled
+ *  @retval     false Send break is disabled
+ */
+__STATIC_INLINE bool DL_UART_isLINSendBreakEnabled(UART_Regs *uart)
+{
+    return ((uart->LCRH & UART_LCRH_BRK_MASK) == UART_LCRH_BRK_ENABLE);
+}
+
+/**
+ *  @brief      Check if parity is enabled
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of parity
+ *
+ *  @retval     true  Parity is enabled
+ *  @retval     false Parity is disabled
+ */
+__STATIC_INLINE bool DL_UART_isParityEnabled(UART_Regs *uart)
+{
+    return ((uart->LCRH & UART_LCRH_PEN_MASK) == UART_LCRH_PEN_ENABLE);
+}
+
+/**
+ *  @brief      Set the parity mode
+ *
+ *  For 9-bit UART mode transmissions, the parity mode affects the address
+ *  byte and data byte indication (9th bit). If DL_UART_PARITY_EVEN or
+ *  DL_UART_PARITY_STICK_ZERO is enabled, then the transferred byte is a data
+ *  byte.  If DL_UART_PARITY_EVEN or DL_UART_PARITY_STICK_ZERO is not enabled,
+ *  then the transferred byte is an address byte.
+ *
+ *  @param[in]  uart    Pointer to the register overlay for the peripheral
+ *  @param[in]  parity  Parity mode to set UART to.
+ *                      One of @ref DL_UART_PARITY
+ */
+__STATIC_INLINE void DL_UART_setParityMode(
+    UART_Regs *uart, DL_UART_PARITY parity)
+{
+    DL_Common_updateReg(&uart->LCRH, (uint32_t) parity,
+        (UART_LCRH_PEN_MASK | UART_LCRH_EPS_MASK | UART_LCRH_SPS_MASK));
+}
+
+/**
+ *  @brief      Get parity mode
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The current parity mode being used
+ *
+ *  @retval     One of @ref DL_UART_PARITY
+ *
+ */
+__STATIC_INLINE DL_UART_PARITY DL_UART_getParityMode(UART_Regs *uart)
+{
+    uint32_t parity = uart->LCRH & (UART_LCRH_PEN_MASK | UART_LCRH_EPS_MASK |
+                                       UART_LCRH_SPS_MASK);
+
+    return (DL_UART_PARITY)(parity);
+}
+
+/**
+ *  @brief      Set the number of stop bits
+ *
+ *  When in 7816 smart code mode (DL_UART_MODE_SMART_CARD mode), the number of
+ *  stop bits is forced to 2
+ *
+ *  @param[in]  uart         Pointer to the register overlay for the peripheral
+ *  @param[in]  numStopBits  The number of stop bits transmitted.
+ *                           One of @ref DL_UART_STOP_BITS
+ */
+__STATIC_INLINE void DL_UART_setStopBits(
+    UART_Regs *uart, DL_UART_STOP_BITS numStopBits)
+{
+    DL_Common_updateReg(
+        &uart->LCRH, (uint32_t) numStopBits, UART_LCRH_STP2_MASK);
+}
+
+/**
+ *  @brief      Get the number of stop bits
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The number of stop bits transmitted.
+ *
+ *  @retval     One of @ref DL_UART_STOP_BITS
+ */
+__STATIC_INLINE DL_UART_STOP_BITS DL_UART_getStopBits(UART_Regs *uart)
+{
+    uint32_t numStopBits = uart->LCRH & UART_LCRH_STP2_MASK;
+
+    return (DL_UART_STOP_BITS)(numStopBits);
+}
+
+/**
+ *  @brief      Set the word length
+ *
+ *  @param[in]  uart        Pointer to the register overlay for the peripheral
+ *  @param[in]  wordLength  The number of data bits transmitted or received in
+ *                           a frame. One of @ref DL_UART_WORD_LENGTH
+ */
+__STATIC_INLINE void DL_UART_setWordLength(
+    UART_Regs *uart, DL_UART_WORD_LENGTH wordLength)
+{
+    DL_Common_updateReg(
+        &uart->LCRH, (uint32_t) wordLength, UART_LCRH_WLEN_MASK);
+}
+
+/**
+ *  @brief      Get the word length
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The length of the data bits transmitted or received in a frame
+ *
+ *  @retval     One of @ref DL_UART_WORD_LENGTH
+ */
+__STATIC_INLINE DL_UART_WORD_LENGTH DL_UART_getWordLength(UART_Regs *uart)
+{
+    uint32_t wordLength = uart->LCRH & UART_LCRH_WLEN_MASK;
+
+    return (DL_UART_WORD_LENGTH)(wordLength);
+}
+
+/**
+ *  @brief      Send idle pattern
+ *
+ *  When enabled, a SENDIDLE period of 11 bit times will be sent on the TX
+ *  line. The bit is cleared by hardware afterwards.
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_enableSendIdlePattern(UART_Regs *uart)
+{
+    uart->LCRH |= UART_LCRH_SENDIDLE_ENABLE;
+}
+
+/**
+ *  @brief      Disable send idle pattern
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disableSendIdlePattern(UART_Regs *uart)
+{
+    uart->LCRH &= ~(UART_LCRH_SENDIDLE_MASK);
+}
+
+/**
+ *  @brief      Check if send idle pattern is enabled
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of the send idle pattern
+ *
+ *  @retval     true  Send idle pattern is enabled
+ *  @retval     false Send idle pattern is disabled
+ */
+__STATIC_INLINE bool DL_UART_isSendIdlePatternEnabled(UART_Regs *uart)
+{
+    return (
+        (uart->LCRH & UART_LCRH_SENDIDLE_MASK) == UART_LCRH_SENDIDLE_ENABLE);
+}
+
+/**
+ *  @brief      Set external driver setup value
+ *
+ *  Defines the number of UARTclk ticks the signal to control the external
+ *  driver for the RS485 will be set before the START bit is sent
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *  @param[in]  val   The number of UARTclk ticks the signal before the RS485
+ *                    is setup. Value between 0 - 31.
+ */
+__STATIC_INLINE void DL_UART_setExternalDriverSetup(
+    UART_Regs *uart, uint32_t val)
+{
+    DL_Common_updateReg(&uart->LCRH, val << UART_LCRH_EXTDIR_SETUP_OFS,
+        UART_LCRH_EXTDIR_SETUP_MASK);
+}
+
+/**
+ *  @brief      Get the external driver setup value
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return    The number of UARTclk ticks the signal to control the
+ *             external driver
+ *
+ *  @retval     0 - 31 The number of UARTclk ticks
+ */
+__STATIC_INLINE uint32_t DL_UART_getExternalDriverSetup(UART_Regs *uart)
+{
+    return ((uart->LCRH &
+             UART_LCRH_EXTDIR_SETUP_MASK >> UART_LCRH_EXTDIR_SETUP_OFS));
+}
+
+/**
+ *  @brief      Set external driver setup hold
+ *
+ *  Defines the number of UARTclk ticks the signal to control the external
+ *  driver for the RS485 will be reset after the beginning of the stop bit.
+ *  If 2 STOP bits are enabled, the RS485 will be reset at the beginning of
+ *  the 2nd STOP bit.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *  @param[in]  val   The number of UARTclk ticks the signal to hold the
+ *                    external driver before the RS485 will be reset.
+ *                    Value between 0 - 31.
+ */
+__STATIC_INLINE void DL_UART_setExternalDriverHold(
+    UART_Regs *uart, uint32_t val)
+{
+    DL_Common_updateReg(&uart->LCRH, val << UART_LCRH_EXTDIR_HOLD_OFS,
+        UART_LCRH_EXTDIR_HOLD_MASK);
+}
+
+/**
+ *  @brief      Get the external driver setup hold
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ *
+ *  @return     The number of UARTclk ticks the signal to hold the
+ *              external driver before the RS485 will be reset
+ *
+ *  @retval     0 - 31 The number of UARTclk ticks
+ */
+__STATIC_INLINE uint32_t DL_UART_getExternalDriverHold(UART_Regs *uart)
+{
+    return ((
+        uart->LCRH & UART_LCRH_EXTDIR_HOLD_MASK >> UART_LCRH_EXTDIR_HOLD_OFS));
+}
+
+/**
+ *  @brief      Checks if the UART is busy
+ *
+ *  This bit is set as soon as the transmit FIFO or TXDATA register becomes
+ *  non-empty (regardless of whether UART is enabled) or if a receive data is
+ *  currently ongoing (after the start edge have been detected until a complete
+ *  byte, including all stop bits, has been received by the shift register).
+ *
+ *  In IDLE Line mode the Busy signal also stays set during the idle time
+ *  generation.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of the UART Busy bit
+ *
+ *  @retval     true   The UART is busy
+ *  @retval     false  The UART is not busy
+ *
+ */
+__STATIC_INLINE bool DL_UART_isBusy(UART_Regs *uart)
+{
+    return ((uart->STAT & UART_STAT_BUSY_MASK) == UART_STAT_BUSY_SET);
+}
+
+/**
+ *  @brief      Checks if the RX FIFO is empty
+ *
+ *  The meaning of this bit depends on if the FIFOs were enabled.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the empty status of the RX FIFO
+ *
+ *  @retval     true   If the FIFO is enabled, the receive FIFO is empty.
+ *                     If the FIFO is disabled, the receiver has no data.
+ *  @retval     false  The receiver is not empty
+ *
+ *  @sa         DL_UART_enableFIFOs
+ */
+__STATIC_INLINE bool DL_UART_isRXFIFOEmpty(UART_Regs *uart)
+{
+    return ((uart->STAT & UART_STAT_RXFE_MASK) == UART_STAT_RXFE_SET);
+}
+
+/**
+ *  @brief      Checks if the RX FIFO is full
+ *
+ *  The meaning of this bit depends on if the FIFOs were enabled.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the full status of the RX FIFO
+ *
+ *  @retval     true   If the FIFO is enabled, the receive FIFO is full.
+ *                     If the FIFO is disabled, the receiver has 1-byte
+ *                     of data.
+ *  @retval     false  The receiver is not full
+ *
+ *  @sa         DL_UART_enableFIFOs
+ */
+__STATIC_INLINE bool DL_UART_isRXFIFOFull(UART_Regs *uart)
+{
+    return ((uart->STAT & UART_STAT_RXFF_MASK) == UART_STAT_RXFF_SET);
+}
+
+/**
+ *  @brief      Checks if the TX FIFO is empty
+ *
+ *  The meaning of this bit depends on if the FIFOs were enabled.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the empty status of the TX FIFO
+ *
+ *  @retval     true   If the FIFO is enabled, the transmit FIFO is empty.
+ *                     If the FIFO is disabled, the transmitter has no data.
+ *  @retval     false  The transmitter is not empty
+ *
+ *  @sa         DL_UART_enableFIFOs
+ */
+__STATIC_INLINE bool DL_UART_isTXFIFOEmpty(UART_Regs *uart)
+{
+    return ((uart->STAT & UART_STAT_TXFE_MASK) == UART_STAT_TXFE_SET);
+}
+
+/**
+ *  @brief      Checks if the TX FIFO is full
+ *
+ *  The meaning of this bit depends on if the FIFOs were enabled.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the full status of the TX FIFO
+ *
+ *  @retval     true   If the FIFO is enabled, the transmit FIFO is full.
+ *                     If the FIFO is disabled, the transmitter has 1-byte
+ *                     of data.
+ *  @retval     false  The transmitter is not full
+ *
+ *  @sa         DL_UART_enableFIFOs
+ */
+__STATIC_INLINE bool DL_UART_isTXFIFOFull(UART_Regs *uart)
+{
+    return ((uart->STAT & UART_STAT_TXFF_MASK) == UART_STAT_TXFF_SET);
+}
+
+/**
+ *  @brief      Checks if UART is clear to send
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the status of the CTS signal
+ *
+ *  @retval     true   The CTS signal is asserted (low)
+ *  @retval     false  The CTS signal is not asserted (high)
+ *
+ *  @sa         DL_UART_isClearToSendEnabled
+ */
+__STATIC_INLINE bool DL_UART_isClearToSend(UART_Regs *uart)
+{
+    return ((uart->STAT & UART_STAT_CTS_MASK) == UART_STAT_CTS_SET);
+}
+
+/**
+ *  @brief      Checks if Idle mode has been detected
+ *
+ *  Idle mode has been detected in Idleline-Multiprocessor-Mode. The IDLE bit
+ *  is used as an address tag for each block of characters. In idle-line
+ *  multiprocessor format, this bit is set when a received character is an
+ *  address.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the status if Idle mode has been detected
+ *
+ *  @retval     true  Idle has been detected before last received character
+ *  @retval     false Idle has not been detected before last received character
+ *
+ */
+__STATIC_INLINE bool DL_UART_isIdleModeDetected(UART_Regs *uart)
+{
+    return ((uart->STAT & UART_STAT_IDLE_MASK) == UART_STAT_IDLE_SET);
+}
+
+/**
+ *  @brief      Set the TX FIFO interrupt threshold level
+ *
+ *  Select the threshold for the transmit FIFO interrupt. The interrupts are
+ *  generated based on a transition through a level rather than being based on
+ *  the level. That is, the interrupts are generated when the fill level
+ *  progresses through the trigger level. For example, if the transmit trigger
+ *  level is set to the half-way mark, the interrupt is triggered when the
+ *  transmit FIFO becomes half empty. In other words, if the transmit FIFO was
+ *  filled with four characters, the interrupt would trigger once there are
+ *  two or less characters after transmitting.
+ *
+ *  @param[in]  uart       Pointer to the register overlay for the peripheral
+ *  @param[in]  threshold  One of @ref DL_UART_TX_FIFO_LEVEL
+ *
+ */
+__STATIC_INLINE void DL_UART_setTXFIFOThreshold(
+    UART_Regs *uart, DL_UART_TX_FIFO_LEVEL threshold)
+{
+    DL_Common_updateReg(
+        &uart->IFLS, (uint32_t) threshold, UART_IFLS_TXIFLSEL_MASK);
+}
+
+/**
+ *  @brief      Get the TX FIFO interrupt threshold level
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The TX FIFO interrupt threshold level
+ *
+ *  @retval     One of @ref DL_UART_TX_FIFO_LEVEL
+ */
+__STATIC_INLINE DL_UART_TX_FIFO_LEVEL DL_UART_getTXFIFOThreshold(
+    UART_Regs *uart)
+{
+    uint32_t threshold = uart->IFLS & UART_IFLS_TXIFLSEL_MASK;
+
+    return (DL_UART_TX_FIFO_LEVEL)(threshold);
+}
+
+/**
+ *  @brief      Set the RX FIFO interrupt threshold level. The interrupts are
+ *  generated based on a transition through a level rather than being based on
+ *  the level. That is, the interrupts are generated when the fill level
+ *  progresses through the trigger level. For example, if the receive trigger
+ *  level is set to the half-way mark, the interrupt is triggered when the
+ *  receive FIFO becomes half full. In other words, the interrupt is triggered
+ *  after the receive FIFO is filled with two or more characters.
+ *
+ *  @param[in]  uart       Pointer to the register overlay for the peripheral
+ *  @param[in]  threshold  One of @ref DL_UART_RX_FIFO_LEVEL
+ */
+__STATIC_INLINE void DL_UART_setRXFIFOThreshold(
+    UART_Regs *uart, DL_UART_RX_FIFO_LEVEL threshold)
+{
+    DL_Common_updateReg(
+        &uart->IFLS, (uint32_t) threshold, UART_IFLS_RXIFLSEL_MASK);
+}
+
+/**
+ *  @brief      Get the RX FIFO interrupt threshold level
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The RX FIFO interrupt threshold level
+ *
+ *  @retval     One of @ref DL_UART_RX_FIFO_LEVEL
+ */
+__STATIC_INLINE DL_UART_RX_FIFO_LEVEL DL_UART_getRXFIFOThreshold(
+    UART_Regs *uart)
+{
+    uint32_t threshold = uart->IFLS & UART_IFLS_RXIFLSEL_MASK;
+
+    return (DL_UART_RX_FIFO_LEVEL)(threshold);
+}
+
+/**
+ *  @brief      Set the RX interrupt timeout
+ *
+ *  When an additional character has not been received within the set
+ *  timeout, a RX interrupt will still trigger even if the FIFO level has not
+ *  been reached. A value of 0 disables this function.
+ *
+ *  @param[in]  uart     Pointer to the register overlay for the peripheral
+ *  @param[in]  timeout  Timeout to set the RX interrupt to.
+ *                       Value between 0 - 15
+ */
+__STATIC_INLINE void DL_UART_setRXInterruptTimeout(
+    UART_Regs *uart, uint32_t timeout)
+{
+    DL_Common_updateReg(
+        &uart->IFLS, timeout << UART_IFLS_RXTOSEL_OFS, UART_IFLS_RXTOSEL_MASK);
+}
+
+/**
+ *  @brief      Get the RX interrupt timeout
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The RX interrupt timeout value
+ *
+ *  @retval     0 - 15  The RX interrupt timeout value
+ *
+ */
+__STATIC_INLINE uint32_t DL_UART_getRXInterruptTimeout(UART_Regs *uart)
+{
+    return ((uart->IFLS & UART_IFLS_RXTOSEL_MASK) >> UART_IFLS_RXTOSEL_OFS);
+}
+
+/**
+ *  @brief      Get Integer Baud-Rate Divisor
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The integer component of the baud rate divisor
+ *
+ *  @retval     0 - 65535 The integer baud date divisor
+ */
+__STATIC_INLINE uint32_t DL_UART_getIntegerBaudRateDivisor(UART_Regs *uart)
+{
+    return (uart->IBRD & UART_IBRD_DIVINT_MASK);
+}
+
+/**
+ *  @brief      Get Fractional Baud-Rate Divisor
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The fractional component of the baud rate divisor
+ *
+ *  @retval     0 - 63  The fractional baud date divisor
+ */
+__STATIC_INLINE uint32_t DL_UART_getFractionalBaudRateDivisor(UART_Regs *uart)
+{
+    return (uart->FBRD & UART_FBRD_DIVFRAC_MASK);
+}
+
+/**
+ *  @brief      Set the baud rate divisor
+ *
+ *  Set the integer baud rate divisor and fractional baud rate divisor
+ *  components of the baud rate divisor
+ *
+ *  @param[in]  uart               Pointer to the register overlay for the
+ *                                 peripheral
+ *  @param[in]  integerDivisor     The integer component of the baud rate
+ *                                 divisor
+ *  @param[in]  fractionalDivisor  The fractional component of the baud rate
+ *                                 divisor
+ */
+__STATIC_INLINE void DL_UART_setBaudRateDivisor(
+    UART_Regs *uart, uint32_t integerDivisor, uint32_t fractionalDivisor)
+{
+    DL_Common_updateReg(&uart->IBRD, integerDivisor, UART_IBRD_DIVINT_MASK);
+    DL_Common_updateReg(
+        &uart->FBRD, fractionalDivisor, UART_FBRD_DIVFRAC_MASK);
+
+    // When updating the baud-rate divisor (UARTIBRD or UARTIFRD),
+    // the LCRH register must also be written to (any bit in LCRH can
+    // be written to for updating the baud-rate divisor).
+    DL_Common_updateReg(
+        &uart->LCRH, (uart->LCRH & UART_LCRH_BRK_MASK), UART_LCRH_BRK_MASK);
+}
+
+/**
+ *  @brief      Set the baud rate divisor for IrDA mode
+ *
+ *  Set the integer baud rate divisor and fractional baud rate divisor
+ *  components of the baud rate divisor
+ *  Divide integerDivisor by clkDivisor2 + 1 as a way of reducing the UART
+ *  clock frequency, which in turn reduces the baud rate divisor further
+ *  in accordance to IrDA standards
+ *
+ *  @param[in]  uart               Pointer to the register overlay for the
+ *                                 peripheral
+ *  @param[in]  integerDivisor     The integer component of the baud rate
+ *                                 divisor
+ *  @param[in]  fractionalDivisor  The fractional component of the baud rate
+ *                                 divisor
+ *  @param[in]  clkDivisor2        The additional factor to divide the clock,
+ *                                 One of @ref DL_UART_CLOCK_DIVIDE2_RATIO
+ *
+ */
+__STATIC_INLINE void DL_UART_setIrDABaudRateDivisor(UART_Regs *uart,
+    uint32_t integerDivisor, uint32_t fractionalDivisor,
+    DL_UART_CLOCK_DIVIDE2_RATIO clkDivisor2)
+{
+    DL_Common_updateReg(&uart->IBRD,
+        (integerDivisor / ((uint32_t) clkDivisor2 + 1)),
+        UART_IBRD_DIVINT_MASK);
+    DL_Common_updateReg(
+        &uart->FBRD, fractionalDivisor, UART_FBRD_DIVFRAC_MASK);
+
+    // When updating the baud-rate divisor (UARTIBRD or UARTIFRD),
+    // the LCRH register must also be written to (any bit in LCRH can
+    // be written to for updating the baud-rate divisor).
+    DL_Common_updateReg(
+        &uart->LCRH, (uart->LCRH & UART_LCRH_BRK_MASK), UART_LCRH_BRK_MASK);
+}
+
+/**
+ *  @brief      Set the pulse width select for the digital glitch suppresion
+ *
+ *  Controls the pulse width select for glitch suppression on the RX line.
+ *  The glitch suppression values are in terms of functional clocks.
+ *
+ *  In IrDA mode, this sets the receive filter length. The minimum pulse
+ *  length for receive is given by: t(MIN) = (DGFSEL) / f(IRTXCLK)
+ *
+ *  @param[in]  uart        Pointer to the register overlay for the peripheral
+ *  @param[in]  pulseWidth  Pulse width select for the glitch suppresion.
+ *                          Value between 0 - 63.
+ */
+__STATIC_INLINE void DL_UART_setDigitalPulseWidth(
+    UART_Regs *uart, uint32_t pulseWidth)
+{
+    DL_Common_updateReg(&uart->GFCTL, pulseWidth, UART_GFCTL_DGFSEL_MASK);
+}
+
+/**
+ *  @brief      Get the pulse width select for the digital glitch suppresion
+ *
+ *  Gets the pulse width select for glitch suppression on the RX line.
+ *  The glitch suppression values are in terms of functional clocks.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The digital glitch suppression pulse width
+ *
+ *  @retval     0 indicating digital glitch suppression is disabled
+ *  @retval     1 - 63 the digital glitch suppression pulse width
+ */
+__STATIC_INLINE uint32_t DL_UART_getDigitalPulseWidth(UART_Regs *uart)
+{
+    return (uart->GFCTL & UART_GFCTL_DGFSEL_MASK);
+}
+
+/**
+ *  @brief      Writes data into the TX FIFO to transmit
+ *
+ *  Puts the data into the TX FIFO without checking it's status. Use if already
+ *  sure the TX FIFO has space for the write. See related APIs for additional
+ *  transmit options.
+ *
+ *  For transmitted data, if the FIFO is enabled, data written to this
+ *  location is pushed onto the transmit FIFO. If the FIFO is disabled,
+ *  data is stored in the 1-byte deep transmitter.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *  @param[in]  data  The data to transmit
+ *
+ *
+ *  @sa         DL_UART_transmitDataBlocking
+ *  @sa         DL_UART_transmitDataCheck
+ */
+__STATIC_INLINE void DL_UART_transmitData(UART_Regs *uart, uint8_t data)
+{
+    uart->TXDATA = data;
+}
+
+/**
+ *  @brief      Reads data from the RX FIFO
+ *
+ *  Reads the data from the RX FIFO without checking its status. Use if
+ *  already sure the RX FIFO has data available. See related APIs for
+ *  additional receive options.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The data in the RX FIFO
+ *
+ *  @sa         DL_UART_receiveDataBlocking
+ *  @sa         DL_UART_receiveDataCheck
+ */
+__STATIC_INLINE uint8_t DL_UART_receiveData(UART_Regs *uart)
+{
+    return ((uint8_t)(uart->RXDATA & UART_RXDATA_DATA_MASK));
+}
+
+/**
+ *  @brief      Gets the status of the error flags of the received data
+ *
+ *  @param[in]  uart       Pointer to the register overlay for the peripheral
+ *  @param[in]  errorMask  Bit mask of error flags to check. Bitwise OR of
+ *                         @ref DL_UART_ERROR.
+ *
+ *  @return     The status of the requested UART error flags
+ *
+ *  @retval     Bitwise OR of @ref DL_UART_ERROR values
+ */
+__STATIC_INLINE uint32_t DL_UART_getErrorStatus(
+    UART_Regs *uart, uint32_t errorMask)
+{
+    return (uart->RXDATA & errorMask);
+}
+
+/**
+ *  @brief      Set the LIN counter value
+ *
+ *  The LIN counter is a 16 bit up counter clocked by the functional clock of
+ *  the UART
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ *  @param[in]  value  Pulse width select for the glitch suppresion.
+ */
+__STATIC_INLINE void DL_UART_setLINCounterValue(
+    UART_Regs *uart, uint16_t value)
+{
+    DL_Common_updateReg(&uart->LINCNT, value, UART_LINCNT_VALUE_MASK);
+}
+
+/**
+ *  @brief      Get the LIN counter value
+ *
+ *  The LIN counter is a 16 bit up counter clocked by the module clock of
+ *  the UART
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The clock counter value
+ *
+ *  @retval     0 - 65535  The clock counter value
+ *
+ */
+__STATIC_INLINE uint16_t DL_UART_getLINCounterValue(UART_Regs *uart)
+{
+    return ((uint16_t)(uart->LINCNT & UART_LINCNT_VALUE_MASK));
+}
+
+/**
+ *  @brief      Enable the LIN counter
+ *
+ *  The LIN counter will only count when enabled.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_enableLINCounter(UART_Regs *uart)
+{
+    uart->LINCTL |= UART_LINCTL_CTRENA_ENABLE;
+}
+
+/**
+ *  @brief      Check if the LIN counter is enabled
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of the LIN counter
+ *
+ *  @retval     true   LIN counter is enabled
+ *  @retval     false  LIN counter is disabled
+ */
+__STATIC_INLINE bool DL_UART_isLINCounterEnabled(UART_Regs *uart)
+{
+    return (
+        (uart->LINCTL & UART_LINCTL_CTRENA_MASK) == UART_LINCTL_CTRENA_ENABLE);
+}
+
+/**
+ *  @brief      Disable the LIN counter
+ *
+ *  LIN counter will only count when enabled.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disableLINCounter(UART_Regs *uart)
+{
+    uart->LINCTL &= ~(UART_LINCTL_CTRENA_MASK);
+}
+
+/**
+ *  @brief   Enable LIN counter clear and start counting on falling edge of RXD
+ *
+ *  When enabled, the counter is set to 0 and starts counting on the LIN counter
+ *  on a falling edge of RXD.
+ *
+ *  The LIN counter will only count when it is enabled.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @sa  DL_UART_enableLINCounter
+ */
+__STATIC_INLINE void DL_UART_enableLINCounterClearOnFallingEdge(
+    UART_Regs *uart)
+{
+    uart->LINCTL |= UART_LINCTL_ZERONE_ENABLE;
+}
+
+/**
+ *  @brief      Check if LIN counting on falling edge of RXD is enabled
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of counting on falling edge of RXD
+ *
+ *  @retval     true   Counting on falling edge is enabled
+ *  @retval     false  Counting on falling edge is disabled
+ */
+__STATIC_INLINE bool DL_UART_isLINCounterClearOnFallingEdge(UART_Regs *uart)
+{
+    return (
+        (uart->LINCTL & UART_LINCTL_ZERONE_MASK) == UART_LINCTL_ZERONE_ENABLE);
+}
+
+/**
+ *  @brief      Disable LIN counting on falling edge of RXD
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disableLINCounterClearOnFallingEdge(
+    UART_Regs *uart)
+{
+    uart->LINCTL &= ~(UART_LINCTL_ZERONE_MASK);
+}
+
+/**
+ *  @brief      Enable LIN counter incrementing while RXD signal is low
+ *
+ *  When LIN counter is enabled and the signal on RXD is low, the counter
+ *  increments
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @sa  DL_UART_enableLINCounter
+ */
+__STATIC_INLINE void DL_UART_enableLINCountWhileLow(UART_Regs *uart)
+{
+    uart->LINCTL |= UART_LINCTL_CNTRXLOW_ENABLE;
+}
+
+/**
+ *  @brief   Check if LIN counter increments while RXD signal is low is enabled
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of counter increments while RXD signal is low
+ *
+ *  @retval     true   Counter increments while RXD signal is low is enabled
+ *  @retval     false  Counter increments while RXD signal is low is disabled
+ */
+__STATIC_INLINE bool DL_UART_isLINCountWhileLowEnabled(UART_Regs *uart)
+{
+    return ((uart->LINCTL & UART_LINCTL_CNTRXLOW_MASK) ==
+            UART_LINCTL_CNTRXLOW_ENABLE);
+}
+
+/**
+ *  @brief      Disable LIN counter increments while RXD signal is low
+ *
+ *  LIN counter will not increment while the RXD signal is low
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disableLINCountWhileLow(UART_Regs *uart)
+{
+    uart->LINCTL &= ~(UART_LINCTL_CNTRXLOW_MASK);
+}
+
+/**
+ *  @brief      Enable capture of the LIN counter on a falling edge
+ *
+ *  When enabled, the LIN counter value is captured to the LINC0 register on
+ *  each falling RXD edge. A LINC0 interrupt is triggered when enabled.
+ *  Disables counter compare match mode if enabled.
+ *
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @sa  DL_UART_configLINMode
+ */
+__STATIC_INLINE void DL_UART_enableLINFallingEdgeCapture(UART_Regs *uart)
+{
+    DL_Common_updateReg(&uart->LINCTL,
+        UART_LINCTL_LINC0CAP_ENABLE | UART_LINCTL_LINC0_MATCH_DISABLE,
+        UART_LINCTL_LINC0CAP_MASK | UART_LINCTL_LINC0_MATCH_MASK);
+}
+
+/**
+ *  @brief      Check status of capture of LIN counter on a falling edge
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of capture the LIN counter on a falling edge
+ *
+ *  @retval     true   Capture to LINC0 on falling RXD edge is enabled
+ *  @retval     false  Capture to LINC0 on falling RXD edge is disabled
+ */
+__STATIC_INLINE bool DL_UART_isLINFallingEdgeCaptureEnabled(UART_Regs *uart)
+{
+    return ((uart->LINCTL & UART_LINCTL_LINC0CAP_MASK) ==
+            UART_LINCTL_LINC0CAP_ENABLE);
+}
+
+/**
+ *  @brief      Disable capture of LIN counter on a falling edge
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disableLINFallingEdgeCapture(UART_Regs *uart)
+{
+    uart->LINCTL &= ~(UART_LINCTL_LINC0CAP_MASK);
+}
+
+/**
+ *  @brief      Enable capture of the LIN counter on a rising edge
+ *
+ *  When enabled the LIN counter value is captured to LINC1 register on each
+ *  rising RXD edge. A LINC1 interrupt is triggered when enabled.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_UART_enableLINRisingEdgeCapture(UART_Regs *uart)
+{
+    uart->LINCTL |= UART_LINCTL_LINC1CAP_ENABLE;
+}
+
+/**
+ *  @brief      Check status of capture of LIN counter on a rising edge
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of capture of LIN counter on a rising edge
+ *
+ *  @retval     true   Capture to LINC1 on rising RXD edge is enabled
+ *  @retval     false  Capture to LINC1 on rising RXD edge is disabled
+ */
+__STATIC_INLINE bool DL_UART_isLINRisingEdgeCaptureEnabled(UART_Regs *uart)
+{
+    return ((uart->LINCTL & UART_LINCTL_LINC1CAP_MASK) ==
+            UART_LINCTL_LINC1CAP_ENABLE);
+}
+
+/**
+ *  @brief      Disable capture of LIN counter on a rising edge
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disableLINRisingEdgeCapture(UART_Regs *uart)
+{
+    uart->LINCTL &= ~(UART_LINCTL_LINC1CAP_MASK);
+}
+
+/**
+ *  @brief      Enable LIN counter compare match mode
+ *
+ *  When enabled, a match between a value in LINC0 and the LIN counter can
+ *  trigger a LINC0 interrupt. Disables capture on falling edge if enabled.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_enableLINCounterCompareMatch(UART_Regs *uart)
+{
+    DL_Common_updateReg(&uart->LINCTL,
+        UART_LINCTL_LINC0_MATCH_ENABLE | UART_LINCTL_LINC0CAP_DISABLE,
+        UART_LINCTL_LINC0CAP_MASK | UART_LINCTL_LINC0_MATCH_MASK);
+}
+
+/**
+ *  @brief      Setup LIN counter control for sync field validation
+ *
+ *  Enable LIN counter capture on rising RX edge. Enable LIN counter capture on falling RX edge.
+ *  Enable LIN counter clearing on RX falling edge. Enable LIN counter.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_enableLINSyncFieldValidationCounterControl(
+    UART_Regs *uart)
+{
+    DL_Common_updateReg(&uart->LINCTL,
+        UART_LINCTL_LINC0CAP_ENABLE | UART_LINCTL_LINC1CAP_ENABLE |
+            UART_LINCTL_ZERONE_ENABLE | UART_LINCTL_CTRENA_ENABLE,
+        UART_LINCTL_LINC0CAP_MASK | UART_LINCTL_LINC1CAP_MASK |
+            UART_LINCTL_ZERONE_MASK | UART_LINCTL_CTRENA_MASK);
+}
+
+/**
+ *  @brief      Setup LIN counter control for LIN reception
+ *
+ * Enable count while low signal on RXD. Enable LIN counter clearing on RXD falling edge.
+ * Enable LIN counter.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_enableLINReceptionCountControl(UART_Regs *uart)
+{
+    DL_Common_updateReg(&uart->LINCTL,
+        UART_LINCTL_CNTRXLOW_ENABLE | UART_LINCTL_ZERONE_ENABLE |
+            UART_LINCTL_CTRENA_ENABLE,
+        UART_LINCTL_CNTRXLOW_MASK | UART_LINCTL_ZERONE_MASK |
+            UART_LINCTL_CTRENA_MASK);
+}
+
+/**
+ *  @brief      Check if LIN counter compare match mode is enabled
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of counter compare match mode
+ *
+ *  @retval     true   LIN counter compare match mode is enabled
+ *  @retval     false  LIN counter compare match mode is disabled
+ */
+__STATIC_INLINE bool DL_UART_isLINCounterCompareMatchEnabled(UART_Regs *uart)
+{
+    return ((uart->LINCTL & UART_LINCTL_LINC0_MATCH_MASK) ==
+            UART_LINCTL_LINC0_MATCH_ENABLE);
+}
+
+/**
+ *  @brief      Disable LIN counter compare match mode
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disableLINCounterCompareMatch(UART_Regs *uart)
+{
+    uart->LINCTL &= ~(UART_LINCTL_LINC0_MATCH_MASK);
+}
+
+/**
+ *  @brief      Set the value to be compared to the LIN counter
+ *
+ *  Sets the value of LINC0 to be used to compare to the LIN counter. For use
+ *  when LIN counter compare match mode is enabled.
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ *  @param[in]  value  Value to be compared to the LIN counter for matching.
+ *                     Value between 0 - 65535.
+ *
+ *  @sa  DL_UART_enableLINCounterCompareMatch
+ */
+__STATIC_INLINE void DL_UART_setLINCounterCompareValue(
+    UART_Regs *uart, uint16_t value)
+{
+    DL_Common_updateReg(&uart->LINC0, value, UART_LINC0_DATA_MASK);
+}
+
+/**
+ *  @brief      Get the LINC0 counter value
+ *
+ *  Captures current LINCTR value on RXD falling edge.
+ *
+ *  If capture is enabled with @ref DL_UART_enableLINFallingEdgeCapture, a
+ *  capture can generate a LINC0 interrupt.
+ *  If compare mode is enabled with @ref DL_UART_enableLINCounterCompareMatch,
+ *  a counter match can generate a LINC0 interrupt.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The LINC0 counter value
+ *
+ *  @retval     0 - 65535  The LINC0 counter value
+ *
+ *  @sa  DL_UART_enableLINFallingEdgeCapture
+ *  @sa  DL_UART_enableLINCounterCompareMatch
+ */
+__STATIC_INLINE uint16_t DL_UART_getLINFallingEdgeCaptureValue(UART_Regs *uart)
+{
+    return ((uint16_t)(uart->LINC0 & UART_LINC0_DATA_MASK));
+}
+
+/**
+ *  @brief      Get the LINC1 counter value
+ *
+ *  Captures current LINCTR value on RXD rising edge. For use when LIN rising
+ *  edge capture is enabled. It can generate a LINC1 interrupt on capture.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The LINC1 counter value
+ *
+ *  @retval     0 - 65535  The LINC1 counter value
+ *
+ *  @sa  DL_UART_enableLINRisingEdgeCapture
+ */
+__STATIC_INLINE uint16_t DL_UART_getLINRisingEdgeCaptureValue(UART_Regs *uart)
+{
+    return ((uint16_t)(uart->LINC1 & UART_LINC1_DATA_MASK));
+}
+
+/**
+ *  @brief      Enable the IrDA encoder/decoder
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_enableIrDAMode(UART_Regs *uart)
+{
+    uart->IRCTL |= UART_IRCTL_IREN_ENABLE;
+}
+
+/**
+ *  @brief      Check if the IrDA encoder/decoder is enabled
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The status of IrDA mode
+ *
+ *  @retval     true   IrDA mode is enabled
+ *  @retval     false  IrDA mode is disabled
+ */
+__STATIC_INLINE bool DL_UART_isIrDAModeEnabled(UART_Regs *uart)
+{
+    return ((uart->IRCTL & UART_IRCTL_IREN_MASK) == UART_IRCTL_IREN_ENABLE);
+}
+
+/**
+ *  @brief      Disable the IrDA encoder/decoder
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disableIrDAMode(UART_Regs *uart)
+{
+    uart->IRCTL &= ~(UART_IRCTL_IREN_MASK);
+}
+
+/**
+ *  @brief      Set the IrDA transmit pulse clock select
+ *
+ *  @param[in]  uart   Pointer to the register overlay for the peripheral
+ *  @param[in]  uartClock  The clock select for the IrDA pulse data to be based on.
+ *                     One of @ref DL_UART_IRDA_CLOCK
+ */
+__STATIC_INLINE void DL_UART_setIrDATXPulseClockSelect(
+    UART_Regs *uart, DL_UART_IRDA_CLOCK uartClock)
+{
+    DL_Common_updateReg(
+        &uart->IRCTL, (uint32_t) uartClock, UART_IRCTL_IRTXCLK_MASK);
+}
+
+/**
+ *  @brief      Get the IrDA transmit pulse clock select
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The clock select that the IrDA pulse data is based on
+ *
+ *  @retval     One of @ref DL_UART_IRDA_CLOCK
+ *
+ */
+__STATIC_INLINE DL_UART_IRDA_CLOCK DL_UART_getIrDATXPulseClockSelect(
+    UART_Regs *uart)
+{
+    uint32_t uartClock = uart->IRCTL & UART_IRCTL_IRTXCLK_MASK;
+
+    return (DL_UART_IRDA_CLOCK)(uartClock);
+}
+
+/**
+ *  @brief      Set the IrDA configurations
+ *
+ *  Calculates the baud rate divisor given the clock output of the UART clock
+ *  source and the target baud rate. This API also enables IrDA mode.
+ *
+ *  @param[in]  uart         Pointer to the register overlay for the peripheral
+ *  @param[in]  polarity     The receive input polarity.
+ *                           One of @ref DL_UART_IRDA_POLARITY.
+ *  @param[in]  pulseLength  The length of the IrDA transmit pulse.
+ *  @param[in]  irdaClk      The clock used for the transmit pulse.
+ *                           One of @ref DL_UART_IRDA_CLOCK.
+ */
+void DL_UART_configIrDAMode(UART_Regs *uart, DL_UART_IRDA_POLARITY polarity,
+    uint32_t pulseLength, DL_UART_IRDA_CLOCK irdaClk);
+
+/**
+ *  @brief      Set the IrDA transmit pulse length
+ *
+ *  The pulse length can be calculated with the following equation:
+ *      IRTXPLx = pulseLength * 2 * irdaClk - 1
+ *      (IRTXCLK = functional clock of the UART)
+ *
+ *  To set the pulse time of 3/16 bit period required by the IrDA period,
+ *  16-bit oversampling is selected with HSE = 0, the baud rate clock is
+ *  selected with IRTXCLK = 1, and the pulse length is set to six one-half
+ *  clock cycles with IRTXPLx = 6 - 1 - 5.
+ *
+ *  @param[in]  uart         Pointer to the register overlay for the peripheral
+ *  @param[in]  pulseLength  The length of the IrDA transmit pulse.
+ *  @param[in]  irdaClk      The clock used for the transmit pulse.
+ *                           One of @ref DL_UART_IRDA_CLOCK.
+ */
+void DL_UART_setIrDAPulseLength(
+    UART_Regs *uart, uint32_t pulseLength, DL_UART_IRDA_CLOCK irdaClk);
+
+/**
+ *  @brief      Get the IrDA transmit pulse length
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The IrDA transmit pulse length is set to
+ *
+ *  @retval     0 - 63  The IrDA transmit pulse length
+ */
+__STATIC_INLINE uint32_t DL_UART_getIrDATXPulseLength(UART_Regs *uart)
+{
+    return (uart->IRCTL & UART_IRCTL_IRTXPL_MASK);
+}
+
+/**
+ *  @brief      Set the IrDA receive input UCAxRXD polarity
+ *
+ *  @param[in]  uart      Pointer to the register overlay for the peripheral
+ *  @param[in]  polarity  The value to set the IrDA RX pulse polarity to.
+ *                        One of @ref DL_UART_IRDA_POLARITY
+ */
+__STATIC_INLINE void DL_UART_setIrDARXPulsePolarity(
+    UART_Regs *uart, DL_UART_IRDA_POLARITY polarity)
+{
+    DL_Common_updateReg(
+        &uart->IRCTL, (uint32_t) polarity, UART_IRCTL_IRRXPL_MASK);
+}
+
+/**
+ *  @brief      Get the IrDA receive input UCAxRXD polarity
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The IrDA RX pulse polarity
+ *
+ *  @retval     One of @ref DL_UART_IRDA_POLARITY
+ */
+__STATIC_INLINE DL_UART_IRDA_POLARITY DL_UART_getIrDARXPulsePolarity(
+    UART_Regs *uart)
+{
+    uint32_t polarity = uart->IRCTL & UART_IRCTL_IRRXPL_MASK;
+
+    return (DL_UART_IRDA_POLARITY)(polarity);
+}
+
+/**
+ *  @brief      Set the address mask for DALI, 9-bit, or Idle-Line mode
+ *
+ *  The address bits are masked to create a set of addresses to be matched
+ *  with the received address byte.
+ *
+ *  A 0 bit in the MSK bitfield configures that the corresponding bit in the
+ *  ADDR bitfield of the ADDR register is don't care.
+ *  A 1 bit in the MSK bitfield configures, that the corresponding bit in the
+ *  ADDR bitfield of the ADDR register must match.
+ *
+ *  Used in DALI, UART 9-Bit or Idle-Line mode.
+ *
+ *  @param[in]  uart         Pointer to the register overlay for the peripheral
+ *  @param[in]  addressMask  The address mask to set
+ */
+__STATIC_INLINE void DL_UART_setAddressMask(
+    UART_Regs *uart, uint32_t addressMask)
+{
+    DL_Common_updateReg(&uart->AMASK, addressMask, UART_AMASK_VALUE_MASK);
+}
+
+/**
+ *  @brief      Get the address mask being used
+ *
+ *  The address bits are masked to create a set of addresses to be matched
+ *  with the received address byte.
+ *
+ *  A 0 bit in the MSK bitfield configures that the corresponding bit in the
+ *  ADDR bitfield of the ADDR register is don't care.
+ *  A 1 bit in the MSK bitfield configures, that the corresponding bit in the
+ *  ADDR bitfield of the ADDR register must match.
+ *
+ *  Used in DALI, UART 9-Bit or Idle-Line mode.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The address mask being used
+ *
+ *  @retval     0-255  The address mask
+ *
+ */
+__STATIC_INLINE uint32_t DL_UART_getAddressMask(UART_Regs *uart)
+{
+    return (uart->AMASK & UART_AMASK_VALUE_MASK);
+}
+
+/**
+ *  @brief      Set the address
+ *
+ *  Used to write the specific address that should be matched with the
+ *  receiving byte when the Address Mask (AMASK) is set to FFh. This register
+ *  is used in conjunction with AMASK to form a match for address-byte
+ *  received.
+ *
+ *  Used in DALI, UART 9-Bit or Idle-Line mode.
+ *
+ *  @param[in]  uart     Pointer to the register overlay for the peripheral
+ *  @param[in]  address  The address to set
+ */
+__STATIC_INLINE void DL_UART_setAddress(UART_Regs *uart, uint32_t address)
+{
+    DL_Common_updateReg(&uart->ADDR, address, UART_ADDR_VALUE_MASK);
+}
+
+/**
+ *  @brief      Get the address being used
+ *
+ *  Used to write the specific address that should be matched with the
+ *  receiving byte when the Address Mask (AMASK) is set to FFh. This register
+ *  is used in conjunction with AMASK to form a match for address-byte
+ *  received.
+ *
+ *  Used in DALI, UART 9-Bit or Idle-Line mode.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The address being used
+ *
+ *  @retval     0-255  The address being used
+ *
+ */
+__STATIC_INLINE uint32_t DL_UART_getAddress(UART_Regs *uart)
+{
+    return (uart->ADDR & UART_ADDR_VALUE_MASK);
+}
+
+/**
+ *  @brief      Enable UART interrupts
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_UART_INTERRUPT.
+ */
+__STATIC_INLINE void DL_UART_enableInterrupt(
+    UART_Regs *uart, uint32_t interruptMask)
+{
+    uart->CPU_INT.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disable UART interrupts
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to disable. Bitwise OR of
+ *                             @ref DL_UART_INTERRUPT.
+ */
+__STATIC_INLINE void DL_UART_disableInterrupt(
+    UART_Regs *uart, uint32_t interruptMask)
+{
+    uart->CPU_INT.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief      Check which UART interrupts are enabled
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_UART_INTERRUPT.
+ *
+ *  @return     Which of the requested UART interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_UART_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_UART_getEnabledInterrupts(
+    UART_Regs *uart, uint32_t interruptMask)
+{
+    return (uart->CPU_INT.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled UART interrupts
+ *
+ *  Checks if any of the UART interrupts that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_UART_INTERRUPT.
+ *
+ *  @return     Which of the requested UART interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_UART_INTERRUPT values
+ *
+ *  @sa         DL_UART_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_UART_getEnabledInterruptStatus(
+    UART_Regs *uart, uint32_t interruptMask)
+{
+    return (uart->CPU_INT.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any UART interrupt
+ *
+ *  Checks if any of the UART interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_UART_INTERRUPT.
+ *
+ *  @return     Which of the requested UART interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_UART_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_UART_getRawInterruptStatus(
+    UART_Regs *uart, uint32_t interruptMask)
+{
+    return (uart->CPU_INT.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending UART interrupt
+ *
+ *  Checks if any of the UART interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     The highest priority pending UART interrupt
+ *
+ *  @retval     TBD
+ */
+__STATIC_INLINE DL_UART_IIDX DL_UART_getPendingInterrupt(UART_Regs *uart)
+{
+    return (DL_UART_IIDX)(uart->CPU_INT.IIDX);
+}
+
+/**
+ *  @brief      Clear pending UART interrupts
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_UART_INTERRUPT.
+ */
+__STATIC_INLINE void DL_UART_clearInterruptStatus(
+    UART_Regs *uart, uint32_t interruptMask)
+{
+    uart->CPU_INT.ICLR = interruptMask;
+}
+
+/**
+ *  @brief      Prepares the UART to change the configuration
+ *
+ *  If the UART has already been enabled, then it is recommended to call this
+ *  function before calling other APIs that make changes to the CTL0 register.
+ *  If changes are made to the CTL0 register without disabling the UART, then
+ *  results are unpredictable. This API performs the following:
+ *  1. Disable the UART.
+ *  2. Wait for the end of transmission or reception of the current character.
+ *  3. Flush the transmit FIFO by clearing bit FEN in the UART control
+ *  register CTL0.
+ *
+ *  @post After calling this API, the user must be re-enabled by calling
+ *        @ref DL_UART_enable.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_changeConfig(UART_Regs *uart)
+{
+    DL_UART_disable(uart);
+    while (DL_UART_isBusy(uart)) {
+        ;
+    }
+    DL_UART_disableFIFOs(uart);
+}
+
+/**
+ *  @brief      Enable the analog glitch filter on the RX input
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_enableAnalogGlitchFilter(UART_Regs *uart)
+{
+    uart->GFCTL |= UART_GFCTL_AGFEN_ENABLE;
+}
+
+/**
+ *  @brief      Disable the analog glitch filter on the RX input
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disableAnalogGlitchFilter(UART_Regs *uart)
+{
+    uart->GFCTL &= ~(UART_GFCTL_AGFEN_MASK);
+}
+
+/**
+ * @brief      Returns if analog glitch filter is enabled
+ *
+ * @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ * @return true   if analog glitch filter is enabled
+ * @return false  if analog glitch filter is disabled
+ */
+__STATIC_INLINE bool DL_UART_isAnalogGlitchFilterEnabled(UART_Regs *uart)
+{
+    return ((uart->GFCTL & UART_GFCTL_AGFEN_MASK) == UART_GFCTL_AGFEN_ENABLE);
+}
+
+/**
+ *  @brief      Enable analog and digital noise glitch filter chaining
+ *
+ * When enabled, analog and digital glitch filters are chained and the output
+ * of the combination is made available to the IP logic for sampling.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_enableGlitchFilterChaining(UART_Regs *uart)
+{
+    uart->GFCTL |= UART_GFCTL_CHAIN_ENABLED;
+}
+
+/**
+ *  @brief      Disable analog and digital noise glitch filter chaining
+ *
+ * When disabled, only digital filter output is available to the IP logic
+ * for sampling.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_UART_disableGlitchFilterChaining(UART_Regs *uart)
+{
+    uart->GFCTL &= ~(UART_GFCTL_CHAIN_MASK);
+}
+
+/**
+ * @brief      Returns if glitch filter chaining enabled
+ *
+ * @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ * @return true   if glitch filter chaining is enabled
+ * @return false  if glitch filter chaining is disabled
+ */
+__STATIC_INLINE bool DL_UART_isGlitchFilterChainingEnabled(UART_Regs *uart)
+{
+    return ((uart->GFCTL & UART_GFCTL_CHAIN_MASK) == UART_GFCTL_CHAIN_ENABLED);
+}
+
+/**
+ *  @brief      Set the pulse width select for the analog glitch suppresion
+ *
+ *  Sets the pulse width select for the analog glitch
+ *  suppression on the RX line. See device datasheet for exact values.
+ *
+ *  This only applies to Power Domain 0 (PD0).
+ *
+ *  @param[in]  uart        Pointer to the register overlay for the peripheral
+ *  @param[in]  pulseWidth  Pulse width select for the glitch suppresion.
+                            One of @ref DL_UART_PULSE_WIDTH
+ */
+__STATIC_INLINE void DL_UART_setAnalogPulseWidth(
+    UART_Regs *uart, DL_UART_PULSE_WIDTH pulseWidth)
+{
+    DL_Common_updateReg(
+        &uart->GFCTL, (uint32_t) pulseWidth, UART_GFCTL_AGFSEL_MASK);
+}
+
+/**
+ *  @brief      Get the pulse width select for the glitch suppresion
+ *
+ *  Gets the pulse width select for the analog glitch
+ *  suppression on the RX line. See device datasheet for exact values.
+ *
+ *  This only applies to Power Domain 0 (PD0).
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The pulse width select for the glitch suppression
+ *
+ *  @retval     One of @ref DL_UART_PULSE_WIDTH
+
+ */
+__STATIC_INLINE DL_UART_PULSE_WIDTH DL_UART_getAnalogPulseWidth(
+    UART_Regs *uart)
+{
+    uint32_t pulseWidth = uart->GFCTL & UART_GFCTL_AGFSEL_MASK;
+
+    return (DL_UART_PULSE_WIDTH)(pulseWidth);
+}
+
+/**
+ *  @brief      Blocks to ensure transmit is ready before sending data
+ *
+ *  Puts the data into the TX FIFO after blocking to ensure the TX FIFO is not
+ *  full. Will wait indefintely until there is space in the TX FIFO. See
+ *  related APIs for additional transmit options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 8 bits.
+ *
+ *  @param[in]  uart  pointer to the register overlay for the peripheral
+ *  @param[in]  data  data to send
+ *
+ *  @sa         DL_UART_transmitData
+ *  @sa         DL_UART_transmitDataCheck
+ */
+void DL_UART_transmitDataBlocking(UART_Regs *uart, uint8_t data);
+
+/**
+ *  @brief      Blocks to ensure receive is ready before reading data
+ *
+ *  Reads the data from the RX FIFO after blocking to ensure the RX FIFO is not
+ *  empty. Will wait indefintely until there is data in the RX FIFO. See
+ *  related APIs for additional receive options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 8 bits.
+ *
+ *  @param[in]  uart  pointer to the register overlay for the peripheral
+ *
+ *  @return     The data in the RX FIFO
+ *
+ *  @sa         DL_UART_transmitData
+ *  @sa         DL_UART_transmitDataCheck
+ */
+uint8_t DL_UART_receiveDataBlocking(UART_Regs *uart);
+
+/**
+ *  @brief      Checks the TX FIFO before trying to transmit data
+ *
+ *  Checks if the TX FIFO is already full before trying to add new data to the
+ *  FIFO. Exits immediately if full rather than trying to block. See related
+ *  APIs for additional transmit options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 8 bits.
+ *
+ *  @param[in]  uart  pointer to the register overlay for the peripheral
+ *  @param[in]  data  data to send
+ *
+ *  @return     If the transmit occurred
+ *
+ *  @retval     true  if data was added to the TX FIFO
+ *  @retval     false if the TX FIFO was full and data was not added
+ *
+ *  @sa         DL_UART_transmitData
+ *  @sa         DL_UART_transmitDataBlocking
+ */
+bool DL_UART_transmitDataCheck(UART_Regs *uart, uint8_t data);
+
+/**
+ *  @brief      Checks the RX FIFO before trying to transmit data
+ *
+ *  Checks if the RX FIFO is already empty before trying to read new data from
+ *  the FIFO. Exits immediately if empty rather than trying to block. See
+ *  related APIs for additional receive options.
+ *
+ *  Can be used for any data transfers that are less than or equal to 8 bits.
+ *
+ *  @param[in]  uart   pointer to the register overlay for the peripheral
+ *  @param[in]  buffer a buffer to write the received data into
+ *
+ *  @return     If the receive occurred
+ *
+ *  @retval     true  if data was read from the RX FIFO
+ *  @retval     false if the RX FIFO was empty and data was not read
+ *
+ *  @sa         DL_UART_receiveData
+ *  @sa         DL_UART_receiveDataBlocking
+ */
+bool DL_UART_receiveDataCheck(UART_Regs *uart, uint8_t *buffer);
+
+/**
+ *  @brief       Read all available data out of the RX FIFO using 8 bit access
+ *
+ *  @param[in]   uart      Pointer to the register overlay for the peripheral
+ *  @param[out]  buffer    Buffer to write received data into
+ *  @param[in]   maxCount  Max number of bytes to read from the RX FIFO
+ *
+ *  @return      Number of bytes read from the RX FIFO
+ */
+uint32_t DL_UART_drainRXFIFO(
+    UART_Regs *uart, uint8_t *buffer, uint32_t maxCount);
+
+/**
+ *  @brief      Fill the TX FIFO until full using 8 bit access
+ *
+ *  Continuously write data into the TX FIFO until it is filled up or count has
+ *  been reached.
+ *
+ *  @param[in]  uart    Pointer to the register overlay for the peripheral
+ *  @param[in]  buffer  Buffer of data to write to the TX FIFO
+ *  @param[in]  count   Max number of bytes to write to the TX FIFO
+ *
+ *  @return     Number of bytes written to the TX FIFO
+ */
+uint32_t DL_UART_fillTXFIFO(UART_Regs *uart, uint8_t *buffer, uint32_t count);
+
+/**
+ *  @brief      Enable UART interrupt for triggering the DMA receive event
+ *
+ * Enables the UART interrupt to be used as the condition to generate an
+ * event to directly trigger the DMA. This API configures the DMA_TRIG_RX
+ * register, which is the event publisher used for triggering the DMA to do
+ * a receive data transfer.
+ *
+ * @note Only one interrupt source should be enabled at a time.
+ *
+ *  @param[in]  uart       Pointer to the register overlay for the
+ *                         peripheral
+ *  @param[in]  interrupt  Interrupt to enable as the trigger condition for
+ *                         the DMA. One of @ref DL_UART_DMA_INTERRUPT_RX.
+ */
+__STATIC_INLINE void DL_UART_enableDMAReceiveEvent(
+    UART_Regs *uart, uint32_t interrupt)
+{
+    uart->DMA_TRIG_RX.IMASK = interrupt;
+}
+
+/**
+ *  @brief      Enable UART interrupt for triggering the DMA transmit event
+ *
+ * Enables the UART interrupt to be used as the condition to generate an
+ * event to directly trigger the DMA. This API configures the DMA_TRIG_TX
+ * register, which is the event publisher used for triggering the DMA to do
+ * a transmit data transfer.
+ *
+ * @note DMA_TRIG_TX only has one transmit interrupt source
+ *
+ *  @param[in]  uart       Pointer to the register overlay for the
+ *                         peripheral
+ */
+__STATIC_INLINE void DL_UART_enableDMATransmitEvent(UART_Regs *uart)
+{
+    uart->DMA_TRIG_TX.IMASK = UART_DMA_TRIG_TX_IMASK_TXINT_SET;
+}
+
+/**
+ *  @brief      Disables UART interrupt from triggering the DMA receive event
+ *
+ * Disables the UART interrupt as the condition to generate an event to
+ * directly trigger the DMA. This API configures the DMA_TRIG_RX
+ * register, which is the event publisher used for triggering the DMA to do
+ * a receive data transfer.
+ *
+ *  @param[in]  uart       Pointer to the register overlay for the
+ *                         peripheral
+ *  @param[in]  interrupt  Interrupt to disable as the trigger condition for
+ *                         the DMA. One of @ref DL_UART_DMA_INTERRUPT_RX.
+ */
+__STATIC_INLINE void DL_UART_disableDMAReceiveEvent(
+    UART_Regs *uart, uint32_t interrupt)
+{
+    uart->DMA_TRIG_RX.IMASK &= ~(interrupt);
+}
+
+/**
+ *  @brief      Disables UART interrupt from triggering the DMA transmit event
+ *
+ * Disables the UART interrupt as the condition to generate an event to
+ * directly trigger the DMA. This API configures the DMA_TRIG_TX
+ * register, which is the event publisher used for triggering the DMA to do
+ * a transmit data transfer.
+ *
+ * @note DMA_TRIG_TX only has one transmit interrupt source
+ *
+ *  @param[in]  uart       Pointer to the register overlay for the
+ *                         peripheral
+ */
+__STATIC_INLINE void DL_UART_disableDMATransmitEvent(UART_Regs *uart)
+{
+    uart->DMA_TRIG_TX.IMASK = UART_DMA_TRIG_TX_IMASK_TXINT_CLR;
+}
+
+/**
+ *  @brief      Check which UART interrupt for DMA receive events is enabled
+ *
+ *  This API checks the DMA_TRIG_RX register, which is the event publisher used
+ *  for triggering the DMA to do a receive data transfer.
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check Bitwise OR of
+ *                             @ref DL_UART_DMA_INTERRUPT_RX.
+ *
+ *  @return     Which of the requested UART interrupts is enabled
+ *
+ *  @retval     One of @ref DL_UART_DMA_INTERRUPT_RX
+ */
+__STATIC_INLINE uint32_t DL_UART_getEnabledDMAReceiveEvent(
+    UART_Regs *uart, uint32_t interruptMask)
+{
+    return (uart->DMA_TRIG_RX.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check if UART interrupt for DMA transmit event is enabled
+ *
+ *  This API checks the DMA_TRIG_TX register, which is the event publisher used
+ *  for triggering the DMA to do a transmit data transfer.
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     The requested UART interrupt status
+ *
+ *  @retval     DL_UART_DMA_INTERRUPT_TX if enabled, 0 if not enabled
+ */
+__STATIC_INLINE uint32_t DL_UART_getEnabledDMATransmitEvent(UART_Regs *uart)
+{
+    return (uart->DMA_TRIG_TX.IMASK & UART_DMA_TRIG_TX_IMASK_TXINT_MASK);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled UART interrupt for DMA receive event
+ *
+ * Checks if any of the UART interrupts for the DMA receive event that were
+ * previously enabled are pending.
+ * This API checks the DMA_TRIG_RX register, which is the event publisher used
+ * for triggering the DMA to do a receive data transfer.
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_UART_DMA_INTERRUPT_RX.
+ *
+ *  @return     The requested UART interrupt status
+ *
+ *  @retval     One of @ref DL_UART_DMA_INTERRUPT_RX
+ *
+ *  @sa         DL_UART_enableDMAReceiveEvent
+ */
+__STATIC_INLINE uint32_t DL_UART_getEnabledDMAReceiveEventStatus(
+    UART_Regs *uart, uint32_t interruptMask)
+{
+    return (uart->DMA_TRIG_RX.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled UART interrupt for DMA transmit event
+ *
+ * Checks if the UART interrupt for the DMA transmit event that was
+ * previously enabled is pending.
+ * This API checks the DMA_TRIG_TX register, which is the event publisher used
+ * for triggering the DMA to do a transmit data transfer.
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     The requested UART interrupt status
+ *
+ *  @retval     DL_UART_DMA_INTERRUPT_TX if enabled, 0 if not enabled
+ *
+ *  @sa         DL_UART_enableDMATransmitEvent
+ */
+__STATIC_INLINE uint32_t DL_UART_getEnabledDMATransmitEventStatus(
+    UART_Regs *uart)
+{
+    return (uart->DMA_TRIG_TX.MIS & UART_DMA_TRIG_TX_MIS_TXINT_MASK);
+}
+
+/**
+ *  @brief      Check interrupt flag of any UART interrupt for DMA receive event
+ *
+ *  Checks if any of the UART interrupts for DMA receive event are pending.
+ *  Interrupts do not have to be previously enabled.
+ *  This API checks the DMA_TRIG_RX register, which is the event publisher used
+ *  for triggering the DMA to do a receive data transfer.
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_UART_DMA_INTERRUPT_RX.
+ *
+ *  @return     Which of the requested UART interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_UART_DMA_INTERRUPT_RX values
+ */
+__STATIC_INLINE uint32_t DL_UART_getRawDMAReceiveEventStatus(
+    UART_Regs *uart, uint32_t interruptMask)
+{
+    return (uart->DMA_TRIG_RX.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any UART interrupt for DMA transmit event
+ *
+ *  Checks if any of the UART interrupts for DMA transmit event are pending.
+ *  Interrupts do not have to be previously enabled.
+ *  This API checks the DMA_TRIG_TX register, which is the event publisher used
+ *  for triggering the DMA to do a transmit data transfer.
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     The requested UART interrupt status
+ *
+ *  @retval     DL_UART_DMA_INTERRUPT_TX if enabled, 0 if not enabled
+ */
+__STATIC_INLINE uint32_t DL_UART_getRawDMATransmitEventStatus(UART_Regs *uart)
+{
+    return (uart->DMA_TRIG_TX.RIS & UART_DMA_TRIG_TX_RIS_TXINT_MASK);
+}
+
+/**
+ *  @brief      Get highest priority pending UART interrupt for DMA receive event
+ *
+ *  Checks if any of the UART interrupts for DMA receive event are pending.
+ *  Interrupts do not have to be previously enabled.
+ *  This API checks the DMA_TRIG_RX register, which is the event publisher used
+ *  for triggering the DMA to do a receive data transfer.
+ *
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     The highest priority pending UART interrupt
+ *
+ *  @retval     One of @ref DL_UART_DMA_IIDX_RX
+ */
+__STATIC_INLINE DL_UART_DMA_IIDX_RX DL_UART_getPendingDMAReceiveEvent(
+    UART_Regs *uart)
+{
+    return (DL_UART_DMA_IIDX_RX)(uart->DMA_TRIG_RX.IIDX);
+}
+
+/**
+ *  @brief      Get highest priority pending UART interrupt for DMA transmit event
+ *
+ *  Checks if the UART interrupt for DMA transmit event is pending.
+ *  Interrupts do not have to be previously enabled.
+ *  This API checks the DMA_TRIG_TX register, which is the event publisher used
+ *  for triggering the DMA to do a transmit data transfer.
+ *
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *
+ *  @return     The highest priority pending UART interrupt
+ *
+ *  @retval     DL_UART_DMA_IIDX_TX if pending, 0 if not pending
+ */
+__STATIC_INLINE DL_UART_DMA_IIDX_TX DL_UART_getPendingDMATransmitEvent(
+    UART_Regs *uart)
+{
+    return (DL_UART_DMA_IIDX_TX)(uart->DMA_TRIG_TX.IIDX);
+}
+
+/**
+ *  @brief      Clear pending UART interrupts for DMA receive event
+ *
+ *  This API checks the DMA_TRIG_RX register, which is the event publisher used
+ *  for triggering the DMA to do a receive data transfer.
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_UART_DMA_INTERRUPT_RX.
+ */
+__STATIC_INLINE void DL_UART_clearDMAReceiveEventStatus(
+    UART_Regs *uart, uint32_t interruptMask)
+{
+    uart->DMA_TRIG_RX.ICLR = interruptMask;
+}
+
+/**
+ *  @brief      Clear pending UART interrupt for DMA transmit event
+ *
+ *  This API checks the DMA_TRIG_TX register, which is the event publisher used
+ *  for triggering the DMA to do a transmit data transfer.
+ *
+ *  @param[in]  uart           Pointer to the register overlay for the
+ *                             peripheral
+ * @note DMA_TRIG_TX only has one transmit interrupt source
+ */
+__STATIC_INLINE void DL_UART_clearDMATransmitEventStatus(UART_Regs *uart)
+{
+    uart->DMA_TRIG_TX.ICLR = UART_DMA_TRIG_TX_ICLR_TXINT_CLR;
+}
+
+/*!
+ *  @brief Sets the second clock divider ratio
+ *
+ *  This API sets the CLKDIV2 register, which stores the clock divider ratio
+ *  used to further divide the UART function clock in IrDA UART mode
+ *
+ *  @param[in]  uart    Pointer to the register overlay for the peripheral
+ *  @param[in]  ratio   The CLKDIV2 value.  One of @ref DL_UART_CLOCK_DIVIDE_RATIO
+ */
+__STATIC_INLINE void DL_UART_setClockDivider2(
+    UART_Regs *uart, DL_UART_CLOCK_DIVIDE2_RATIO ratio)
+{
+    uart->CLKDIV2 = (uint32_t) ratio;
+}
+
+/*!
+ *  @brief Gets the value of CLKDIV2
+ *
+ *  This API gets the value stored in the CLKDIV2 register, which stores the
+ *  clock divider ratio to further divide the UART function clock in IrDA Mode
+ *
+ *  @param[in]  uart    Pointer to the register overlay for the peripheral
+ *
+ *  @return     The clock divider ratio stored in the CLKDIV2 register
+ *
+ *  @retval     The CLKDIV2 value.  One of @ref DL_UART_CLOCK_DIVIDE2_RATIO
+ */
+
+__STATIC_INLINE DL_UART_CLOCK_DIVIDE2_RATIO DL_UART_getClockDivider2(
+    UART_Regs *uart)
+{
+    uint32_t ratio = uart->CLKDIV2;
+    return (DL_UART_CLOCK_DIVIDE2_RATIO) ratio;
+}
+#ifdef __MSPM0_HAS_UART_MAIN__
+
+/**
+ *  @brief      Save UART Main configuration before entering a power loss state.
+ *
+ *  Some MSPM0G peripherals residing in PD1 domain do not retain register
+ *  contents when entering STOP or STANDBY modes. Please refer to the datasheet
+ *  for the full list of peripheral instances that exhibit this behavior.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr  Configuration backup setup structure. See
+ *                  @ref DL_UART_Main_backupConfig.
+ *
+ *  @retval     FALSE if a configuration already exists in ptr (will not be
+ *              overwritten). TRUE if a configuration was successfully saved
+ *
+ */
+bool DL_UART_Main_saveConfiguration(
+    UART_Regs *uart, DL_UART_Main_backupConfig *ptr);
+
+/**
+ *  @brief      Restore UART Main configuration after leaving a power loss state.
+ *
+ *  Some MSPM0G peripherals residing in PD1 domain do not retain register
+ *  contents when entering STOP or STANDBY modes. Please refer to the datasheet
+ *  for the full list of peripheral instances that exhibit this behavior.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr   Configuration backup setup structure. See
+ *                    @ref DL_UART_Main_backupConfig.
+ *
+ *  @retval     FALSE if a configuration does not exist in ptr (will not be
+ *              loaded). TRUE if a configuration successfully loaded
+ *
+ */
+bool DL_UART_Main_restoreConfiguration(
+    UART_Regs *uart, DL_UART_Main_backupConfig *ptr);
+
+#endif /* __MSPM0_HAS_UART_MAIN__ */
+
+#ifdef __MSPM0_HAS_UART_EXTD__
+
+/**
+ *  @brief      Save UART Extend configuration before entering a power loss
+ *              state.
+ *
+ *  Some MSPM0G peripherals residing in PD1 domain do not retain register
+ *  contents when entering STOP or STANDBY modes. Please refer to the datasheet
+ *  for the full list of peripheral instances that exhibit this behavior.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr   Configuration backup setup structure. See
+ *                    @ref DL_UART_Extend_backupConfig.
+ *
+ *  @retval     FALSE if a configuration already exists in ptr (will not be
+ *              overwritten). TRUE if a configuration was successfully saved
+ *
+ */
+bool DL_UART_Extend_saveConfiguration(
+    UART_Regs *uart, DL_UART_Extend_backupConfig *ptr);
+
+/**
+ *  @brief      Restore UART Extend configuration after leaving a power loss
+ *              state.
+ *
+ *  Some MSPM0G peripherals residing in PD1 domain do not retain register
+ *  contents when entering STOP or STANDBY modes. Please refer to the datasheet
+ *  for the full list of peripheral instances that exhibit this behavior.
+ *
+ *  @param[in]  uart  Pointer to the register overlay for the peripheral
+ *
+ *  @param[in]  ptr   Configuration backup setup structure. See
+ *                    @ref DL_UART_Extend_backupConfig.
+ *
+ *  @retval     FALSE if a configuration does not exist in ptr (will not be
+ *              loaded). TRUE if a configuration successfully loaded
+ *
+ */
+bool DL_UART_Extend_restoreConfiguration(
+    UART_Regs *uart, DL_UART_Extend_backupConfig *ptr);
+
+#endif /* __MSPM0_HAS_UART_EXTD__ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_UART_MAIN__ || __MSPM0_HAS_UART_EXTD__ */
+
+#else
+#warning \
+    "TI highly recommends accessing uart with dl_uart_main, dl_uart_extend.h only."
+#endif /* ti_dl_dl_uart_main__include ti_dl_dl_uart_extend__include */
+
+#endif /* ti_dl_dl_uart__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_uart_extend.h
+++ b/mspm0/source/ti/driverlib/dl_uart_extend.h
@@ -1,0 +1,1480 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_uart_extend.h
+ *  @brief      UART Driver Library
+ *  @defgroup   UARTEXT UART Extend (UART-Extend)
+ *
+ *  @anchor ti_dl_dl_uart_ext_Overview
+ *  # Overview
+ *
+ *  The UART Extend Driver Library enables configuration of UART-Extend, which
+ *  provides extended UART functionality for LIN, DALI, IrDA, ISO7816 and
+ *  Manchester codec.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup UARTEXT
+ * @{
+ */
+#ifndef ti_dl_dl_uart_extend__include
+#define ti_dl_dl_uart_extend__include
+
+#include <ti/driverlib/dl_uart.h>
+
+#ifdef __MSPM0_HAS_UART_EXTD__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/**
+ * @brief Redirects to common @ref DL_UART_Config
+ *
+ */
+typedef DL_UART_Config                                   DL_UART_Extend_Config;
+
+/**
+ * @brief Redirects to common @ref DL_UART_ClockConfig
+ *
+ */
+typedef DL_UART_ClockConfig                         DL_UART_Extend_ClockConfig;
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_DMA_DONE_TX
+ */
+#define DL_UART_EXTEND_INTERRUPT_DMA_DONE_TX    (DL_UART_INTERRUPT_DMA_DONE_TX)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_DMA_DONE_RX
+ */
+#define DL_UART_EXTEND_INTERRUPT_DMA_DONE_RX    (DL_UART_INTERRUPT_DMA_DONE_RX)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_CTS_DONE
+ */
+#define DL_UART_EXTEND_INTERRUPT_CTS_DONE          (DL_UART_INTERRUPT_CTS_DONE)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_ADDRESS_MATCH
+ */
+#define DL_UART_EXTEND_INTERRUPT_ADDRESS_MATCH                                \
+                                              (DL_UART_INTERRUPT_ADDRESS_MATCH)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_LINC0_MATCH
+ */
+#define DL_UART_EXTEND_INTERRUPT_LINC0_MATCH    (DL_UART_INTERRUPT_LINC0_MATCH)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_EOT_DONE
+ */
+#define DL_UART_EXTEND_INTERRUPT_EOT_DONE          (DL_UART_INTERRUPT_EOT_DONE)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_TX
+ */
+#define DL_UART_EXTEND_INTERRUPT_TX                      (DL_UART_INTERRUPT_TX)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_RX
+ */
+#define DL_UART_EXTEND_INTERRUPT_RX                      (DL_UART_INTERRUPT_RX)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_LIN_RISING_EDGE
+ */
+#define DL_UART_EXTEND_INTERRUPT_LIN_RISING_EDGE                              \
+                                            (DL_UART_INTERRUPT_LIN_RISING_EDGE)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_LIN_FALLING_EDGE
+ */
+#define DL_UART_EXTEND_INTERRUPT_LIN_FALLING_EDGE                             \
+                                           (DL_UART_INTERRUPT_LIN_FALLING_EDGE)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_RXD_POS_EDGE
+ */
+#define DL_UART_EXTEND_INTERRUPT_RXD_POS_EDGE  (DL_UART_INTERRUPT_RXD_POS_EDGE)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_RXD_NEG_EDGE
+ */
+#define DL_UART_EXTEND_INTERRUPT_RXD_NEG_EDGE  (DL_UART_INTERRUPT_RXD_NEG_EDGE)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_OVERRUN_ERROR
+ */
+#define DL_UART_EXTEND_INTERRUPT_OVERRUN_ERROR  DL_UART_INTERRUPT_OVERRUN_ERROR
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_BREAK_ERROR
+ */
+#define DL_UART_EXTEND_INTERRUPT_BREAK_ERROR      DL_UART_INTERRUPT_BREAK_ERROR
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_PARITY_ERROR
+ */
+#define DL_UART_EXTEND_INTERRUPT_PARITY_ERROR    DL_UART_INTERRUPT_PARITY_ERROR
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_FRAMING_ERROR
+ */
+#define DL_UART_EXTEND_INTERRUPT_FRAMING_ERROR  DL_UART_INTERRUPT_FRAMING_ERROR
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_RX_TIMEOUT_ERROR
+ */
+#define DL_UART_EXTEND_INTERRUPT_RX_TIMEOUT_ERROR                             \
+                                             DL_UART_INTERRUPT_RX_TIMEOUT_ERROR
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_NOISE_ERROR
+ */
+#define DL_UART_EXTEND_INTERRUPT_NOISE_ERROR                                  \
+                                                  DL_UART_INTERRUPT_NOISE_ERROR
+
+/*!
+ * @brief UART interrupt index for DMA done on transmit
+ */
+#define DL_UART_EXTEND_IIDX_DMA_DONE_TX                DL_UART_IIDX_DMA_DONE_TX
+
+/*!
+ * @brief UART interrupt index for DMA done on receive
+ */
+#define DL_UART_EXTEND_IIDX_DMA_DONE_RX                DL_UART_IIDX_DMA_DONE_RX
+
+/*!
+ * @brief UART interrupt index for clear to send
+ */
+#define DL_UART_EXTEND_IIDX_CTS_DONE                      DL_UART_IIDX_CTS_DONE
+
+/*!
+ * @brief UART interrupt index for 9-bit mode address match
+ */
+#define DL_UART_EXTEND_IIDX_ADDRESS_MATCH            DL_UART_IIDX_ADDRESS_MATCH
+
+/*!
+ * @brief UART interrupt index for end of transmission
+ */
+#define DL_UART_EXTEND_IIDX_EOT_DONE                      DL_UART_IIDX_EOT_DONE
+
+/*!
+ * @brief UART interrupt index for UART transmit
+ */
+#define DL_UART_EXTEND_IIDX_TX                                  DL_UART_IIDX_TX
+
+/*!
+ * @brief UART interrupt index for UART receive
+ */
+#define DL_UART_EXTEND_IIDX_RX                                  DL_UART_IIDX_RX
+
+ /*!
+ * @brief UART interrupt index for LIN hardware counter overflow
+ */
+#define DL_UART_EXTEND_IIDX_LIN_COUNTER_OVERFLOW                              \
+                                              DL_UART_IIDX_LIN_COUNTER_OVERFLOW
+
+/*!
+ * @brief UART interrupt index for LIN rising edge LINC1
+ */
+#define DL_UART_EXTEND_IIDX_LIN_RISING_EDGE        DL_UART_IIDX_LIN_RISING_EDGE
+
+/*!
+ * @brief UART interrupt index for LIN falling edge LINC0
+ */
+#define DL_UART_EXTEND_IIDX_LIN_FALLING_EDGE      DL_UART_IIDX_LIN_FALLING_EDGE
+
+/*!
+ * @brief UART interrupt index for positive edge on UARTxRXD
+ */
+#define DL_UART_EXTEND_IIDX_RXD_POS_EDGE              DL_UART_IIDX_RXD_POS_EDGE
+
+/*!
+ * @brief UART interrupt index for negative edge on UARTxRXD
+ */
+#define DL_UART_EXTEND_IIDX_RXD_NEG_EDGE              DL_UART_IIDX_RXD_NEG_EDGE
+
+/*!
+ * @brief UART interrupt index for overrun error
+ */
+#define DL_UART_EXTEND_IIDX_OVERRUN_ERROR            DL_UART_IIDX_OVERRUN_ERROR
+
+/*!
+ * @brief UART interrupt index for break error
+ */
+#define DL_UART_EXTEND_IIDX_BREAK_ERROR                DL_UART_IIDX_BREAK_ERROR
+
+/*!
+ * @brief UART interrupt index for parity error
+ */
+#define DL_UART_EXTEND_IIDX_PARITY_ERROR              DL_UART_IIDX_PARITY_ERROR
+
+/*!
+ * @brief UART interrupt index for framing error
+ */
+#define DL_UART_EXTEND_IIDX_FRAMING_ERROR            DL_UART_IIDX_FRAMING_ERROR
+
+/*!
+ * @brief UART interrupt index for receive timeout
+ */
+#define DL_UART_EXTEND_IIDX_RX_TIMEOUT_ERROR      DL_UART_IIDX_RX_TIMEOUT_ERROR
+
+/*!
+ * @brief UART interrupt index for noise error
+ */
+#define DL_UART_EXTEND_IIDX_NOISE_ERROR                DL_UART_IIDX_NOISE_ERROR
+
+/*!
+ * @brief UART interrupt index for no interrupt
+ */
+#define DL_UART_EXTEND_IIDX_NO_INTERRUPT              DL_UART_IIDX_NO_INTERRUPT
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DMA_IIDX_RX_TRIGGER
+ */
+#define DL_UART_EXTEND_DMA_IIDX_RX_TRIGGER          DL_UART_DMA_IIDX_RX_TRIGGER
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DMA_IIDX_RX_TIMEOUT_TRIGGER
+ */
+#define DL_UART_EXTEND_DMA_IIDX_RX_TIMEOUT_TRIGGER                            \
+                                            DL_UART_DMA_IIDX_RX_TIMEOUT_TRIGGER
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DMA_IIDX_TX_TRIGGER
+ */
+#define DL_UART_EXTEND_DMA_IIDX_TX_TRIGGER          DL_UART_DMA_IIDX_TX_TRIGGER
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DMA_INTERRUPT_RX
+ */
+#define DL_UART_EXTEND_DMA_INTERRUPT_RX                DL_UART_DMA_INTERRUPT_RX
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DMA_INTERRUPT_RX_TIMEOUT
+ */
+#define DL_UART_EXTEND_DMA_INTERRUPT_RX_TIMEOUT                               \
+                                               DL_UART_DMA_INTERRUPT_RX_TIMEOUT
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DMA_INTERRUPT_TX
+ */
+#define DL_UART_EXTEND_DMA_INTERRUPT_TX               DL_UART_DMA_INTERRUPT_TX
+
+/*!
+ * @brief Redirects to common @ref DL_UART_ERROR_OVERRUN
+ */
+#define DL_UART_EXTEND_ERROR_OVERRUN                      DL_UART_ERROR_OVERRUN
+
+/*!
+ * @brief Redirects to common @ref DL_UART_ERROR_BREAK
+ */
+#define DL_UART_EXTEND_ERROR_BREAK                          DL_UART_ERROR_BREAK
+
+/*!
+ * @brief Redirects to common @ref DL_UART_ERROR_PARITY
+ */
+#define DL_UART_EXTEND_ERROR_PARITY                        DL_UART_ERROR_PARITY
+
+/*!
+ * @brief Redirects to common @ref DL_UART_ERROR_FRAMING
+ */
+#define DL_UART_EXTEND_ERROR_FRAMING                      DL_UART_ERROR_FRAMING
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PULSE_WIDTH_5_NS
+ */
+#define DL_UART_EXTEND_PULSE_WIDTH_5_NS                DL_UART_PULSE_WIDTH_5_NS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PULSE_WIDTH_10_NS
+ */
+#define DL_UART_EXTEND_PULSE_WIDTH_10_NS              DL_UART_PULSE_WIDTH_10_NS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PULSE_WIDTH_25_NS
+ */
+#define DL_UART_EXTEND_PULSE_WIDTH_25_NS              DL_UART_PULSE_WIDTH_25_NS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PULSE_WIDTH_50_NS
+ */
+#define DL_UART_EXTEND_PULSE_WIDTH_50_NS              DL_UART_PULSE_WIDTH_50_NS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_OVERSAMPLING_RATE_16X
+ */
+#define DL_UART_EXTEND_OVERSAMPLING_RATE_16X      DL_UART_OVERSAMPLING_RATE_16X
+
+/*!
+ * @brief Redirects to common @ref DL_UART_OVERSAMPLING_RATE_8X
+ */
+#define DL_UART_EXTEND_OVERSAMPLING_RATE_8X        DL_UART_OVERSAMPLING_RATE_8X
+
+/*!
+ * @brief Redirects to common @ref DL_UART_OVERSAMPLING_RATE_3X
+ */
+#define DL_UART_EXTEND_OVERSAMPLING_RATE_3X        DL_UART_OVERSAMPLING_RATE_3X
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PARITY_EVEN
+ */
+#define DL_UART_EXTEND_PARITY_EVEN                          DL_UART_PARITY_EVEN
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PARITY_ODD
+ */
+#define DL_UART_EXTEND_PARITY_ODD                            DL_UART_PARITY_ODD
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PARITY_STICK_ONE
+ */
+#define DL_UART_EXTEND_PARITY_STICK_ONE                DL_UART_PARITY_STICK_ONE
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PARITY_STICK_ZERO
+ */
+#define DL_UART_EXTEND_PARITY_STICK_ZERO              DL_UART_PARITY_STICK_ZERO
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PARITY_NONE
+ */
+#define DL_UART_EXTEND_PARITY_NONE                          DL_UART_PARITY_NONE
+
+/*!
+ * @brief Redirects to common @ref DL_UART_WORD_LENGTH_5_BITS
+ */
+#define DL_UART_EXTEND_WORD_LENGTH_5_BITS            DL_UART_WORD_LENGTH_5_BITS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_WORD_LENGTH_6_BITS
+ */
+#define DL_UART_EXTEND_WORD_LENGTH_6_BITS            DL_UART_WORD_LENGTH_6_BITS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_WORD_LENGTH_7_BITS
+ */
+#define DL_UART_EXTEND_WORD_LENGTH_7_BITS            DL_UART_WORD_LENGTH_7_BITS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_WORD_LENGTH_8_BITS
+ */
+#define DL_UART_EXTEND_WORD_LENGTH_8_BITS            DL_UART_WORD_LENGTH_8_BITS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_MODE_NORMAL
+ */
+#define DL_UART_EXTEND_MODE_NORMAL                          DL_UART_MODE_NORMAL
+
+/*!
+ * @brief Redirects to common @ref DL_UART_MODE_RS485
+ */
+#define DL_UART_EXTEND_MODE_RS485                            DL_UART_MODE_RS485
+
+/*!
+ * @brief Redirects to common @ref DL_UART_MODE_IDLE_LINE
+ */
+#define DL_UART_EXTEND_MODE_IDLE_LINE                    DL_UART_MODE_IDLE_LINE
+
+/*!
+ * @brief Redirects to common @ref DL_UART_MODE_ADDR_9_BIT
+ */
+#define DL_UART_EXTEND_MODE_ADDR_9_BIT                  DL_UART_MODE_ADDR_9_BIT
+
+/*!
+ * @brief Redirects to common @ref DL_UART_MODE_SMART_CARD
+ */
+#define DL_UART_EXTEND_MODE_SMART_CARD                  DL_UART_MODE_SMART_CARD
+
+/*!
+ * @brief Redirects to common @ref DL_UART_MODE_DALI
+ */
+#define DL_UART_EXTEND_MODE_DALI                              DL_UART_MODE_DALI
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DIRECTION_TX
+ */
+#define DL_UART_EXTEND_DIRECTION_TX                        DL_UART_DIRECTION_TX
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DIRECTION_RX
+ */
+#define DL_UART_EXTEND_DIRECTION_RX                        DL_UART_DIRECTION_RX
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DIRECTION_TX_RX
+ */
+#define DL_UART_EXTEND_DIRECTION_TX_RX                  DL_UART_DIRECTION_TX_RX
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DIRECTION_NONE
+ */
+#define DL_UART_EXTEND_DIRECTION_NONE                    DL_UART_DIRECTION_NONE
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_BUSCLK
+ */
+#define DL_UART_EXTEND_CLOCK_BUSCLK                        DL_UART_CLOCK_BUSCLK
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_MFCLK
+ */
+#define DL_UART_EXTEND_CLOCK_MFCLK                          DL_UART_CLOCK_MFCLK
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_LFCLK
+ */
+#define DL_UART_EXTEND_CLOCK_LFCLK                          DL_UART_CLOCK_LFCLK
+
+/*!
+ * @brief Redirects to common @ref DL_UART_FLOW_CONTROL_RTS
+ */
+#define DL_UART_EXTEND_FLOW_CONTROL_RTS                DL_UART_FLOW_CONTROL_RTS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_FLOW_CONTROL_CTS
+ */
+#define DL_UART_EXTEND_FLOW_CONTROL_CTS                DL_UART_FLOW_CONTROL_CTS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_FLOW_CONTROL_RTS_CTS
+ */
+#define DL_UART_EXTEND_FLOW_CONTROL_RTS_CTS        DL_UART_FLOW_CONTROL_RTS_CTS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_FLOW_CONTROL_NONE
+ */
+#define DL_UART_EXTEND_FLOW_CONTROL_NONE              DL_UART_FLOW_CONTROL_NONE
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RTS_ASSERT
+ */
+#define DL_UART_EXTEND_RTS_ASSERT                            DL_UART_RTS_ASSERT
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RTS_DEASSERT
+ */
+#define DL_UART_EXTEND_RTS_DEASSERT                        DL_UART_RTS_DEASSERT
+
+/*!
+ * @brief Redirects to common @ref DL_UART_STOP_BITS_ONE
+ */
+#define DL_UART_EXTEND_STOP_BITS_ONE                      DL_UART_STOP_BITS_ONE
+
+/*!
+ * @brief Redirects to common @ref DL_UART_STOP_BITS_TWO
+ */
+#define DL_UART_EXTEND_STOP_BITS_TWO                      DL_UART_STOP_BITS_TWO
+
+/*!
+ * @brief Redirects to common @ref DL_UART_TXD_OUT_LOW
+ */
+#define DL_UART_EXTEND_TXD_OUT_LOW                          DL_UART_TXD_OUT_LOW
+
+/*!
+ * @brief Redirects to common @ref DL_UART_TXD_OUT_HIGH
+ */
+#define DL_UART_EXTEND_TXD_OUT_HIGH                        DL_UART_TXD_OUT_HIGH
+
+/*!
+ * @brief Redirects to common @ref DL_UART_TX_FIFO_LEVEL_3_4_EMPTY
+ */
+#define DL_UART_EXTEND_TX_FIFO_LEVEL_3_4_EMPTY  DL_UART_TX_FIFO_LEVEL_3_4_EMPTY
+
+/*!
+ * @brief Redirects to common @ref DL_UART_TX_FIFO_LEVEL_1_4_EMPTY
+ */
+#define DL_UART_EXTEND_TX_FIFO_LEVEL_1_4_EMPTY  DL_UART_TX_FIFO_LEVEL_1_4_EMPTY
+
+/*!
+ * @brief Redirects to common @ref DL_UART_TX_FIFO_LEVEL_EMPTY
+ */
+#define DL_UART_EXTEND_TX_FIFO_LEVEL_EMPTY          DL_UART_TX_FIFO_LEVEL_EMPTY
+
+/*!
+ * @brief Redirects to common @ref DL_UART_TX_FIFO_LEVEL_ONE_ENTRY
+ */
+#define DL_UART_EXTEND_TX_FIFO_LEVEL_ONE_ENTRY  DL_UART_TX_FIFO_LEVEL_ONE_ENTRY
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RX_FIFO_LEVEL_ONE_ENTRY
+ */
+#define DL_UART_EXTEND_RX_FIFO_LEVEL_ONE_ENTRY  DL_UART_RX_FIFO_LEVEL_ONE_ENTRY
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RX_FIFO_LEVEL_FULL
+ */
+#define DL_UART_EXTEND_RX_FIFO_LEVEL_FULL            DL_UART_RX_FIFO_LEVEL_FULL
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RX_FIFO_LEVEL_3_4_FULL
+ */
+#define DL_UART_EXTEND_RX_FIFO_LEVEL_3_4_FULL    DL_UART_RX_FIFO_LEVEL_3_4_FULL
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RX_FIFO_LEVEL_1_2_FULL
+ */
+#define DL_UART_EXTEND_RX_FIFO_LEVEL_1_2_FULL    DL_UART_RX_FIFO_LEVEL_1_2_FULL
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RX_FIFO_LEVEL_1_4_FULL
+ */
+#define DL_UART_EXTEND_RX_FIFO_LEVEL_1_4_FULL    DL_UART_RX_FIFO_LEVEL_1_4_FULL
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_1
+ */
+#define DL_UART_EXTEND_CLOCK_DIVIDE_RATIO_1        DL_UART_CLOCK_DIVIDE_RATIO_1
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_2
+ */
+#define DL_UART_EXTEND_CLOCK_DIVIDE_RATIO_2        DL_UART_CLOCK_DIVIDE_RATIO_2
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_3
+ */
+#define DL_UART_EXTEND_CLOCK_DIVIDE_RATIO_3        DL_UART_CLOCK_DIVIDE_RATIO_3
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_4
+ */
+#define DL_UART_EXTEND_CLOCK_DIVIDE_RATIO_4        DL_UART_CLOCK_DIVIDE_RATIO_4
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_5
+ */
+#define DL_UART_EXTEND_CLOCK_DIVIDE_RATIO_5        DL_UART_CLOCK_DIVIDE_RATIO_5
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_6
+ */
+#define DL_UART_EXTEND_CLOCK_DIVIDE_RATIO_6        DL_UART_CLOCK_DIVIDE_RATIO_6
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_7
+ */
+#define DL_UART_EXTEND_CLOCK_DIVIDE_RATIO_7        DL_UART_CLOCK_DIVIDE_RATIO_7
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_8
+ */
+#define DL_UART_EXTEND_CLOCK_DIVIDE_RATIO_8         DL_UART_CLOCK_DIVIDE_RATIO_8
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_LIN_COUNTER_OVERFLOW
+ */
+#define DL_UART_EXTEND_INTERRUPT_LIN_COUNTER_OVERFLOW                         \
+                                       (DL_UART_INTERRUPT_LIN_COUNTER_OVERFLOW)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_LIN_RISING_EDGE
+ */
+#define DL_UART_EXTEND_INTERRUPT_LIN_RISING_EDGE                              \
+                                            (DL_UART_INTERRUPT_LIN_RISING_EDGE)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_LIN_FALLING_EDGE
+ */
+#define DL_UART_EXTEND_INTERRUPT_LIN_FALLING_EDGE                             \
+                                           (DL_UART_INTERRUPT_LIN_FALLING_EDGE)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_IRDA_CLOCK_BAUD_RATE
+ */
+#define DL_UART_EXTEND_IRDA_CLOCK_BAUD_RATE      (DL_UART_IRDA_CLOCK_BAUD_RATE)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_IRDA_CLOCK_FUNCTIONAL
+ */
+#define DL_UART_EXTEND_IRDA_CLOCK_FUNCTIONAL    (DL_UART_IRDA_CLOCK_FUNCTIONAL)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_IRDA_POLARITY_LOW
+ */
+#define DL_UART_EXTEND_IRDA_POLARITY_LOW            (DL_UART_IRDA_POLARITY_LOW)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_IRDA_POLARITY_HIGH
+ */
+#define DL_UART_EXTEND_IRDA_POLARITY_HIGH          (DL_UART_IRDA_POLARITY_HIGH)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PULSE_WIDTH_3_16_BIT_PERIOD
+ */
+#define DL_UART_EXTEND_PULSE_WIDTH_3_16_BIT_PERIOD                            \
+                                          (DL_UART_PULSE_WIDTH_3_16_BIT_PERIOD)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_init
+ */
+#define DL_UART_Extend_init                                        DL_UART_init
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enablePower
+ */
+#define DL_UART_Extend_enablePower                          DL_UART_enablePower
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disablePower
+ */
+#define DL_UART_Extend_disablePower                        DL_UART_disablePower
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isPowerEnabled
+ */
+#define DL_UART_Extend_isPowerEnabled                    DL_UART_isPowerEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_reset
+ */
+#define DL_UART_Extend_reset                                      DL_UART_reset
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enable
+ */
+#define DL_UART_Extend_enable                                    DL_UART_enable
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isEnabled
+ */
+#define DL_UART_Extend_isEnabled                              DL_UART_isEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disable
+ */
+#define DL_UART_Extend_disable                                  DL_UART_disable
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setClockConfig
+ */
+#define DL_UART_Extend_setClockConfig                    DL_UART_setClockConfig
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getClockConfig
+ */
+#define DL_UART_Extend_getClockConfig                    DL_UART_getClockConfig
+
+/*!
+ * @brief Redirects to common @ref DL_UART_configBaudRate
+ */
+#define DL_UART_Extend_configBaudRate                    DL_UART_configBaudRate
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setOversampling
+ */
+#define DL_UART_Extend_setOversampling                  DL_UART_setOversampling
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getOversampling
+ */
+#define DL_UART_Extend_getOversampling                  DL_UART_getOversampling
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableLoopbackMode
+ */
+#define DL_UART_Extend_enableLoopbackMode            DL_UART_enableLoopbackMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isLoopbackModeEnabled
+ */
+#define DL_UART_Extend_isLoopbackModeEnabled      DL_UART_isLoopbackModeEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableLoopbackMode
+ */
+#define DL_UART_Extend_disableLoopbackMode          DL_UART_disableLoopbackMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setDirection
+ */
+#define DL_UART_Extend_setDirection                        DL_UART_setDirection
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getDirection
+ */
+#define DL_UART_Extend_getDirection                        DL_UART_getDirection
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableMajorityVoting
+ */
+#define DL_UART_Extend_enableMajorityVoting        DL_UART_enableMajorityVoting
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isMajorityVotingEnabled
+ */
+#define DL_UART_Extend_isMajorityVotingEnabled  DL_UART_isMajorityVotingEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableMajorityVoting
+ */
+#define DL_UART_Extend_disableMajorityVoting      DL_UART_disableMajorityVoting
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableMSBFirst
+ */
+#define DL_UART_Extend_enableMSBFirst                    DL_UART_enableMSBFirst
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isMSBFirstEnabled
+ */
+#define DL_UART_Extend_isMSBFirstEnabled              DL_UART_isMSBFirstEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableMSBFirst
+ */
+#define DL_UART_Extend_disableMSBFirst                  DL_UART_disableMSBFirst
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableTransmitPinManualControl
+ */
+#define DL_UART_Extend_enableTransmitPinManualControl                         \
+                                         DL_UART_enableTransmitPinManualControl
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isTransmitPinManualControlEnabled
+ */
+#define DL_UART_Extend_isTransmitPinManualControlEnabled                      \
+                                      DL_UART_isTransmitPinManualControlEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableTransmitPinManualControl
+ */
+#define DL_UART_Extend_disableTransmitPinManualControl                        \
+                                        DL_UART_disableTransmitPinManualControl
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setTransmitPinManualOutput
+ */
+#define DL_UART_Extend_setTransmitPinManualOutput                             \
+                                             DL_UART_setTransmitPinManualOutput
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getTransmitPinManualOutput
+ */
+#define DL_UART_Extend_getTransmitPinManualOutput                             \
+                                             DL_UART_getTransmitPinManualOutput
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setCommunicationMode
+ */
+#define DL_UART_Extend_setCommunicationMode        DL_UART_setCommunicationMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getCommunicationMode
+ */
+#define DL_UART_Extend_getCommunicationMode        DL_UART_getCommunicationMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setFlowControl
+ */
+#define DL_UART_Extend_setFlowControl                    DL_UART_setFlowControl
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getFlowControl
+ */
+#define DL_UART_Extend_getFlowControl                    DL_UART_getFlowControl
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setRTSOutput
+ */
+#define DL_UART_Extend_setRTSOutput                        DL_UART_setRTSOutput
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableFIFOs
+ */
+#define DL_UART_Extend_enableFIFOs                          DL_UART_enableFIFOs
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableFIFOs
+ */
+#define DL_UART_Extend_disableFIFOs                        DL_UART_disableFIFOs
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isFIFOsEnabled
+ */
+#define DL_UART_Extend_isFIFOsEnabled                    DL_UART_isFIFOsEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isParityEnabled
+ */
+#define DL_UART_Extend_isParityEnabled                  DL_UART_isParityEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setParityMode
+ */
+#define DL_UART_Extend_setParityMode                      DL_UART_setParityMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getParityMode
+ */
+#define DL_UART_Extend_getParityMode                      DL_UART_getParityMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setStopBits
+ */
+#define DL_UART_Extend_setStopBits                          DL_UART_setStopBits
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getStopBits
+ */
+#define DL_UART_Extend_getStopBits                          DL_UART_getStopBits
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setWordLength
+ */
+#define DL_UART_Extend_setWordLength                      DL_UART_setWordLength
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getWordLength
+ */
+#define DL_UART_Extend_getWordLength                      DL_UART_getWordLength
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableSendIdlePattern
+ */
+#define DL_UART_Extend_enableSendIdlePattern      DL_UART_enableSendIdlePattern
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableSendIdlePattern
+ */
+#define DL_UART_Extend_disableSendIdlePattern    DL_UART_disableSendIdlePattern
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isSendIdlePatternEnabled
+ */
+#define DL_UART_Extend_isSendIdlePatternEnabled                               \
+                                               DL_UART_isSendIdlePatternEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setExternalDriverSetup
+ */
+#define DL_UART_Extend_setExternalDriverSetup    DL_UART_setExternalDriverSetup
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getExternalDriverSetup
+ */
+#define DL_UART_Extend_getExternalDriverSetup    DL_UART_getExternalDriverSetup
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setExternalDriverHold
+ */
+#define DL_UART_Extend_setExternalDriverHold      DL_UART_setExternalDriverHold
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getExternalDriverHold
+ */
+#define DL_UART_Extend_getExternalDriverHold      DL_UART_getExternalDriverHold
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isBusy
+ */
+#define DL_UART_Extend_isBusy                                    DL_UART_isBusy
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isRXFIFOEmpty
+ */
+#define DL_UART_Extend_isRXFIFOEmpty                      DL_UART_isRXFIFOEmpty
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isRXFIFOFull
+ */
+#define DL_UART_Extend_isRXFIFOFull                        DL_UART_isRXFIFOFull
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isTXFIFOEmpty
+ */
+#define DL_UART_Extend_isTXFIFOEmpty                      DL_UART_isTXFIFOEmpty
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isTXFIFOFull
+ */
+#define DL_UART_Extend_isTXFIFOFull                        DL_UART_isTXFIFOFull
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isClearToSend
+ */
+#define DL_UART_Extend_isClearToSend                      DL_UART_isClearToSend
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isIdleModeDetected
+ */
+#define DL_UART_Extend_isIdleModeDetected            DL_UART_isIdleModeDetected
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setTXFIFOThreshold
+ */
+#define DL_UART_Extend_setTXFIFOThreshold            DL_UART_setTXFIFOThreshold
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getTXFIFOThreshold
+ */
+#define DL_UART_Extend_getTXFIFOThreshold            DL_UART_getTXFIFOThreshold
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setRXFIFOThreshold
+ */
+#define DL_UART_Extend_setRXFIFOThreshold            DL_UART_setRXFIFOThreshold
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getRXFIFOThreshold
+ */
+#define DL_UART_Extend_getRXFIFOThreshold            DL_UART_getRXFIFOThreshold
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setRXInterruptTimeout
+ */
+#define DL_UART_Extend_setRXInterruptTimeout      DL_UART_setRXInterruptTimeout
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getRXInterruptTimeout
+ */
+#define DL_UART_Extend_getRXInterruptTimeout      DL_UART_getRXInterruptTimeout
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getIntegerBaudRateDivisor
+ */
+#define DL_UART_Extend_getIntegerBaudRateDivisor                              \
+                                              DL_UART_getIntegerBaudRateDivisor
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getFractionalBaudRateDivisor
+ */
+#define DL_UART_Extend_getFractionalBaudRateDivisor                           \
+                                           DL_UART_getFractionalBaudRateDivisor
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setBaudRateDivisor
+ */
+#define DL_UART_Extend_setBaudRateDivisor            DL_UART_setBaudRateDivisor
+
+/*!
+ * @brief Redirects to common @ref DL_UART_transmitData
+ */
+#define DL_UART_Extend_transmitData                        DL_UART_transmitData
+
+/*!
+ * @brief Redirects to common @ref DL_UART_receiveData
+ */
+#define DL_UART_Extend_receiveData                          DL_UART_receiveData
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getErrorStatus
+ */
+#define DL_UART_Extend_getErrorStatus                    DL_UART_getErrorStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableInterrupt
+ */
+#define DL_UART_Extend_enableInterrupt                  DL_UART_enableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableInterrupt
+ */
+#define DL_UART_Extend_disableInterrupt                DL_UART_disableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getEnabledInterrupts
+ */
+#define DL_UART_Extend_getEnabledInterrupts        DL_UART_getEnabledInterrupts
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getEnabledInterruptStatus
+ */
+#define DL_UART_Extend_getEnabledInterruptStatus                              \
+                                              DL_UART_getEnabledInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getRawInterruptStatus
+ */
+#define DL_UART_Extend_getRawInterruptStatus      DL_UART_getRawInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getPendingInterrupt
+ */
+#define DL_UART_Extend_getPendingInterrupt          DL_UART_getPendingInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_UART_clearInterruptStatus
+ */
+#define DL_UART_Extend_clearInterruptStatus        DL_UART_clearInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_changeConfig
+ */
+#define DL_UART_Extend_changeConfig                        DL_UART_changeConfig
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableAnalogGlitchFilter
+ */
+#define DL_UART_Extend_enableAnalogGlitchFilter                               \
+                                               DL_UART_enableAnalogGlitchFilter
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableAnalogGlitchFilter
+ */
+#define DL_UART_Extend_disableAnalogGlitchFilter                              \
+                                              DL_UART_disableAnalogGlitchFilter
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isAnalogGlitchFilterEnabled
+ */
+#define DL_UART_Extend_isAnalogGlitchFilterEnabled                            \
+                                            DL_UART_isAnalogGlitchFilterEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableGlitchFilterChaining
+ */
+#define DL_UART_Extend_enableGlitchFilterChaining                             \
+                                            DL_UART_enableGlitchFilterChaining
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableGlitchFilterChaining
+ */
+#define DL_UART_Extend_disableGlitchFilterChaining                            \
+                                            DL_UART_disableGlitchFilterChaining
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isGlitchFilterChainingEnabled
+ */
+#define DL_UART_Extend_isGlitchFilterChainingEnabled                          \
+                                          DL_UART_isGlitchFilterChainingEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setAnalogPulseWidth
+ */
+#define DL_UART_Extend_setAnalogPulseWidth          DL_UART_setAnalogPulseWidth
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getAnalogPulseWidth
+ */
+#define DL_UART_Extend_getAnalogPulseWidth          DL_UART_getAnalogPulseWidth
+
+/*!
+ * @brief Redirects to common @ref DL_UART_transmitDataBlocking
+ */
+#define DL_UART_Extend_transmitDataBlocking        DL_UART_transmitDataBlocking
+
+/*!
+ * @brief Redirects to common @ref DL_UART_receiveDataBlocking
+ */
+#define DL_UART_Extend_receiveDataBlocking          DL_UART_receiveDataBlocking
+
+/*!
+ * @brief Redirects to common @ref DL_UART_transmitDataCheck
+ */
+#define DL_UART_Extend_transmitDataCheck              DL_UART_transmitDataCheck
+
+/*!
+ * @brief Redirects to common @ref DL_UART_receiveDataCheck
+ */
+#define DL_UART_Extend_receiveDataCheck                DL_UART_receiveDataCheck
+
+/*!
+ * @brief Redirects to common @ref DL_UART_drainRXFIFO
+ */
+#define DL_UART_Extend_drainRXFIFO                          DL_UART_drainRXFIFO
+
+/*!
+ * @brief Redirects to common @ref DL_UART_fillTXFIFO
+ */
+#define DL_UART_Extend_fillTXFIFO                            DL_UART_fillTXFIFO
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableDMAReceiveEvent
+ */
+#define DL_UART_Extend_enableDMAReceiveEvent      DL_UART_enableDMAReceiveEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableDMATransmitEvent
+ */
+#define DL_UART_Extend_enableDMATransmitEvent    DL_UART_enableDMATransmitEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableDMAReceiveEvent
+ */
+#define DL_UART_Extend_disableDMAReceiveEvent    DL_UART_disableDMAReceiveEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableDMATransmitEvent
+ */
+#define DL_UART_Extend_disableDMATransmitEvent  DL_UART_disableDMATransmitEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getEnabledDMAReceiveEvent
+ */
+#define DL_UART_Extend_getEnabledDMAReceiveEvent                              \
+                                              DL_UART_getEnabledDMAReceiveEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getEnabledDMATransmitEvent
+ */
+#define DL_UART_Extend_getEnabledDMATransmitEvent                             \
+                                             DL_UART_getEnabledDMATransmitEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getEnabledDMAReceiveEventStatus
+ */
+#define DL_UART_Extend_getEnabledDMAReceiveEventStatus                        \
+                                        DL_UART_getEnabledDMAReceiveEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getEnabledDMATransmitEventStatus
+ */
+#define DL_UART_Extend_getEnabledDMATransmitEventStatus                       \
+                                       DL_UART_getEnabledDMATransmitEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getRawDMAReceiveEventStatus
+ */
+#define DL_UART_Extend_getRawDMAReceiveEventStatus                            \
+                                            DL_UART_getRawDMAReceiveEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getRawDMATransmitEventStatus
+ */
+#define DL_UART_Extend_getRawDMATransmitEventStatus                           \
+                                           DL_UART_getRawDMATransmitEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getPendingDMAReceiveEvent
+ */
+#define DL_UART_Extend_getPendingDMAReceiveEvent                              \
+                                              DL_UART_getPendingDMAReceiveEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getPendingDMATransmitEvent
+ */
+#define DL_UART_Extend_getPendingDMATransmitEvent                             \
+                                             DL_UART_getPendingDMATransmitEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_clearDMAReceiveEventStatus
+ */
+#define DL_UART_Extend_clearDMAReceiveEventStatus                             \
+                                             DL_UART_clearDMAReceiveEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_clearDMATransmitEventStatus
+ */
+#define DL_UART_Extend_clearDMATransmitEventStatus                            \
+                                            DL_UART_clearDMATransmitEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setLINCounterValue
+ */
+#define DL_UART_Extend_setLINCounterValue            DL_UART_setLINCounterValue
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getLINCounterValue
+ */
+#define DL_UART_Extend_getLINCounterValue            DL_UART_getLINCounterValue
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableLINCounter
+ */
+#define DL_UART_Extend_enableLINCounter                DL_UART_enableLINCounter
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isLINCounterEnabled
+ */
+#define DL_UART_Extend_isLINCounterEnabled          DL_UART_isLINCounterEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableLINCounter
+ */
+#define DL_UART_Extend_disableLINCounter              DL_UART_disableLINCounter
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableLINCounterClearOnFallingEdge
+ */
+#define DL_UART_Extend_enableLINCounterClearOnFallingEdge                     \
+                                     DL_UART_enableLINCounterClearOnFallingEdge
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isLINCounterClearOnFallingEdge
+ */
+#define DL_UART_Extend_isLINCounterClearOnFallingEdge                         \
+                                         DL_UART_isLINCounterClearOnFallingEdge
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableLINCounterClearOnFallingEdge
+ */
+#define DL_UART_Extend_disableLINCounterClearOnFallingEdge                    \
+                                    DL_UART_disableLINCounterClearOnFallingEdge
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableLINCountWhileLow
+ */
+#define DL_UART_Extend_enableLINCountWhileLow    DL_UART_enableLINCountWhileLow
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isLINCountWhileLowEnabled
+ */
+#define DL_UART_Extend_isLINCountWhileLowEnabled                              \
+                                              DL_UART_isLINCountWhileLowEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableLINCountWhileLow
+ */
+#define DL_UART_Extend_disableLINCountWhileLow  DL_UART_disableLINCountWhileLow
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableLINFallingEdgeCapture
+ */
+#define DL_UART_Extend_enableLINFallingEdgeCapture                            \
+                                            DL_UART_enableLINFallingEdgeCapture
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isLINFallingEdgeCaptureEnabled
+ */
+#define DL_UART_Extend_isLINFallingEdgeCaptureEnabled                         \
+                                         DL_UART_isLINFallingEdgeCaptureEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableLINFallingEdgeCapture
+ */
+#define DL_UART_Extend_disableLINFallingEdgeCapture                           \
+                                           DL_UART_disableLINFallingEdgeCapture
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableLINRisingEdgeCapture
+ */
+#define DL_UART_Extend_enableLINRisingEdgeCapture                             \
+                                             DL_UART_enableLINRisingEdgeCapture
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isLINRisingEdgeCaptureEnabled
+ */
+#define DL_UART_Extend_isLINRisingEdgeCaptureEnabled                          \
+                                          DL_UART_isLINRisingEdgeCaptureEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableLINRisingEdgeCapture
+ */
+#define DL_UART_Extend_disableLINRisingEdgeCapture                            \
+                                            DL_UART_disableLINRisingEdgeCapture
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableLINCounterCompareMatch
+ */
+#define DL_UART_Extend_enableLINCounterCompareMatch                           \
+                                           DL_UART_enableLINCounterCompareMatch
+
+/*!
+ * @brief Redirects to common
+ * @ref DL_UART_enableLINSyncFieldValidationCounterControl
+ */
+#define DL_UART_Extend_enableLINSyncFieldValidationCounterControl             \
+                             DL_UART_enableLINSyncFieldValidationCounterControl
+
+/*!
+ * @brief Redirects to common @ref DL_UART_Extend_enableLINReceptionCountControl
+ */
+#define DL_UART_Extend_enableLINReceptionCountControl                         \
+                                         DL_UART_enableLINReceptionCountControl
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isLINCounterCompareMatchEnabled
+ */
+#define DL_UART_Extend_isLINCounterCompareMatchEnabled                        \
+                                        DL_UART_isLINCounterCompareMatchEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableLINCounterCompareMatch
+ */
+#define DL_UART_Extend_disableLINCounterCompareMatch                          \
+                                          DL_UART_disableLINCounterCompareMatch
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setLINCounterCompareValue
+ */
+#define DL_UART_Extend_setLINCounterCompareValue                              \
+                                              DL_UART_setLINCounterCompareValue
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getLINFallingEdgeCaptureValue
+ */
+#define DL_UART_Extend_getLINFallingEdgeCaptureValue                          \
+                                          DL_UART_getLINFallingEdgeCaptureValue
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getLINRisingEdgeCaptureValue
+ */
+#define DL_UART_Extend_getLINRisingEdgeCaptureValue                           \
+                                           DL_UART_getLINRisingEdgeCaptureValue
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableLINSendBreak
+ */
+#define DL_UART_Extend_enableLINSendBreak            DL_UART_enableLINSendBreak
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableLINSendBreak
+ */
+#define DL_UART_Extend_disableLINSendBreak          DL_UART_disableLINSendBreak
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isLINSendBreakEnabled
+ */
+#define DL_UART_Extend_isLINSendBreakEnabled      DL_UART_isLINSendBreakEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableIrDAMode
+ */
+#define DL_UART_Extend_enableIrDAMode                    DL_UART_enableIrDAMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isIrDAModeEnabled
+ */
+#define DL_UART_Extend_isIrDAModeEnabled              DL_UART_isIrDAModeEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableIrDAMode
+ */
+#define DL_UART_Extend_disableIrDAMode                  DL_UART_disableIrDAMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setIrDATXPulseClockSelect
+ */
+#define DL_UART_Extend_setIrDATXPulseClockSelect                              \
+                                              DL_UART_setIrDATXPulseClockSelect
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getIrDATXPulseClockSelect
+ */
+#define DL_UART_Extend_getIrDATXPulseClockSelect                              \
+                                              DL_UART_getIrDATXPulseClockSelect
+
+/*!
+ * @brief Redirects to common @ref DL_UART_configIrDAMode
+ */
+#define DL_UART_Extend_configIrDAMode                    DL_UART_configIrDAMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setIrDAPulseLength
+ */
+#define DL_UART_Extend_setIrDAPulseLength            DL_UART_setIrDAPulseLength
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getIrDATXPulseLength
+ */
+#define DL_UART_Extend_getIrDATXPulseLength        DL_UART_getIrDATXPulseLength
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setIrDARXPulsePolarity
+ */
+#define DL_UART_Extend_setIrDARXPulsePolarity    DL_UART_setIrDARXPulsePolarity
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getIrDARXPulsePolarity
+ */
+#define DL_UART_Extend_getIrDARXPulsePolarity    DL_UART_getIrDARXPulsePolarity
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setDigitalPulseWidth
+ */
+#define DL_UART_Extend_setDigitalPulseWidth        DL_UART_setDigitalPulseWidth
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getDigitalPulseWidth
+ */
+#define DL_UART_Extend_getDigitalPulseWidth        DL_UART_getDigitalPulseWidth
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setAddressMask
+ */
+#define DL_UART_Extend_setAddressMask                    DL_UART_setAddressMask
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getAddressMask
+ */
+#define DL_UART_Extend_getAddressMask                    DL_UART_getAddressMask
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setAddress
+ */
+#define DL_UART_Extend_setAddress                            DL_UART_setAddress
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getAddress
+ */
+#define DL_UART_Extend_getAddress                            DL_UART_getAddress
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableManchesterEncoding
+ */
+#define DL_UART_Extend_enableManchesterEncoding                               \
+                                               DL_UART_enableManchesterEncoding
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableManchesterEncoding
+ */
+#define DL_UART_Extend_disableManchesterEncoding                              \
+                                              DL_UART_disableManchesterEncoding
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isManchesterEncodingEnabled
+ */
+#define DL_UART_Extend_isManchesterEncodingEnabled                            \
+                                            DL_UART_isManchesterEncodingEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setClockDivider2
+ */
+#define DL_UART_Extend_setClockDivider2                DL_UART_setClockDivider2
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getClockDivider2
+ */
+#define DL_UART_Extend_getClockDivider2                DL_UART_getClockDivider2
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setIrDABaudRateDivisor
+ */
+#define DL_UART_Extend_setIrDABaudRateDivisor    DL_UART_setIrDABaudRateDivisor
+
+/* clang-format on */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_UART_EXTD__ */
+
+#endif /* ti_dl_dl_uart_extend__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_uart_main.h
+++ b/mspm0/source/ti/driverlib/dl_uart_main.h
@@ -1,0 +1,1114 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_uart_main.h
+ *  @brief      UART Driver Library
+ *  @defgroup   UARTMAIN UART Main (UART-Main)
+ *
+ *  @anchor ti_dl_dl_uart_main_Overview
+ *  # Overview
+ *
+ *  The UART Main Driver Library enables configuration of the MSPM0 UART-Main,
+ *  which provides basic UART functionality.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup UARTMAIN
+ * @{
+ */
+#ifndef ti_dl_dl_uart_main__include
+#define ti_dl_dl_uart_main__include
+
+#include <ti/driverlib/dl_uart.h>
+
+#ifdef __MSPM0_HAS_UART_MAIN__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/**
+ * @brief Redirects to common @ref DL_UART_Config
+ *
+ */
+typedef DL_UART_Config                                     DL_UART_Main_Config;
+
+/**
+ * @brief Redirects to common @ref DL_UART_ClockConfig
+ *
+ */
+typedef DL_UART_ClockConfig                           DL_UART_Main_ClockConfig;
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_DMA_DONE_TX
+ */
+#define DL_UART_MAIN_INTERRUPT_DMA_DONE_TX                                    \
+                                                (DL_UART_INTERRUPT_DMA_DONE_TX)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_DMA_DONE_RX
+ */
+#define DL_UART_MAIN_INTERRUPT_DMA_DONE_RX                                    \
+                                                (DL_UART_INTERRUPT_DMA_DONE_RX)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_CTS_DONE
+ */
+#define DL_UART_MAIN_INTERRUPT_CTS_DONE                                       \
+                                                   (DL_UART_INTERRUPT_CTS_DONE)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_EOT_DONE
+ */
+#define DL_UART_MAIN_INTERRUPT_EOT_DONE            (DL_UART_INTERRUPT_EOT_DONE)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_TX
+ */
+#define DL_UART_MAIN_INTERRUPT_TX                        (DL_UART_INTERRUPT_TX)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_RX
+ */
+#define DL_UART_MAIN_INTERRUPT_RX                        (DL_UART_INTERRUPT_RX)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_RXD_POS_EDGE
+ */
+#define DL_UART_MAIN_INTERRUPT_RXD_POS_EDGE    (DL_UART_INTERRUPT_RXD_POS_EDGE)
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_RXD_NEG_EDGE
+ */
+#define DL_UART_MAIN_INTERRUPT_RXD_NEG_EDGE    (DL_UART_INTERRUPT_RXD_NEG_EDGE)
+
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_OVERRUN_ERROR
+ */
+#define DL_UART_MAIN_INTERRUPT_OVERRUN_ERROR    DL_UART_INTERRUPT_OVERRUN_ERROR
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_BREAK_ERROR
+ */
+#define DL_UART_MAIN_INTERRUPT_BREAK_ERROR        DL_UART_INTERRUPT_BREAK_ERROR
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_PARITY_ERROR
+ */
+#define DL_UART_MAIN_INTERRUPT_PARITY_ERROR      DL_UART_INTERRUPT_PARITY_ERROR
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_FRAMING_ERROR
+ */
+#define DL_UART_MAIN_INTERRUPT_FRAMING_ERROR    DL_UART_INTERRUPT_FRAMING_ERROR
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_RX_TIMEOUT_ERROR
+ */
+#define DL_UART_MAIN_INTERRUPT_RX_TIMEOUT_ERROR                               \
+                                             DL_UART_INTERRUPT_RX_TIMEOUT_ERROR
+
+/*!
+ * @brief Redirects to common @ref DL_UART_INTERRUPT_NOISE_ERROR
+ */
+#define DL_UART_MAIN_INTERRUPT_NOISE_ERROR                                    \
+                                                  DL_UART_INTERRUPT_NOISE_ERROR
+
+/*!
+ * @brief UART interrupt index for DMA done on transmit
+ */
+#define DL_UART_MAIN_IIDX_DMA_DONE_TX                  DL_UART_IIDX_DMA_DONE_TX
+
+/*!
+ * @brief UART interrupt index for DMA done on receive
+ */
+#define DL_UART_MAIN_IIDX_DMA_DONE_RX                  DL_UART_IIDX_DMA_DONE_RX
+
+/*!
+ * @brief UART interrupt index for clear to send
+ */
+#define DL_UART_MAIN_IIDX_CTS_DONE                        DL_UART_IIDX_CTS_DONE
+
+/*!
+ * @brief UART interrupt index for 9-bit mode address match
+ */
+#define DL_UART_MAIN_IIDX_ADDRESS_MATCH              DL_UART_IIDX_ADDRESS_MATCH
+
+/*!
+ * @brief UART interrupt index for end of transmission
+ */
+#define DL_UART_MAIN_IIDX_EOT_DONE                        DL_UART_IIDX_EOT_DONE
+
+/*!
+ * @brief UART interrupt index for UART transmit
+ */
+#define DL_UART_MAIN_IIDX_TX                                    DL_UART_IIDX_TX
+
+/*!
+ * @brief UART interrupt index for UART receive
+ */
+#define DL_UART_MAIN_IIDX_RX                                    DL_UART_IIDX_RX
+
+/*!
+ * @brief UART interrupt index for positive edge on UARTxRXD
+ */
+#define DL_UART_MAIN_IIDX_RXD_POS_EDGE                DL_UART_IIDX_RXD_POS_EDGE
+
+/*!
+ * @brief UART interrupt index for negative edge on UARTxRXD
+ */
+#define DL_UART_MAIN_IIDX_RXD_NEG_EDGE                DL_UART_IIDX_RXD_NEG_EDGE
+
+/*!
+ * @brief UART interrupt index for overrun error
+ */
+#define DL_UART_MAIN_IIDX_OVERRUN_ERROR              DL_UART_IIDX_OVERRUN_ERROR
+
+/*!
+ * @brief UART interrupt index for break error
+ */
+#define DL_UART_MAIN_IIDX_BREAK_ERROR                  DL_UART_IIDX_BREAK_ERROR
+
+/*!
+ * @brief UART interrupt index for parity error
+ */
+#define DL_UART_MAIN_IIDX_PARITY_ERROR                DL_UART_IIDX_PARITY_ERROR
+
+/*!
+ * @brief UART interrupt index for framing error
+ */
+#define DL_UART_MAIN_IIDX_FRAMING_ERROR              DL_UART_IIDX_FRAMING_ERROR
+
+/*!
+ * @brief UART interrupt index for receive timeout
+ */
+#define DL_UART_MAIN_IIDX_RX_TIMEOUT_ERROR        DL_UART_IIDX_RX_TIMEOUT_ERROR
+
+/*!
+ * @brief UART interrupt index for noise error
+ */
+#define DL_UART_MAIN_IIDX_NOISE_ERROR                  DL_UART_IIDX_NOISE_ERROR
+
+/*!
+ * @brief UART interrupt index for no interrupt
+ */
+#define DL_UART_MAIN_IIDX_NO_INTERRUPT                DL_UART_IIDX_NO_INTERRUPT
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DMA_IIDX_RX_TRIGGER
+ */
+#define DL_UART_MAIN_DMA_IIDX_RX_TRIGGER            DL_UART_DMA_IIDX_RX_TRIGGER
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DMA_IIDX_RX_TIMEOUT_TRIGGER
+ */
+#define DL_UART_MAIN_DMA_IIDX_RX_TIMEOUT_TRIGGER                              \
+                                            DL_UART_DMA_IIDX_RX_TIMEOUT_TRIGGER
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DMA_IIDX_TX_TRIGGER
+ */
+#define DL_UART_MAIN_DMA_IIDX_TX_TRIGGER            DL_UART_DMA_IIDX_TX_TRIGGER
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DMA_INTERRUPT_RX
+ */
+#define DL_UART_MAIN_DMA_INTERRUPT_RX                  DL_UART_DMA_INTERRUPT_RX
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DMA_INTERRUPT_RX_TIMEOUT
+ */
+#define DL_UART_MAIN_DMA_INTERRUPT_RX_TIMEOUT                                 \
+                                               DL_UART_DMA_INTERRUPT_RX_TIMEOUT
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DMA_INTERRUPT_TX
+ */
+#define DL_UART_MAIN_DMA_INTERRUPT_TX                  DL_UART_DMA_INTERRUPT_TX
+
+/*!
+ * @brief Redirects to common @ref DL_UART_ERROR_OVERRUN
+ */
+#define DL_UART_MAIN_ERROR_OVERRUN                        DL_UART_ERROR_OVERRUN
+
+/*!
+ * @brief Redirects to common @ref DL_UART_ERROR_BREAK
+ */
+#define DL_UART_MAIN_ERROR_BREAK                            DL_UART_ERROR_BREAK
+
+/*!
+ * @brief Redirects to common @ref DL_UART_ERROR_PARITY
+ */
+#define DL_UART_MAIN_ERROR_PARITY                          DL_UART_ERROR_PARITY
+
+/*!
+ * @brief Redirects to common @ref DL_UART_ERROR_FRAMING
+ */
+#define DL_UART_MAIN_ERROR_FRAMING                        DL_UART_ERROR_FRAMING
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PULSE_WIDTH_5_NS
+ */
+#define DL_UART_MAIN_PULSE_WIDTH_5_NS                  DL_UART_PULSE_WIDTH_5_NS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PULSE_WIDTH_10_NS
+ */
+#define DL_UART_MAIN_PULSE_WIDTH_10_NS                DL_UART_PULSE_WIDTH_10_NS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PULSE_WIDTH_25_NS
+ */
+#define DL_UART_MAIN_PULSE_WIDTH_25_NS                DL_UART_PULSE_WIDTH_25_NS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PULSE_WIDTH_50_NS
+ */
+#define DL_UART_MAIN_PULSE_WIDTH_50_NS                DL_UART_PULSE_WIDTH_50_NS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_OVERSAMPLING_RATE_16X
+ */
+#define DL_UART_MAIN_OVERSAMPLING_RATE_16X        DL_UART_OVERSAMPLING_RATE_16X
+
+/*!
+ * @brief Redirects to common @ref DL_UART_OVERSAMPLING_RATE_8X
+ */
+#define DL_UART_MAIN_OVERSAMPLING_RATE_8X          DL_UART_OVERSAMPLING_RATE_8X
+
+/*!
+ * @brief Redirects to common @ref DL_UART_OVERSAMPLING_RATE_3X
+ */
+#define DL_UART_MAIN_OVERSAMPLING_RATE_3X          DL_UART_OVERSAMPLING_RATE_3X
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PARITY_EVEN
+ */
+#define DL_UART_MAIN_PARITY_EVEN                            DL_UART_PARITY_EVEN
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PARITY_ODD
+ */
+#define DL_UART_MAIN_PARITY_ODD                              DL_UART_PARITY_ODD
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PARITY_STICK_ONE
+ */
+#define DL_UART_MAIN_PARITY_STICK_ONE                  DL_UART_PARITY_STICK_ONE
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PARITY_STICK_ZERO
+ */
+#define DL_UART_MAIN_PARITY_STICK_ZERO                DL_UART_PARITY_STICK_ZERO
+
+/*!
+ * @brief Redirects to common @ref DL_UART_PARITY_NONE
+ */
+#define DL_UART_MAIN_PARITY_NONE                            DL_UART_PARITY_NONE
+
+/*!
+ * @brief Redirects to common @ref DL_UART_WORD_LENGTH_5_BITS
+ */
+#define DL_UART_MAIN_WORD_LENGTH_5_BITS              DL_UART_WORD_LENGTH_5_BITS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_WORD_LENGTH_6_BITS
+ */
+#define DL_UART_MAIN_WORD_LENGTH_6_BITS              DL_UART_WORD_LENGTH_6_BITS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_WORD_LENGTH_7_BITS
+ */
+#define DL_UART_MAIN_WORD_LENGTH_7_BITS              DL_UART_WORD_LENGTH_7_BITS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_WORD_LENGTH_8_BITS
+ */
+#define DL_UART_MAIN_WORD_LENGTH_8_BITS              DL_UART_WORD_LENGTH_8_BITS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_MODE_NORMAL
+ */
+#define DL_UART_MAIN_MODE_NORMAL                            DL_UART_MODE_NORMAL
+
+/*!
+ * @brief Redirects to common @ref DL_UART_MODE_RS485
+ */
+#define DL_UART_MAIN_MODE_RS485                              DL_UART_MODE_RS485
+
+/*!
+ * @brief Redirects to common @ref DL_UART_MODE_IDLE_LINE
+ */
+#define DL_UART_MAIN_MODE_IDLE_LINE                      DL_UART_MODE_IDLE_LINE
+
+/*!
+ * @brief Redirects to common @ref DL_UART_MODE_ADDR_9_BIT
+ */
+#define DL_UART_MAIN_MODE_ADDR_9_BIT                    DL_UART_MODE_ADDR_9_BIT
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DIRECTION_TX
+ */
+#define DL_UART_MAIN_DIRECTION_TX                          DL_UART_DIRECTION_TX
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DIRECTION_RX
+ */
+#define DL_UART_MAIN_DIRECTION_RX                          DL_UART_DIRECTION_RX
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DIRECTION_TX_RX
+ */
+#define DL_UART_MAIN_DIRECTION_TX_RX                    DL_UART_DIRECTION_TX_RX
+
+/*!
+ * @brief Redirects to common @ref DL_UART_DIRECTION_NONE
+ */
+#define DL_UART_MAIN_DIRECTION_NONE                      DL_UART_DIRECTION_NONE
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_BUSCLK
+ */
+#define DL_UART_MAIN_CLOCK_BUSCLK                          DL_UART_CLOCK_BUSCLK
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_MFCLK
+ */
+#define DL_UART_MAIN_CLOCK_MFCLK                            DL_UART_CLOCK_MFCLK
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_LFCLK
+ */
+#define DL_UART_MAIN_CLOCK_LFCLK                            DL_UART_CLOCK_LFCLK
+
+/*!
+ * @brief Redirects to common @ref DL_UART_FLOW_CONTROL_RTS
+ */
+#define DL_UART_MAIN_FLOW_CONTROL_RTS                  DL_UART_FLOW_CONTROL_RTS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_FLOW_CONTROL_CTS
+ */
+#define DL_UART_MAIN_FLOW_CONTROL_CTS                  DL_UART_FLOW_CONTROL_CTS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_FLOW_CONTROL_RTS_CTS
+ */
+#define DL_UART_MAIN_FLOW_CONTROL_RTS_CTS          DL_UART_FLOW_CONTROL_RTS_CTS
+
+/*!
+ * @brief Redirects to common @ref DL_UART_FLOW_CONTROL_NONE
+ */
+#define DL_UART_MAIN_FLOW_CONTROL_NONE                DL_UART_FLOW_CONTROL_NONE
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RTS_ASSERT
+ */
+#define DL_UART_MAIN_RTS_ASSERT                              DL_UART_RTS_ASSERT
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RTS_DEASSERT
+ */
+#define DL_UART_MAIN_RTS_DEASSERT                          DL_UART_RTS_DEASSERT
+
+/*!
+ * @brief Redirects to common @ref DL_UART_STOP_BITS_ONE
+ */
+#define DL_UART_MAIN_STOP_BITS_ONE                        DL_UART_STOP_BITS_ONE
+
+/*!
+ * @brief Redirects to common @ref DL_UART_STOP_BITS_TWO
+ */
+#define DL_UART_MAIN_STOP_BITS_TWO                        DL_UART_STOP_BITS_TWO
+
+/*!
+ * @brief Redirects to common @ref DL_UART_TXD_OUT_LOW
+ */
+#define DL_UART_MAIN_TXD_OUT_LOW                            DL_UART_TXD_OUT_LOW
+
+/*!
+ * @brief Redirects to common @ref DL_UART_TXD_OUT_HIGH
+ */
+#define DL_UART_MAIN_TXD_OUT_HIGH                          DL_UART_TXD_OUT_HIGH
+
+/*!
+ * @brief Redirects to common @ref DL_UART_TX_FIFO_LEVEL_3_4_EMPTY
+ */
+#define DL_UART_MAIN_TX_FIFO_LEVEL_3_4_EMPTY    DL_UART_TX_FIFO_LEVEL_3_4_EMPTY
+
+/*!
+ * @brief Redirects to common @ref DL_UART_TX_FIFO_LEVEL_1_4_EMPTY
+ */
+#define DL_UART_MAIN_TX_FIFO_LEVEL_1_4_EMPTY    DL_UART_TX_FIFO_LEVEL_1_4_EMPTY
+
+/*!
+ * @brief Redirects to common @ref DL_UART_TX_FIFO_LEVEL_EMPTY
+ */
+#define DL_UART_MAIN_TX_FIFO_LEVEL_EMPTY            DL_UART_TX_FIFO_LEVEL_EMPTY
+
+/*!
+ * @brief Redirects to common @ref DL_UART_TX_FIFO_LEVEL_ONE_ENTRY
+ */
+#define DL_UART_MAIN_TX_FIFO_LEVEL_ONE_ENTRY    DL_UART_TX_FIFO_LEVEL_ONE_ENTRY
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RX_FIFO_LEVEL_ONE_ENTRY
+ */
+#define DL_UART_MAIN_RX_FIFO_LEVEL_ONE_ENTRY    DL_UART_RX_FIFO_LEVEL_ONE_ENTRY
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RX_FIFO_LEVEL_FULL
+ */
+#define DL_UART_MAIN_RX_FIFO_LEVEL_FULL              DL_UART_RX_FIFO_LEVEL_FULL
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RX_FIFO_LEVEL_3_4_FULL
+ */
+#define DL_UART_MAIN_RX_FIFO_LEVEL_3_4_FULL      DL_UART_RX_FIFO_LEVEL_3_4_FULL
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RX_FIFO_LEVEL_1_2_FULL
+ */
+#define DL_UART_MAIN_RX_FIFO_LEVEL_1_2_FULL      DL_UART_RX_FIFO_LEVEL_1_2_FULL
+
+/*!
+ * @brief Redirects to common @ref DL_UART_RX_FIFO_LEVEL_1_4_FULL
+ */
+#define DL_UART_MAIN_RX_FIFO_LEVEL_1_4_FULL      DL_UART_RX_FIFO_LEVEL_1_4_FULL
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_1
+ */
+#define DL_UART_MAIN_CLOCK_DIVIDE_RATIO_1          DL_UART_CLOCK_DIVIDE_RATIO_1
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_2
+ */
+#define DL_UART_MAIN_CLOCK_DIVIDE_RATIO_2          DL_UART_CLOCK_DIVIDE_RATIO_2
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_3
+ */
+#define DL_UART_MAIN_CLOCK_DIVIDE_RATIO_3          DL_UART_CLOCK_DIVIDE_RATIO_3
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_4
+ */
+#define DL_UART_MAIN_CLOCK_DIVIDE_RATIO_4          DL_UART_CLOCK_DIVIDE_RATIO_4
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_5
+ */
+#define DL_UART_MAIN_CLOCK_DIVIDE_RATIO_5          DL_UART_CLOCK_DIVIDE_RATIO_5
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_6
+ */
+#define DL_UART_MAIN_CLOCK_DIVIDE_RATIO_6          DL_UART_CLOCK_DIVIDE_RATIO_6
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_7
+ */
+#define DL_UART_MAIN_CLOCK_DIVIDE_RATIO_7          DL_UART_CLOCK_DIVIDE_RATIO_7
+
+/*!
+ * @brief Redirects to common @ref DL_UART_CLOCK_DIVIDE_RATIO_8
+ */
+#define DL_UART_MAIN_CLOCK_DIVIDE_RATIO_8          DL_UART_CLOCK_DIVIDE_RATIO_8
+
+/*!
+ * @brief Redirects to common @ref DL_UART_init
+ */
+#define DL_UART_Main_init                                          DL_UART_init
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enablePower
+ */
+#define DL_UART_Main_enablePower                            DL_UART_enablePower
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disablePower
+ */
+#define DL_UART_Main_disablePower                          DL_UART_disablePower
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isPowerEnabled
+ */
+#define DL_UART_Main_isPowerEnabled                      DL_UART_isPowerEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_reset
+ */
+#define DL_UART_Main_reset                                        DL_UART_reset
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enable
+ */
+#define DL_UART_Main_enable                                      DL_UART_enable
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isEnabled
+ */
+#define DL_UART_Main_isEnabled                                DL_UART_isEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disable
+ */
+#define DL_UART_Main_disable                                    DL_UART_disable
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setClockConfig
+ */
+#define DL_UART_Main_setClockConfig                      DL_UART_setClockConfig
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getClockConfig
+ */
+#define DL_UART_Main_getClockConfig                      DL_UART_getClockConfig
+
+/*!
+ * @brief Redirects to common @ref DL_UART_configBaudRate
+ */
+#define DL_UART_Main_configBaudRate                      DL_UART_configBaudRate
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setOversampling
+ */
+#define DL_UART_Main_setOversampling                    DL_UART_setOversampling
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getOversampling
+ */
+#define DL_UART_Main_getOversampling                    DL_UART_getOversampling
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableLoopbackMode
+ */
+#define DL_UART_Main_enableLoopbackMode              DL_UART_enableLoopbackMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isLoopbackModeEnabled
+ */
+#define DL_UART_Main_isLoopbackModeEnabled        DL_UART_isLoopbackModeEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableLoopbackMode
+ */
+#define DL_UART_Main_disableLoopbackMode            DL_UART_disableLoopbackMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setDirection
+ */
+#define DL_UART_Main_setDirection                          DL_UART_setDirection
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getDirection
+ */
+#define DL_UART_Main_getDirection                          DL_UART_getDirection
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableMajorityVoting
+ */
+#define DL_UART_Main_enableMajorityVoting          DL_UART_enableMajorityVoting
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isMajorityVotingEnabled
+ */
+#define DL_UART_Main_isMajorityVotingEnabled    DL_UART_isMajorityVotingEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableMajorityVoting
+ */
+#define DL_UART_Main_disableMajorityVoting        DL_UART_disableMajorityVoting
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableMSBFirst
+ */
+#define DL_UART_Main_enableMSBFirst                      DL_UART_enableMSBFirst
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isMSBFirstEnabled
+ */
+#define DL_UART_Main_isMSBFirstEnabled                DL_UART_isMSBFirstEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableMSBFirst
+ */
+#define DL_UART_Main_disableMSBFirst                    DL_UART_disableMSBFirst
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableTransmitPinManualControl
+ */
+#define DL_UART_Main_enableTransmitPinManualControl                           \
+                                         DL_UART_enableTransmitPinManualControl
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isTransmitPinManualControlEnabled
+ */
+#define DL_UART_Main_isTransmitPinManualControlEnabled                        \
+                                      DL_UART_isTransmitPinManualControlEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableTransmitPinManualControl
+ */
+#define DL_UART_Main_disableTransmitPinManualControl                          \
+                                        DL_UART_disableTransmitPinManualControl
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setTransmitPinManualOutput
+ */
+#define DL_UART_Main_setTransmitPinManualOutput                               \
+                                             DL_UART_setTransmitPinManualOutput
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getTransmitPinManualOutput
+ */
+#define DL_UART_Main_getTransmitPinManualOutput                               \
+                                             DL_UART_getTransmitPinManualOutput
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setCommunicationMode
+ */
+#define DL_UART_Main_setCommunicationMode          DL_UART_setCommunicationMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getCommunicationMode
+ */
+#define DL_UART_Main_getCommunicationMode          DL_UART_getCommunicationMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setFlowControl
+ */
+#define DL_UART_Main_setFlowControl                      DL_UART_setFlowControl
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getFlowControl
+ */
+#define DL_UART_Main_getFlowControl                      DL_UART_getFlowControl
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setRTSOutput
+ */
+#define DL_UART_Main_setRTSOutput                          DL_UART_setRTSOutput
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableFIFOs
+ */
+#define DL_UART_Main_enableFIFOs                            DL_UART_enableFIFOs
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableFIFOs
+ */
+#define DL_UART_Main_disableFIFOs                          DL_UART_disableFIFOs
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isFIFOsEnabled
+ */
+#define DL_UART_Main_isFIFOsEnabled                      DL_UART_isFIFOsEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isParityEnabled
+ */
+#define DL_UART_Main_isParityEnabled                    DL_UART_isParityEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setParityMode
+ */
+#define DL_UART_Main_setParityMode                        DL_UART_setParityMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getParityMode
+ */
+#define DL_UART_Main_getParityMode                        DL_UART_getParityMode
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setStopBits
+ */
+#define DL_UART_Main_setStopBits                            DL_UART_setStopBits
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getStopBits
+ */
+#define DL_UART_Main_getStopBits                            DL_UART_getStopBits
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setWordLength
+ */
+#define DL_UART_Main_setWordLength                        DL_UART_setWordLength
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getWordLength
+ */
+#define DL_UART_Main_getWordLength                        DL_UART_getWordLength
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableSendIdlePattern
+ */
+#define DL_UART_Main_enableSendIdlePattern        DL_UART_enableSendIdlePattern
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableSendIdlePattern
+ */
+#define DL_UART_Main_disableSendIdlePattern      DL_UART_disableSendIdlePattern
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isSendIdlePatternEnabled
+ */
+#define DL_UART_Main_isSendIdlePatternEnabled  DL_UART_isSendIdlePatternEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setExternalDriverSetup
+ */
+#define DL_UART_Main_setExternalDriverSetup      DL_UART_setExternalDriverSetup
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getExternalDriverSetup
+ */
+#define DL_UART_Main_getExternalDriverSetup      DL_UART_getExternalDriverSetup
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setExternalDriverHold
+ */
+#define DL_UART_Main_setExternalDriverHold        DL_UART_setExternalDriverHold
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getExternalDriverHold
+ */
+#define DL_UART_Main_getExternalDriverHold        DL_UART_getExternalDriverHold
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isBusy
+ */
+#define DL_UART_Main_isBusy                                      DL_UART_isBusy
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isRXFIFOEmpty
+ */
+#define DL_UART_Main_isRXFIFOEmpty                        DL_UART_isRXFIFOEmpty
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isRXFIFOFull
+ */
+#define DL_UART_Main_isRXFIFOFull                          DL_UART_isRXFIFOFull
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isTXFIFOEmpty
+ */
+#define DL_UART_Main_isTXFIFOEmpty                        DL_UART_isTXFIFOEmpty
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isTXFIFOFull
+ */
+#define DL_UART_Main_isTXFIFOFull                          DL_UART_isTXFIFOFull
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isClearToSend
+ */
+#define DL_UART_Main_isClearToSend                        DL_UART_isClearToSend
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isIdleModeDetected
+ */
+#define DL_UART_Main_isIdleModeDetected              DL_UART_isIdleModeDetected
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setTXFIFOThreshold
+ */
+#define DL_UART_Main_setTXFIFOThreshold              DL_UART_setTXFIFOThreshold
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getTXFIFOThreshold
+ */
+#define DL_UART_Main_getTXFIFOThreshold              DL_UART_getTXFIFOThreshold
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setRXFIFOThreshold
+ */
+#define DL_UART_Main_setRXFIFOThreshold              DL_UART_setRXFIFOThreshold
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getRXFIFOThreshold
+ */
+#define DL_UART_Main_getRXFIFOThreshold              DL_UART_getRXFIFOThreshold
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setRXInterruptTimeout
+ */
+#define DL_UART_Main_setRXInterruptTimeout        DL_UART_setRXInterruptTimeout
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getRXInterruptTimeout
+ */
+#define DL_UART_Main_getRXInterruptTimeout        DL_UART_getRXInterruptTimeout
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getIntegerBaudRateDivisor
+ */
+#define DL_UART_Main_getIntegerBaudRateDivisor                                \
+                                              DL_UART_getIntegerBaudRateDivisor
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getFractionalBaudRateDivisor
+ */
+#define DL_UART_Main_getFractionalBaudRateDivisor                             \
+                                           DL_UART_getFractionalBaudRateDivisor
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setBaudRateDivisor
+ */
+#define DL_UART_Main_setBaudRateDivisor              DL_UART_setBaudRateDivisor
+
+/*!
+ * @brief Redirects to common @ref DL_UART_transmitData
+ */
+#define DL_UART_Main_transmitData                          DL_UART_transmitData
+
+/*!
+ * @brief Redirects to common @ref DL_UART_receiveData
+ */
+#define DL_UART_Main_receiveData                            DL_UART_receiveData
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getErrorStatus
+ */
+#define DL_UART_Main_getErrorStatus                      DL_UART_getErrorStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableInterrupt
+ */
+#define DL_UART_Main_enableInterrupt                    DL_UART_enableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableInterrupt
+ */
+#define DL_UART_Main_disableInterrupt                  DL_UART_disableInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getEnabledInterrupts
+ */
+#define DL_UART_Main_getEnabledInterrupts          DL_UART_getEnabledInterrupts
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getEnabledInterruptStatus
+ */
+#define DL_UART_Main_getEnabledInterruptStatus                                \
+                                              DL_UART_getEnabledInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getRawInterruptStatus
+ */
+#define DL_UART_Main_getRawInterruptStatus        DL_UART_getRawInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getPendingInterrupt
+ */
+#define DL_UART_Main_getPendingInterrupt            DL_UART_getPendingInterrupt
+
+/*!
+ * @brief Redirects to common @ref DL_UART_clearInterruptStatus
+ */
+#define DL_UART_Main_clearInterruptStatus          DL_UART_clearInterruptStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_changeConfig
+ */
+#define DL_UART_Main_changeConfig                          DL_UART_changeConfig
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableAnalogGlitchFilter
+ */
+#define DL_UART_Main_enableAnalogGlitchFilter  DL_UART_enableAnalogGlitchFilter
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableAnalogGlitchFilter
+ */
+#define DL_UART_Main_disableAnalogGlitchFilter                                \
+                                              DL_UART_disableAnalogGlitchFilter
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isAnalogGlitchFilterEnabled
+ */
+#define DL_UART_Main_isAnalogGlitchFilterEnabled                              \
+                                            DL_UART_isAnalogGlitchFilterEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableGlitchFilterChaining
+ */
+#define DL_UART_Main_enableGlitchFilterChaining                               \
+                                            DL_UART_enableGlitchFilterChaining
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableGlitchFilterChaining
+ */
+#define DL_UART_Main_disableGlitchFilterChaining                              \
+                                            DL_UART_disableGlitchFilterChaining
+
+/*!
+ * @brief Redirects to common @ref DL_UART_isGlitchFilterChainingEnabled
+ */
+#define DL_UART_Main_isGlitchFilterChainingEnabled                            \
+                                          DL_UART_isGlitchFilterChainingEnabled
+
+/*!
+ * @brief Redirects to common @ref DL_UART_setAnalogPulseWidth
+ */
+#define DL_UART_Main_setAnalogPulseWidth            DL_UART_setAnalogPulseWidth
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getAnalogPulseWidth
+ */
+#define DL_UART_Main_getAnalogPulseWidth            DL_UART_getAnalogPulseWidth
+
+/*!
+ * @brief Redirects to common @ref DL_UART_transmitDataBlocking
+ */
+#define DL_UART_Main_transmitDataBlocking          DL_UART_transmitDataBlocking
+
+/*!
+ * @brief Redirects to common @ref DL_UART_receiveDataBlocking
+ */
+#define DL_UART_Main_receiveDataBlocking            DL_UART_receiveDataBlocking
+
+/*!
+ * @brief Redirects to common @ref DL_UART_transmitDataCheck
+ */
+#define DL_UART_Main_transmitDataCheck                DL_UART_transmitDataCheck
+
+/*!
+ * @brief Redirects to common @ref DL_UART_receiveDataCheck
+ */
+#define DL_UART_Main_receiveDataCheck                  DL_UART_receiveDataCheck
+
+/*!
+ * @brief Redirects to common @ref DL_UART_drainRXFIFO
+ */
+#define DL_UART_Main_drainRXFIFO                            DL_UART_drainRXFIFO
+
+/*!
+ * @brief Redirects to common @ref DL_UART_fillTXFIFO
+ */
+#define DL_UART_Main_fillTXFIFO                              DL_UART_fillTXFIFO
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableDMAReceiveEvent
+ */
+#define DL_UART_Main_enableDMAReceiveEvent        DL_UART_enableDMAReceiveEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_enableDMATransmitEvent
+ */
+#define DL_UART_Main_enableDMATransmitEvent      DL_UART_enableDMATransmitEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableDMAReceiveEvent
+ */
+#define DL_UART_Main_disableDMAReceiveEvent      DL_UART_disableDMAReceiveEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_disableDMATransmitEvent
+ */
+#define DL_UART_Main_disableDMATransmitEvent    DL_UART_disableDMATransmitEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getEnabledDMAReceiveEvent
+ */
+#define DL_UART_Main_getEnabledDMAReceiveEvent                                \
+                                              DL_UART_getEnabledDMAReceiveEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getEnabledDMATransmitEvent
+ */
+#define DL_UART_Main_getEnabledDMATransmitEvent                               \
+                                             DL_UART_getEnabledDMATransmitEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getEnabledDMAReceiveEventStatus
+ */
+#define DL_UART_Main_getEnabledDMAReceiveEventStatus                          \
+                                        DL_UART_getEnabledDMAReceiveEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getEnabledDMATransmitEventStatus
+ */
+#define DL_UART_Main_getEnabledDMATransmitEventStatus                         \
+                                       DL_UART_getEnabledDMATransmitEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getRawDMAReceiveEventStatus
+ */
+#define DL_UART_Main_getRawDMAReceiveEventStatus                              \
+                                            DL_UART_getRawDMAReceiveEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getRawDMATransmitEventStatus
+ */
+#define DL_UART_Main_getRawDMATransmitEventStatus                             \
+                                           DL_UART_getRawDMATransmitEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getPendingDMAReceiveEvent
+ */
+#define DL_UART_Main_getPendingDMAReceiveEvent                                \
+                                              DL_UART_getPendingDMAReceiveEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_getPendingDMATransmitEvent
+ */
+#define DL_UART_Main_getPendingDMATransmitEvent                               \
+                                             DL_UART_getPendingDMATransmitEvent
+
+/*!
+ * @brief Redirects to common @ref DL_UART_clearDMAReceiveEventStatus
+ */
+#define DL_UART_Main_clearDMAReceiveEventStatus                               \
+                                             DL_UART_clearDMAReceiveEventStatus
+
+/*!
+ * @brief Redirects to common @ref DL_UART_clearDMATransmitEventStatus
+ */
+#define DL_UART_Main_clearDMATransmitEventStatus                              \
+                                            DL_UART_clearDMATransmitEventStatus
+
+/* clang-format on */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_UART_MAIN__ */
+
+#endif /* ti_dl_dl_uart_main__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_vref.c
+++ b/mspm0/source/ti/driverlib/dl_vref.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ti/driverlib/dl_vref.h>
+
+#ifdef __MSPM0_HAS_VREF__
+
+void DL_VREF_configReference(VREF_Regs *vref, DL_VREF_Config *config)
+{
+    vref->CTL0 = (uint32_t) config->vrefEnable | (uint32_t) config->bufConfig |
+                 (uint32_t) config->shModeEnable;
+    vref->CTL2 = (config->shCycleCount << VREF_CTL2_SHCYCLE_OFS) |
+                 (config->holdCycleCount << VREF_CTL2_HCYCLE_OFS);
+}
+
+void DL_VREF_setClockConfig(VREF_Regs *vref, DL_VREF_ClockConfig *config)
+{
+    vref->CLKSEL = (uint32_t) config->clockSel;
+    vref->CLKDIV = (uint32_t) config->divideRatio;
+}
+
+void DL_VREF_getClockConfig(VREF_Regs *vref, DL_VREF_ClockConfig *config)
+{
+    config->clockSel    = (DL_VREF_CLOCK) vref->CLKSEL;
+    config->divideRatio = (DL_VREF_CLOCK_DIVIDE) vref->CLKDIV;
+}
+
+#endif /* __MSPM0_HAS_VREF__ */

--- a/mspm0/source/ti/driverlib/dl_vref.h
+++ b/mspm0/source/ti/driverlib/dl_vref.h
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_vref.h
+ *  @brief      Voltage Reference (VREF) Driver Library
+ *  @defgroup   VREF Voltage Reference (VREF)
+ *
+ *  @anchor ti_dl_dl_vref_Overview
+ *  # Overview
+ *
+ *  The Voltage Reference Driver Library allows full configuration of
+ *  the MSPM0 VREF module.
+ *  The VREF module contains a configurable voltage reference buffer which
+ *  allows users to supply a stable internal reference to on-board analog
+ *  peripherals. It also supports bringing in an external reference for
+ *  applications where higher accuracy is required.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup VREF
+ * @{
+ */
+#ifndef ti_dl_dl_m0p_vref__include
+#define ti_dl_dl_m0p_vref__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __MSPM0_HAS_VREF__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_VREF_CTL1_READY
+ * @{
+ */
+
+/*!
+* @brief VREF bit in CTL1 indicating the module is ready is not set
+*/
+#define DL_VREF_CTL1_READY_NOTRDY    (VREF_CTL1_READY_NOTRDY)
+
+/*!
+* @brief VREF bit in CTL1 indicating the module is ready is set
+*/
+#define DL_VREF_CTL1_READY_RDY    (VREF_CTL1_READY_RDY)
+
+
+/** @}*/
+
+/** @addtogroup DL_VREF_SH
+ * @{
+ */
+
+/*!
+* @brief Minimum value for VREF sample and hold, if enabled
+*/
+#define DL_VREF_SH_MIN             (VREF_CTL2_SHCYCLE_MINIMUM)
+
+/*!
+* @brief Maximum value for VREF sample and hold, if enabled
+*/
+#define DL_VREF_SH_MAX             (VREF_CTL2_SHCYCLE_MAXIMUM)
+
+/** @}*/
+
+/** @addtogroup DL_VREF_HOLD
+ * @{
+ */
+
+/*!
+* @brief Minimum value for VREF hold, if enabled
+*/
+#define DL_VREF_HOLD_MIN             (VREF_CTL2_HCYCLE_MINIMUM)
+
+/*!
+* @brief Maximum value for VREF hold, if enabled
+*/
+#define DL_VREF_HOLD_MAX             (VREF_CTL2_HCYCLE_MAXIMUM)
+
+/** @}*/
+
+/* clang-format on */
+
+/*! @enum DL_VREF_CLOCK */
+typedef enum {
+    /*! Set VREF clock source as LFCLK  */
+    DL_VREF_CLOCK_LFCLK = VREF_CLKSEL_LFCLK_SEL_MASK,
+    /*! Set VREF clock source as MFCLK  */
+    DL_VREF_CLOCK_MFCLK = VREF_CLKSEL_MFCLK_SEL_MASK,
+    /*! Set VREF clock source as BUSCLK  */
+    DL_VREF_CLOCK_BUSCLK = VREF_CLKSEL_BUSCLK_SEL_MASK,
+} DL_VREF_CLOCK;
+
+/*! @enum DL_VREF_CLOCK_DIVIDE */
+typedef enum {
+    /*! Clock divide by 1 */
+    DL_VREF_CLOCK_DIVIDE_1 = 0,
+    /*! Clock divide by 2 */
+    DL_VREF_CLOCK_DIVIDE_2 = 1,
+    /*! Clock divide by 4 */
+    DL_VREF_CLOCK_DIVIDE_4 = 3,
+    /*! Clock divide by 6 */
+    DL_VREF_CLOCK_DIVIDE_6 = 5,
+    /*! Clock divide by 8 */
+    DL_VREF_CLOCK_DIVIDE_8 = 7,
+} DL_VREF_CLOCK_DIVIDE;
+
+/*! @enum DL_VREF_ENABLE */
+typedef enum {
+    /*! VREF control set disabled */
+    DL_VREF_ENABLE_DISABLE = VREF_CTL0_ENABLE_DISABLE,
+    /*! VREF control set enabled */
+    DL_VREF_ENABLE_ENABLE = VREF_CTL0_ENABLE_ENABLE,
+} DL_VREF_ENABLE;
+
+/*! @enum DL_VREF_BUFCONFIG */
+typedef enum {
+    /*! Configure VREF output buffer to 2.5V */
+    DL_VREF_BUFCONFIG_OUTPUT_2_5V = VREF_CTL0_BUFCONFIG_OUTPUT2P5V,
+    /*! Configure VREF output buffer to 1.4V */
+    DL_VREF_BUFCONFIG_OUTPUT_1_4V = VREF_CTL0_BUFCONFIG_OUTPUT1P4V,
+} DL_VREF_BUFCONFIG;
+
+/*! @enum DL_VREF_SHMODE */
+typedef enum {
+    /*! Set VREF sample and hold mode to disabled */
+    DL_VREF_SHMODE_DISABLE = VREF_CTL0_SHMODE_DISABLE,
+    /*! Set VREF sample and hold mode to enabled */
+    DL_VREF_SHMODE_ENABLE = VREF_CTL0_SHMODE_ENABLE,
+} DL_VREF_SHMODE;
+
+/*!
+ *  @brief  Configuration struct for @ref DL_VREF_setClockConfig.
+ */
+typedef struct {
+    /*! Selects VREF module clock source @ref DL_VREF_CLOCK */
+    DL_VREF_CLOCK clockSel;
+    /*! Selects the divide ratio. One of @ref DL_VREF_CLOCK_DIVIDE */
+    DL_VREF_CLOCK_DIVIDE divideRatio;
+} DL_VREF_ClockConfig;
+
+/**
+ * @brief Configuration struct for @ref DL_VREF_Config.
+ */
+typedef struct {
+    /*! VREF enable setting. Either @ref DL_VREF_ENABLE_DISABLE or @ref DL_VREF_ENABLE_ENABLE */
+    DL_VREF_ENABLE vrefEnable;
+    /*! VREF buffer configuration setting. Either @ref DL_VREF_BUFCONFIG_OUTPUT_1_4V or @ref DL_VREF_BUFCONFIG_OUTPUT_2_5V */
+    DL_VREF_BUFCONFIG bufConfig;
+    /*! VREF sample and hold enable configuration setting. Either @ref DL_VREF_SHMODE_DISABLE or @ref DL_VREF_SHMODE_ENABLE */
+    DL_VREF_SHMODE shModeEnable;
+    /*! Number of cycles to sample and hold for, if sample and hold mode is enabled. Minimum @ref DL_VREF_SH_MAX, maximum @ref DL_VREF_SH_MAX */
+    uint32_t shCycleCount;
+    /*! Number of cycles to hold for, if sample and hold mode is enabled. Minimum @ref DL_VREF_HOLD_MAX, maximum @ref DL_VREF_HOLD_MIN */
+    uint32_t holdCycleCount;
+} DL_VREF_Config;
+
+/**
+ * @brief Enables power on VREF module
+ *
+ * @param vref       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_VREF_enablePower(VREF_Regs *vref)
+{
+    vref->GPRCM.PWREN = VREF_PWREN_KEY_UNLOCK_W | VREF_PWREN_ENABLE_ENABLE;
+}
+
+/**
+ * @brief Disable power on VREF module
+ *
+ * @param vref       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_VREF_disablePower(VREF_Regs *vref)
+{
+    vref->GPRCM.PWREN = VREF_PWREN_KEY_UNLOCK_W | VREF_PWREN_ENABLE_DISABLE;
+}
+
+/**
+ *  @brief      Enables Internal VREF
+ *
+ *  This function only enables the internal VREF but doesn't configure all
+ *  settings. It's recommended to use @ref DL_VREF_configReference to configure
+ *  and enable VREF with all parameters.
+ *
+ *  @param vref       Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_VREF_enableInternalRef(VREF_Regs *vref)
+{
+    vref->CTL0 |= VREF_CTL0_ENABLE_ENABLE;
+}
+
+/**
+ *  @brief      Disables Internal VREF, allows for External VREF
+ *
+ *  The internal VREF must be disabled when using external VREF input.
+ *
+ *  @param vref       Pointer to the register overlay for the peripheral
+ *
+ */
+__STATIC_INLINE void DL_VREF_disableInternalRef(VREF_Regs *vref)
+{
+    vref->CTL0 &= ~VREF_CTL0_ENABLE_MASK;
+}
+
+/**
+ *  @brief      Checks if the internal VREF is enabled
+ *
+ *  @param vref       Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns the enabled status of the vref peripheral
+ *
+ *  @retval     true  The internal VREF is enabled
+ *  @retval     false The internal VREF is disabled, external VREF can be used
+ */
+__STATIC_INLINE bool DL_VREF_isEnabled(VREF_Regs *vref)
+{
+    return ((vref->CTL0 & VREF_CTL0_ENABLE_MASK) == VREF_CTL0_ENABLE_ENABLE);
+}
+
+#if (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPM0L122X_L222X)
+/**
+ *  @brief      Enable VREF buffer as internal reference input for comparator
+ *
+ * @param vref       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_VREF_enableInternalRefCOMP(VREF_Regs *vref)
+{
+    vref->CTL0 |= VREF_CTL0_COMP_VREF_ENABLE_ENABLE;
+}
+
+/**
+ *  @brief      Checks if VREF buffer for comparator is enabled
+ *
+ * @param vref       Pointer to the register overlay for the peripheral
+ *
+ *  @return     Returns if VREF buffer for comparator is enabled
+ *
+ *  @retval     true  VREF buffer for comparator is enabled
+ *  @retval     false VREF buffer for comparator is disabled
+ */
+__STATIC_INLINE bool DL_VREF_isInternalRefCOMPEnabled(VREF_Regs *vref)
+{
+    return ((vref->CTL0 & VREF_CTL0_COMP_VREF_ENABLE_MASK) ==
+            VREF_CTL0_COMP_VREF_ENABLE_ENABLE);
+}
+
+/**
+ *  @brief      Disable VREF buffer as internal reference input for comparator
+ *
+ * @param vref       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_VREF_disableInternalRefCOMP(VREF_Regs *vref)
+{
+    vref->CTL0 &= ~(VREF_CTL0_COMP_VREF_ENABLE_MASK);
+}
+#endif
+
+/**
+ * @brief Set the clock select and clock divide fields in VREF
+ *
+ * @param vref       Pointer to the register overlay for the peripheral
+ *
+ * @param config     Pointer to the configuration structure
+ */
+void DL_VREF_setClockConfig(VREF_Regs *vref, DL_VREF_ClockConfig *config);
+
+/**
+ * @brief Copy the clock select and clock divide fields in VREF to config
+ *
+ * @param vref       Pointer to the register overlay for the peripheral
+ *
+ * @param config     Pointer to the configuration structure
+ */
+void DL_VREF_getClockConfig(VREF_Regs *vref, DL_VREF_ClockConfig *config);
+
+/**
+ * @brief Resets the VREF module
+ *
+ * @param vref       Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_VREF_reset(VREF_Regs *vref)
+{
+    vref->GPRCM.RSTCTL =
+        VREF_RSTCTL_RESETASSERT_MASK | VREF_RSTCTL_KEY_UNLOCK_W;
+}
+
+/**
+ * @brief Returns if VREF peripheral was reset
+ *
+ * @param vref        Pointer to the register overlay for the VREF peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_VREF_isReset(VREF_Regs *vref)
+{
+    return (vref->GPRCM.STAT & VREF_STAT_RESETSTKY_MASK) ==
+           VREF_STAT_RESETSTKY_RESET;
+}
+
+/**
+ * @brief Returns VREF register status
+ *
+ * @param vref        Pointer to the register overlay for the VREF peripheral
+ *
+ * @return VREF status bits set. Either @ref DL_VREF_CTL1_READY_NOTRDY or @ref DL_VREF_CTL1_READY_RDY
+ *
+ */
+__STATIC_INLINE uint32_t DL_VREF_getStatus(VREF_Regs *vref)
+{
+    return vref->CTL1 & VREF_CTL1_READY_MASK;
+}
+
+/**
+ * @brief Configure VREF enable, control registers
+ *
+ * @param vref        Pointer to the register overlay for the VREF peripheral
+ *
+ * @param config      Pointer to @ref DL_VREF_Config structure to configure the peripheral
+ *
+ */
+void DL_VREF_configReference(VREF_Regs *vref, DL_VREF_Config *config);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_VREF__ */
+
+#endif /* ti_dl_dl_m0p_vref__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/dl_wwdt.h
+++ b/mspm0/source/ti/driverlib/dl_wwdt.h
@@ -1,0 +1,562 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_wwdt.h
+ *  @brief      Window Watchdog Timer (WWDT) Driver Library
+ *  @defgroup   WWDT Window Watchdog Timer (WWDT)
+ *
+ *  @anchor ti_dl_dl_wwdt_Overview
+ *  # Overview
+ *
+ *  The Window Watchdog Timer Driver Library allows full configuration of
+ *  the MSPM0 WWDT module.
+ *  The window watchdog timer (WWDT) supervises code execution.
+ *  If the application software does not successfully reset the window
+ *  watchdog within the programmed open time window, the window watchdog
+ *  generates a SYSRST.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup WWDT
+ * @{
+ */
+#ifndef ti_dl_dl_wwdt__include
+#define ti_dl_dl_wwdt__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+
+#ifdef __MSPM0_HAS_WWDT__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/*! @enum DL_WWDT_CLOCK_DIVIDE */
+typedef enum {
+    /*! Clock source divide by 1 */
+    DL_WWDT_CLOCK_DIVIDE_1 = 0x00000000,
+    /*! Clock source divide by 2 */
+    DL_WWDT_CLOCK_DIVIDE_2 = 0x00000001,
+    /*! Clock source divide by 3 */
+    DL_WWDT_CLOCK_DIVIDE_3 = 0x00000002,
+    /*! Clock source divide by 4 */
+    DL_WWDT_CLOCK_DIVIDE_4 = 0x00000003,
+    /*! Clock source divide by 5 */
+    DL_WWDT_CLOCK_DIVIDE_5 = 0x00000004,
+    /*! Clock source divide by 6 */
+    DL_WWDT_CLOCK_DIVIDE_6 = 0x00000005,
+    /*! Clock source divide by 7 */
+    DL_WWDT_CLOCK_DIVIDE_7 = 0x00000006,
+    /*! Clock source divide by 8 */
+    DL_WWDT_CLOCK_DIVIDE_8 = 0x00000007
+} DL_WWDT_CLOCK_DIVIDE;
+
+/*! @enum DL_WWDT_WINDOW */
+typedef enum {
+    /*! Window 0 active */
+    DL_WWDT_WINDOW0 = WWDT_WWDTCTL1_WINSEL_WIN0,
+    /*! Window 1 active */
+    DL_WWDT_WINDOW1 = WWDT_WWDTCTL1_WINSEL_WIN1
+} DL_WWDT_WINDOW;
+
+/*! @enum DL_WWDT_WINDOW_PERIOD */
+typedef enum {
+    /*! 0% closed window period */
+    DL_WWDT_WINDOW_PERIOD_0 = WWDT_WWDTCTL0_WINDOW0_SIZE_0,
+    /*! 12% closed window period */
+    DL_WWDT_WINDOW_PERIOD_12 = WWDT_WWDTCTL0_WINDOW0_SIZE_12,
+    /*! 18% closed window period */
+    DL_WWDT_WINDOW_PERIOD_18 = WWDT_WWDTCTL0_WINDOW0_SIZE_18,
+    /*! 25% closed window period */
+    DL_WWDT_WINDOW_PERIOD_25 = WWDT_WWDTCTL0_WINDOW0_SIZE_25,
+    /*! 50% closed window period */
+    DL_WWDT_WINDOW_PERIOD_50 = WWDT_WWDTCTL0_WINDOW0_SIZE_50,
+    /*! 75% closed window period */
+    DL_WWDT_WINDOW_PERIOD_75 = WWDT_WWDTCTL0_WINDOW0_SIZE_75,
+    /*! 81% closed window period */
+    DL_WWDT_WINDOW_PERIOD_81 = WWDT_WWDTCTL0_WINDOW0_SIZE_81,
+    /*! 87% closed window period */
+    DL_WWDT_WINDOW_PERIOD_87 = WWDT_WWDTCTL0_WINDOW0_SIZE_87
+} DL_WWDT_WINDOW_PERIOD;
+
+/*! @enum DL_WWDT_TIMER_PERIOD */
+typedef enum {
+    /*! 2^6 timer period count */
+    DL_WWDT_TIMER_PERIOD_6_BITS = WWDT_WWDTCTL0_PER_EN_6,
+    /*! 2^8 timer period count */
+    DL_WWDT_TIMER_PERIOD_8_BITS = WWDT_WWDTCTL0_PER_EN_8,
+    /*! 2^10 timer period count */
+    DL_WWDT_TIMER_PERIOD_10_BITS = WWDT_WWDTCTL0_PER_EN_10,
+    /*! 2^12 timer period count */
+    DL_WWDT_TIMER_PERIOD_12_BITS = WWDT_WWDTCTL0_PER_EN_12,
+    /*! 2^15 timer period count */
+    DL_WWDT_TIMER_PERIOD_15_BITS = WWDT_WWDTCTL0_PER_EN_15,
+    /*! 2^18 timer period count */
+    DL_WWDT_TIMER_PERIOD_18_BITS = WWDT_WWDTCTL0_PER_EN_18,
+    /*! 2^21 timer period count */
+    DL_WWDT_TIMER_PERIOD_21_BITS = WWDT_WWDTCTL0_PER_EN_21,
+    /*! 2^25 timer period count */
+    DL_WWDT_TIMER_PERIOD_25_BITS = WWDT_WWDTCTL0_PER_EN_25
+} DL_WWDT_TIMER_PERIOD;
+
+/*! @enum DL_WWDT_SLEEP_MODE */
+typedef enum {
+    /*! Stop the watchdog while in sleep */
+    DL_WWDT_STOP_IN_SLEEP = WWDT_WWDTCTL0_STISM_STOP,
+    /*! Keep the watchdog running in sleep */
+    DL_WWDT_RUN_IN_SLEEP = WWDT_WWDTCTL0_STISM_CONT
+} DL_WWDT_SLEEP_MODE;
+
+/*! @enum DL_WWDT_MODE */
+typedef enum {
+    /*! The watchdog is in watchdog mode */
+    DL_WWDT_WATCHDOG_MODE = 0x0,
+    /*! The watchdog is in interval timer mode */
+    DL_WWDT_INTERVAL_TIMER_MODE = WWDT_WWDTCTL0_MODE_INTERVAL
+} DL_WWDT_MODE;
+
+/*! @enum DL_WWDT_IIDX */
+typedef enum {
+    /*! Interrupt index for WWDT if no interrupt is pending */
+    DL_WWDT_IIDX_NO_INT = WWDT_IIDX_STAT_NO_INTR,
+    /*! WWDT interrupt index for interval timer */
+    DL_WWDT_IIDX_INTERVAL_TIMER = WWDT_IIDX_STAT_INTTIM
+} DL_WWDT_IIDX;
+
+/* clang-format on */
+
+/*!
+ *  @brief      Initializes the Window Watchdog Timer in watchdog mode
+ *
+ *  While in watchdog mode, the Window Watchdog Timer must be serviced
+ *  periodically or the device will be reset. After calling this initialization
+ *  API the watchdog will automatically start running with whatever window is
+ *  currently selected. See @ref DL_WWDT_setActiveWindow for setting the active
+ *  window, this is typically window 0 upon startup.
+ *
+ *  Once running, the watchdog will need to be restarted periodically with @ref
+ *  DL_WWDT_restart.
+ *
+ *  The watchdog can only be initialized once, so this API can only be called
+ *  once, and you may not later call @ref DL_WWDT_initIntervalTimerMode.
+ *
+ *  @param[in]  wwdt                Pointer to the register overlay for
+ *                                  peripheral
+ *  @param[in]  divider             Clock divider for the timer. One of @ref
+ *                                  DL_WWDT_CLOCK_DIVIDE.
+ *  @param[in]  period              Period for the timer. One of @ref
+ *                                  DL_WWDT_TIMER_PERIOD.
+ *  @param[in]  sleepMode           Enable/disable the timer running in sleep
+ *                                  mode. One of @ref DL_WWDT_SLEEP_MODE.
+ *  @param[in]  window0ClosedPeriod The percentage of the total period that
+ *                                  reset window 0 should be closed. One of
+ *                                  @ref DL_WWDT_WINDOW_PERIOD.
+ *  @param[in]  window1ClosedPeriod The percentage of the total period that
+ *                                  reset window 1 should be closed. One of
+ *                                  @ref DL_WWDT_WINDOW_PERIOD.
+ *
+ *  @sa         DL_WWDT_initIntervalTimerMode
+ *  @sa         DL_WWDT_setActiveWindow
+ *  @sa         DL_WWDT_restart
+ *
+ */
+__STATIC_INLINE void DL_WWDT_initWatchdogMode(WWDT_Regs *wwdt,
+    DL_WWDT_CLOCK_DIVIDE divider, DL_WWDT_TIMER_PERIOD period,
+    DL_WWDT_SLEEP_MODE sleepMode, DL_WWDT_WINDOW_PERIOD window0ClosedPeriod,
+    DL_WWDT_WINDOW_PERIOD window1ClosedPeriod)
+{
+    /* Window1 is shifted because the #defines used as an input are shared
+       between window 0 and window 1 */
+    wwdt->WWDTCTL0 =
+        (WWDT_WWDTCTL0_KEY_UNLOCK_W | (uint32_t) divider | (uint32_t) period |
+            (uint32_t) sleepMode | (uint32_t) window0ClosedPeriod |
+            ((uint32_t) window1ClosedPeriod << 4));
+}
+
+/*!
+ *  @brief      Initializes the Window Watchdog Timer in interval timer mode
+ *
+ *  The Window Watchdog Timer can be used as a simple interval timer if you do
+ *  not need watchdog/reset functionality. After calling this initialization
+ *  API the timer will automatically start running and start interrupting
+ *  periodically.
+ *
+ *  The WWDT can only be initialized once, so this API can only be called once,
+ *  and you may not later call @ref DL_WWDT_initWatchdogMode.
+ *
+ *  @param[in]  wwdt      Pointer to the register overlay for peripheral
+ *  @param[in]  divider   Clock divider for the timer. One of
+ *                        @ref DL_WWDT_CLOCK_DIVIDE.
+ *  @param[in]  period    Period for the timer. One of @ref
+ *                        DL_WWDT_TIMER_PERIOD.
+ *  @param[in]  sleepMode Enable/disable the timer running in sleep mode. One
+ *                        of @ref DL_WWDT_SLEEP_MODE.
+ *
+ *  @sa         DL_WWDT_initWatchdogMode
+ */
+__STATIC_INLINE void DL_WWDT_initIntervalTimerMode(WWDT_Regs *wwdt,
+    DL_WWDT_CLOCK_DIVIDE divider, DL_WWDT_TIMER_PERIOD period,
+    DL_WWDT_SLEEP_MODE sleepMode)
+{
+    wwdt->WWDTCTL0 =
+        (WWDT_WWDTCTL0_KEY_UNLOCK_W | (uint32_t) divider | (uint32_t) period |
+            (uint32_t) sleepMode | WWDT_WWDTCTL0_MODE_INTERVAL);
+}
+
+/**
+ * @brief Enables power on WWDT module
+ *
+ * @param wwdt        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_WWDT_enablePower(WWDT_Regs *wwdt)
+{
+    wwdt->GPRCM.PWREN = (WWDT_PWREN_KEY_UNLOCK_W | WWDT_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Disables power on wwdt module
+ *
+ * @param wwdt        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_WWDT_disablePower(WWDT_Regs *wwdt)
+{
+    wwdt->GPRCM.PWREN = (WWDT_PWREN_KEY_UNLOCK_W | WWDT_PWREN_ENABLE_DISABLE);
+}
+
+/**
+ * @brief Returns if  power on wwdt module
+ *
+ * @param wwdt        Pointer to the register overlay for the peripheral
+ *
+ * @return true if power is enabled
+ * @return false if power is disabled
+ */
+__STATIC_INLINE bool DL_WWDT_isPowerEnabled(WWDT_Regs *wwdt)
+{
+    return ((wwdt->GPRCM.PWREN & WWDT_PWREN_ENABLE_MASK) ==
+            WWDT_PWREN_ENABLE_ENABLE);
+}
+
+/**
+ * @brief Resets wwdt peripheral
+ *
+ * @param wwdt        Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_WWDT_reset(WWDT_Regs *wwdt)
+{
+    wwdt->GPRCM.RSTCTL =
+        (WWDT_RSTCTL_KEY_UNLOCK_W | WWDT_RSTCTL_RESETSTKYCLR_CLR |
+            WWDT_RSTCTL_RESETASSERT_ASSERT);
+}
+
+/**
+ * @brief Returns if wwdt peripheral was reset
+ *
+ * @param wwdt        Pointer to the register overlay for the peripheral
+ *
+ * @return true if peripheral was reset
+ * @return false if peripheral wasn't reset
+ *
+ */
+__STATIC_INLINE bool DL_WWDT_isReset(WWDT_Regs *wwdt)
+{
+    return ((wwdt->GPRCM.STAT & WWDT_STAT_RESETSTKY_MASK) ==
+            WWDT_STAT_RESETSTKY_RESET);
+}
+
+/*!
+ *  @brief      Restarts the Window Watchdog
+ *
+ *  When the Window Watchdog Timer is in watchdog mode it must be periodically
+ *  serviced to avoid a hardware reset. This API must be called after the
+ *  closed window of the watchdog has passed but before the watchdog resets the
+ *  device.
+ *
+ *  @param[in]  wwdt  Pointer to the register overlay for peripheral
+ */
+__STATIC_INLINE void DL_WWDT_restart(WWDT_Regs *wwdt)
+{
+    wwdt->WWDTCNTRST = 0x00A7;
+}
+
+/*!
+ *  @brief      Checks if the Window Watchdog Timer is actively running
+ *
+ *  @param[in]  wwdt  Pointer to the register overlay for peripheral
+ *
+ *  @return     Returns the running status of the Window Watchdog Timer
+ *
+ *  @retval     true  The Window Watchdog Timer is running
+ *  @retval     false The Window Watchdog Timer is not running
+ */
+__STATIC_INLINE bool DL_WWDT_isRunning(WWDT_Regs *wwdt)
+{
+    return (wwdt->WWDTSTAT == WWDT_WWDTSTAT_RUN_ON);
+}
+
+/*!
+ *  @brief Set the active window being used
+ *
+ *  The Window Watchdog Timer module allows you to switch between two different
+ *  configured windows. This allows you to configure the watchdog with two
+ *  different window sizes and switch between them during your application.
+ *
+ *  @param[in]  wwdt    Pointer to the register overlay for peripheral
+ *  @param[in]  window  The window to set as active. One of @ref
+ *                      DL_WWDT_WINDOW.
+ *
+ */
+__STATIC_INLINE void DL_WWDT_setActiveWindow(
+    WWDT_Regs *wwdt, DL_WWDT_WINDOW window)
+{
+    wwdt->WWDTCTL1 = (WWDT_WWDTCTL1_KEY_UNLOCK_W | (uint32_t) window);
+}
+
+/*!
+ *  @brief      Get the active window being used
+ *
+ *  @param[in]  wwdt  Pointer to the register overlay for peripheral
+ *
+ *  @return     The active window being used
+ *
+ *  @retval     One of @ref DL_WWDT_WINDOW
+ */
+__STATIC_INLINE DL_WWDT_WINDOW DL_WWDT_getActiveWindow(WWDT_Regs *wwdt)
+{
+    uint32_t window = (wwdt->WWDTCTL1 & WWDT_WWDTCTL1_WINSEL_MASK);
+
+    return (DL_WWDT_WINDOW)(window);
+}
+
+/*!
+ *  @brief      Get the sleep mode being used
+ *
+ *  @param[in]  wwdt  Pointer to the register overlay for peripheral
+ *
+ *  @return     The current sleep mode
+ *
+ *  @retval     One of @ref DL_WWDT_SLEEP_MODE
+ */
+__STATIC_INLINE DL_WWDT_SLEEP_MODE DL_WWDT_getSleepMode(WWDT_Regs *wwdt)
+{
+    uint32_t mode = (wwdt->WWDTCTL0 & WWDT_WWDTCTL0_STISM_MASK);
+
+    return (DL_WWDT_SLEEP_MODE)(mode);
+}
+
+/*!
+ *  @brief      Get the mode the watchdog is running in
+ *
+ *  @param[in]  wwdt  Pointer to the register overlay for peripheral
+ *
+ *  @return     The current mode the watchdog is running in
+ *
+ *  @retval     One of @ref DL_WWDT_MODE
+ */
+__STATIC_INLINE DL_WWDT_MODE DL_WWDT_getMode(WWDT_Regs *wwdt)
+{
+    uint32_t mode = (wwdt->WWDTCTL0 & WWDT_WWDTCTL0_MODE_MASK);
+
+    return (DL_WWDT_MODE)(mode);
+}
+
+/*!
+ *  @brief      Get the window closed percentage for a watchdog window
+ *
+ *  @param[in]  wwdt    Pointer to the register overlay for peripheral
+ *  @param[in]  window  The window to get the closed window percentage of. One
+ *                      of @ref DL_WWDT_WINDOW.
+ *
+ *  @return     The desired window's closed percentage
+ *
+ *  @retval     One of @ref DL_WWDT_WINDOW_PERIOD
+ */
+__STATIC_INLINE DL_WWDT_WINDOW_PERIOD DL_WWDT_getWindowPeriod(
+    WWDT_Regs *wwdt, DL_WWDT_WINDOW window)
+{
+    uint32_t period;
+
+    if (window == DL_WWDT_WINDOW0) {
+        period = (wwdt->WWDTCTL0 & WWDT_WWDTCTL0_WINDOW0_MASK);
+    } else {
+        period = ((wwdt->WWDTCTL0 & WWDT_WWDTCTL0_WINDOW1_MASK) >> 4);
+    }
+
+    return (DL_WWDT_WINDOW_PERIOD)(period);
+}
+
+/*!
+ *  @brief      Get the timer period for the watchdog
+ *
+ *  @param[in]  wwdt  Pointer to the register overlay for peripheral
+ *
+ *  @return     The current timer period for the watchdog
+ *
+ *  @retval     One of @ref DL_WWDT_TIMER_PERIOD
+ */
+__STATIC_INLINE DL_WWDT_TIMER_PERIOD DL_WWDT_getTimerPeriod(WWDT_Regs *wwdt)
+{
+    uint32_t period = (wwdt->WWDTCTL0 & WWDT_WWDTCTL0_PER_MASK);
+
+    return (DL_WWDT_TIMER_PERIOD)(period);
+}
+
+/*!
+ *  @brief      Get the clock divider for the watchdog
+ *
+ *  @param[in]  wwdt  Pointer to the register overlay for peripheral
+ *
+ *  @return     The current clock divider used
+ *
+ *  @retval     One of @ref DL_WWDT_CLOCK_DIVIDE
+ */
+__STATIC_INLINE DL_WWDT_CLOCK_DIVIDE DL_WWDT_getClockDivider(WWDT_Regs *wwdt)
+{
+    uint32_t clockDivider = (wwdt->WWDTCTL0 & WWDT_WWDTCTL0_CLKDIV_MASK);
+
+    return (DL_WWDT_CLOCK_DIVIDE)(clockDivider);
+}
+
+/**
+ *  @brief      Enable WWDT interrupt
+ *
+ *  @param[in]  wwdt  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_WWDT_enableInterrupt(WWDT_Regs *wwdt)
+{
+    wwdt->CPU_INT.IMASK = WWDT_IMASK_INTTIM_SET;
+}
+
+/**
+ *  @brief      Disable WWDT interrupt
+ *
+ *  @param[in]  wwdt  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_WWDT_disableInterrupt(WWDT_Regs *wwdt)
+{
+    wwdt->CPU_INT.IMASK = WWDT_IMASK_INTTIM_CLR;
+}
+
+/**
+ *  @brief      Check if WWDT interrupt is enabled
+ *
+ *  @param[in]  wwdt Pointer to the register overlay for the peripheral
+ *
+ *  @return     If the WWDT interrupt is enabled
+ *
+ *  @retval     true  The WWDT interrupt is enabled
+ *  @retval     false The WWDT interrupt is disabled
+ */
+__STATIC_INLINE bool DL_WWDT_isInterruptEnabled(WWDT_Regs *wwdt)
+{
+    return ((wwdt->CPU_INT.IMASK & WWDT_IMASK_INTTIM_SET) ==
+            WWDT_IMASK_INTTIM_SET);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled WWDT interrupt
+ *
+ *  Checks if the WWDT interrupt that was previously enabled is pending.
+ *
+ *  @param[in]  wwdt  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If the enabled WWDT interrupt is pending
+ *
+ *  @retval     true  The WWDT interrupt is pending
+ *  @retval     false The WWDT interrupt is not pending
+ *
+ *  @sa         DL_WWDT_enableInterrupt
+ */
+__STATIC_INLINE bool DL_WWDT_getEnabledInterruptStatus(WWDT_Regs *wwdt)
+{
+    return ((wwdt->CPU_INT.MIS & WWDT_MIS_INTTIM_SET) == WWDT_MIS_INTTIM_SET);
+}
+
+/**
+ *  @brief      Check interrupt flag of any WWDT interrupt
+ *
+ *  Checks if the WWDT interrupt is pending. Interrupt does not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  wwdt  Pointer to the register overlay for the peripheral
+ *
+ *  @return     If the WWDT interrupt is pending
+ *
+ *  @retval     true  The WWDT interrupt is pending
+ *  @retval     false The WWDT interrupt is not pending
+ */
+__STATIC_INLINE uint32_t DL_WWDT_getRawInterruptStatus(WWDT_Regs *wwdt)
+{
+    return (wwdt->CPU_INT.RIS & WWDT_RIS_INTTIM_SET);
+}
+
+/**
+ *  @brief      Get highest priority pending WWDT interrupt
+ *
+ *  Checks if any of the WWDT interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  wwdt  Pointer to the register overlay for the peripheral
+ *
+ *  @return     The highest priority pending WWDT interrupt
+ *
+ *  @retval     One of @ref DL_WWDT_IIDX
+ */
+__STATIC_INLINE DL_WWDT_IIDX DL_WWDT_getPendingInterrupt(WWDT_Regs *wwdt)
+{
+    return (DL_WWDT_IIDX)(wwdt->CPU_INT.IIDX);
+}
+
+/**
+ *  @brief      Clear pending WWDT interrupt
+ *
+ *  @param[in]  wwdt  Pointer to the register overlay for the peripheral
+ */
+__STATIC_INLINE void DL_WWDT_clearInterruptStatus(WWDT_Regs *wwdt)
+{
+    wwdt->CPU_INT.ICLR = WWDT_ICLR_INTTIM_CLR;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MSPM0_HAS_WWDT__ */
+
+#endif /* ti_dl_dl_wwdt__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/driverlib.h
+++ b/mspm0/source/ti/driverlib/driverlib.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ti_dl_dl_driverlib__include
+#define ti_dl_dl_driverlib__include
+
+#include <ti/driverlib/dl_adc12.h>
+#include <ti/driverlib/dl_aes.h>
+#include <ti/driverlib/dl_aesadv.h>
+#include <ti/driverlib/dl_common.h>
+#include <ti/driverlib/dl_comp.h>
+#include <ti/driverlib/dl_crc.h>
+#include <ti/driverlib/dl_crcp.h>
+#include <ti/driverlib/dl_dac12.h>
+#include <ti/driverlib/dl_dma.h>
+#include <ti/driverlib/dl_flashctl.h>
+#include <ti/driverlib/dl_gpamp.h>
+#include <ti/driverlib/dl_gpio.h>
+#include <ti/driverlib/dl_i2c.h>
+#include <ti/driverlib/dl_iwdt.h>
+#include <ti/driverlib/dl_keystorectl.h>
+#include <ti/driverlib/dl_lcd.h>
+#include <ti/driverlib/dl_lfss.h>
+#include <ti/driverlib/dl_mathacl.h>
+#include <ti/driverlib/dl_mcan.h>
+#include <ti/driverlib/dl_opa.h>
+#include <ti/driverlib/dl_rtc.h>
+#include <ti/driverlib/dl_rtc_a.h>
+#include <ti/driverlib/dl_rtc_common.h>
+#include <ti/driverlib/dl_scratchpad.h>
+#include <ti/driverlib/dl_spi.h>
+#include <ti/driverlib/dl_tamperio.h>
+#include <ti/driverlib/dl_timera.h>
+#include <ti/driverlib/dl_timerg.h>
+#include <ti/driverlib/dl_trng.h>
+#include <ti/driverlib/dl_uart_extend.h>
+#include <ti/driverlib/dl_uart_main.h>
+#include <ti/driverlib/dl_vref.h>
+#include <ti/driverlib/dl_wwdt.h>
+#include <ti/driverlib/m0p/dl_factoryregion.h>
+#include <ti/driverlib/m0p/dl_interrupt.h>
+#include <ti/driverlib/m0p/dl_sysctl.h>
+#include <ti/driverlib/m0p/dl_systick.h>
+
+#endif /* ti_dl_dl_driverlib__include */

--- a/mspm0/source/ti/driverlib/m0p/dl_core.h
+++ b/mspm0/source/ti/driverlib/m0p/dl_core.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_core.h
+ *  @brief      CPU Core Driver Library
+ *  @defgroup   CORE M0P Core
+ *
+ *  @anchor ti_dl_m0p_dl_core_Overview
+ *  # Overview
+ *
+ *  The Core module enables software to read from core registers of the CPU to
+ *  get more information about the device at runtime.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup CORE
+ * @{
+ */
+#ifndef ti_dl_m0p_dl_core__include
+#define ti_dl_m0p_dl_core__include
+
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_CORE_CACHE
+ *  @{
+ */
+
+/*!
+ * @brief Enables instruction caching on flash access
+ */
+#define DL_CORE_CACHE_ENABLED                          (CPUSS_CTL_ICACHE_ENABLE)
+
+/*!
+ * @brief Disables instruction caching on flash access
+ */
+#define DL_CORE_CACHE_DISABLED                        (CPUSS_CTL_ICACHE_DISABLE)
+
+/** @}*/
+
+/** @addtogroup DL_CORE_PREFETCH
+ *  @{
+ */
+
+/*!
+ * @brief Enables instruction prefetch to Flash
+ */
+#define DL_CORE_PREFETCH_ENABLED                     (CPUSS_CTL_PREFETCH_ENABLE)
+
+/*!
+ * @brief Disables instruction prefetch to Flash
+ */
+#define DL_CORE_PREFETCH_DISABLED                   (CPUSS_CTL_PREFETCH_DISABLE)
+
+/** @}*/
+
+/** @addtogroup DL_CORE_LITERAL_CACHE
+ *  @{
+ */
+
+/*!
+ * @brief Enables caching and prefetching of literals.
+ * This is set only if the ICACHE or PREFETCH bits have been set respectively.
+ */
+#define DL_CORE_LITERAL_CACHE_ENABLED                   (CPUSS_CTL_LITEN_ENABLE)
+
+/*!
+ * @brief Disables caching and prefetching of literals
+ */
+#define DL_CORE_LITERAL_CACHE_DISABLED                 (CPUSS_CTL_LITEN_DISABLE)
+
+/** @}*/
+
+
+/**
+ * @brief Alias for DL_Common_delayCycles
+ */
+#define delay_cycles(cycles) DL_Common_delayCycles(cycles)
+
+/** @}*/
+
+/* clang-format on  */
+
+
+/**
+ *  @brief   Get the implementer code for the processor
+ *
+ *  @return  The implementer code
+ *
+ *  @retval  0x41 for ARM
+ */
+__STATIC_INLINE uint32_t DL_CORE_getImplementer(void)
+{
+    return (
+        (SCB->CPUID & SCB_CPUID_IMPLEMENTER_Msk) >> SCB_CPUID_IMPLEMENTER_Pos);
+}
+
+/**
+ *  @brief   Get the major revision number 'n' in the 'npm' revision status
+ *
+ *  @return  The major revision number
+ *
+ *  @retval  0x00 for revision 0
+ */
+__STATIC_INLINE uint32_t DL_CORE_getVariant(void)
+{
+    return ((SCB->CPUID & SCB_CPUID_VARIANT_Msk) >> SCB_CPUID_VARIANT_Pos);
+}
+
+/**
+ *  @brief   Get the architecture of the processor
+ *
+ *  @return  Value that defines the architecture of the processor
+ *
+ *  @retval  0x0C for ARMv6-M architecture
+ */
+__STATIC_INLINE uint32_t DL_CORE_getArchitecture(void)
+{
+    return ((SCB->CPUID & SCB_CPUID_ARCHITECTURE_Msk) >>
+            SCB_CPUID_ARCHITECTURE_Pos);
+}
+
+/**
+ *  @brief   Get part number of the processor (not the device)
+ *
+ *  @return  Value that defines the processor
+ *
+ *  @retval  0x0C60 for Cortex-M0+
+ */
+__STATIC_INLINE uint32_t DL_CORE_getPartNumber(void)
+{
+    return ((SCB->CPUID & SCB_CPUID_PARTNO_Msk) >> SCB_CPUID_PARTNO_Pos);
+}
+
+/**
+ *  @brief   Get the minor revision number 'm' in the 'npm' revision status
+ *
+ *  @return  The minor revision number
+ *
+ *  @retval  0x01 for patch 1
+ */
+__STATIC_INLINE uint32_t DL_CORE_getRevision(void)
+{
+    return ((SCB->CPUID & (uint32_t)SCB_CPUID_REVISION_Msk) >> (uint32_t)SCB_CPUID_REVISION_Pos);
+}
+
+/**
+ * @brief Configures instruction caching in flash accesses and instruction
+ *        prefetch  to flash
+ *
+ * @param icache [in]    Instruction cache option @ref DL_CORE_CACHE
+ * @param prefetch [in]  Instruction prefetch option @ref DL_CORE_PREFETCH
+ * @param litCache [in]  Literal cache option @ref DL_CORE_LITERAL_CACHE
+ *
+ */
+__STATIC_INLINE void DL_CORE_configInstruction(uint32_t icache, uint32_t prefetch, uint32_t litCache)
+{
+    CPUSS->CTL = (icache | prefetch | litCache);
+}
+
+/**
+ * @brief Returns instruction caching, prefetch, and literal cache configuration
+ *
+ * @return Bitwise OR of @ref DL_CORE_CACHE and @ref DL_CORE_PREFETCH and
+ * @ref DL_CORE_LITERAL_CACHE
+ */
+__STATIC_INLINE uint32_t DL_CORE_getInstructionConfig(void)
+{
+    return(CPUSS->CTL & (CPUSS_CTL_ICACHE_MASK | CPUSS_CTL_PREFETCH_MASK | CPUSS_CTL_LITEN_MASK));
+}
+
+#ifdef __cplusplus
+}
+
+#endif
+
+#endif /* ti_dl_m0p_dl_core__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/m0p/dl_factoryregion.h
+++ b/mspm0/source/ti/driverlib/m0p/dl_factoryregion.h
@@ -1,0 +1,658 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_factoryregion.h
+ *  @brief      Factory Region Driver Library
+ *  @defgroup   FACTORYREGION Factory Region (FACTORYREGION)
+ *
+ *  @anchor ti_dl_dl_factoryregion_Overview
+ *  # Overview
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup FACTORYREGION
+ * @{
+ */
+#ifndef ti_dl_dl_factoryregion__include
+#define ti_dl_dl_factoryregion__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+#include <ti/driverlib/m0p/dl_core.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/* clang-format on */
+
+/**
+ *  @brief   Get the size of the MAIN Flash region
+ *
+ *  @return  The size of the MAIN Flash region in number of kB.
+ */
+__STATIC_INLINE uint16_t DL_FactoryRegion_getMAINFlashSize(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint16_t flashSize =
+        FACTORYREGION->SRAMFLASH & FACTORYREGION_SRAMFLASH_MAINFLASH_SZ_MASK;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return flashSize;
+}
+
+/**
+ *  @brief   Get the size of the SRAM Flash region
+ *
+ *  @return  The size of the SRAM Flash region in number of kB.
+ */
+__STATIC_INLINE uint16_t DL_FactoryRegion_getSRAMFlashSize(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint16_t flashSize =
+        (FACTORYREGION->SRAMFLASH & FACTORYREGION_SRAMFLASH_SRAM_SZ_MASK) >>
+        FACTORYREGION_SRAMFLASH_SRAM_SZ_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return flashSize;
+}
+
+/**
+ *  @brief   Get the size of the DATA Flash region
+ *
+ *  @return  The size of the DATA Flash region in number of kB.
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getDATAFlashSize(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint16_t flashSize = (FACTORYREGION->SRAMFLASH &
+                             FACTORYREGION_SRAMFLASH_DATAFLASH_SZ_MASK) >>
+                         FACTORYREGION_SRAMFLASH_DATAFLASH_SZ_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return flashSize;
+}
+
+/**
+ *  @brief   Get the number of Flash banks on the device
+ *
+ *  @return  The number of flash banks. A value between [1, 4].
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getNumBanks(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t numBanks = ((FACTORYREGION->SRAMFLASH &
+                            FACTORYREGION_SRAMFLASH_MAINNUMBANKS_MASK) >>
+                           FACTORYREGION_SRAMFLASH_MAINNUMBANKS_OFS) +
+                       (uint8_t) 1;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return numBanks;
+}
+
+/**
+ *  @brief   Get the trace ID of the device
+ *
+ *  @return  The trace ID of the device.
+ */
+__STATIC_INLINE uint32_t DL_FactoryRegion_getTraceID(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint32_t traceID =
+        FACTORYREGION->TRACEID & FACTORYREGION_TRACEID_DATA_MASK;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return traceID;
+}
+
+/**
+ *  @brief   Get JEDEC bank and company code
+ *
+ *  @return  TI's JEDEC bank and company code
+ */
+__STATIC_INLINE uint16_t DL_FactoryRegion_getManufacturerCode(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint16_t manufacturerCode =
+        (FACTORYREGION->DEVICEID & FACTORYREGION_DEVICEID_MANUFACTURER_MASK) >>
+        FACTORYREGION_DEVICEID_MANUFACTURER_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return manufacturerCode;
+}
+
+/**
+ *  @brief   Get the part number of the device
+ *
+ *  @return  The part number of the device
+ */
+__STATIC_INLINE uint16_t DL_FactoryRegion_getPartNumber(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint16_t partNumber =
+        (FACTORYREGION->DEVICEID & FACTORYREGION_DEVICEID_PARTNUM_MASK) >>
+        FACTORYREGION_DEVICEID_PARTNUM_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return partNumber;
+}
+
+/**
+ *  @brief   Get the version of the device
+ *
+ *  @return  The version of the device
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getVersion(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t version =
+        (FACTORYREGION->DEVICEID & FACTORYREGION_DEVICEID_VERSION_MASK) >>
+        FACTORYREGION_DEVICEID_VERSION_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return version;
+}
+
+/**
+ *  @brief   Get the bit pattern identifying the part
+ *
+ *  @return  The bit pattern identifying the part
+ */
+__STATIC_INLINE uint16_t DL_FactoryRegion_getUserIDPart(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint16_t userIDPart =
+        (FACTORYREGION->USERID & FACTORYREGION_USERID_PART_MASK) >>
+        FACTORYREGION_USERID_PART_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return userIDPart;
+}
+
+/**
+ *  @brief   Get the bit pattern identifying a variant of a part
+ *
+ *  @return  The bit pattern identifying a variant of a part
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getUserIDVariant(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+    uint8_t userIDVariant =
+        (FACTORYREGION->USERID & FACTORYREGION_USERID_VARIANT_MASK) >>
+        FACTORYREGION_USERID_VARIANT_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return userIDVariant;
+}
+
+/**
+ *  @brief   Get the value that preserves compatibility with lesser minorrev values
+ *
+ *  Monotonic increasing value indicating a new revision that preserves
+ *  compatibility with lesser minorrev values. New capability may
+ *  be introduced such that lesser minorrev numbers may not be
+ *  compatible with greater if the new capability is used
+ *
+ *  @return  The value that preserves compatibility with lesser minorrev values
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getUserIDMinorRev(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t minorRev =
+        (FACTORYREGION->USERID & FACTORYREGION_USERID_MINORREV_MASK) >>
+        FACTORYREGION_USERID_MINORREV_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return minorRev;
+}
+
+/**
+ *  @brief   Get the value that preserves compatibility with lesser majorrev values
+ *
+ *  Monotonic increasing value indicating a new revision significant
+ *  enough that users of the device may have to revise PCB or or
+ *  software design
+ *
+ *  @return  The value that tells users they may have to revise PCB or majorrev design
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getUserIDMajorRev(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t majorRev =
+        (FACTORYREGION->USERID & FACTORYREGION_USERID_MAJORREV_MASK) >>
+        FACTORYREGION_USERID_MAJORREV_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return majorRev;
+}
+
+/**
+ *  @brief   Get the UART RXD PIN used by BSL
+ *
+ *  @return  The UART RXD PIN used by BSL
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getBSLPinUARTRXDPad(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t bslUARTRXDPad = (FACTORYREGION->BSLPIN_UART &
+                                FACTORYREGION_BSLPIN_UART_UART_RXD_PAD_MASK) >>
+                            FACTORYREGION_BSLPIN_UART_UART_RXD_PAD_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return bslUARTRXDPad;
+}
+
+/**
+ *  @brief   Get the UART RXD Pin function selection value used by BSL
+ *
+ *  @return  The UART RXD Pin function selection value used by BSL
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getBSLPinUARTRXDFunction(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t bslUARTRXDFunction =
+        (FACTORYREGION->BSLPIN_UART &
+            FACTORYREGION_BSLPIN_UART_UART_RXD_PF_MASK) >>
+        FACTORYREGION_BSLPIN_UART_UART_RXD_PF_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return bslUARTRXDFunction;
+}
+
+/**
+ *  @brief   Get the UART TXD PIN used by BSL
+ *
+ *  @return  The UART TXD PIN used by BSL
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getBSLPinUARTTXDPad(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t bslUARTTXDPad = (FACTORYREGION->BSLPIN_UART &
+                                FACTORYREGION_BSLPIN_UART_UART_TXD_PAD_MASK) >>
+                            FACTORYREGION_BSLPIN_UART_UART_TXD_PAD_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return bslUARTTXDPad;
+}
+
+/**
+ *  @brief   Get the UART TXD Pin function selection value used by BSL
+ *
+ *  @return  The UART TXD Pin function selection value used by BSL
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getBSLPinUARTTXDFunction(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t bslUARTTXDFunction =
+        (FACTORYREGION->BSLPIN_UART &
+            FACTORYREGION_BSLPIN_UART_UART_TXD_PF_MASK) >>
+        FACTORYREGION_BSLPIN_UART_UART_TXD_PF_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return bslUARTTXDFunction;
+}
+
+/**
+ *  @brief   Get the I2C SDA Pin used by BSL
+ *
+ *  @return  The I2C SDA Pin used by BSL
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getBSLPinI2CSDAPad(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t bslI2CSDAPad = (FACTORYREGION->BSLPIN_I2C &
+                               FACTORYREGION_BSLPIN_I2C_I2C_SDA_PAD_MASK) >>
+                           FACTORYREGION_BSLPIN_I2C_I2C_SDA_PAD_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return bslI2CSDAPad;
+}
+
+/**
+ *  @brief   Get the I2C SDA Pin function selection value used by BSL
+ *
+ *  @return  The I2C SDA Pin function selection value used by BSL
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getBSLPinI2CSDAFunction(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t bslI2CSDAFunction =
+        (FACTORYREGION->BSLPIN_I2C &
+            FACTORYREGION_BSLPIN_I2C_I2C_SDA_PF_MASK) >>
+        FACTORYREGION_BSLPIN_I2C_I2C_SDA_PF_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return bslI2CSDAFunction;
+}
+
+/**
+ *  @brief   Get the I2C SCL Pin used by BSL
+ *
+ *  @return  The I2C SCL Pin used by BSL
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getBSLPinI2CSCLPad(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t bslI2CSCLPad = (FACTORYREGION->BSLPIN_I2C &
+                               FACTORYREGION_BSLPIN_I2C_I2C_SCL_PAD_MASK) >>
+                           FACTORYREGION_BSLPIN_I2C_I2C_SCL_PAD_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return bslI2CSCLPad;
+}
+
+/**
+ *  @brief   Get the I2C SCL Pin function selection value used by BSL
+ *
+ *  @return  The I2C SCL Pin function selection value used by BSL
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getBSLPinI2CSCLFunction(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t bslI2CSCLFunction =
+        (FACTORYREGION->BSLPIN_I2C &
+            FACTORYREGION_BSLPIN_I2C_I2C_SCL_PF_MASK) >>
+        FACTORYREGION_BSLPIN_I2C_I2C_SCL_PF_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return bslI2CSCLFunction;
+}
+
+/**
+ *  @brief   Get the GPIO level used by BSL pin invocation
+ *
+ *  @return  The GPIO level used by BSL pin invocation
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getBSLPinInvokeGPIOLevel(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t bslInvokeGPIOLevel =
+        (FACTORYREGION->BSLPIN_INVOKE &
+            FACTORYREGION_BSLPIN_INVOKE_GPIO_LEVEL_MASK) >>
+        FACTORYREGION_BSLPIN_INVOKE_GPIO_LEVEL_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return bslInvokeGPIOLevel;
+}
+
+/**
+ *  @brief   Get the GPIO Pin selection value used by BSL pin invocation
+ *
+ *  @return  The GPIO Pin selection value used by BSL pin invocation
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getBSLPinInvokeGPIOPin(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t bslInvokeGPIOPin =
+        (FACTORYREGION->BSLPIN_INVOKE &
+            FACTORYREGION_BSLPIN_INVOKE_GPIO_PIN_SEL_MASK) >>
+        FACTORYREGION_BSLPIN_INVOKE_GPIO_PIN_SEL_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return bslInvokeGPIOPin;
+}
+
+/**
+ *  @brief   Get the GPIO module selection used by BSL pin invocation
+ *
+ *  @return  The GPIO module selection used by BSL pin invocation
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getBSLPinInvokeGPIOModule(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t bslInvokeGPIOModule =
+        (FACTORYREGION->BSLPIN_INVOKE &
+            FACTORYREGION_BSLPIN_INVOKE_GPIO_REG_SEL_MASK) >>
+        FACTORYREGION_BSLPIN_INVOKE_GPIO_REG_SEL_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return bslInvokeGPIOModule;
+}
+
+/**
+ *  @brief   Get the BSL invocation pin number
+ *
+ *  @return  The BSL invocation pin number
+ */
+__STATIC_INLINE uint8_t DL_FactoryRegion_getBSLPinInvokeGPIOModulePad(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint8_t bslInvokeGPIOModulePad =
+        (FACTORYREGION->BSLPIN_INVOKE &
+            FACTORYREGION_BSLPIN_INVOKE_BSL_PAD_MASK) >>
+        FACTORYREGION_BSLPIN_INVOKE_BSL_PAD_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return bslInvokeGPIOModulePad;
+}
+
+/**
+ *  @brief   Get the ADC conversion results of temperature sensor output voltage
+ *
+ *  @return  The ADC conversion results of temperature sensor output voltage
+ */
+__STATIC_INLINE uint32_t DL_FactoryRegion_getTemperatureVoltage(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint32_t tempVoltage =
+        (FACTORYREGION->TEMP_SENSE0 & FACTORYREGION_TEMP_SENSE0_DATA_MASK) >>
+        FACTORYREGION_TEMP_SENSE0_DATA_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return tempVoltage;
+}
+
+/**
+ *  @brief   Get the BOOTCRC value
+ *
+ *  The 32-bit CRC of all locations in OPEN including reserved locations.
+ *
+ *  @return  The BOOTCRC value
+ */
+__STATIC_INLINE uint32_t DL_FactoryRegion_getBOOTCRCData(void)
+{
+    /* Save CPUSS state and then disable the cache before TRIM access */
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    uint32_t BOOTCRCData =
+        (FACTORYREGION->BOOTCRC & FACTORYREGION_BOOTCRC_DATA_MASK) >>
+        FACTORYREGION_BOOTCRC_DATA_OFS;
+
+    /* Restore CPUSS state */
+    CPUSS->CTL = ctlTemp;
+
+    return BOOTCRCData;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_dl_dl_factoryregion__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/m0p/dl_interrupt.c
+++ b/mspm0/source/ti/driverlib/m0p/dl_interrupt.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+
+#include <ti/driverlib/m0p/dl_interrupt.h>
+
+/* 32 Device Peripheral Exceptions + 16 reserved M0+ Exceptions */
+#define NUM_RES_M0_EXC ((uint32_t) 16)
+#define NUM_DEV_PERIPH_EXC ((uint32_t) 32)
+#define NUM_INTERRUPTS (NUM_RES_M0_EXC + NUM_DEV_PERIPH_EXC)
+
+#if defined(__IAR_SYSTEMS_ICC__)
+#pragma data_alignment = 256
+static __no_init void (*InterruptRAMVectors[NUM_INTERRUPTS])(void) @ "VTABLE";
+#else
+static __attribute__((section(".vtable"))) void (
+    *InterruptRAMVectors[NUM_INTERRUPTS])(void) __attribute__((aligned(256)));
+#endif
+void DL_Interrupt_registerInterrupt(
+    uint32_t exceptionNumber, void (*intHandler)(void))
+{
+    void (**baseAddress)(void);
+    uint32_t i;
+
+    /* See if the RAM vector table has been initialized */
+    if (SCB->VTOR != (uint32_t) InterruptRAMVectors) {
+        baseAddress = (void (**)(void)) SCB->VTOR;
+
+        /* Copy the vector table from Flash to RAM */
+        for (i = 0; i < NUM_INTERRUPTS; i++) {
+            InterruptRAMVectors[i] = baseAddress[i];
+        }
+
+        SCB->VTOR = (uint32_t) InterruptRAMVectors;
+    }
+
+    InterruptRAMVectors[exceptionNumber + NUM_RES_M0_EXC] = intHandler;
+}
+
+void DL_Interrupt_unregisterInterrupt(uint32_t exceptionNumber)
+{
+    InterruptRAMVectors[exceptionNumber + NUM_RES_M0_EXC] = Default_Handler;
+}

--- a/mspm0/source/ti/driverlib/m0p/dl_interrupt.h
+++ b/mspm0/source/ti/driverlib/m0p/dl_interrupt.h
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_interrupt.h
+ *  @brief      Interrupt Management Driver Library
+*  @defgroup   INTERRUPT M0P Interrupts
+ *
+ *  @anchor ti_dl_m0p_dl_interrupt_Overview
+ *  # Overview
+ *
+ *  The Cortex-M0+ architecture is limited to 32 device interrupts. To enable
+ *  interrupt handling on devices that need more than 32 interrupts, the
+ *  interrupts are grouped together.
+ *
+ *  For example, "Group 0" contains the interrupt flags for the WWDT0, WWDT1,
+ *  DEBUGSS, FLASH, and SYSCTL peripherals. Once the interrupt fires for Group 0,
+ *  the application must check to see which peripheral from Group 0 was the
+ *  source using the APIs in this module.
+ *
+ *  This PI module is not for controlling the NVIC or the I-bit in the CPSR
+ *  register. It's best to use the CMSIS-Core APIs that are delivered as part
+ *  of CMSIS-Core in the `source/third_party/CMSIS/Core/Include/core_cm0plus.h`
+ *  file within the SDK.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup INTERRUPT
+ * @{
+ */
+#ifndef ti_dl_m0p_dl_interrupt__include
+#define ti_dl_m0p_dl_interrupt__include
+
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/devices/msp/peripherals/m0p/hw_cpuss.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_INTERRUPT_GROUP_IIDX
+ *  @{
+ */
+
+/*!
+ *  @brief WWDT0 Interrupt in Group 0
+ */
+#define DL_INTERRUPT_GROUP0_IIDX_WWDT0          (CPUSS_INT_GROUP_IIDX_STAT_INT0)
+
+/*!
+ *  @brief WWDT1 Interrupt in Group 0.
+ *  @note This is a device specific interrupt. Please consult the device TRM to
+ *        determine if the interrupt is enabled as part of Group 0 interrupts.
+ */
+#define DL_INTERRUPT_GROUP0_IIDX_WWDT1          (CPUSS_INT_GROUP_IIDX_STAT_INT1)
+
+/*!
+ *  @brief DEBUGSS Interrupt in Group 0
+ */
+#define DL_INTERRUPT_GROUP0_IIDX_DEBUGSS        (CPUSS_INT_GROUP_IIDX_STAT_INT2)
+
+/*!
+ *  @brief FLASH Interrupt in Group 0
+ */
+#define DL_INTERRUPT_GROUP0_IIDX_FLASH          (CPUSS_INT_GROUP_IIDX_STAT_INT3)
+
+/*!
+ *  @brief WUC FSUB0 Interrupt in Group 0
+ */
+#define DL_INTERRUPT_GROUP0_IIDX_WUC_FSUB0      (CPUSS_INT_GROUP_IIDX_STAT_INT4)
+
+/*!
+ *  @brief WUC FSUB0 Interrupt in Group 1
+ */
+#define DL_INTERRUPT_GROUP0_IIDX_WUC_FSUB1      (CPUSS_INT_GROUP_IIDX_STAT_INT5)
+
+/*!
+ *  @brief SYSCTL (PMCU) Interrupt in Group 0
+ */
+#define DL_INTERRUPT_GROUP0_IIDX_SYSCTL         (CPUSS_INT_GROUP_IIDX_STAT_INT6)
+
+/*!
+ *  @brief GPIOA Interrupt in Group 1
+ */
+#define DL_INTERRUPT_GROUP1_IIDX_GPIOA          (CPUSS_INT_GROUP_IIDX_STAT_INT0)
+
+/*!
+ *  @brief GPIOB Interrupt in Group 1
+ *  @note This is a device specific interrupt. Please consult the device TRM to
+ *        determine if the interrupt is enabled as part of Group 1 interrupts.
+ */
+#define DL_INTERRUPT_GROUP1_IIDX_GPIOB          (CPUSS_INT_GROUP_IIDX_STAT_INT1)
+
+/*!
+ *  @brief COMP0 Interrupt in Group 1
+ */
+#define DL_INTERRUPT_GROUP1_IIDX_COMP0          (CPUSS_INT_GROUP_IIDX_STAT_INT2)
+
+/*!
+ *  @brief COMP1 Interrupt in Group 1
+ *  @note This is a device specific interrupt. Please consult the device TRM to
+ *        determine if the interrupt is enabled as part of Group 1 interrupts.
+ */
+#define DL_INTERRUPT_GROUP1_IIDX_COMP1          (CPUSS_INT_GROUP_IIDX_STAT_INT3)
+
+/*!
+ *  @brief COMP2 Interrupt in Group 1
+ *  @note This is a device specific interrupt. Please consult the device TRM to
+ *        determine if the interrupt is enabled as part of Group 1 interrupts.
+ */
+#define DL_INTERRUPT_GROUP1_IIDX_COMP2          (CPUSS_INT_GROUP_IIDX_STAT_INT4)
+
+/*!
+ *  @brief TRNG Interrupt in Group 1
+ *  @note This is a device specific interrupt. Please consult the device TRM to
+ *        determine if the interrupt is enabled as part of Group 1 interrupts.
+ */
+#define DL_INTERRUPT_GROUP1_IIDX_TRNG           (CPUSS_INT_GROUP_IIDX_STAT_INT5)
+
+/** @}*/
+
+/** @addtogroup DL_INTERRUPT_GROUP_INTERRUPTS
+ *  @{
+ */
+/*!
+ *  @brief WWDT0 Interrupt in Group 0
+ */
+#define DL_INTERRUPT_GROUP0_WWDT0               (CPUSS_INT_GROUP_IMASK_INT_INT0)
+/*!
+ *  @brief WWDT1 Interrupt in Group 0
+ */
+#define DL_INTERRUPT_GROUP0_WWDT1               (CPUSS_INT_GROUP_IMASK_INT_INT1)
+/*!
+ *  @brief DEBUGSS Interrupt in Group 0
+ */
+#define DL_INTERRUPT_GROUP0_DEBUGSS             (CPUSS_INT_GROUP_IMASK_INT_INT2)
+/*!
+ *  @brief FLASH Interrupt in Group 0
+ */
+#define DL_INTERRUPT_GROUP0_FLASH               (CPUSS_INT_GROUP_IMASK_INT_INT3)
+/*!
+ *  @brief Generic event subscriber 0 in Group 0
+ */
+#define DL_INTERRUPT_GROUP0_WUC_FSUB0           (CPUSS_INT_GROUP_IMASK_INT_INT4)
+/*!
+ *  @brief Generic event subscriber 1 in Group 0
+ */
+#define DL_INTERRUPT_GROUP0_WUC_FSUB1           (CPUSS_INT_GROUP_IMASK_INT_INT5)
+/*!
+ *  @brief PMCU (system controller) in Group 0
+ */
+#define DL_INTERRUPT_GROUP0_PMCU                (CPUSS_INT_GROUP_IMASK_INT_INT6)
+
+/*!
+ *  @brief GPIOA Interrupt in Group 1
+ */
+#define DL_INTERRUPT_GROUP1_GPIOA               (CPUSS_INT_GROUP_IMASK_INT_INT0)
+/*!
+ *  @brief GPIOB Interrupt in Group 1
+ *  @note This is a device specific interrupt. Please consult the device TRM to
+ *        determine if the interrupt is enabled as part of Group 1 interrupts.
+ */
+#define DL_INTERRUPT_GROUP1_GPIOB               (CPUSS_INT_GROUP_IMASK_INT_INT1)
+/*!
+ *  @brief COMP0 Interrupt in Group 1
+ *  @note This is a device specific interrupt. Please consult the device TRM to
+ *        determine if the interrupt is enabled as part of Group 1 interrupts.
+ */
+#define DL_INTERRUPT_GROUP1_COMP0               (CPUSS_INT_GROUP_IMASK_INT_INT2)
+/*!
+ *  @brief COMP1 Interrupt in Group 1
+ *  @note This is a device specific interrupt. Please consult the device TRM to
+ *        determine if the interrupt is enabled as part of Group 1 interrupts.
+ */
+#define DL_INTERRUPT_GROUP1_COMP1               (CPUSS_INT_GROUP_IMASK_INT_INT3)
+/*!
+ *  @brief COMP2 Interrupt in Group 1
+ *  @note This is a device specific interrupt. Please consult the device TRM to
+ *        determine if the interrupt is enabled as part of Group 1 interrupts.
+ */
+#define DL_INTERRUPT_GROUP1_COMP2               (CPUSS_INT_GROUP_IMASK_INT_INT4)
+/*!
+ *  @brief TRNG Interrupt in Group 1
+ *  @note This is a device specific interrupt. Please consult the device TRM to
+ *        determine if the interrupt is enabled as part of Group 1 interrupts.
+ */
+#define DL_INTERRUPT_GROUP1_TRNG                (CPUSS_INT_GROUP_IMASK_INT_INT5)
+
+/** @}*/
+
+/* clang-format on */
+
+/*! @enum DL_INTERRUPT_GROUP */
+typedef enum {
+    /*! Selects interrupt group 0 */
+    DL_INTERRUPT_GROUP_0 = 0,
+    /*! Selects interrupt group 1 */
+    DL_INTERRUPT_GROUP_1 = 1
+} DL_INTERRUPT_GROUP;
+
+/**
+ *  @brief      Device default Handler
+ *
+ *  This function is defined as part of the device startup file.
+ */
+extern void Default_Handler(void);
+
+/**
+ *  @brief      Checks interrupt flag status in the selected group of interrupts
+ *
+ *  Checks if any of the interrupts in the group are pending. When calling the
+ *  function, ensure that the interrupts passed in the mask are applicable to
+ *  the requested interrupt group.
+ *
+ *  @param[in]  group          Group of interrupts to check.
+ *                             @ref DL_INTERRUPT_GROUP
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_INTERRUPT_GROUP_INTERRUPTS.
+ *
+ *  @return     Which of the requested group interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_INTERRUPT_GROUP_INTERRUPTS values
+ */
+static inline uint32_t DL_Interrupt_getStatusGroup(
+    DL_INTERRUPT_GROUP group, uint32_t interruptMask)
+{
+    return (CPUSS->INT_GROUP[(uint32_t) group].RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority interrupt pending in the selected interrupt
+ *              group
+ *
+ *  @param[in]  group  Group of interrupts to check
+ *
+ *  @return     The highest priority pending interrupt for the group requested.
+ *              One of @ref DL_INTERRUPT_GROUP_IIDX
+ */
+__STATIC_INLINE uint32_t DL_Interrupt_getPendingGroup(DL_INTERRUPT_GROUP group)
+{
+    return (CPUSS->INT_GROUP[group].IIDX);
+}
+
+/**
+ *  @brief      Clear selected interrupt flags in the selected interrupt group
+ *
+ *  Clears any of the desired interrupts in the group. When calling the
+ *  function, ensure that the interrupts passed in the mask are applicable to
+ *  the requested interrupt group.
+ *
+ *  @param[in]  group          Group of interrupts to check.
+ *                             @ref DL_INTERRUPT_GROUP
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_INTERRUPT_GROUP_INTERRUPTS.
+ */
+static inline void DL_Interrupt_clearGroup(
+    DL_INTERRUPT_GROUP group, uint32_t interruptMask)
+{
+    CPUSS->INT_GROUP[(uint32_t) group].ICLR |= interruptMask;
+}
+
+/**
+ *  @brief     Register a function to be called when an interrupt occurs
+ *
+ *  This allows you to register a function to be called during an interrupt,
+ *  allowing you to override the interrupt handler at run time. The function
+ *  moves the interrupt vector table from Flash to SRAM so that the interrupt
+ *  handler functions can be overwritten.
+ *
+ *  This function should only be used if the application requires specifying
+ *  the interrupt handler at run time. If it does not need to be changed at
+ *  run time consider placing the ISR function pointer in the startup file to
+ *  link the function into the interrupt table.
+ *
+ *  Example of usage:
+ *  @code
+ *  DL_Interrupt_registerInterrupt(TIMA0_INT_IRQn, redirectedInterruptHandler);
+*   @endcode
+ *
+ *  @param[in] exceptionNumber  The interrupt number to register the handler.
+ *                              Interrupt numbers are device specific, please
+ *                              consult the device datasheet for valid
+ *                              interrupt numbers.
+ *  @param[in] intHandler       A pointer to a function to call for the desired
+ *                              interrupt
+ */
+void DL_Interrupt_registerInterrupt(
+    uint32_t exceptionNumber, void (*intHandler)(void));
+
+/**
+ *  @brief      Unregister a function to be called when an interrupt occurs
+ *
+ *  Overrides the registered interrupt function to jump into a simple while(1)
+ *  loop rather than the previously registered interrupt function. Requires
+ *  that @ref DL_Interrupt_registerInterrupt was previously called so that the
+ *  interrupt vector table has been moved to RAM.
+ *
+ *  Example of usage:
+ *  @code DL_Interrupt_unregisterInterrupt(TIMA0_INT_IRQn); @endcode
+ *
+ *  @param[in]  exceptionNumber  The interrupt number to unregister.
+ *                               Interrupt numbers are device specific, please
+ *                               consult the device datasheet for valid
+ *                               interrupt numbers.
+ */
+void DL_Interrupt_unregisterInterrupt(uint32_t exceptionNumber);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_dl_m0p_dl_interrupt__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/m0p/dl_sysctl.h
+++ b/mspm0/source/ti/driverlib/m0p/dl_sysctl.h
@@ -1,0 +1,69 @@
+/*****************************************************************************
+
+  Copyright (C) 2020 Texas Instruments Incorporated - http://www.ti.com/
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   Neither the name of Texas Instruments Incorporated nor the names of
+   its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+/* This file automatically includes the specific device header file
+   without the need to include a specific device header.
+   The device #define is set automatically through the toolchain on basis
+   of the device chosen in the device selection menu (.e.g -D__MICRO1__).      */
+/** @defgroup   SYSCTL M0P System Control (SYSCTL) */
+/** @addtogroup SYSCTL
+ * @{
+ */
+
+#ifndef ti_driverlib_m0p_sysctl__include
+#define ti_driverlib_m0p_sysctl__include
+
+/******************************************************************************
+* MSP devices
+******************************************************************************/
+#include <ti/devices/DeviceFamily.h>
+
+#if (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPM0G1X0X_G3X0X)
+#include <ti/driverlib/m0p/sysctl/dl_sysctl_mspm0g1x0x_g3x0x.h>
+#elif (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPM0L11XX_L13XX)
+#include <ti/driverlib/m0p/sysctl/dl_sysctl_mspm0l11xx_l13xx.h>
+#elif (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPM0C110X) || \
+    (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPS003FX)
+#include <ti/driverlib/m0p/sysctl/dl_sysctl_mspm0c110x.h>
+#elif (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPM0L122X_L222X)
+#include <ti/driverlib/m0p/sysctl/dl_sysctl_mspm0l122x_l222x.h>
+
+/********************************************************************
+ *
+ ********************************************************************/
+#else
+#error "Failed to match a default include file"
+#endif
+
+#endif /* ti_driverlib_m0p_sysctl__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/m0p/dl_systick.h
+++ b/mspm0/source/ti/driverlib/m0p/dl_systick.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_systick.h
+ *  @brief      System Tick Timer (SysTick) Driver Library
+ *  @defgroup   SYSTICK M0P System Tick Timer (SysTick)
+ *
+ *  @anchor ti_dl_m0p_dl_systick_Overview
+ *  # Overview
+ *
+ *  SysTick is a simple timer that is part of the Cortex-M architecture. Its
+ *  intended purpose is to provide a periodic interrupt for an RTOS, but it can
+ *  be used for other simple timing purposes.
+ *
+ *  <hr>
+ ******************************************************************************
+ */
+/** @addtogroup SYSTICK
+ * @{
+ */
+#ifndef ti_dl_m0p_dl_systick__include
+#define ti_dl_m0p_dl_systick__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/**
+ *  @brief Redirects DL_SYSTICK_config to CMSIS standard SysTick_Config
+ */
+#define DL_SYSTICK_config(x)                                   SysTick_Config(x)
+
+/* clang-format on */
+
+/**
+ *  @brief     Initializes the System Tick Timer (SysTick)
+ *
+ *  Initializes the System Tick Timer by configuring the desired period. Resets
+ *  the counter so that, once enabled, the SysTick starts counting from 0. Does
+ *  not start the timer or enable the interrupt.
+ *
+ *  @param[in] period       The period in ticks for the SysTick to fire. Value
+ *                          between 0x00000002 - 0x01000000.
+ */
+__STATIC_INLINE void DL_SYSTICK_init(uint32_t period)
+{
+    SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk;
+    SysTick->LOAD = period - (uint32_t) 1;
+    SysTick->VAL  = 0;
+}
+
+/**
+ *  @brief     Set the period for the SysTick
+ *
+ *  Calling this function does not cause the SysTick counter to reload
+ *  immediately. If you want to change the period and reset the counter use
+ *  the @ref DL_SYSTICK_init function or @ref DL_SYSTICK_resetValue.
+ *
+ *  @param[in] period  The period in ticks for the SysTick to fire. Value
+ *                     between 0x00000002 - 0x01000000.
+ */
+__STATIC_INLINE void DL_SYSTICK_setPeriod(uint32_t period)
+{
+    SysTick->LOAD = period - (uint32_t) 1;
+}
+
+/**
+ *  @brief  Reset the current value of the SysTick
+ *
+ *  Resets the current value of the SysTick back to 0, essentially resetting
+ *  the period.
+ */
+__STATIC_INLINE void DL_SYSTICK_resetValue(void)
+{
+    SysTick->VAL = 0;
+}
+
+/**
+ *  @brief   Get the period for the SysTick
+ *
+ *  @return  The period in ticks for the SysTick to fire
+ *
+ *  @retval  Value between 0x00000002 - 0x01000000.
+ */
+__STATIC_INLINE uint32_t DL_SYSTICK_getPeriod(void)
+{
+    return (SysTick->LOAD + (uint32_t) 1);
+}
+
+/**
+ *  @brief   Get the current value of SysTick counter
+ *
+ *  @return  The current value of the counter in ticks
+ *
+ *  @retval  Value between 0x00000000 - 0x00FFFFFF.
+ */
+__STATIC_INLINE uint32_t DL_SYSTICK_getValue(void)
+{
+    return SysTick->VAL;
+}
+
+/**
+ *  @brief  Enable the SysTick interrupt
+ */
+__STATIC_INLINE void DL_SYSTICK_enableInterrupt(void)
+{
+    SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;
+}
+
+/**
+ *  @brief  Disable the SysTick interrupt
+ */
+__STATIC_INLINE void DL_SYSTICK_disableInterrupt(void)
+{
+    SysTick->CTRL &= ~(SysTick_CTRL_TICKINT_Msk);
+}
+
+/**
+ *  @brief  Enable the SysTick, starts counting once enabled
+ *
+ *  Once enabled, the SysTick will start counting from whatever value it was
+ *  disabled with. To ensure a full period, use @ref DL_SYSTICK_init
+ *  or @ref DL_SYSTICK_resetValue before enabling.
+ */
+__STATIC_INLINE void DL_SYSTICK_enable(void)
+{
+    SysTick->CTRL |= (SysTick_CTRL_CLKSOURCE_Msk | SysTick_CTRL_ENABLE_Msk);
+}
+
+/**
+ *  @brief  Disable the SysTick, stops counting once disabled
+ */
+__STATIC_INLINE void DL_SYSTICK_disable(void)
+{
+    SysTick->CTRL &= ~(SysTick_CTRL_ENABLE_Msk);
+}
+
+/**
+ *  @brief   Checks if the SysTick is enabled
+ *
+ *  @return  Returns the enabled status of the SysTick
+ *
+ *  @retval  true  The SysTick is enabled and counting
+ *  @retval  false The SysTick is disabled and not counting
+ */
+__STATIC_INLINE bool DL_SYSTICK_isEnabled(void)
+{
+    return (
+        (SysTick->CTRL & SysTick_CTRL_ENABLE_Msk) == SysTick_CTRL_ENABLE_Msk);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_dl_m0p_dl_systick__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/m0p/sysctl/dl_sysctl_mspm0g1x0x_g3x0x.c
+++ b/mspm0/source/ti/driverlib/m0p/sysctl/dl_sysctl_mspm0g1x0x_g3x0x.c
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <ti/devices/DeviceFamily.h>
+
+#if (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPM0G1X0X_G3X0X)
+
+#include <ti/driverlib/m0p/dl_core.h>
+#include <ti/driverlib/m0p/sysctl/dl_sysctl_mspm0g1x0x_g3x0x.h>
+
+void DL_SYSCTL_configSYSPLL(DL_SYSCTL_SYSPLLConfig *config)
+{
+    /* PLL configurations are retained in lower reset levels. Set default
+     * behavior of disabling the PLL to keep a consistent behavior regardless
+     * of reset level. */
+    DL_SYSCTL_disableSYSPLL();
+
+    /* Check that SYSPLL is disabled before configuration */
+    while ((DL_SYSCTL_getClockStatus() & (DL_SYSCTL_CLK_STATUS_SYSPLL_OFF)) !=
+           (DL_SYSCTL_CLK_STATUS_SYSPLL_OFF)) {
+        ;
+    }
+
+    // set SYSPLL reference clock
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SYSPLLCFG0,
+        ((uint32_t) config->sysPLLRef), SYSCTL_SYSPLLCFG0_SYSPLLREF_MASK);
+
+    // set predivider PDIV (divides reference clock)
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SYSPLLCFG1, ((uint32_t) config->pDiv),
+        SYSCTL_SYSPLLCFG1_PDIV_MASK);
+
+    // save CPUSS CTL state and disable the cache
+    uint32_t ctlTemp = DL_CORE_getInstructionConfig();
+    DL_CORE_configInstruction(DL_CORE_PREFETCH_ENABLED, DL_CORE_CACHE_DISABLED,
+        DL_CORE_LITERAL_CACHE_ENABLED);
+
+    __NOP();
+
+    // populate SYSPLLPARAM0/1 tuning registers from flash, based on input freq
+    SYSCTL->SOCLOCK.SYSPLLPARAM0 =
+        *(volatile uint32_t *) ((uint32_t) config->inputFreq);
+    SYSCTL->SOCLOCK.SYSPLLPARAM1 =
+        *(volatile uint32_t *) ((uint32_t) config->inputFreq + (uint32_t) 0x4);
+
+    // restore CPUSS CTL state
+    CPUSS->CTL = ctlTemp;
+
+    // set feedback divider QDIV (multiplies to give output frequency)
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SYSPLLCFG1,
+        ((config->qDiv << SYSCTL_SYSPLLCFG1_QDIV_OFS) &
+            SYSCTL_SYSPLLCFG1_QDIV_MASK),
+        SYSCTL_SYSPLLCFG1_QDIV_MASK);
+
+    // write clock output dividers, enable outputs, and MCLK source to SYSPLLCFG0
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SYSPLLCFG0,
+        (((config->rDivClk2x << SYSCTL_SYSPLLCFG0_RDIVCLK2X_OFS) &
+             SYSCTL_SYSPLLCFG0_RDIVCLK2X_MASK) |
+            ((config->rDivClk1 << SYSCTL_SYSPLLCFG0_RDIVCLK1_OFS) &
+                SYSCTL_SYSPLLCFG0_RDIVCLK1_MASK) |
+            ((config->rDivClk0 << SYSCTL_SYSPLLCFG0_RDIVCLK0_OFS) &
+                SYSCTL_SYSPLLCFG0_RDIVCLK0_MASK) |
+            config->enableCLK2x | config->enableCLK1 | config->enableCLK0 |
+            (uint32_t) config->sysPLLMCLK),
+        (SYSCTL_SYSPLLCFG0_RDIVCLK2X_MASK | SYSCTL_SYSPLLCFG0_RDIVCLK1_MASK |
+            SYSCTL_SYSPLLCFG0_RDIVCLK0_MASK |
+            SYSCTL_SYSPLLCFG0_ENABLECLK2X_MASK |
+            SYSCTL_SYSPLLCFG0_ENABLECLK1_MASK |
+            SYSCTL_SYSPLLCFG0_ENABLECLK0_MASK |
+            SYSCTL_SYSPLLCFG0_MCLK2XVCO_MASK));
+
+    // enable SYSPLL
+    SYSCTL->SOCLOCK.HSCLKEN |= SYSCTL_HSCLKEN_SYSPLLEN_ENABLE;
+
+    // wait until SYSPLL startup is stabilized
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_SYSPLLGOOD_MASK) !=
+           DL_SYSCTL_CLK_STATUS_SYSPLL_GOOD) {
+        ;
+    }
+}
+
+void DL_SYSCTL_setLFCLKSourceLFXT(DL_SYSCTL_LFCLKConfig *config)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.LFCLKCFG,
+        ((uint32_t) config->lowCap << SYSCTL_LFCLKCFG_LOWCAP_OFS) |
+            (uint32_t) config->xt1Drive,
+        (SYSCTL_LFCLKCFG_XT1DRIVE_MASK | SYSCTL_LFCLKCFG_LOWCAP_MASK));
+    // start the LFXT oscillator
+    SYSCTL->SOCLOCK.LFXTCTL =
+        (SYSCTL_LFXTCTL_KEY_VALUE | SYSCTL_LFXTCTL_STARTLFXT_TRUE);
+    // wait until LFXT oscillator is stable
+    // if it does not stabilize, check the hardware/IOMUX settings
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_LFXTGOOD_MASK) !=
+           DL_SYSCTL_CLK_STATUS_LFXT_GOOD) {
+        ;
+    }
+    if (config->monitor) {
+        // set the LFCLK monitor
+        SYSCTL->SOCLOCK.LFCLKCFG |= SYSCTL_LFCLKCFG_MONITOR_ENABLE;
+    }
+
+    // switch LFCLK source from LFOSC to LFXT
+    SYSCTL->SOCLOCK.LFXTCTL =
+        (SYSCTL_LFXTCTL_KEY_VALUE | SYSCTL_LFXTCTL_SETUSELFXT_TRUE);
+}
+
+void DL_SYSCTL_switchMCLKfromSYSOSCtoLFCLK(bool disableSYSOSC)
+{
+    if (disableSYSOSC == false) {
+        // Set SYSOSC back to base frequency if left enabled
+        DL_SYSCTL_setSYSOSCFreq(DL_SYSCTL_SYSOSC_FREQ_BASE);
+        SYSCTL->SOCLOCK.SYSOSCCFG &= ~SYSCTL_SYSOSCCFG_DISABLE_ENABLE;
+    } else {
+        SYSCTL->SOCLOCK.SYSOSCCFG |= SYSCTL_SYSOSCCFG_DISABLE_ENABLE;
+    }
+    SYSCTL->SOCLOCK.MCLKCFG |= SYSCTL_MCLKCFG_USELFCLK_ENABLE;
+
+    // Verify LFCLK -> MCLK
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_CURMCLKSEL_MASK) !=
+           DL_SYSCTL_CLK_STATUS_MCLK_SOURCE_LFCLK) {
+        ;
+    }
+}
+
+void DL_SYSCTL_switchMCLKfromLFCLKtoSYSOSC(void)
+{
+    // Only one should have been set, but clear both because unknown incoming state
+    // Clear SYSOSCCFG.DISABLE to get SYSOSC running again
+    // Clear MCLKCFG.USELFCLK to switch MCLK source from LFCLK to SYSOSC
+    SYSCTL->SOCLOCK.SYSOSCCFG &= ~SYSCTL_SYSOSCCFG_DISABLE_ENABLE;
+    SYSCTL->SOCLOCK.MCLKCFG &= ~SYSCTL_MCLKCFG_USELFCLK_ENABLE;
+
+    // Verify SYSOSC -> MCLK
+    while (((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_CURMCLKSEL_MASK) ==
+            DL_SYSCTL_CLK_STATUS_MCLK_SOURCE_LFCLK)) {
+        ;
+    }
+}
+
+void DL_SYSCTL_switchMCLKfromSYSOSCtoHSCLK(DL_SYSCTL_HSCLK_SOURCE source)
+{
+    // Assume desired HS sources already enabled per their requirements (SYSPLL, HFXT, HFCLK_IN)
+    // Selected desired HSCLK source
+    DL_SYSCTL_setHSCLKSource(source);
+
+    // Verify HSCLK source is valid
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_HSCLKGOOD_MASK) !=
+           DL_SYSCTL_CLK_STATUS_HSCLK_GOOD) {
+        ;
+    }
+
+    // Switch MCLK to HSCLK
+    SYSCTL->SOCLOCK.MCLKCFG |= SYSCTL_MCLKCFG_USEHSCLK_ENABLE;
+
+    // Verify HSCLK -> MCLK
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_HSCLKMUX_MASK) !=
+           DL_SYSCTL_CLK_STATUS_MCLK_SOURCE_HSCLK) {
+        ;
+    }
+}
+
+void DL_SYSCTL_switchMCLKfromHSCLKtoSYSOSC(void)
+{
+    // Switch MCLK to SYSOSC
+    SYSCTL->SOCLOCK.MCLKCFG &= ~SYSCTL_MCLKCFG_USEHSCLK_ENABLE;
+
+    // Verify SYSOSC -> MCLK
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_HSCLKMUX_MASK) ==
+           DL_SYSCTL_CLK_STATUS_MCLK_SOURCE_HSCLK) {
+        ;
+    }
+}
+
+void DL_SYSCTL_setHFCLKSourceHFXT(DL_SYSCTL_HFXT_RANGE range)
+{
+    /* Some crystal configurations are retained in lower reset levels. Set
+     * default behavior of HFXT to keep a consistent behavior regardless of
+     * reset level. */
+    DL_SYSCTL_disableHFXT();
+
+    DL_SYSCTL_setHFXTFrequencyRange(range);
+    /* Set startup time to ~0.512ms based on TYP datasheet recommendation */
+    DL_SYSCTL_setHFXTStartupTime(8);
+    SYSCTL->SOCLOCK.HSCLKEN |= SYSCTL_HSCLKEN_HFXTEN_ENABLE;
+    DL_SYSCTL_enableHFCLKStartupMonitor();
+    /* Wait until HFXT oscillator is stable. If it does not stabilize, check the
+     hardware/IOMUX settings */
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_HFCLKGOOD_MASK) !=
+           DL_SYSCTL_CLK_STATUS_HFCLK_GOOD) {
+        ;
+    }
+}
+
+void DL_SYSCTL_setHFCLKSourceHFXTParams(
+    DL_SYSCTL_HFXT_RANGE range, uint32_t startupTime, bool monitorEnable)
+{
+    /* Some crystal configurations are retained in lower reset levels. Set
+     * default behavior of HFXT to keep a consistent behavior regardless of
+     * reset level. */
+    DL_SYSCTL_disableHFXT();
+
+    DL_SYSCTL_setHFXTFrequencyRange(range);
+    DL_SYSCTL_setHFXTStartupTime(startupTime);
+    SYSCTL->SOCLOCK.HSCLKEN |= SYSCTL_HSCLKEN_HFXTEN_ENABLE;
+
+    if (monitorEnable == true) {
+        DL_SYSCTL_enableHFCLKStartupMonitor();
+        /* Wait until HFXT oscillator is stable. If it does not stabilize, check the
+        hardware/IOMUX settings */
+        while (
+            (DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_HFCLKGOOD_MASK) !=
+            DL_SYSCTL_CLK_STATUS_HFCLK_GOOD) {
+            ;
+        }
+    } else {
+        DL_SYSCTL_disableHFCLKStartupMonitor();
+    }
+}
+
+void DL_SYSCTL_configFCC(DL_SYSCTL_FCC_TRIG_TYPE trigLvl,
+    DL_SYSCTL_FCC_TRIG_SOURCE trigSrc, DL_SYSCTL_FCC_CLOCK_SOURCE clkSrc)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.GENCLKCFG,
+        (uint32_t) trigLvl | (uint32_t) trigSrc | (uint32_t) clkSrc,
+        SYSCTL_GENCLKCFG_FCCLVLTRIG_MASK | SYSCTL_GENCLKCFG_FCCTRIGSRC_MASK |
+            SYSCTL_GENCLKCFG_FCCSELCLK_MASK);
+}
+
+DL_SYSCTL_POWER_POLICY_RUN_SLEEP DL_SYSCTL_getPowerPolicyRUNSLEEP(void)
+{
+    DL_SYSCTL_POWER_POLICY_RUN_SLEEP policy =
+        DL_SYSCTL_POWER_POLICY_RUN_SLEEP_NOT_ENABLED;
+
+    // Check if SLEEP is enabled
+    if ((SCB->SCR & SCB_SCR_SLEEPDEEP_Msk) != SCB_SCR_SLEEPDEEP_Msk) {
+        // Check which policy is enabled
+        if ((SYSCTL->SOCLOCK.MCLKCFG & SYSCTL_MCLKCFG_USELFCLK_MASK) ==
+            SYSCTL_MCLKCFG_USELFCLK_ENABLE) {
+            policy = DL_SYSCTL_POWER_POLICY_RUN_SLEEP1;
+        } else if ((SYSCTL->SOCLOCK.SYSOSCCFG &
+                       SYSCTL_SYSOSCCFG_DISABLESTOP_MASK) ==
+                   SYSCTL_SYSOSCCFG_DISABLESTOP_ENABLE) {
+            policy = DL_SYSCTL_POWER_POLICY_RUN_SLEEP2;
+        } else {
+            policy = DL_SYSCTL_POWER_POLICY_RUN_SLEEP0;
+        }
+    }
+    return policy;
+}
+
+DL_SYSCTL_POWER_POLICY_STOP DL_SYSCTL_getPowerPolicySTOP(void)
+{
+    DL_SYSCTL_POWER_POLICY_STOP policy =
+        DL_SYSCTL_POWER_POLICY_STOP_NOT_ENABLED;
+
+    // Check if STOP is enabled
+    if ((SYSCTL->SOCLOCK.PMODECFG == SYSCTL_PMODECFG_DSLEEP_STOP) &&
+        (SCB->SCR & SCB_SCR_SLEEPDEEP_Msk) == SCB_SCR_SLEEPDEEP_Msk) {
+        // Check which policy is enabled
+        if ((SYSCTL->SOCLOCK.SYSOSCCFG & SYSCTL_SYSOSCCFG_USE4MHZSTOP_MASK) ==
+            SYSCTL_SYSOSCCFG_USE4MHZSTOP_ENABLE) {
+            policy = DL_SYSCTL_POWER_POLICY_STOP1;
+        } else if ((SYSCTL->SOCLOCK.SYSOSCCFG &
+                       SYSCTL_SYSOSCCFG_DISABLESTOP_MASK) ==
+                   SYSCTL_SYSOSCCFG_DISABLESTOP_ENABLE) {
+            policy = DL_SYSCTL_POWER_POLICY_STOP2;
+        } else {
+            policy = DL_SYSCTL_POWER_POLICY_STOP0;
+        }
+    }
+    return policy;
+}
+
+DL_SYSCTL_POWER_POLICY_STANDBY DL_SYSCTL_getPowerPolicySTANDBY(void)
+{
+    DL_SYSCTL_POWER_POLICY_STANDBY policy =
+        DL_SYSCTL_POWER_POLICY_STANDBY_NOT_ENABLED;
+
+    // Check if STOP is enabled
+    if ((SYSCTL->SOCLOCK.PMODECFG == SYSCTL_PMODECFG_DSLEEP_STANDBY) &&
+        (SCB->SCR & SCB_SCR_SLEEPDEEP_Msk) == SCB_SCR_SLEEPDEEP_Msk) {
+        // Check which policy is enabled
+        if ((SYSCTL->SOCLOCK.MCLKCFG & SYSCTL_MCLKCFG_STOPCLKSTBY_MASK) ==
+            SYSCTL_MCLKCFG_STOPCLKSTBY_ENABLE) {
+            policy = DL_SYSCTL_POWER_POLICY_STANDBY1;
+        } else {
+            policy = DL_SYSCTL_POWER_POLICY_STANDBY0;
+        }
+    }
+    return policy;
+}
+
+#endif /* DeviceFamily_PARENT_MSPM0G1X0X_G3X0X */

--- a/mspm0/source/ti/driverlib/m0p/sysctl/dl_sysctl_mspm0g1x0x_g3x0x.h
+++ b/mspm0/source/ti/driverlib/m0p/sysctl/dl_sysctl_mspm0g1x0x_g3x0x.h
@@ -1,0 +1,2733 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_sysctl_mspm0g1x0x_g3x0x.h
+ *  @brief      System Control (SysCtl)
+ *  @defgroup   SYSCTL_MSPM0G1X0X_G3X0X MSPM0G1X0X_G3X0X System Control (SYSCTL)
+ *
+ *  @anchor ti_dl_m0p_dl_mspm0g1x0x_g3x0x_sysctl_Overview
+ *  # Overview
+ *
+ *  The System Control (SysCtl) module enables control over system wide
+ *  settings like clocks and power management.
+ *
+ *  <hr>
+ *
+ ******************************************************************************
+ */
+/** @addtogroup SYSCTL_MSPM0G1X0X_G3X0X
+ * @{
+ */
+#ifndef ti_dl_m0p_dl_sysctl_sysctl__include
+#define ti_dl_m0p_dl_sysctl_sysctl__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_SYSCTL_RESET
+ *  @{
+ */
+/*!
+ * @brief Perform a CPU reset
+ *
+ * This clears the state of the CPU logic. Peripheral states are not affected
+ */
+ #define DL_SYSCTL_RESET_CPU                       (SYSCTL_RESETLEVEL_LEVEL_CPU)
+
+/*!
+ * @brief Perform a Boot reset
+ *
+ * This triggers execution of the device boot configuration routine and resets
+ * the majority of the core logic while also power cycling the SRAM
+ */
+ #define DL_SYSCTL_RESET_BOOT                     (SYSCTL_RESETLEVEL_LEVEL_BOOT)
+
+/*!
+ * @brief Perform a POR reset
+ *
+ * This performas a POR reset which is a complete device reset
+ */
+ #define DL_SYSCTL_RESET_POR                       (SYSCTL_RESETLEVEL_LEVEL_POR)
+
+/*!
+ * @brief Perform system reset and exit bootloader to the application
+ */
+ #define DL_SYSCTL_RESET_BOOTLOADER_EXIT                                       \
+                                        (SYSCTL_RESETLEVEL_LEVEL_BOOTLOADEREXIT)
+
+ /*!
+ * @brief Perform system reset and run bootloader
+ */
+ #define DL_SYSCTL_RESET_BOOTLOADER_ENTRY                                      \
+                                       (SYSCTL_RESETLEVEL_LEVEL_BOOTLOADERENTRY)
+
+
+/** @addtogroup DL_SYSCTL_NMI
+ *  @{
+ */
+/*! @brief  Non-maskable interrupt for SRAM Double Error Detect */
+#define DL_SYSCTL_NMI_SRAM_DED                      (SYSCTL_NMIISET_SRAMDED_SET)
+/*! @brief  Non-maskable interrupt for Flash Double Error Detect */
+#define DL_SYSCTL_NMI_FLASH_DED                    (SYSCTL_NMIISET_FLASHDED_SET)
+/*! @brief  Non-maskable interrupt for LFCLK Monitor Fail */
+#define DL_SYSCTL_NMI_LFCLK_FAIL                  (SYSCTL_NMIISET_LFCLKFAIL_SET)
+/*! @brief  Non-maskable interrupt for Watchdog 1 Fault */
+#define DL_SYSCTL_NMI_WWDT1_FAULT                     (SYSCTL_NMIISET_WWDT1_SET)
+/*! @brief  Non-maskable interrupt for Watchdog 0 Fault */
+#define DL_SYSCTL_NMI_WWDT0_FAULT                     (SYSCTL_NMIISET_WWDT0_SET)
+/*! @brief  Non-maskable interrupt for early BOR */
+#define DL_SYSCTL_NMI_BORLVL                         (SYSCTL_NMIISET_BORLVL_SET)
+/** @}*/
+
+/** @addtogroup DL_SYSCTL_INTERRUPT
+ *  @{
+ */
+/*! @brief  Low Frequency Oscillator is stabilized and ready to use */
+#define DL_SYSCTL_INTERRUPT_LFOSC_GOOD           (SYSCTL_IMASK_LFOSCGOOD_ENABLE)
+/*! @brief  Analog clocking consistency error */
+#define DL_SYSCTL_INTERRUPT_ANALOG_CLOCK_ERROR   (SYSCTL_IMASK_ANACLKERR_ENABLE)
+/*! @brief  Flash Single Error Correct */
+#define DL_SYSCTL_INTERRUPT_FLASH_SEC             (SYSCTL_IMASK_FLASHSEC_ENABLE)
+
+/*! @brief  SRAM Single Error Correct */
+#define DL_SYSCTL_INTERRUPT_SRAM_SEC               (SYSCTL_IMASK_SRAMSEC_ENABLE)
+
+/*! @brief  Low Frequency Crystal is stabilized and ready to use */
+#define DL_SYSCTL_INTERRUPT_LFXT_GOOD             (SYSCTL_IMASK_LFXTGOOD_ENABLE)
+/*! @brief  High Frequency Clock is stabilized and ready to use */
+#define DL_SYSCTL_INTERRUPT_HFCLK_GOOD           (SYSCTL_IMASK_HFCLKGOOD_ENABLE)
+/*! @brief  System PLL is stabilized and ready to use */
+#define DL_SYSCTL_INTERRUPT_SYSPLL_GOOD         (SYSCTL_IMASK_SYSPLLGOOD_ENABLE)
+/*! @brief  High Speed Clock is stabilized and ready to use */
+#define DL_SYSCTL_INTERRUPT_HSCLK_GOOD           (SYSCTL_IMASK_HSCLKGOOD_ENABLE)
+/** @}*/
+
+/** @addtogroup DL_SYSCTL_CLK_STATUS
+ *  @{
+ */
+/*! @brief Error with Anacomp High Speed CP Clock Generation - SYSOSC must not
+ *         run at 4MHz */
+#define DL_SYSCTL_CLK_STATUS_ANACOMP_ERROR (SYSCTL_CLKSTATUS_ACOMPHSCLKERR_TRUE)
+/*! @brief Error with OPAMP Clock Generation */
+#define DL_SYSCTL_CLK_STATUS_OPAMP_ERROR     (SYSCTL_CLKSTATUS_OPAMPCLKERR_TRUE)
+/*! @brief Writes to SYSPLLCFG0-1, SYSPLLPARAM0-1 are blocked */
+#define DL_SYSCTL_CLK_STATUS_SYSPLL_CONFIG_BLOCKED                             \
+                                            (SYSCTL_CLKSTATUS_SYSPLLBLKUPD_TRUE)
+/*! @brief Writes to HFCLKCLKCFG are blocked */
+#define DL_SYSCTL_CLK_STATUS_HFCLK_CONFIG_BLOCKED                              \
+                                             (SYSCTL_CLKSTATUS_HFCLKBLKUPD_TRUE)
+/*! @brief SYSOSC Frequency Correcting Loop Mode ON */
+#define DL_SYSCTL_CLK_STATUS_FCL_ON           (SYSCTL_CLKSTATUS_FCLMODE_ENABLED)
+/*! @brief Clock Fail for LFXT or EXLF clock source */
+#define DL_SYSCTL_CLK_STATUS_LFCLK_FAIL        (SYSCTL_CLKSTATUS_LFCLKFAIL_TRUE)
+/*! @brief High Speed Clock Good */
+#define DL_SYSCTL_CLK_STATUS_HSCLK_GOOD        (SYSCTL_CLKSTATUS_HSCLKGOOD_TRUE)
+/*! @brief High Speed Clock Stuck Fault */
+#define DL_SYSCTL_CLK_STATUS_HSCLK_FAULT       (SYSCTL_CLKSTATUS_HSCLKDEAD_TRUE)
+/*! @brief SYSPLL is OFF or DEAD */
+#define DL_SYSCTL_CLK_STATUS_SYSPLL_OFF        (SYSCTL_CLKSTATUS_SYSPLLOFF_TRUE)
+/*! @brief HFCLKs is OFF or DEAD */
+#define DL_SYSCTL_CLK_STATUS_HFCLK_OFF          (SYSCTL_CLKSTATUS_HFCLKOFF_TRUE)
+/*! @brief All PLLs, HFCLKs are OFF or DEAD */
+#define DL_SYSCTL_CLK_STATUS_HSCLK_OFF         (SYSCTL_CLKSTATUS_HSCLKSOFF_TRUE)
+/*! @brief LFOSC is Valid */
+#define DL_SYSCTL_CLK_STATUS_LFOSC_GOOD        (SYSCTL_CLKSTATUS_LFOSCGOOD_TRUE)
+/*! @brief LFXT is Valid */
+#define DL_SYSCTL_CLK_STATUS_LFXT_GOOD          (SYSCTL_CLKSTATUS_LFXTGOOD_TRUE)
+/*! @brief SYSTEM PLL ON */
+#define DL_SYSCTL_CLK_STATUS_SYSPLL_GOOD      (SYSCTL_CLKSTATUS_SYSPLLGOOD_TRUE)
+/*! @brief High Frequency Clock ON */
+#define DL_SYSCTL_CLK_STATUS_HFCLK_GOOD        (SYSCTL_CLKSTATUS_HFCLKGOOD_TRUE)
+/*! @brief MCLK now sourced from HSCLK, otherwise SYSOSC */
+#define DL_SYSCTL_CLK_STATUS_MCLK_SOURCE_HSCLK (SYSCTL_CLKSTATUS_HSCLKMUX_HSCLK)
+/*! @brief MCLK now sourced from LFCLK */
+#define DL_SYSCTL_CLK_STATUS_MCLK_SOURCE_LFCLK                                 \
+                                             (SYSCTL_CLKSTATUS_CURMCLKSEL_LFCLK)
+/*! @brief Analog clocking error */
+#define DL_SYSCTL_CLK_STATUS_ANALOG_CLOCK_ERROR                                \
+                                               (SYSCTL_CLKSTATUS_ANACLKERR_TRUE)
+/*! @brief Frequency Clock Counter (FCC) done */
+#define DL_SYSCTL_CLK_STATUS_FCC_DONE            (SYSCTL_CLKSTATUS_FCCDONE_DONE)
+/*! @brief = LFCLK sourced from the LFXT (crystal) */
+#define DL_SYSCTL_CLK_STATUS_LFCLK_SOURCE_LFXT  (SYSCTL_CLKSTATUS_LFCLKMUX_LFXT)
+/*! @brief = LFCLK sourced from LFCLK_IN (external digital clock input) */
+#define DL_SYSCTL_CLK_STATUS_LFCLK_SOURCE_EXLF  (SYSCTL_CLKSTATUS_LFCLKMUX_EXLF)
+/*! @brief = SYSOSC is at low frequency (4MHz) */
+#define DL_SYSCTL_CLK_STATUS_SYSOSC_4MHZ  (SYSCTL_CLKSTATUS_SYSOSCFREQ_SYSOSC4M)
+/*! @brief = SYSOSC is at the user-trimmed frequency (16 or 24MHz) */
+#define DL_SYSCTL_CLK_STATUS_SYSOSC_USERTRIM_FREQ                              \
+                                        (SYSCTL_CLKSTATUS_SYSOSCFREQ_SYSOSCUSER)
+/*! @brief = HSCLK current sourced from the HFCLK */
+#define DL_SYSCTL_CLK_STATUS_HSCLK_SOURCE_HFCLK                                \
+                                            (SYSCTL_CLKSTATUS_CURHSCLKSEL_HFCLK)
+/** @}*/
+
+/** @addtogroup DL_SYSCTL_STATUS
+ *  @{
+ */
+
+/*! @brief IO is locked due to SHUTDOWN */
+#define DL_SYSCTL_STATUS_SHUTDOWN_IO_LOCK_TRUE                                 \
+                                              (SYSCTL_SYSSTATUS_SHDNIOLOCK_TRUE)
+/*! @brief User has disabled external reset pin */
+#define DL_SYSCTL_STATUS_EXT_RESET_PIN_DISABLED                                \
+                                            (SYSCTL_SYSSTATUS_EXTRSTPINDIS_TRUE)
+/*! @brief User has disabled SWD port  */
+#define DL_SYSCTL_STATUS_SWD_DISABLED          (SYSCTL_SYSSTATUS_SWDCFGDIS_TRUE)
+
+/*! @brief PMU IFREF good */
+#define DL_SYSCTL_STATUS_PMU_IFREF_GOOD      (SYSCTL_SYSSTATUS_PMUIREFGOOD_TRUE)
+/*! @brief VBOOST (Analog Charge Pump) started up properly */
+#define DL_SYSCTL_STATUS_VBOOST_GOOD        (SYSCTL_SYSSTATUS_ANACPUMPGOOD_TRUE)
+/*! @brief Brown Out Reset event status indicator */
+#define DL_SYSCTL_STATUS_BOR_EVENT                (SYSCTL_SYSSTATUS_BORLVL_TRUE)
+/*! @brief MCAN0 ready */
+#define DL_SYSCTL_STATUS_MCAN0_READY          (SYSCTL_SYSSTATUS_MCAN0READY_TRUE)
+/*! @brief Double Error Detect on Flash */
+#define DL_SYSCTL_STATUS_FLASH_DED              (SYSCTL_SYSSTATUS_FLASHDED_TRUE)
+/*! @brief Single Error Correction on Flash */
+#define DL_SYSCTL_STATUS_FLASH_SEC              (SYSCTL_SYSSTATUS_FLASHSEC_TRUE)
+/*! @brief Current Brown Out Reset minimum level */
+#define DL_SYSCTL_STATUS_BOR_LEVEL0                                            \
+                                  (SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVELMIN)
+/*! @brief Current Brown Out Reset level 1 */
+#define DL_SYSCTL_STATUS_BOR_LEVEL1 (SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVEL1)
+/*! @brief Current Brown Out Reset level 2 */
+#define DL_SYSCTL_STATUS_BOR_LEVEL2 (SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVEL2)
+/*! @brief Current Brown Out Reset level 3 */
+#define DL_SYSCTL_STATUS_BOR_LEVEL3 (SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVEL3)
+/** @}*/
+
+/** @addtogroup DL_SYSCTL_SYSPLL_CLK2X
+ *  @{
+ */
+/*! @brief Enable CLK2x output */
+#define DL_SYSCTL_SYSPLL_CLK2X_ENABLE     (SYSCTL_SYSPLLCFG0_ENABLECLK2X_ENABLE)
+
+/*! @brief Disable CLK2x output */
+#define DL_SYSCTL_SYSPLL_CLK2X_DISABLE    (SYSCTL_SYSPLLCFG0_ENABLECLK2X_DISABLE)
+/** @}*/
+
+/** @addtogroup DL_SYSCTL_SYSPLL_CLK1
+ *  @{
+ */
+/*! @brief Enable CLK1 output */
+#define DL_SYSCTL_SYSPLL_CLK1_ENABLE       (SYSCTL_SYSPLLCFG0_ENABLECLK1_ENABLE)
+
+/*! @brief Disable CLK1 output */
+#define DL_SYSCTL_SYSPLL_CLK1_DISABLE     (SYSCTL_SYSPLLCFG0_ENABLECLK1_DISABLE)
+/** @}*/
+
+/** @addtogroup DL_SYSCTL_SYSPLL_CLK0
+ *  @{
+ */
+/*! @brief Enable CLK0 output */
+#define DL_SYSCTL_SYSPLL_CLK0_ENABLE       (SYSCTL_SYSPLLCFG0_ENABLECLK0_ENABLE)
+
+/*! @brief Disable CLK0 output */
+#define DL_SYSCTL_SYSPLL_CLK0_DISABLE     (SYSCTL_SYSPLLCFG0_ENABLECLK0_DISABLE)
+/** @}*/
+
+/* clang-format on */
+
+/*! @enum DL_SYSCTL_SYSPLL_MCLK */
+typedef enum {
+    /*! Use PLL CLK2x as source for MCLK */
+    DL_SYSCTL_SYSPLL_MCLK_CLK2X = SYSCTL_SYSPLLCFG0_MCLK2XVCO_ENABLE,
+    /*! Use PLL CLK0 as source for MCLK */
+    DL_SYSCTL_SYSPLL_MCLK_CLK0 = SYSCTL_SYSPLLCFG0_MCLK2XVCO_DISABLE,
+} DL_SYSCTL_SYSPLL_MCLK;
+
+/*! @enum DL_SYSCTL_SYSPLL_REF */
+typedef enum {
+    /*! Use SYSOSC as input source for SYSPLL */
+    DL_SYSCTL_SYSPLL_REF_SYSOSC = SYSCTL_SYSPLLCFG0_SYSPLLREF_SYSOSC,
+    /*! Use HFCLK as input source for SYSPLL */
+    DL_SYSCTL_SYSPLL_REF_HFCLK = SYSCTL_SYSPLLCFG0_SYSPLLREF_HFCLK,
+} DL_SYSCTL_SYSPLL_REF;
+
+/*! @enum DL_SYSCTL_SYSPLL_PDIV */
+typedef enum {
+    /*! Predivide input reference freq to PLL feedback loop by 1 */
+    DL_SYSCTL_SYSPLL_PDIV_1 = SYSCTL_SYSPLLCFG1_PDIV_REFDIV1,
+    /*! Predivide input reference freq to PLL feedback loop by 2 */
+    DL_SYSCTL_SYSPLL_PDIV_2 = SYSCTL_SYSPLLCFG1_PDIV_REFDIV2,
+    /*! Predivide input reference freq to PLL feedback loop by 4 */
+    DL_SYSCTL_SYSPLL_PDIV_4 = SYSCTL_SYSPLLCFG1_PDIV_REFDIV4,
+    /*! Predivide input reference freq to PLL feedback loop by 8 */
+    DL_SYSCTL_SYSPLL_PDIV_8 = SYSCTL_SYSPLLCFG1_PDIV_REFDIV8,
+} DL_SYSCTL_SYSPLL_PDIV;
+
+/** @enum DL_SYSCTL_SYSPLL_INPUT_FREQ */
+typedef enum {
+    /*! PLL feedback loop input clock frequency [4MHz, 8MHz) */
+    DL_SYSCTL_SYSPLL_INPUT_FREQ_4_8_MHZ = 0x41C4001C,
+    /*! PLL feedback loop input clock frequency [8MHz, 16MHz) */
+    DL_SYSCTL_SYSPLL_INPUT_FREQ_8_16_MHZ = 0x41C40024,
+    /*! PLL feedback loop input clock frequency [16MHz, 32MHz) */
+    DL_SYSCTL_SYSPLL_INPUT_FREQ_16_32_MHZ = 0x41C4002C,
+    /*! PLL feedback loop input clock frequency [32MHz, 48MHz] */
+    DL_SYSCTL_SYSPLL_INPUT_FREQ_32_48_MHZ = 0x41C40034,
+} DL_SYSCTL_SYSPLL_INPUT_FREQ;
+
+/*! @brief  Configuration struct for @ref DL_SYSCTL_configSYSPLL. */
+typedef struct {
+    /*! Output divider for CLK2x. [0x0,0xF,0x1] => [/1,/16,1] */
+    uint32_t rDivClk2x;
+    /*! Output divider for CLK1. [0x0,0xF,0x1] => [/2,/32,2] */
+    uint32_t rDivClk1;
+    /*! Output divider for CLK0. [0x0,0xF,0x1] => [/2,/32,2] */
+    uint32_t rDivClk0;
+    /*! PLL CLK2x output enabled or not. @ref DL_SYSCTL_SYSPLL_CLK2X */
+    uint32_t enableCLK2x;
+    /*! PLL CLK2x output enabled or not. @ref DL_SYSCTL_SYSPLL_CLK1 */
+    uint32_t enableCLK1;
+    /*! PLL CLK2x output enabled or not. @ref DL_SYSCTL_SYSPLL_CLK0 */
+    uint32_t enableCLK0;
+    /*! Select which PLL output to use as source for MCLK. @ref DL_SYSCTL_SYSPLL_MCLK */
+    DL_SYSCTL_SYSPLL_MCLK sysPLLMCLK;
+    /*! SYSPLL reference clock source. @ref DL_SYSCTL_SYSPLL_REF */
+    DL_SYSCTL_SYSPLL_REF sysPLLRef;
+    /*! PLL feedback clock divider. [0x01,0x7F,1] => [/1,/127,1] */
+    uint32_t qDiv;
+    /*! PLL reference clock divider. @ref DL_SYSCTL_SYSPLL_PDIV */
+    DL_SYSCTL_SYSPLL_PDIV pDiv;
+    /*! PLL feedback loop input clock frequency. Affects startup time and power consumption. @ref DL_SYSCTL_SYSPLL_INPUT_FREQ */
+    DL_SYSCTL_SYSPLL_INPUT_FREQ inputFreq;
+} DL_SYSCTL_SYSPLLConfig;
+
+/*! @enum DL_SYSCTL_NMI_IIDX */
+typedef enum {
+    /*! @brief  NMI interrupt index for SRAM Double Error Detect */
+    DL_SYSCTL_NMI_IIDX_SRAM_DED = SYSCTL_NMIIIDX_STAT_SRAMDED,
+    /*! @brief  NMI interrupt index for Flash Double Error Detect */
+    DL_SYSCTL_NMI_IIDX_FLASH_DED = SYSCTL_NMIIIDX_STAT_FLASHDED,
+    /*! @brief  NMI interrupt index for LFCLK Monitor Fail */
+    DL_SYSCTL_NMI_IIDX_LFCLK_FAIL = SYSCTL_NMIIIDX_STAT_LFCLKFAIL,
+    /*! @brief  NMI interrupt index for Watchdog 1 Fault */
+    DL_SYSCTL_NMI_IIDX_WWDT1_FAULT = SYSCTL_NMIIIDX_STAT_WWDT1,
+    /*! @brief  NMI interrupt index for Watchdog 0 Fault */
+    DL_SYSCTL_NMI_IIDX_WWDT0_FAULT = SYSCTL_NMIIIDX_STAT_WWDT0,
+    /*! @brief  NMI interrupt index for early BOR */
+    DL_SYSCTL_NMI_IIDX_BORLVL = SYSCTL_NMIIIDX_STAT_BORLVL,
+    /*! @brief  NMI interrupt index for no interrupt pending */
+    DL_SYSCTL_NMI_IIDX_NO_INT = SYSCTL_NMIIIDX_STAT_NO_INTR,
+} DL_SYSCTL_NMI_IIDX;
+
+/** @}*/
+
+/*! @enum DL_SYSCTL_IIDX */
+typedef enum {
+    /*! @brief  Low Frequency Oscillator is stabilized and ready to use */
+    DL_SYSCTL_IIDX_LFOSC_GOOD = SYSCTL_IIDX_STAT_LFOSCGOOD,
+    /*! @brief  Analog clocking consistency error */
+    DL_SYSCTL_IIDX_ANALOG_CLOCK_ERROR = SYSCTL_IIDX_STAT_ANACLKERR,
+    /*! @brief  Flash Single Error Correct */
+    DL_SYSCTL_IIDX_FLASH_SEC = SYSCTL_IIDX_STAT_FLASHSEC,
+
+    /*! @brief  SRAM Single Error Correct */
+    DL_SYSCTL_IIDX_SRAM_SEC = SYSCTL_IIDX_STAT_SRAMSEC,
+
+    /*! @brief  Low Frequency Crystal is stabilized and ready to use */
+    DL_SYSCTL_IIDX_LFXT_GOOD = SYSCTL_IIDX_STAT_LFXTGOOD,
+    /*! @brief  High Frequency Clock is stabilized and ready to use */
+    DL_SYSCTL_IIDX_HFCLK_GOOD = SYSCTL_IIDX_STAT_HFCLKGOOD,
+    /*! @brief  System PLL is stabilized and ready to use */
+    DL_SYSCTL_IIDX_SYSPLL_GOOD = SYSCTL_IIDX_STAT_SYSPLLGOOD,
+    /*! @brief  High Speed Clock is stabilized and ready to use */
+    DL_SYSCTL_IIDX_HSCLK_GOOD = SYSCTL_IIDX_STAT_HSCLKGOOD,
+} DL_SYSCTL_IIDX;
+
+/*! @enum DL_SYSCTL_ERROR_BEHAVIOR */
+typedef enum {
+    /*! @brief  The error event will trigger a SYSRST */
+    DL_SYSCTL_ERROR_BEHAVIOR_RESET = 0x0,
+    /*! @brief  The error event will trigger an NMI */
+    DL_SYSCTL_ERROR_BEHAVIOR_NMI = 0x1,
+} DL_SYSCTL_ERROR_BEHAVIOR;
+
+/*! @enum DL_SYSCTL_SYSOSC_FREQ */
+typedef enum {
+    /*! Use 4MHz for System Oscillator (SYSOSC) */
+    DL_SYSCTL_SYSOSC_FREQ_4M = (SYSCTL_SYSOSCCFG_FREQ_SYSOSC4M),
+    /*! Use BASE (32MHz) for System Oscillator (SYSOSC) */
+    DL_SYSCTL_SYSOSC_FREQ_BASE = (SYSCTL_SYSOSCCFG_FREQ_SYSOSCBASE),
+    /*! User will trim the System Oscillator (SYSOSC) to 16MHz or 24MHz */
+    DL_SYSCTL_SYSOSC_FREQ_USERTRIM = (SYSCTL_SYSOSCCFG_FREQ_SYSOSCUSER),
+} DL_SYSCTL_SYSOSC_FREQ;
+
+/** @enum DL_SYSCTL_SYSOSC_USERTRIM_FREQ */
+typedef enum {
+    /*! Set SYSOSC user trim frequency target to 16MHz */
+    DL_SYSCTL_SYSOSC_USERTRIM_FREQ_16M =
+        (SYSCTL_SYSOSCTRIMUSER_FREQ_SYSOSC16M),
+    /*! Set SYSOSC user trim frequency target to 24MHz */
+    DL_SYSCTL_SYSOSC_USERTRIM_FREQ_24M =
+        (SYSCTL_SYSOSCTRIMUSER_FREQ_SYSOSC24M),
+} DL_SYSCTL_SYSOSC_USERTRIM_FREQ;
+
+/*! @brief  Configuration struct for @ref DL_SYSCTL_configSYSOSCUserTrim. */
+typedef struct {
+    /*! Frequency Correcting Loop resistor divide value [0x0, 0x1FF] */
+    uint32_t rDiv;
+    /*! Resistor fine trim [0x0, 0xF] */
+    uint32_t resistorFine;
+    /*! Resistor coarse trim [0x0, 0x3F] */
+    uint32_t resistorCoarse;
+    /*! Capacitor trim [0x0, 0x7] */
+    uint32_t capacitor;
+    /*! SYSOSC user trim frequency target */
+    DL_SYSCTL_SYSOSC_USERTRIM_FREQ freq;
+} DL_SYSCTL_SYSOSCUserTrimConfig;
+
+/** @enum DL_SYSCTL_ULPCLK_DIV */
+typedef enum {
+    /*! ULPCLK is MCLK */
+    DL_SYSCTL_ULPCLK_DIV_1 = (SYSCTL_MCLKCFG_UDIV_NODIVIDE),
+    /*! ULPCLK is MCLK divided by 2 */
+    DL_SYSCTL_ULPCLK_DIV_2 = (SYSCTL_MCLKCFG_UDIV_DIVIDE2),
+    /*! ULPCLK is MCLK divided by 3 */
+    DL_SYSCTL_ULPCLK_DIV_3 = (SYSCTL_MCLKCFG_UDIV_DIVIDE3),
+} DL_SYSCTL_ULPCLK_DIV;
+
+/** @enum DL_SYSCTL_LFXT_DRIVE_STRENGTH */
+typedef enum {
+    /*! Lowest Drive and Current */
+    DL_SYSCTL_LFXT_DRIVE_STRENGTH_LOWEST =
+        (SYSCTL_LFCLKCFG_XT1DRIVE_LOWESTDRV),
+    /*! Lower Drive and Current */
+    DL_SYSCTL_LFXT_DRIVE_STRENGTH_LOWER = (SYSCTL_LFCLKCFG_XT1DRIVE_LOWERDRV),
+    /*! Higher Drive and Current */
+    DL_SYSCTL_LFXT_DRIVE_STRENGTH_HIGHER =
+        (SYSCTL_LFCLKCFG_XT1DRIVE_HIGHERDRV),
+    /*! Highest Drive and Current */
+    DL_SYSCTL_LFXT_DRIVE_STRENGTH_HIGHEST =
+        (SYSCTL_LFCLKCFG_XT1DRIVE_HIGHESTDRV),
+} DL_SYSCTL_LFXT_DRIVE_STRENGTH;
+
+/*! @brief  Configuration struct for @ref DL_SYSCTL_LFCLKConfig. */
+typedef struct {
+    /*! Enable if CAP is less than 3pF to reduce power consumption */
+    bool lowCap;
+    /*! Enable to use monitor for LFXT, EXLF failure */
+    bool monitor;
+    /*! Drive strength and power consumption option */
+    DL_SYSCTL_LFXT_DRIVE_STRENGTH xt1Drive;
+} DL_SYSCTL_LFCLKConfig;
+
+/** @enum DL_SYSCTL_HFXT_RANGE */
+typedef enum {
+    /*! HFXT frequency range between 4 and 8 MHz */
+    DL_SYSCTL_HFXT_RANGE_4_8_MHZ = SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE4TO8,
+    /*! HFXT frequency range between 8.01 and 16 MHz */
+    DL_SYSCTL_HFXT_RANGE_8_16_MHZ = SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE8TO16,
+    /*! HFXT frequency range between 16.01 and 32 MHz */
+    DL_SYSCTL_HFXT_RANGE_16_32_MHZ = SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE16TO32,
+    /*! HFXT frequency range between 32.01 and 48 MHz */
+    DL_SYSCTL_HFXT_RANGE_32_48_MHZ = SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE32TO48,
+} DL_SYSCTL_HFXT_RANGE;
+
+/*! @enum DL_SYSCTL_HSCLK_SOURCE */
+typedef enum {
+    /*! Use SYSPLL as input source for HSCLK */
+    DL_SYSCTL_HSCLK_SOURCE_SYSPLL = SYSCTL_HSCLKCFG_HSCLKSEL_SYSPLL,
+    /*! Use HFLK as input source for HSCLK */
+    DL_SYSCTL_HSCLK_SOURCE_HFCLK = SYSCTL_HSCLKCFG_HSCLKSEL_HFCLKCLK,
+} DL_SYSCTL_HSCLK_SOURCE;
+
+/** @enum DL_SYSCTL_MCLK_SOURCE */
+typedef enum {
+    /*! Use System Oscillator (SYSOSC) as MCLK source (default after reset) */
+    DL_SYSCTL_MCLK_SOURCE_SYSOSC = SYSCTL_MCLKCFG_USEHSCLK_DISABLE,
+    /*! Use High Speed Clock (HSCLK) as MCLK source (HFCLK, PLL,...) */
+    DL_SYSCTL_MCLK_SOURCE_HSCLK = SYSCTL_MCLKCFG_USEHSCLK_ENABLE,
+    /*! Use the Low Frequency Clock (LFCLK) as the clock source */
+    DL_SYSCTL_MCLK_SOURCE_LFCLK = SYSCTL_MCLKCFG_USELFCLK_ENABLE,
+} DL_SYSCTL_MCLK_SOURCE;
+
+/** @enum DL_SYSCTL_MCLK_DIVIDER */
+typedef enum {
+    /*! Disable MCLK divider. Change SYSOSC freq only when MDIV is disabled */
+    DL_SYSCTL_MCLK_DIVIDER_DISABLE = 0x0,
+    /*! Divide MCLK frequency by 2 */
+    DL_SYSCTL_MCLK_DIVIDER_2 = 0x1,
+    /*! Divide MCLK frequency by 3 */
+    DL_SYSCTL_MCLK_DIVIDER_3 = 0x2,
+    /*! Divide MCLK frequency by 4 */
+    DL_SYSCTL_MCLK_DIVIDER_4 = 0x3,
+    /*! Divide MCLK frequency by 5 */
+    DL_SYSCTL_MCLK_DIVIDER_5 = 0x4,
+    /*! Divide MCLK frequency by 6 */
+    DL_SYSCTL_MCLK_DIVIDER_6 = 0x5,
+    /*! Divide MCLK frequency by 7 */
+    DL_SYSCTL_MCLK_DIVIDER_7 = 0x6,
+    /*! Divide MCLK frequency by 8 */
+    DL_SYSCTL_MCLK_DIVIDER_8 = 0x7,
+    /*! Divide MCLK frequency by 9 */
+    DL_SYSCTL_MCLK_DIVIDER_9 = 0x8,
+    /*! Divide MCLK frequency by 10 */
+    DL_SYSCTL_MCLK_DIVIDER_10 = 0x9,
+    /*! Divide MCLK frequency by 11 */
+    DL_SYSCTL_MCLK_DIVIDER_11 = 0xA,
+    /*! Divide MCLK frequency by 12 */
+    DL_SYSCTL_MCLK_DIVIDER_12 = 0xB,
+    /*! Divide MCLK frequency by 13 */
+    DL_SYSCTL_MCLK_DIVIDER_13 = 0xC,
+    /*! Divide MCLK frequency by 14 */
+    DL_SYSCTL_MCLK_DIVIDER_14 = 0xD,
+    /*! Divide MCLK frequency by 15 */
+    DL_SYSCTL_MCLK_DIVIDER_15 = 0xE,
+    /*! Divide MCLK frequency by 16 */
+    DL_SYSCTL_MCLK_DIVIDER_16 = 0xF,
+} DL_SYSCTL_MCLK_DIVIDER;
+
+/** @enum DL_SYSCTL_CLK_OUT_SOURCE */
+typedef enum {
+    /*! Use System Oscillator (SYSOSC) as CLK_OUT source */
+    DL_SYSCTL_CLK_OUT_SOURCE_SYSOSC = SYSCTL_GENCLKCFG_EXCLKSRC_SYSOSC,
+    /*! Use Ultra Low Power Clock (ULPCLK) as CLK_OUT source.
+      * @ref DL_SYSCTL_CLK_OUT_DIVIDE_DISABLE must not be selected for this
+      * configuration.  */
+    DL_SYSCTL_CLK_OUT_SOURCE_ULPCLK = SYSCTL_GENCLKCFG_EXCLKSRC_ULPCLK,
+    /*! Use Low Frequency Clock (LFCLK) as CLK_OUT source */
+    DL_SYSCTL_CLK_OUT_SOURCE_LFCLK = SYSCTL_GENCLKCFG_EXCLKSRC_LFCLK,
+    /*! Use Middle Frequency Precision Clock (MFPCLK) as CLK_OUT source.
+      * @ref DL_SYSCTL_CLK_OUT_DIVIDE_DISABLE must not be selected for this
+      * configuration.  */
+    DL_SYSCTL_CLK_OUT_SOURCE_MFPCLK = SYSCTL_GENCLKCFG_EXCLKSRC_MFPCLK,
+    /*! Use High Frequency Clock (HFCLK) as CLK_OUT source */
+    DL_SYSCTL_CLK_OUT_SOURCE_HFCLK = SYSCTL_GENCLKCFG_EXCLKSRC_HFCLK,
+    /*! Use System PLL Output 1 (SYSPLLOUT1) as CLK_OUT source */
+    DL_SYSCTL_CLK_OUT_SOURCE_SYSPLLOUT1 = SYSCTL_GENCLKCFG_EXCLKSRC_SYSPLLOUT1,
+} DL_SYSCTL_CLK_OUT_SOURCE;
+
+/** @enum DL_SYSCTL_CLK_OUT_DIVIDE */
+typedef enum {
+    /*! Disable the External Clock (CLK_OUT) output divider */
+    DL_SYSCTL_CLK_OUT_DIVIDE_DISABLE = SYSCTL_GENCLKCFG_EXCLKDIVEN_PASSTHRU,
+    /*! Divide External Clock (CLK_OUT) output by 2 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_2 =
+        SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE | SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV2,
+    /*! Divide External Clock (CLK_OUT) output by 4 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_4 =
+        SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE | SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV4,
+    /*! Divide External Clock (CLK_OUT) output by 6 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_6 =
+        SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE | SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV6,
+    /*! Divide External Clock (CLK_OUT) output by 8 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_8 =
+        SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE | SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV8,
+    /*! Divide External Clock (CLK_OUT) output by 10 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_10 = SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE |
+                                  SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV10,
+    /*! Divide External Clock (CLK_OUT) output by 12 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_12 = SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE |
+                                  SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV12,
+    /*! Divide External Clock (CLK_OUT) output by 14 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_14 = SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE |
+                                  SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV14,
+    /*! Divide External Clock (CLK_OUT) output by 16 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_16 = SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE |
+                                  SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV16,
+} DL_SYSCTL_CLK_OUT_DIVIDE;
+
+/** @enum DL_SYSCTL_MFPCLK_SOURCE */
+typedef enum {
+    /*! Use System Oscillator (SYSOSC) as MFPCLK source */
+    DL_SYSCTL_MFPCLK_SOURCE_SYSOSC = SYSCTL_GENCLKCFG_MFPCLKSRC_SYSOSC,
+    /*! Use High Frequency Clock (HFCLK) as MFPCLK source */
+    DL_SYSCTL_MFPCLK_SOURCE_HFCLK = SYSCTL_GENCLKCFG_MFPCLKSRC_HFCLK,
+} DL_SYSCTL_MFPCLK_SOURCE;
+
+/** @enum DL_SYSCTL_HFCLK_MFPCLK_DIVIDER */
+typedef enum {
+    /*! HFCLK is not divided before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_DISABLE = 0x0,
+    /*! Divide HFCLK by 2 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_2 = 0x1,
+    /*! Divide HFCLK by 3 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_3 = 0x2,
+    /*! Divide HFCLK by 4 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_4 = 0x3,
+    /*! Divide HFCLK by 5 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_5 = 0x4,
+    /*! Divide HFCLK by 6 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_6 = 0x5,
+    /*! Divide HFCLK by 7 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_7 = 0x6,
+    /*! Divide HFCLK by 8 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_8 = 0x7,
+    /*! Divide HFCLK by 9 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_9 = 0x8,
+    /*! Divide HFCLK by 10 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_10 = 0x9,
+    /*! Divide HFCLK by 11 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_11 = 0xA,
+    /*! Divide HFCLK by 12 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_12 = 0xB,
+    /*! Divide HFCLK by 13 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_13 = 0xC,
+    /*! Divide HFCLK by 14 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_14 = 0xD,
+    /*! Divide HFCLK by 15 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_15 = 0xE,
+    /*! Divide HFCLK by 16 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_16 = 0xF,
+} DL_SYSCTL_HFCLK_MFPCLK_DIVIDER;
+
+/** @enum DL_SYSCTL_FCC_TRIG_TYPE */
+typedef enum {
+    /*! FCC trigger is rising-edge to rising-edge pulse */
+    DL_SYSCTL_FCC_TRIG_TYPE_RISE_RISE = SYSCTL_GENCLKCFG_FCCLVLTRIG_RISE2RISE,
+    /*! FCC trigger is active-high pulse level */
+    DL_SYSCTL_FCC_TRIG_TYPE_LEVEL = SYSCTL_GENCLKCFG_FCCLVLTRIG_LEVEL,
+} DL_SYSCTL_FCC_TRIG_TYPE;
+
+/** @enum DL_SYSCTL_FCC_TRIG_SOURCE */
+typedef enum {
+    /*! FCC trigger source is FCC_IN external pin */
+    DL_SYSCTL_FCC_TRIG_SOURCE_FCC_IN = SYSCTL_GENCLKCFG_FCCTRIGSRC_EXTPIN,
+    /*! FCC trigger source is LFCLK */
+    DL_SYSCTL_FCC_TRIG_SOURCE_LFCLK = SYSCTL_GENCLKCFG_FCCTRIGSRC_LFCLK,
+} DL_SYSCTL_FCC_TRIG_SOURCE;
+
+/** @enum DL_SYSCTL_FCC_CLOCK_SOURCE */
+typedef enum {
+    /*! FCC clock source to capture is MCLK */
+    DL_SYSCTL_FCC_CLOCK_SOURCE_MCLK = SYSCTL_GENCLKCFG_FCCSELCLK_MCLK,
+    /*! FCC clock source to capture is SYSOSC */
+    DL_SYSCTL_FCC_CLOCK_SOURCE_SYSOSC = SYSCTL_GENCLKCFG_FCCSELCLK_SYSOSC,
+    /*! FCC clock source to capture is HFCLK */
+    DL_SYSCTL_FCC_CLOCK_SOURCE_HFCLK = SYSCTL_GENCLKCFG_FCCSELCLK_HFCLK,
+    /*! FCC clock source to capture is CLK_OUT */
+    DL_SYSCTL_FCC_CLOCK_SOURCE_CLK_OUT = SYSCTL_GENCLKCFG_FCCSELCLK_EXTCLK,
+    /*! FCC clock source to capture is SYSPLLCLK0 */
+    DL_SYSCTL_FCC_CLOCK_SOURCE_SYSPLLCLK0 =
+        SYSCTL_GENCLKCFG_FCCSELCLK_SYSPLLCLK0,
+    /*! FCC clock source to capture is SYSPLLCLK1 */
+    DL_SYSCTL_FCC_CLOCK_SOURCE_SYSPLLCLK1 =
+        SYSCTL_GENCLKCFG_FCCSELCLK_SYSPLLCLK1,
+    /*! FCC clock source to capture is SYSPLLCLK2X */
+    DL_SYSCTL_FCC_CLOCK_SOURCE_SYSPLLCLK2X =
+        SYSCTL_GENCLKCFG_FCCSELCLK_SYSPLLCLK2X,
+    /*! FCC clock source to capture is FCC_IN */
+    DL_SYSCTL_FCC_CLOCK_SOURCE_FCC_IN = SYSCTL_GENCLKCFG_FCCSELCLK_FCCIN,
+} DL_SYSCTL_FCC_CLOCK_SOURCE;
+
+/** @enum DL_SYSCTL_FCC_TRIG_CNT */
+typedef enum {
+    /*! One monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_01 =
+        ((uint32_t) 0 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Two monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_02 =
+        ((uint32_t) 1 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Three monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_03 =
+        ((uint32_t) 2 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Four monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_04 =
+        ((uint32_t) 3 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Five monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_05 =
+        ((uint32_t) 4 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Six monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_06 =
+        ((uint32_t) 5 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Seven monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_07 =
+        ((uint32_t) 6 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Eight monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_08 =
+        ((uint32_t) 7 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Nine monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_09 =
+        ((uint32_t) 8 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Ten monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_10 =
+        ((uint32_t) 9 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Eleven monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_11 =
+        ((uint32_t) 10 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twelve monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_12 =
+        ((uint32_t) 11 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Thirteen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_13 =
+        ((uint32_t) 12 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Fourteen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_14 =
+        ((uint32_t) 13 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Fifteen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_15 =
+        ((uint32_t) 14 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Sixteen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_16 =
+        ((uint32_t) 15 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Seventeen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_17 =
+        ((uint32_t) 16 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Eighteen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_18 =
+        ((uint32_t) 17 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Nineteen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_19 =
+        ((uint32_t) 18 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_20 =
+        ((uint32_t) 19 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-one monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_21 =
+        ((uint32_t) 20 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-two monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_22 =
+        ((uint32_t) 21 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-three monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_23 =
+        ((uint32_t) 22 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-four monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_24 =
+        ((uint32_t) 23 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-five monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_25 =
+        ((uint32_t) 24 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-six monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_26 =
+        ((uint32_t) 25 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-seven monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_27 =
+        ((uint32_t) 26 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-eight monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_28 =
+        ((uint32_t) 27 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-nine monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_29 =
+        ((uint32_t) 28 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Thirty monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_30 =
+        ((uint32_t) 29 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Thirty-one monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_31 =
+        ((uint32_t) 30 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Thirty-two monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_32 =
+        ((uint32_t) 31 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+} DL_SYSCTL_FCC_TRIG_CNT;
+
+/** @enum DL_SYSCTL_VBOOST */
+typedef enum {
+    /*! VBOOST enabled only when COMP/OPA/GPAMP is enabled */
+    DL_SYSCTL_VBOOST_ONDEMAND = SYSCTL_GENCLKCFG_ANACPUMPCFG_ONDEMAND,
+    /*! VBOOST enabled in RUN/SLEEP, and in STOP/STANDBY if COMP/OPA/GPAMP is enabled */
+    DL_SYSCTL_VBOOST_ONACTIVE = SYSCTL_GENCLKCFG_ANACPUMPCFG_ONACTIVE,
+    /*! VBOOST enabled in all power modes except SHUTDOWN for fastest startup */
+    DL_SYSCTL_VBOOST_ONALWAYS = SYSCTL_GENCLKCFG_ANACPUMPCFG_ONALWAYS,
+} DL_SYSCTL_VBOOST;
+
+/** @enum DL_SYSCTL_FLASH_WAIT_STATE */
+typedef enum {
+    /*! 0 flash wait states */
+    DL_SYSCTL_FLASH_WAIT_STATE_0 = ((uint32_t) 0x00000000U),
+    /*! 1 flash wait states */
+    DL_SYSCTL_FLASH_WAIT_STATE_1 = ((uint32_t) 0x00000100U),
+    /*! 2 flash wait states */
+    DL_SYSCTL_FLASH_WAIT_STATE_2 = ((uint32_t) 0x00000200U),
+} DL_SYSCTL_FLASH_WAIT_STATE;
+
+/** @enum DL_SYSCTL_POWER_POLICY_RUN_SLEEP */
+typedef enum {
+    /*! RUN/SLEEP power policy is not enabled */
+    DL_SYSCTL_POWER_POLICY_RUN_SLEEP_NOT_ENABLED = 0x0,
+    /*! Enable RUN0/SLEEP0 power mode policy. */
+    DL_SYSCTL_POWER_POLICY_RUN_SLEEP0 = 0x1,
+    /*! Enable the RUN1/SLEEP1 power mode policy */
+    DL_SYSCTL_POWER_POLICY_RUN_SLEEP1 = 0x2,
+    /*! Enable the RUN2/SLEEP2 power mode policy */
+    DL_SYSCTL_POWER_POLICY_RUN_SLEEP2 = 0x3,
+} DL_SYSCTL_POWER_POLICY_RUN_SLEEP;
+
+/** @enum DL_SYSCTL_POWER_POLICY_STOP */
+typedef enum {
+    /*! STOP power policy is not enabled */
+    DL_SYSCTL_POWER_POLICY_STOP_NOT_ENABLED = 0x0,
+    /*! Enable the STOP0 power mode policy */
+    DL_SYSCTL_POWER_POLICY_STOP0 = 0x1,
+    /*! Enable the STOP1 power mode policy */
+    DL_SYSCTL_POWER_POLICY_STOP1 = 0x2,
+    /*! Enable the STOP2 power mode policy */
+    DL_SYSCTL_POWER_POLICY_STOP2 = 0x3,
+} DL_SYSCTL_POWER_POLICY_STOP;
+
+/** @enum DL_SYSCTL_POWER_POLICY_STANDBY */
+typedef enum {
+    /*! STANDBY power policy is not enabled */
+    DL_SYSCTL_POWER_POLICY_STANDBY_NOT_ENABLED = 0x0,
+    /*! Enable the STANDBY0 power mode policy */
+    DL_SYSCTL_POWER_POLICY_STANDBY0 = 0x1,
+    /*! Enable the STANDBY1 power mode policy */
+    DL_SYSCTL_POWER_POLICY_STANDBY1 = 0x2,
+} DL_SYSCTL_POWER_POLICY_STANDBY;
+
+/** @enum DL_SYSCTL_BOR_THRESHOLD_LEVEL */
+typedef enum {
+    /*! BOR0 threshold level. This is the minimum allowed threshold.
+     * A BOR0- violation will force a re-boot. */
+    DL_SYSCTL_BOR_THRESHOLD_LEVEL_0 = SYSCTL_BORTHRESHOLD_LEVEL_BORMIN,
+    /*! BOR1 threshold level. A BOR1- violation generates an interrupt */
+    DL_SYSCTL_BOR_THRESHOLD_LEVEL_1 = SYSCTL_BORTHRESHOLD_LEVEL_BORLEVEL1,
+    /*! BOR2 threshold level. A BOR2- violation generates an interrupt */
+    DL_SYSCTL_BOR_THRESHOLD_LEVEL_2 = SYSCTL_BORTHRESHOLD_LEVEL_BORLEVEL2,
+    /*! BOR3 threshold level. A BOR3- violation generates an interrupt */
+    DL_SYSCTL_BOR_THRESHOLD_LEVEL_3 = SYSCTL_BORTHRESHOLD_LEVEL_BORLEVEL3,
+} DL_SYSCTL_BOR_THRESHOLD_LEVEL;
+
+/** @enum DL_SYSCTL_SHUTDOWN_STORAGE_BYTE */
+typedef enum {
+    /*! Shutdown Storage Byte 0 */
+    DL_SYSCTL_SHUTDOWN_STORAGE_BYTE_0 = 0x0,
+    /*! Shutdown Storage Byte 1 */
+    DL_SYSCTL_SHUTDOWN_STORAGE_BYTE_1 = 0x1,
+    /*! Shutdown Storage Byte 2 */
+    DL_SYSCTL_SHUTDOWN_STORAGE_BYTE_2 = 0x2,
+    /*! Shutdown Storage Byte 3 */
+    DL_SYSCTL_SHUTDOWN_STORAGE_BYTE_3 = 0x3,
+} DL_SYSCTL_SHUTDOWN_STORAGE_BYTE;
+
+/** @enum DL_SYSCTL_RESET_CAUSE */
+typedef enum {
+    /*! No Reset Since Last Read */
+    DL_SYSCTL_RESET_CAUSE_NO_RESET = SYSCTL_RSTCAUSE_ID_NORST,
+    /*! (VDD < POR- violation) or (PMU trim parity fault) or (SHUTDNSTOREx parity fault) */
+    DL_SYSCTL_RESET_CAUSE_POR_HW_FAILURE = SYSCTL_RSTCAUSE_ID_PORHWFAIL,
+    /*! NRST pin reset (>1s) */
+    DL_SYSCTL_RESET_CAUSE_POR_EXTERNAL_NRST = SYSCTL_RSTCAUSE_ID_POREXNRST,
+    /*! Software-triggered POR */
+    DL_SYSCTL_RESET_CAUSE_POR_SW_TRIGGERED = SYSCTL_RSTCAUSE_ID_PORSW,
+    /*! VDD < BOR- violation */
+    DL_SYSCTL_RESET_CAUSE_BOR_SUPPLY_FAILURE = SYSCTL_RSTCAUSE_ID_BORSUPPLY,
+    /*! Wake from SHUTDOWN */
+    DL_SYSCTL_RESET_CAUSE_BOR_WAKE_FROM_SHUTDOWN =
+        SYSCTL_RSTCAUSE_ID_BORWAKESHUTDN,
+    /*! Non-PMU trim parity fault */
+    DL_SYSCTL_RESET_CAUSE_BOOTRST_NON_PMU_PARITY_FAULT =
+        SYSCTL_RSTCAUSE_ID_BOOTNONPMUPARITY,
+    /*! Fatal clock fault */
+    DL_SYSCTL_RESET_CAUSE_BOOTRST_CLOCK_FAULT = SYSCTL_RSTCAUSE_ID_BOOTCLKFAIL,
+    /*! Software-triggered BOOTRST */
+    DL_SYSCTL_RESET_CAUSE_BOOTRST_SW_TRIGGERED = SYSCTL_RSTCAUSE_ID_BOOTSW,
+    /*! NRST pin reset (<1s) */
+    DL_SYSCTL_RESET_CAUSE_BOOTRST_EXTERNAL_NRST =
+        SYSCTL_RSTCAUSE_ID_BOOTEXNRST,
+    /*! BSL exit */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_BSL_EXIT = SYSCTL_RSTCAUSE_ID_SYSBSLEXIT,
+    /*! BSL entry */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_BSL_ENTRY = SYSCTL_RSTCAUSE_ID_SYSBSLENTRY,
+    /*! WWDT0 violation */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_WWDT0_VIOLATION = SYSCTL_RSTCAUSE_ID_SYSWWDT0,
+    /*! WWDT1 violation */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_WWDT1_VIOLATION = SYSCTL_RSTCAUSE_ID_SYSWWDT1,
+    /*! Uncorrectable flash ECC error */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_FLASH_ECC_ERROR =
+        SYSCTL_RSTCAUSE_ID_SYSFLASHECC,
+    /*! CPULOCK violation */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_CPU_LOCKUP_VIOLATION =
+        SYSCTL_RSTCAUSE_ID_SYSCPULOCK,
+    /*! Debug-triggered SYSRST */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_DEBUG_TRIGGERED = SYSCTL_RSTCAUSE_ID_SYSDBG,
+    /*! Software-triggered SYSRST */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_SW_TRIGGERED = SYSCTL_RSTCAUSE_ID_SYSSW,
+    /*! Debug-triggered CPURST */
+    DL_SYSCTL_RESET_CAUSE_CPURST_DEBUG_TRIGGERED = SYSCTL_RSTCAUSE_ID_CPUDBG,
+    /*! Software-triggered CPURST */
+    DL_SYSCTL_RESET_CAUSE_CPURST_SW_TRIGGERED = SYSCTL_RSTCAUSE_ID_CPUSW,
+} DL_SYSCTL_RESET_CAUSE;
+
+/**
+ *  @brief  Enable sleep on exit
+ *
+ *  Enables sleep on exit when the CPU moves from handler mode to thread mode.
+ *  By enabling, allows an interrupt driven application to avoid returning to
+ *  an empty main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_enableSleepOnExit(void)
+{
+    SCB->SCR |= SCB_SCR_SLEEPONEXIT_Msk;
+}
+
+/**
+ *  @brief  Disable sleep on exit
+ *
+ *  Disables sleep on exit when the CPU moves from handler mode to thread mode.
+ */
+__STATIC_INLINE void DL_SYSCTL_disableSleepOnExit(void)
+{
+    SCB->SCR &= ~(SCB_SCR_SLEEPONEXIT_Msk);
+}
+
+/**
+ *  @brief  Check if sleep on exit is enabled
+ */
+__STATIC_INLINE bool DL_SYSCTL_isSleepOnExitEnabled(void)
+{
+    return ((SCB->SCR & SCB_SCR_SLEEPONEXIT_Msk) == SCB_SCR_SLEEPONEXIT_Msk);
+}
+
+/**
+ *  @brief  Enable send event on pending bit
+ *
+ *  When enabled, any enabled event and all interrupts (including disabled
+ *  interrupts) can wakeup the processor.
+ */
+__STATIC_INLINE void DL_SYSCTL_enableEventOnPend(void)
+{
+    SCB->SCR |= SCB_SCR_SEVONPEND_Msk;
+}
+
+/**
+ *  @brief  Disable send event on pending bit
+ *
+ *  When disabled, only enabled interrupts or events can wake up the processor.
+ *  Disabled interrupts are excluded.
+ */
+__STATIC_INLINE void DL_SYSCTL_disableEventOnPend(void)
+{
+    SCB->SCR &= ~(SCB_SCR_SEVONPEND_Msk);
+}
+
+/**
+ *  @brief   Check if send event on pending bit is enabled
+ *
+ *  @return  Returns the enabled status of the send event on pending bit
+ *
+ *  @retval  true  Send event on pending bit is enabled
+ *  @retval  false Send event on pending bit is disabled
+ */
+__STATIC_INLINE bool DL_SYSCTL_isEventOnPendEnabled(void)
+{
+    return ((SCB->SCR & SCB_SCR_SEVONPEND_Msk) == SCB_SCR_SEVONPEND_Msk);
+}
+
+/*!
+ *  @brief  Change MCLK source
+ *
+ *  To ensure good clocking behavior, these are the recommended steps for transition.
+ *  Valid sources and destinations: LFCLK, SYSOSC, HSCLK
+ *
+ *  Depending on current MCLK source, steps to switch to next MCLK source can vary.
+ *  This is a macro that redirects to the different possible transitions.
+ *
+ *  Only valid for RUN modes. In low power modes, MCLK transitions are handled by hardware.
+ *
+ *  @note Different transition APIs may require different input parameters
+ *  Transitions between LFCLK and HSCLK requires going through SYSOSC.
+ *
+ *  @sa DL_SYSCTL_switchMCLKfromSYSOSCtoLFCLK
+ *  @sa DL_SYSCTL_switchMCLKfromLFCLKtoSYSOSC
+ *  @sa DL_SYSCTL_switchMCLKfromSYSOSCtoHSCLK
+ *  @sa DL_SYSCTL_switchMCLKfromHSCLKtoSYSOSC
+ */
+#define DL_SYSCTL_setMCLKSource(current, next, ...) \
+    DL_SYSCTL_switchMCLKfrom##current##to##next(__VA_ARGS__);
+
+/**
+ *  @brief  Change MCLK source from SYSOSC to LFCLK
+ *
+ *  @pre    If disabling SYSOSC, high speed oscillators (SYSPLL, HFXT...) must be disabled beforehand.
+ *  @post   MCLK source is switched to LFCLK, function will busy-wait until confirmed.
+ *
+ *  @param[in] disableSYSOSC   Whether to leave SYSOSC running or not
+ */
+void DL_SYSCTL_switchMCLKfromSYSOSCtoLFCLK(bool disableSYSOSC);
+
+/**
+ *  @brief  Change MCLK source from LFCLK to SYSOSC
+ *
+ *  @post   MCLK source is switched to SYSOSC, function will busy-wait until confirmed.
+ */
+void DL_SYSCTL_switchMCLKfromLFCLKtoSYSOSC(void);
+
+/**
+ *  @brief  Change MCLK source from SYSOSC to HSCLK
+ *
+ *  @pre    The desired HSCLK source is enabled beforehand (SYSPLL, HFXT, HFCLK_IN).
+ *  @post   MCLK source is switched to HSCLK, function will busy-wait until confirmed.
+ *
+ *  @param[in] source   Desired high-speed clock source
+ */
+void DL_SYSCTL_switchMCLKfromSYSOSCtoHSCLK(DL_SYSCTL_HSCLK_SOURCE source);
+
+/**
+ *  @brief  Change MCLK source from HSCLK to SYSOSC
+ *
+ *  @pre    MCLK is sourced from a valid, running HSCLK source (SYSPLL, HFXT, HFCLK_IN)
+ *  @post   MCLK source is switched to SYSOSC, function will busy-wait until confirmed.
+ *
+ *  @note   No HSCLK sources are disabled by this function
+ */
+void DL_SYSCTL_switchMCLKfromHSCLKtoSYSOSC(void);
+
+/**
+ *  @brief     Set the RUN/SLEEP mode power policy to RUN0/SLEEP0
+ *
+ * In RUN0, the MCLK and the CPUCLK run from a fast clock source (SYSOSC,
+ * HFCLK, or SYSPLL).
+ *
+ * Setting the RUN power policy will also set the SLEEP power policy.
+ * The SLEEP mode behavior is always identical to RUN mode, just with the
+ * CPUCLK disabled. As such, the SLEEP behavior is determined by the
+ * configuration of the RUN mode. To actually enter SLEEP mode, you must call
+ * `__WFI()` to wait for interrupts or `__WFE()` to wait for ARM events.
+ * `__WFI()` is used in interrupt-driven applications, and `__WFE()` is used
+ * for interactions between the interrupt handler and main application.
+ *
+ * There are three RUN/SLEEP mode policy options: RUN0/SLEEP0, RUN1/SLEEP1,
+ * and RUN2/SLEEP2. Refer to the device TRM for more information on each policy
+ *
+ * @sa DL_SYSCTL_setMCLKSource
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicyRUN0SLEEP0(void)
+{
+    DL_SYSCTL_setMCLKSource(LFCLK, SYSOSC);
+    SCB->SCR &= ~(SCB_SCR_SLEEPDEEP_Msk);
+}
+
+/**
+ *  @brief     Set the RUN/SLEEP mode power policy to RUN1/SLEEP1
+ *
+ * In RUN1, the MCLK and the CPUCLK run from LFCLK (at 32kHz) to reduce active
+ * power, but SYSOSC is left enabled to service analog modules such as an ADC,
+ * DAC, OPA, or COMP (in HS mode).
+ *
+ * Setting the RUN power policy will also set the SLEEP power policy.
+ * The SLEEP mode behavior is always identical to RUN mode, just with the
+ * CPUCLK disabled. As such, the SLEEP behavior is determined by the
+ * configuration of the RUN mode. To actually enter SLEEP mode, you must call
+ * `__WFI()` to wait for interrupts or `__WFE()` to wait for ARM events.
+ * `__WFI()` is used in interrupt-driven applications, and `__WFE()` is used
+ * for interactions between the interrupt handler and main application.
+ *
+ * There are three RUN/SLEEP mode policy options: RUN0/SLEEP0, RUN1/SLEEP1,
+ * and RUN2/SLEEP2. Refer to the device TRM for more information on each policy
+ *
+ * @sa DL_SYSCTL_setMCLKSource
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicyRUN1SLEEP1(void)
+{
+    DL_SYSCTL_setMCLKSource(SYSOSC, LFCLK, (bool) false);
+    SCB->SCR &= ~(SCB_SCR_SLEEPDEEP_Msk);
+}
+
+/**
+ *  @brief     Set the RUN/SLEEP mode power policy to RUN2/SLEEP2
+ *
+ * In RUN2, the MCLK and the CPUCLK run from LFCLK (at 32kHz), and SYSOSC is
+ * completely disabled to save power. This is the lowest power state with
+ * the CPU running
+ *
+ * Setting the RUN power policy will also set the SLEEP power policy.
+ * The SLEEP mode behavior is always identical to RUN mode, just with the
+ * CPUCLK disabled. As such, the SLEEP behavior is determined by the
+ * configuration of the RUN mode. To actually enter SLEEP mode, you must call
+ * `__WFI()` to wait for interrupts or `__WFE()` to wait for ARM events.
+ * `__WFI()` is used in interrupt-driven applications, and `__WFE()` is used
+ * for interactions between the interrupt handler and main application.
+ *
+ * There are three RUN/SLEEP mode policy options: RUN0/SLEEP0, RUN1/SLEEP1,
+ * and RUN2/SLEEP2. Refer to the device TRM for more information on each policy
+ *
+ * @note Since this turns off SYSOSC, HSCLK sources MUST be disabled before calling
+ *
+ * @sa DL_SYSCTL_setMCLKSource
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicyRUN2SLEEP2(void)
+{
+    DL_SYSCTL_setMCLKSource(SYSOSC, LFCLK, (bool) true);
+    SCB->SCR &= ~(SCB_SCR_SLEEPDEEP_Msk);
+}
+
+/**
+ *  @brief     Get the RUN/SLEEP mode power policy
+ *
+ * Get which RUN/SLEEP power policy has been set.
+ *
+ * The SLEEP mode behavior is always identical to RUN mode, just with the
+ * CPUCLK disabled. As such, the SLEEP behavior is determined by the
+ * configuration of the RUN mode.
+ *
+ *  @return  Returns the current RUN/SLEEP mode power policy
+ *
+ *  @retval  One of @ref DL_SYSCTL_POWER_POLICY_RUN_SLEEP
+
+ */
+DL_SYSCTL_POWER_POLICY_RUN_SLEEP DL_SYSCTL_getPowerPolicyRUNSLEEP(void);
+
+/**
+ *  @brief     Set the STOP mode power policy to STOP0
+ *
+ * In STOP0, the SYSOSC is left running at the current frequency when entering
+ * STOP mode (either 32MHz, 24MHz, 16MHz, or 4MHz). ULPCLK is always limited
+ * to 4MHz automatically by hardware, but SYSOSC is not disturbed to support
+ * consistent operation of analog peripherals such as the ADC, OPA, or COMP.
+ *
+ * There are three STOP mode policy options: STOP0, STOP1, and STOP2.
+ * Refer to the device TRM for more information on each policy.
+ *
+ * @post This API does not actually enter STOP mode. After using this API to
+ * set the power policy, to enter STOP mode you must call `__WFI()` to
+ * wait for interrupts or `__WFE()` to wait for ARM events. `__WFI()` is used
+ * in interrupt-driven applications, and `__WFE()` is used for interactions
+ * between the interrupt handler and main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicySTOP0(void)
+{
+    SYSCTL->SOCLOCK.PMODECFG = SYSCTL_PMODECFG_DSLEEP_STOP;
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+    SYSCTL->SOCLOCK.SYSOSCCFG &= ~(
+        SYSCTL_SYSOSCCFG_USE4MHZSTOP_MASK | SYSCTL_SYSOSCCFG_DISABLESTOP_MASK);
+    SYSCTL->SOCLOCK.MCLKCFG &= ~(SYSCTL_MCLKCFG_USELFCLK_MASK);
+}
+
+/**
+ *  @brief     Set the STOP mode power policy to STOP1
+ *
+ * In STOP1, the SYSOSC is gear shifted from its current frequency to 4MHz for
+ * the lowest power consumption in STOP mode with SYSOSC running. SYSOSC and
+ * ULPCLK both run at 4MHz.
+ *
+ * There are three STOP mode policy options: STOP0, STOP1, and STOP2.
+ * Refer to the device TRM for more information on each policy.
+ *
+ * @post This API does not actually enter STOP mode. After using this API to
+ * set the power policy, to enter STOP mode you must call `__WFI()` to
+ * wait for interrupts or `__WFE()` to wait for ARM events. `__WFI()` is used
+ * in interrupt-driven applications, and `__WFE()` is used for interactions
+ * between the interrupt handler and main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicySTOP1(void)
+{
+    SYSCTL->SOCLOCK.PMODECFG = SYSCTL_PMODECFG_DSLEEP_STOP;
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+    SYSCTL->SOCLOCK.SYSOSCCFG |= SYSCTL_SYSOSCCFG_USE4MHZSTOP_MASK;
+    SYSCTL->SOCLOCK.SYSOSCCFG &= ~(SYSCTL_SYSOSCCFG_DISABLESTOP_MASK);
+    SYSCTL->SOCLOCK.MCLKCFG &= ~(SYSCTL_MCLKCFG_USELFCLK_MASK);
+}
+
+/**
+ *  @brief     Set the STOP mode power policy to STOP2
+ *
+ * In STOP2, the SYSOSC is disabled and the ULPCLK is sourced from LFCLK at
+ * 32kHz. This is the lowest power state in STOP mode.
+ *
+ * There are three STOP mode policy options: STOP0, STOP1, and STOP2.
+ * Refer to the device TRM for more information on each policy.
+ *
+ * @post This API does not actually enter STOP mode. After using this API to
+ * set the power policy, to enter STOP mode you must call `__WFI()` to
+ * wait for interrupts or `__WFE()` to wait for ARM events. `__WFI()` is used
+ * in interrupt-driven applications, and `__WFE()` is used for interactions
+ * between the interrupt handler and main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicySTOP2(void)
+{
+    SYSCTL->SOCLOCK.PMODECFG = SYSCTL_PMODECFG_DSLEEP_STOP;
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+    SYSCTL->SOCLOCK.SYSOSCCFG &= ~(SYSCTL_SYSOSCCFG_USE4MHZSTOP_MASK);
+    SYSCTL->SOCLOCK.SYSOSCCFG |= SYSCTL_SYSOSCCFG_DISABLESTOP_MASK;
+}
+
+/**
+ *  @brief     Get the STOP mode power policy
+ *
+ * Get which STOP power policy has been set.
+ *
+ *  @return  Returns the current STOP mode power policy
+ *
+ *  @retval  One of @ref DL_SYSCTL_POWER_POLICY_STOP if a STOP power policy
+ */
+DL_SYSCTL_POWER_POLICY_STOP DL_SYSCTL_getPowerPolicySTOP(void);
+
+/**
+ *  @brief     Set the STANDBY mode power policy to STANDBY0
+ *
+ * In STANDBY0, all PD0 peripherals receive the ULPCLK and LFCLK, and the RTC
+ * receives RTCCLK.
+ *
+ * There are two STANDBY mode policy options: STANDBY0 and STANDBY1.
+ *
+ * @post This API does not actually enter STANDBY mode. After using this API to
+ * set the power policy, to enter STANDBY mode you must call `__WFI()` to
+ * wait for interrupts or `__WFE()` to wait for ARM events. `__WFI()` is used
+ * in interrupt-driven applications, and `__WFE()` is used for interactions
+ * between the interrupt handler and main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicySTANDBY0(void)
+{
+    SYSCTL->SOCLOCK.PMODECFG = SYSCTL_PMODECFG_DSLEEP_STANDBY;
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+    SYSCTL->SOCLOCK.MCLKCFG &= ~(SYSCTL_MCLKCFG_STOPCLKSTBY_MASK);
+}
+
+/**
+ *  @brief     Set the STANDBY mode power policy to STANDBY1
+ *
+ * In STANDBY1, only TIMG0 and TIMG1 receive ULPCLK/LFCLK. The RTC continues
+ * to receive RTCCLK. A TIMG0/1 interrupt, RTC interrupt, or ADC trigger in
+ * STANDBY1 always triggers an asynchronous fast clock request to wake the
+ * system. Other PD0 peripherals (such as UART, I2C, GPIO, and COMP) can also
+ * wake the system upon an external event through an asynchronous fast clock
+ * request, but they are not actively clocked in STANDBY1.
+ *
+ * There are two STANDBY mode policy options: STANDBY0 and STANDBY1.
+ *
+ * @post This API does not actually enter STANDBY mode. After using this API to
+ * set the power policy, to enter STANDBY mode you must call `__WFI()` to
+ * wait for interrupts or `__WFE()` to wait for ARM events. `__WFI()` is used
+ * in interrupt-driven applications, and `__WFE()` is used for interactions
+ * between the interrupt handler and main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicySTANDBY1(void)
+{
+    SYSCTL->SOCLOCK.PMODECFG = SYSCTL_PMODECFG_DSLEEP_STANDBY;
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+    SYSCTL->SOCLOCK.MCLKCFG |= SYSCTL_MCLKCFG_STOPCLKSTBY_MASK;
+}
+
+/**
+ *  @brief     Get the STANDBY mode power policy
+ *
+ * Get which STANDBY power policy has been set.
+ *
+ *  @return  Returns the current STANDBY mode power policy
+ *
+ *  @retval  One of @ref DL_SYSCTL_POWER_POLICY_STANDBY
+ */
+DL_SYSCTL_POWER_POLICY_STANDBY DL_SYSCTL_getPowerPolicySTANDBY(void);
+
+/**
+ *  @brief     Set power policy to SHUTDOWN mode
+ *
+ * In SHUTDOWN mode, no clocks are available. The core regulator is completely
+ * disabled and all SRAM and register contents are lost, with the exception of
+ * the 4 bytes of general purpose memory in SYSCTL which may be used to store
+ * state information. The BOR and bandgap circuit are disabled. The device may
+ * wake up via a wake-up capable IO, a debug connection, or NRST. SHUTDOWN mode
+ * has the lowest current consumption of any operating mode. Exiting SHUTDOWN
+ * mode triggers a BOR.
+ *
+ * There is only one SHUTDOWN mode policy option: SHUTDOWN.
+ *
+ * @post This API does not actually enter SHUTDOWN mode. After using this API
+ * to enable SHUTDOWN mode, to enter SHUTDOWN mode you must call `__WFI()` to
+ * wait for interrupts or `__WFE()` to wait for ARM events. `__WFI()` is used
+ * in interrupt-driven applications, and `__WFE()` is used for interactions
+ * between the interrupt handler and main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicySHUTDOWN(void)
+{
+    SYSCTL->SOCLOCK.PMODECFG = SYSCTL_PMODECFG_DSLEEP_SHUTDOWN;
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+}
+
+/**
+ *  @brief     Set the brown-out reset (BOR) threshold level
+ *
+ *  Note that this API does NOT activate the BOR threshold. After setting the
+ *  threshold level with this API, call @ref DL_SYSCTL_activateBORThreshold
+ *  to actually activate the new threshold.
+ *
+ * During startup, the BOR threshold defaults to BOR0 (the lowet value) to
+ * ensure the device always starts at the specified VDD minimum. After boot,
+ * the BOR threshold level can be configured to a different level. When the
+ * BOR threshold is BOR0, a BOR0- violation always generates a BOR- violation
+ * signal to SYSCTL, generating a BOR level reset. When the BOR threshold is
+ * re-configured to BOR1, BOR2, or BOR3 the BOR circuit will generate a SYSCTL
+ * interrupt rather than asserting a BOR- violation. This may be used to give
+ * the application an indication that the supply has dropped below a certain
+ * level without causing a reset. If the BOR is in interrupt mode (threshold
+ * level of BOR1-3), and VDD drops below the respective BORx- level, an
+ * interrupt will be generated and the BOR circuit will automatically switch
+ * the BOR threshold level to BOR0 to ensure that a BOR- violation is
+ * asserted if VDD drops below BOR0-.
+ *
+ *  @param[in]  thresholdLevel  The BOR threshold level to set.
+ *                              One of @ref DL_SYSCTL_BOR_THRESHOLD_LEVEL.
+ *
+ *  @post       DL_SYSCTL_activateBORThreshold
+ */
+__STATIC_INLINE void DL_SYSCTL_setBORThreshold(
+    DL_SYSCTL_BOR_THRESHOLD_LEVEL thresholdLevel)
+{
+    SYSCTL->SOCLOCK.BORTHRESHOLD = (uint32_t) thresholdLevel;
+}
+
+/**
+ *  @brief   Get the brown-out reset (BOR) threshold level
+ *
+ *  @return  Returns the current BOR threshold level.
+ *
+ *  @retval  One of @ref DL_SYSCTL_BOR_THRESHOLD_LEVEL
+ */
+__STATIC_INLINE DL_SYSCTL_BOR_THRESHOLD_LEVEL DL_SYSCTL_getBORThreshold(void)
+{
+    return (DL_SYSCTL_BOR_THRESHOLD_LEVEL)(SYSCTL->SOCLOCK.BORTHRESHOLD);
+}
+
+/**
+ *  @brief      Activate the BOR threshold level
+ *
+ *  Attempts to change the active BOR mode to the BOR threshold that was set
+ *  via @ref DL_SYSCTL_setBORThreshold.
+ *
+ *  Setting this bit also clears any prior BOR violation status indications.
+ *
+ *  After calling this API, the change can be validated by calling
+ *  @ref DL_SYSCTL_getStatus and checking the return value.
+ *
+ *  @pre        DL_SYSCTL_setBORThreshold
+ */
+__STATIC_INLINE void DL_SYSCTL_activateBORThreshold(void)
+{
+    SYSCTL->SOCLOCK.BORCLRCMD =
+        SYSCTL_BORCLRCMD_KEY_VALUE | SYSCTL_BORCLRCMD_GO_TRUE;
+}
+
+/**
+ *  @brief      Resets the device
+ *
+ *  Resets the device using the type of reset selected. This function does not
+ *  return, the reset will happen immediately.
+ *
+ *  @param[in]  resetType  Type of reset to perform. One of @ref
+ *                         DL_SYSCTL_RESET.
+ */
+__STATIC_INLINE void DL_SYSCTL_resetDevice(uint32_t resetType)
+{
+    SYSCTL->SOCLOCK.RESETLEVEL = resetType;
+    SYSCTL->SOCLOCK.RESETCMD =
+        SYSCTL_RESETCMD_KEY_VALUE | SYSCTL_RESETCMD_GO_TRUE;
+}
+
+/**
+ *  @brief      Enable SYSCTL interrupts
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_SYSCTL_INTERRUPT.
+ */
+__STATIC_INLINE void DL_SYSCTL_enableInterrupt(uint32_t interruptMask)
+{
+    SYSCTL->SOCLOCK.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disable SYSCTL interrupts
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_SYSCTL_INTERRUPT.
+ */
+__STATIC_INLINE void DL_SYSCTL_disableInterrupt(uint32_t interruptMask)
+{
+    SYSCTL->SOCLOCK.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief      Check which SYSCTL interrupts are enabled
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SYSCTL_INTERRUPT.
+ *
+ *  @return     Which of the requested SYSCTL interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_SYSCTL_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getEnabledInterrupts(uint32_t interruptMask)
+{
+    return (SYSCTL->SOCLOCK.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled SYSCTL interrupts
+ *
+ *  Checks if any of the SYSCTL interrupts that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SYSCTL_INTERRUPT.
+ *
+ *  @return     Which of the requested SYSCTL interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_SYSCTL_INTERRUPT values
+ *
+ *  @sa         DL_SYSCTL_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getEnabledInterruptStatus(
+    uint32_t interruptMask)
+{
+    return (SYSCTL->SOCLOCK.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any SYSCTL interrupt
+ *
+ *  Checks if any of the SYSCTL interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SYSCTL_INTERRUPT.
+ *
+ *  @return     Which of the requested SYSCTL interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_SYSCTL_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getRawInterruptStatus(
+    uint32_t interruptMask)
+{
+    return (SYSCTL->SOCLOCK.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending SYSCTL interrupt
+ *
+ *  Checks if any of the SYSCTL interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @return     The highest priority pending SYSCTL interrupt
+ *
+ *  @retval     One of @ref DL_SYSCTL_IIDX values
+ */
+__STATIC_INLINE DL_SYSCTL_IIDX DL_SYSCTL_getPendingInterrupt(void)
+{
+    return (DL_SYSCTL_IIDX)(SYSCTL->SOCLOCK.IIDX);
+}
+
+/**
+ *  @brief      Clear pending SYSCTL interrupts
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_SYSCTL_INTERRUPT.
+ */
+__STATIC_INLINE void DL_SYSCTL_clearInterruptStatus(uint32_t interruptMask)
+{
+    SYSCTL->SOCLOCK.ICLR = interruptMask;
+}
+
+/**
+ *  @brief      Check interrupt flag of any SYSCTL non-maskable interrupt
+ *
+ *  Checks if any of the SYSCTL non-maskable interrupts are pending. Interrupts
+ *  do not have to be previously enabled.
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SYSCTL_NMI.
+ *
+ *  @return     Which of the requested SYSCTL non-maskable interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_SYSCTL_NMI values
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getRawNonMaskableInterruptStatus(
+    uint32_t interruptMask)
+{
+    return (SYSCTL->SOCLOCK.NMIRIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending SYSCTL non-maskable interrupt
+ *
+ *  Checks if any of the SYSCTL non-maskable interrupts are pending. Interrupts
+ *  do not have to be previously enabled.
+ *
+ *  @return     The highest priority pending SYSCTL non-maskable interrupt
+ *
+ *  @retval     One of @ref DL_SYSCTL_NMI_IIDX values
+ */
+__STATIC_INLINE DL_SYSCTL_NMI_IIDX DL_SYSCTL_getPendingNonMaskableInterrupt(
+    void)
+{
+    return (DL_SYSCTL_NMI_IIDX)(SYSCTL->SOCLOCK.NMIIIDX);
+}
+
+/**
+ *  @brief      Clear pending SYSCTL non-maskable interrupts
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_SYSCTL_NMI.
+ */
+__STATIC_INLINE void DL_SYSCTL_clearNonMaskableInterruptStatus(
+    uint32_t interruptMask)
+{
+    SYSCTL->SOCLOCK.NMIICLR = interruptMask;
+}
+
+/**
+ *  @brief  Set the behavior when a Flash ECC double error detect (DED) occurs
+ *
+ *  Configures whether a Flash ECC double error detect (DED) will trigger
+ *  a SYSRST or an NMI (non-maskable interrupt). By default, this error will
+ *  trigger a SYSRST.
+ *
+ *  @param[in] behavior The behavior when a Flash ECC DED error occurrs
+ *
+ *  @sa        DL_SYSCTL_enableNonMaskableInterrupt
+ */
+__STATIC_INLINE void DL_SYSCTL_setFlashDEDErrorBehavior(
+    DL_SYSCTL_ERROR_BEHAVIOR behavior)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SYSTEMCFG,
+        (((uint32_t) behavior << SYSCTL_SYSTEMCFG_FLASHECCRSTDIS_OFS)) |
+            SYSCTL_SYSTEMCFG_KEY_VALUE,
+        (SYSCTL_SYSTEMCFG_FLASHECCRSTDIS_MASK | SYSCTL_SYSTEMCFG_KEY_MASK));
+}
+
+/**
+ *  @brief  Get the behavior when a Flash ECC double error detect (DED) occurs
+ *
+ *  By default, this error will trigger a SYSRST.
+ *
+ *  @return The behavior when a Flash ECC DED error occurs
+ *
+ *  3@retval One of @ref DL_SYSCTL_ERROR_BEHAVIOR
+ */
+__STATIC_INLINE DL_SYSCTL_ERROR_BEHAVIOR DL_SYSCTL_getFlashDEDErrorBehavior(
+    void)
+{
+    uint32_t behavior =
+        (SYSCTL->SOCLOCK.SYSTEMCFG & SYSCTL_SYSTEMCFG_FLASHECCRSTDIS_MASK) >>
+        SYSCTL_SYSTEMCFG_FLASHECCRSTDIS_OFS;
+
+    return (DL_SYSCTL_ERROR_BEHAVIOR)(behavior);
+}
+
+/**
+ *  @brief  Set the behavior when a WWDT0 error occurs
+ *
+ *  Configures whether a WWDT0 error will trigger a BOOTRST or an NMI
+ * (non-maskable interrupt). By default, this error will trigger a BOOTRST.
+ *
+ *  @param[in] behavior The behavior when a Flash ECC DED occurrs
+ *
+ *  @sa        DL_SYSCTL_enableNonMaskableInterrupt
+ */
+__STATIC_INLINE void DL_SYSCTL_setWWDT0ErrorBehavior(
+    DL_SYSCTL_ERROR_BEHAVIOR behavior)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SYSTEMCFG,
+        (((uint32_t) behavior << SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_OFS)) |
+            SYSCTL_SYSTEMCFG_KEY_VALUE,
+        (SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_MASK | SYSCTL_SYSTEMCFG_KEY_MASK));
+}
+
+/**
+ *  @brief  Get the behavior when a WWDT0 error occurs
+ *
+ *  By default, this error will trigger a BOOTRST.
+ *
+ *  @return The behavior when a WWDT0 error occurs
+ *
+ *  @retval One of @ref DL_SYSCTL_ERROR_BEHAVIOR
+ */
+__STATIC_INLINE DL_SYSCTL_ERROR_BEHAVIOR DL_SYSCTL_getWWDT0ErrorBehavior(void)
+{
+    uint32_t behavior =
+        (SYSCTL->SOCLOCK.SYSTEMCFG & SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_MASK) >>
+        SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_OFS;
+
+    return (DL_SYSCTL_ERROR_BEHAVIOR)(behavior);
+}
+
+/**
+ *  @brief  Set the behavior when a WWDT1 error occurs
+ *
+ *  Configures whether a WWDT1 error will trigger a SYSRST or an NMI
+ * (non-maskable interrupt). By default, this error will trigger a SYSRST.
+ *
+ *  @param[in] behavior The behavior when a Flash ECC DED occurrs
+ *
+ *  @sa        DL_SYSCTL_enableNonMaskableInterrupt
+ */
+__STATIC_INLINE void DL_SYSCTL_setWWDT1ErrorBehavior(
+    DL_SYSCTL_ERROR_BEHAVIOR behavior)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SYSTEMCFG,
+        (((uint32_t) behavior << SYSCTL_SYSTEMCFG_WWDTLP1RSTDIS_OFS)) |
+            SYSCTL_SYSTEMCFG_KEY_VALUE,
+        (SYSCTL_SYSTEMCFG_WWDTLP1RSTDIS_MASK | SYSCTL_SYSTEMCFG_KEY_MASK));
+}
+
+/**
+ *  @brief  Get the behavior when a WWDT1 error occurs
+ *
+ *  By default, this error will trigger a SYSRST.
+ *
+ *  @return The behavior when a WWDT1 error occurs
+ *
+ *  @retval One of @ref DL_SYSCTL_ERROR_BEHAVIOR
+ */
+__STATIC_INLINE DL_SYSCTL_ERROR_BEHAVIOR DL_SYSCTL_getWWDT1ErrorBehavior(void)
+{
+    uint32_t behavior =
+        (SYSCTL->SOCLOCK.SYSTEMCFG & SYSCTL_SYSTEMCFG_WWDTLP1RSTDIS_MASK) >>
+        SYSCTL_SYSTEMCFG_WWDTLP1RSTDIS_OFS;
+
+    return (DL_SYSCTL_ERROR_BEHAVIOR)(behavior);
+}
+
+/**
+ *  @brief Set the Main Clock (MCLK) divider (MDIV)
+ *
+ *  Additionally, can use this function to disable MDIV. MDIV must be disabled
+ *  before changing SYSOSC frequency.
+ *
+ *  MDIV is not valid if MCLK source is HSCLK.
+ *  MDIV is not used if MCLK source if LFCLK.
+ *
+ *  @param[in] divider Should be DL_SYSCTL_MCLK_DIVIDER_DISABLE if source is
+ *  HSCLK, a don't care if LFCLK, and one of DL_SYSCTL_MCLK_DIVIDER if SYSOSC.
+ */
+__STATIC_INLINE void DL_SYSCTL_setMCLKDivider(DL_SYSCTL_MCLK_DIVIDER divider)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.MCLKCFG, (uint32_t) divider,
+        SYSCTL_MCLKCFG_MDIV_MASK);
+}
+/**
+ *  @brief Get the Main Clock (MCLK) divider (MDIV)
+ *
+ *  @return The value of the Main Clock (MCLK) divider (MDIV)
+ *
+ *  @retval Should be DL_SYSCTL_MCLK_DIVIDER_DISABLE if source is HSCLK, a
+ *  don't care if LFCLK, and one of DL_SYSCTL_MCLK_DIVIDER if SYSOSC.
+ */
+__STATIC_INLINE DL_SYSCTL_MCLK_DIVIDER DL_SYSCTL_getMCLKDivider(void)
+{
+    uint32_t divider = SYSCTL->SOCLOCK.MCLKCFG & SYSCTL_MCLKCFG_MDIV_MASK;
+
+    return (DL_SYSCTL_MCLK_DIVIDER)(divider);
+}
+
+/**
+ *  @brief   Get the source for the Main Clock (MCLK)
+ *
+ *  @return  The source for the Main Clock (MCLK)
+ *
+ *  @retval  One of @ref DL_SYSCTL_MCLK_SOURCE
+ */
+__STATIC_INLINE DL_SYSCTL_MCLK_SOURCE DL_SYSCTL_getMCLKSource(void)
+{
+    uint32_t source =
+        SYSCTL->SOCLOCK.MCLKCFG &
+        (SYSCTL_MCLKCFG_USEHSCLK_MASK | SYSCTL_MCLKCFG_USELFCLK_MASK);
+
+    return (DL_SYSCTL_MCLK_SOURCE)(source);
+}
+
+/**
+ *  @brief     Set the target frequency of the System Oscillator (SYSOSC)
+ *
+ *  Target/desired SYSOSC frequency may be different than current/actual SYSOSC
+ *  frequency during gear shift and other operations.
+ *
+ *  The System Oscillator (SYSOSC) is an on-chip, accurate, configurable
+ *  oscillator with factory trimmed support for 32MHz (base frequency) and 4MHz
+ *  (low frequency) operation.
+ *  It can also operate at 16MHz or 24MHz by using the
+ *  @ref DL_SYSCTL_configSYSOSCUserTrim function instead.
+ *
+ *  SYSOSC provides a flexible high-speed clock source for the system in cases
+ *  where the HFXT is either not present or not used.
+ *
+ *  MDIV must be disabled before changing SYSOSC freq. See @ref DL_SYSCTL_setMCLKDivider.
+ *
+ *  @param[in] freq  Target frequency to use for the System Oscillator (SYSOSC).
+ *                  @ref DL_SYSCTL_SYSOSC_FREQ_4M or @ref DL_SYSCTL_SYSOSC_FREQ_BASE.
+ *
+ *  @sa DL_SYSCTL_configSYSOSCUserTrim
+ *  @sa DL_SYSCTL_setMCLKDivider
+ */
+__STATIC_INLINE void DL_SYSCTL_setSYSOSCFreq(DL_SYSCTL_SYSOSC_FREQ freq)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SYSOSCCFG, (uint32_t) freq,
+        SYSCTL_SYSOSCCFG_FREQ_MASK);
+}
+
+/**
+ *  @brief     Trim the System Oscillator (SYSOSC) to 16MHz or 24MHz
+ *
+ *  The trim values supplied in the config struct must be determined by
+ *  experimentation. Please refer to the "SYSOSC User Trim Procedure" section
+ *  in the CKM Technical Reference Manual.
+ *  Each device must be trimmed individually for accuracy.
+ *
+ *  MDIV must be disabled before changing SYSOSC freq. See @ref DL_SYSCTL_setMCLKDivider.
+ *
+ *  @param[in]  config         Pointer to the SYSOSC user trim configuration struct
+ *                             @ref DL_SYSCTL_SYSOSCUserTrimConfig.
+ *
+ *  @sa DL_SYSCTL_setSYSOSCFreq
+ *  @sa DL_SYSCTL_setMCLKDivider
+ */
+__STATIC_INLINE void DL_SYSCTL_configSYSOSCUserTrim(
+    DL_SYSCTL_SYSOSCUserTrimConfig *config)
+{
+    SYSCTL->SOCLOCK.SYSOSCTRIMUSER =
+        ((config->rDiv << SYSCTL_SYSOSCTRIMUSER_RDIV_OFS) &
+            SYSCTL_SYSOSCTRIMUSER_RDIV_MASK) |
+        ((config->resistorFine << SYSCTL_SYSOSCTRIMUSER_RESFINE_OFS) &
+            SYSCTL_SYSOSCTRIMUSER_RESFINE_MASK) |
+        ((config->resistorCoarse << SYSCTL_SYSOSCTRIMUSER_RESCOARSE_OFS) &
+            SYSCTL_SYSOSCTRIMUSER_RESCOARSE_MASK) |
+        (config->capacitor << SYSCTL_SYSOSCTRIMUSER_CAP_OFS) |
+        ((uint32_t) config->freq);
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SYSOSCCFG,
+        SYSCTL_SYSOSCCFG_FREQ_SYSOSCUSER, SYSCTL_SYSOSCCFG_FREQ_MASK);
+}
+
+/**
+ *  @brief   Get the target frequency of the System Oscillator (SYSOSC)
+ *  Target/desired SYSOSC frequency may be different than current/actual SYSOSC
+ *  frequency during gear shift and other operations.
+ *  This function matches what is input by @ref DL_SYSCTL_setSYSOSCFreq.
+ *
+ *  @return  The target frequency of System Oscillator (SYSOSC). One of
+ *           @ref DL_SYSCTL_SYSOSC_FREQ.
+ */
+__STATIC_INLINE DL_SYSCTL_SYSOSC_FREQ DL_SYSCTL_getTargetSYSOSCFreq(void)
+{
+    uint32_t freq = SYSCTL->SOCLOCK.SYSOSCCFG & SYSCTL_SYSOSCCFG_FREQ_MASK;
+
+    return (DL_SYSCTL_SYSOSC_FREQ)(freq);
+}
+
+/**
+ *  @brief   Get the current frequency of the System Oscillator (SYSOSC)
+ *  Current/actual SYSOSC frequency may be different than target/desired SYSOSC
+ *  frequency during gear shift and other operations.
+ *
+ *  @return  The current frequency of System Oscillator (SYSOSC). One of
+ *           @ref DL_SYSCTL_SYSOSC_FREQ.
+ */
+__STATIC_INLINE DL_SYSCTL_SYSOSC_FREQ DL_SYSCTL_getCurrentSYSOSCFreq(void)
+{
+    uint32_t freq =
+        SYSCTL->SOCLOCK.CLKSTATUS & SYSCTL_CLKSTATUS_SYSOSCFREQ_MASK;
+
+    return (DL_SYSCTL_SYSOSC_FREQ)(freq);
+}
+
+/**
+ *  @brief   Returns status of the different clocks in CKM
+ *
+ *  @return  Full status of all clock selections
+ *
+ *  @retval  Bitwise OR of @ref DL_SYSCTL_CLK_STATUS.
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getClockStatus(void)
+{
+    return (SYSCTL->SOCLOCK.CLKSTATUS);
+}
+
+/**
+ *  @brief   Returns general status of SYSCTL
+ *
+ *  @return  Full status of all general conditions in SYSCTL
+ *
+ *  @retval  Bitwise OR of @ref DL_SYSCTL_STATUS.
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getStatus(void)
+{
+    return (SYSCTL->SOCLOCK.SYSSTATUS);
+}
+
+/**
+ *  @brief   Clear the ECC error bits in SYSSTATUS
+ *
+ *  The ECC error bits in SYSSTATUS are sticky (they remain set when an ECC
+ *  error occurs even if future reads do not have errors), and can be
+ *  cleared through this API.
+ */
+__STATIC_INLINE void DL_SYSCTL_clearECCErrorStatus(void)
+{
+    SYSCTL->SOCLOCK.SYSSTATUSCLR =
+        (SYSCTL_SYSSTATUSCLR_ALLECC_CLEAR | SYSCTL_SYSSTATUSCLR_KEY_VALUE);
+}
+
+/**
+ *  @brief     Configure SYSPLL output frequencies
+ *
+ *  @pre    SYSPLL is disabled (SYSPLLOFF in CLKSTATUS)
+ *  @pre    SYSOSC is running at base frequency (32MHz) even if HFCLK is the
+ *          SYSPLL reference
+ *  @post   SYSPLL has completed startup and outputs chosen frequencies
+ *
+ *  @note   For practical purposes, it is not required to wait until SYSPLL
+ *          completes startup, but do not go into STOP/STANDBY or use SYSPLL
+ *          until completed.
+ *
+ *  @param[in]  config  Pointer to the SYSPLL configuration struct
+ *              @ref DL_SYSCTL_SYSPLLConfig. Elements sysPLLRef, pDiv, and
+ *              inputFreq control desired startup time versus power consumption.
+ */
+void DL_SYSCTL_configSYSPLL(DL_SYSCTL_SYSPLLConfig *config);
+
+/**
+ *  @brief     Set the divider for the Ultra Low Power Clock (ULPCLK)
+ *
+ *  The Ultra Low Power Clock (ULPCLK) is always sourced from the Main Clock
+ *  (MCLK) but can be divided down to a lower frequency. The ULPCLK should
+ *  always remain under 40MHz.
+ *
+ *  The ULPCLK can be used to drive some peripherals on the system.
+ *
+ *  @param[in] divider  Clock divider for Ultra Low Power Clock (ULPCLK). One
+ *                      of @ref DL_SYSCTL_ULPCLK_DIV.
+ */
+__STATIC_INLINE void DL_SYSCTL_setULPCLKDivider(DL_SYSCTL_ULPCLK_DIV divider)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.MCLKCFG, (uint32_t) divider,
+        SYSCTL_MCLKCFG_UDIV_MASK);
+}
+
+/**
+ *  @brief   Get divider used for the Ultra Low Power Clock (ULPCLK)
+ *
+ *  @return  The divider used for Ultra Low Power Clock (ULPCLK)
+ *
+ *  @retval  One of @ref DL_SYSCTL_ULPCLK_DIV.
+ */
+__STATIC_INLINE DL_SYSCTL_ULPCLK_DIV DL_SYSCTL_getULPCLKDivider(void)
+{
+    uint32_t divider = SYSCTL->SOCLOCK.MCLKCFG & SYSCTL_MCLKCFG_UDIV_MASK;
+
+    return (DL_SYSCTL_ULPCLK_DIV)(divider);
+}
+
+/**
+ *  @brief Change LFCLK source to external crystal LFXT
+ *
+ * LFOSC is the internal 32kHz oscillator and default LFCLK source after a BOR.
+ * Once LFCLK source is changed, the change is locked, LFOSC is disabled to
+ * save power, and LFCLK source cannot be selected again without BOR.
+ *
+ * LFXT is an ultra-low power crystal oscillator which supports driving a
+ * standard 32.768kHz watch crystal.
+ *
+ * To use the LFXT, a watch crystal must be populated between LFXIN and LFXOUT
+ * pins. Find more info in LFXT section of CKM Technical Reference Manual.
+ *
+ * GPIO/IOMUX must be configure LFXT functionality for LFXIN and LFXOUT before
+ * calling this function.
+ *
+ * This basic implementation will busy-wait until LFXT oscillator is stabilized.
+ * But a more advanced implementation can do other things while the LFXT is
+ * stabilizing. You can enable LFXTGOOD interrupt, or check CLKSTATUS.LFXTGOOD
+ * when convenient, as long as you do not switch the source via
+ * SETUSELFXT until LFXTGOOD is set.
+ *
+ * LFCLK_IN and LFXT are mutually exclusive.
+ * This function assumes LFCLK_IN is disabled (default).
+ *
+ *  @param[in]  config         Pointer to the LFCLK configuration struct
+ *                             @ref DL_SYSCTL_LFCLKConfig.
+ */
+void DL_SYSCTL_setLFCLKSourceLFXT(DL_SYSCTL_LFCLKConfig *config);
+
+/**
+ *  @brief Change LFCLK source to external digital LFCLK_IN
+ *
+ * LFOSC is the internal 32kHz oscillator and default LFCLK source after a BOR.
+ * Once LFCLK source is changed, the change is locked, LFOSC is disabled to
+ * save power, and LFCLK source cannot be selected again without BOR.
+ *
+ * LFCLK_IN is a low frequency digital clock input compatible with 32.768kHz
+ * typical frequency digital square wave CMOS clock inputs (typical duty
+ * cycle of 50%).
+ *
+ * Digital clock input must be valid and GPIO/IOMUX must be configured
+ * separately on the appropriate pin before calling this function to enable
+ * LFCLK_IN.
+ *
+ * LFCLK_IN and LFXT are mutually exclusive.
+ * This function assumes LFXT is disabled (default).
+ */
+__STATIC_INLINE void DL_SYSCTL_setLFCLKSourceEXLF(void)
+{
+    SYSCTL->SOCLOCK.EXLFCTL =
+        (SYSCTL_EXLFCTL_KEY_VALUE | SYSCTL_EXLFCTL_SETUSEEXLF_TRUE);
+}
+
+/**
+ *  @brief Change HFCLK source to external crystal HFXT with default parameters
+ *
+ * HFXT is a high frequency crystal oscillator which supports standard crystals
+ * and resonators in the 4-48MHz range to generate a stable high-speed
+ * reference clock for the system.
+ *
+ * To use the HFXT, a crystal or resonator must be populated between HFXIN and HFXOUT
+ * pins. Find more info in HFXT section of CKM Technical Reference Manual.
+ *
+ * GPIO/IOMUX must be configure HFXT functionality for HFXIN and HFXOUT before
+ * calling this function.
+ *
+ * The HFXT startup time is set to ~0.512ms based on the TYP datasheet
+ * recommendation. Additionally, the HFCLK startup monitor is enabled.
+ *
+ * This basic implementation will busy-wait until HFXT oscillator is stabilized.
+ * But a more advanced implementation can do other things while the HFXT is
+ * stabilizing. You can enable HFCLKGOOD interrupt, or check CLKSTATUS.HFCLKGOOD
+ * when convenient, as long as you do not switch the source before HFCLKGOOD is set.
+ *
+ * To modify the default HFXT startup time or disable the startup monitor, use
+ * @ref DL_SYSCTL_setHFCLKSourceHFXTParams instead of this API.
+ *
+ *  @param[in]  range   HFXT frequency range
+ */
+void DL_SYSCTL_setHFCLKSourceHFXT(DL_SYSCTL_HFXT_RANGE range);
+
+/**
+ *  @brief Change HFCLK source to external crystal HFXT with custom parameters
+ *
+ * HFXT is a high frequency crystal oscillator which supports standard crystals
+ * and resonators in the 4-48MHz range to generate a stable high-speed
+ * reference clock for the system.
+ *
+ * To use the HFXT, a crystal or resonator must be populated between HFXIN and HFXOUT
+ * pins. Find more info in HFXT section of CKM Technical Reference Manual.
+ *
+ * GPIO/IOMUX must be configure HFXT functionality for HFXIN and HFXOUT before
+ * calling this function.
+ *
+ * If the HFCLK startup monitor is enabled, then the HFXT will be checked after
+ * the amount of time specified by the startupTime parameter.
+ * This basic implementation will busy-wait until HFXT oscillator is stabilized.
+ * But a more advanced implementation can do other things while the HFXT is
+ * stabilizing. You can enable HFCLKGOOD interrupt, or check CLKSTATUS.HFCLKGOOD
+ * when convenient, as long as you do not switch the source before HFCLKGOOD is set.
+ *
+ * If the HFCLK startup monitor is disabled, then this implementation will not
+ * check if the HFXT oscillator is stabilized.
+ *
+ *  @param[in]  range           HFXT frequency range
+ *  @param[in]  startupTime     HFXT startup time
+ *  @param[in]  monitorEnable   Whether to enable the HFCLK startup monitor
+
+ */
+void DL_SYSCTL_setHFCLKSourceHFXTParams(
+    DL_SYSCTL_HFXT_RANGE range, uint32_t startupTime, bool monitorEnable);
+
+/**
+ *  @brief      Disable the SYSPLL
+ *
+ *  If SYSPLL is already enabled, application software should not disable the
+ *  SYSPLL until the SYSPLLGOOD or SYSPLOFF bit is set in the CLKSTATUS
+ *  register, indicating that the SYSPLL transitioned to a stable active or a
+ *  stable dead state.
+ *
+ *  @sa DL_SYSCTL_getClockStatus
+ */
+__STATIC_INLINE void DL_SYSCTL_disableSYSPLL(void)
+{
+    SYSCTL->SOCLOCK.HSCLKEN &= ~(SYSCTL_HSCLKEN_SYSPLLEN_MASK);
+}
+
+/**
+ *  @brief      Disable the HFXT
+ *
+ *  If HFXT is already enabled, application software must verify that either an
+ *  HFCLKGOOD indication or an HFCLKOFF (off/dead) indication in the CLKSTATUS
+ *  register was asserted by hardware before attempting to disable the HFXT
+ *  by clearing HFXTEN. When disabling the HFXT by clearing HFXTEN, the HFXT
+ *  must not be re-enabled again until the HFCLKOFF bit in the CLKSTATUS
+ *  register is set by hardware.
+ *
+ *  @sa DL_SYSCTL_getClockStatus
+ */
+__STATIC_INLINE void DL_SYSCTL_disableHFXT(void)
+{
+    SYSCTL->SOCLOCK.HSCLKEN &= ~(SYSCTL_HSCLKEN_HFXTEN_MASK);
+}
+
+/**
+ *  @brief Change HFCLK source to external digital HFCLK_IN
+ *
+ * HFCLK_IN can be used to bypass the HFXT circuit and bring 4-48MHz typical
+ * frequency digital clock into the devce as HFCLK source instead of HFXT.
+ *
+ * HFCLK_IN is a digital clock input compatible with digital square wave CMOS
+ * clock inputs and should have typical duty cycle of 50%.
+ *
+ * Digital clock input must be valid and GPIO/IOMUX must be configured
+ * separately on the appropriate pin before calling this function to enable
+ * HFCLK_IN.
+ */
+__STATIC_INLINE void DL_SYSCTL_setHFCLKSourceHFCLKIN(void)
+{
+    /* Some crystal configurations are retained in lower reset levels. Set
+     * default behavior of HFXT to keep a consistent behavior regardless of
+     * reset level. */
+    DL_SYSCTL_disableHFXT();
+
+    SYSCTL->SOCLOCK.HSCLKEN |= SYSCTL_HSCLKEN_USEEXTHFCLK_ENABLE;
+}
+
+/**
+ *  @brief   Get the source of High Speed Clock (HSCLK)
+ *
+ * HSCLK can be sourced by SYSPLL or HFCLK.
+ * HSCLK is an optional source for MCLK alongside SYSOSC or LFCLK.
+ *
+ *  @return  The source of HSCLK. One of @ref DL_SYSCTL_HSCLK_SOURCE.
+ */
+__STATIC_INLINE DL_SYSCTL_HSCLK_SOURCE DL_SYSCTL_getHSCLKSource(void)
+{
+    uint32_t source = SYSCTL->SOCLOCK.HSCLKCFG & SYSCTL_HSCLKCFG_HSCLKSEL_MASK;
+
+    return (DL_SYSCTL_HSCLK_SOURCE)(source);
+}
+
+/**
+ *  @brief   Set the source of High Speed Clock (HSCLK)
+ *
+ * HSCLK can be sourced by SYSPLL or HFCLK.
+ * HSCLK is an optional source for MCLK alongside SYSOSC or LFCLK.
+ *
+ *  @param[in]  source  The source of HSCLK. One of @ref DL_SYSCTL_HSCLK_SOURCE.
+ */
+__STATIC_INLINE void DL_SYSCTL_setHSCLKSource(DL_SYSCTL_HSCLK_SOURCE source)
+{
+    SYSCTL->SOCLOCK.HSCLKCFG = (uint32_t) source;
+}
+
+/**
+ *  @brief   Get the source of Middle Frequency Precision Clock (MFPCLK)
+ *
+ *  MFPCLK is a continuous 4MHz to DAC module in RUN/SLEEP/STOP mode.
+ *  Unlike MFCLK, MFPCLK is async to MCLK/ULPCLK, providing higher DAC precision and performance.
+ *  MFPCLK is the only clock source for DAC.
+ *
+ *  @return  The source of MFPCLK. One of @ref DL_SYSCTL_MFPCLK_SOURCE.
+ */
+__STATIC_INLINE DL_SYSCTL_MFPCLK_SOURCE DL_SYSCTL_getMFPCLKSource(void)
+{
+    uint32_t source =
+        SYSCTL->SOCLOCK.GENCLKCFG & SYSCTL_GENCLKCFG_MFPCLKSRC_MASK;
+
+    return (DL_SYSCTL_MFPCLK_SOURCE)(source);
+}
+
+/**
+ *  @brief   Set the source of Middle Frequency Precision Clock (MFPCLK)
+ *
+ *  MFPCLK is a continuous 4MHz to DAC module in RUN/SLEEP/STOP mode.
+ *  Unlike MFCLK, MFPCLK is async to MCLK/ULPCLK, providing higher DAC precision and performance.
+ *  MFPCLK is the only clock source for DAC.
+ *
+ *  @param[in]  source  The source of MFPCLK. One of @ref DL_SYSCTL_MFPCLK_SOURCE.
+ */
+__STATIC_INLINE void DL_SYSCTL_setMFPCLKSource(DL_SYSCTL_MFPCLK_SOURCE source)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.GENCLKCFG, (uint32_t) source,
+        SYSCTL_GENCLKCFG_MFPCLKSRC_MASK);
+}
+
+/**
+ *  @brief  Enable the Medium Frequency Clock (MFCLK)
+ *
+ *  MFCLK provides a continuous 4MHz clock to drive certain peripherals on the system.
+ *  The 4MHz rate is always derived from SYSOSC, and the divider is automatically
+ *  applied to maintain the 4MHz rate regardless of SYSOSC frequency.
+ *  MCLK is ideal for timers and serial interfaces which require a constant
+ *  clock source in RUN/SLEEP/STOP power modes.
+ *
+ *  MFCLK can only run if 3 conditions are met:
+ *
+ *  1) Power mode must be RUN, SLEEP, or STOP.
+ *  2) USEMFTICK register bit is set, which this function does
+ *  3) MDIV must be set to @ref DL_SYSCTL_MCLK_DIVIDER_DISABLE by @ref DL_SYSCTL_setMCLKDivider.
+ *
+ *  If MCLK source is not SYSOSC, MCLK frequency must be >=32MHz for correct operation of MFCLK.
+ *
+ *  @sa DL_SYSCTL_setMCLKDivider
+ *  @sa DL_SYSCTL_getMCLKSource
+ *  @sa DL_SYSCTL_getMCLKFreq
+ */
+__STATIC_INLINE void DL_SYSCTL_enableMFCLK(void)
+{
+    SYSCTL->SOCLOCK.MCLKCFG |= SYSCTL_MCLKCFG_USEMFTICK_ENABLE;
+}
+
+/**
+ *  @brief  Disable the Medium Frequency Clock (MFCLK)
+ */
+__STATIC_INLINE void DL_SYSCTL_disableMFCLK(void)
+{
+    SYSCTL->SOCLOCK.MCLKCFG &= ~(SYSCTL_MCLKCFG_USEMFTICK_ENABLE);
+}
+
+/**
+ *  @brief  Enable the Middle Frequency Precision Clock (MFPCLK)
+ *
+ *  MFPCLK provides a continuous 4MHz clock to the DAC.
+ *
+ *  MFPCLK can be sources from either SYSOSC or HFCLK (HFXT or HFCLK_IN).
+ *
+ *  The DAC does not have a clock selection mux. Its clock source is selected
+ *  by configuring MFPCLK.
+ *
+ *  @sa DL_SYSCTL_disableMFPCLK
+ */
+__STATIC_INLINE void DL_SYSCTL_enableMFPCLK(void)
+{
+    SYSCTL->SOCLOCK.GENCLKEN |= SYSCTL_GENCLKEN_MFPCLKEN_ENABLE;
+}
+
+/**
+ *  @brief  Disable the Middle Frequency Precision Clock (MFPCLK)
+ *  @sa DL_SYSCTL_enableMFPCLK
+ */
+__STATIC_INLINE void DL_SYSCTL_disableMFPCLK(void)
+{
+    SYSCTL->SOCLOCK.GENCLKEN &= ~(SYSCTL_GENCLKEN_MFPCLKEN_ENABLE);
+}
+
+/**
+ *  @brief  Set the divider for HFCLK when HFCLK is used as the MFPCLK source
+ *
+ *  @param[in] divider   The divider of HFCLK for MFPCLK
+ *                       One of @ref DL_SYSCTL_HFCLK_MFPCLK_DIVIDER.
+ */
+__STATIC_INLINE void DL_SYSCTL_setHFCLKDividerForMFPCLK(
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER divider)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.GENCLKCFG,
+        ((uint32_t) divider << SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_OFS),
+        SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_MASK);
+}
+
+/**
+ *  @brief   Get the divider for HFCLK when HFCLK is used as the MFPCLK source
+ *
+ *  @return  Returns the divider for HFCLK for MFPCLK
+ *
+ *  @retval  One of @ref DL_SYSCTL_HFCLK_MFPCLK_DIVIDER
+ */
+__STATIC_INLINE DL_SYSCTL_HFCLK_MFPCLK_DIVIDER
+DL_SYSCTL_getHFCLKDividerForMFPCLK(void)
+{
+    uint32_t divider =
+        (SYSCTL->SOCLOCK.GENCLKCFG & SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_MASK) >>
+        SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_OFS;
+
+    return (DL_SYSCTL_HFCLK_MFPCLK_DIVIDER)(divider);
+}
+
+/**
+ *  @brief  Enable the External Clock (CLK_OUT)
+ *
+ *  CLK_OUT is provided for pushing out digital clocks to external circuits, such
+ *  as an external ADC which does not have its own clock source.
+ *
+ *  IOMUX setting for CLK_OUT must be configured before using this function.
+ *
+ *  CLK_OUT has a typical duty cycle of 50% if clock source is HFCLK, SYSPLLOUT1,
+ *  SYSOSC, or LFCLK. If source is MCLK, ULPCLK, or MFCLK, duty cycle is not
+ *  guaranteed to be 50%.
+ *
+ *  This function performs multiple operations:
+ *  1) Sets the CLK_OUT source
+ *  2) Sets the CLK_OUT divider value
+ *  3) Enables the CLK_OUT divider, which can be disabled by @ref DL_SYSCTL_disableExternalClockDivider
+ *  4) Enables the CLK_OUT, which can be disabled by @ref DL_SYSCTL_disableExternalClock
+ *
+ *  @param[in]  source  The source of CLK_OUT. One of @ref DL_SYSCTL_CLK_OUT_SOURCE.
+ *  @param[in]  divider The divider of CLK_OUT. One of @ref DL_SYSCTL_CLK_OUT_DIVIDE.
+ *
+ *  @sa DL_SYSCTL_disableExternalClock
+ *  @sa DL_SYSCTL_disableExternalClockDivider
+ */
+__STATIC_INLINE void DL_SYSCTL_enableExternalClock(
+    DL_SYSCTL_CLK_OUT_SOURCE source, DL_SYSCTL_CLK_OUT_DIVIDE divider)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.GENCLKCFG,
+        (uint32_t) divider | (uint32_t) source,
+        SYSCTL_GENCLKCFG_EXCLKDIVEN_MASK | SYSCTL_GENCLKCFG_EXCLKDIVVAL_MASK |
+            SYSCTL_GENCLKCFG_EXCLKSRC_MASK);
+    SYSCTL->SOCLOCK.GENCLKEN |= SYSCTL_GENCLKEN_EXCLKEN_ENABLE;
+}
+
+/**
+ *  @brief  Disable the External Clock (CLK_OUT)
+ *  @sa DL_SYSCTL_enableExternalClock
+ */
+__STATIC_INLINE void DL_SYSCTL_disableExternalClock(void)
+{
+    SYSCTL->SOCLOCK.GENCLKEN &= ~(SYSCTL_GENCLKEN_EXCLKEN_ENABLE);
+}
+
+/**
+ *  @brief  Disable the External Clock (CLK_OUT) Divider
+ *  @sa DL_SYSCTL_enableExternalClock
+ */
+__STATIC_INLINE void DL_SYSCTL_disableExternalClockDivider(void)
+{
+    SYSCTL->SOCLOCK.GENCLKCFG &= ~(SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE);
+}
+
+/**
+ *  @brief  Blocks all asynchronous fast clock requests
+ *
+ *  To block specific async fast clock requests on certain IP, refer to their
+ *  individual driverlib. Examples include: RTC, UART, SPI, I2C.
+ */
+__STATIC_INLINE void DL_SYSCTL_blockAllAsyncFastClockRequests(void)
+{
+    SYSCTL->SOCLOCK.SYSOSCCFG |= SYSCTL_SYSOSCCFG_BLOCKASYNCALL_ENABLE;
+}
+
+/**
+ *  @brief  Allows all asynchronous fast clock requests
+ *
+ *  Although this allows all async fast clock requests, individual IPs may still
+ *  be blocking theirs.
+ *
+ *  To allow specific async fast clock requests on certain IP, refer to their
+ *  individual driverlib. Examples include: RTC, UART, SPI, I2C, GPIO.
+ */
+__STATIC_INLINE void DL_SYSCTL_allowAllAsyncFastClockRequests(void)
+{
+    SYSCTL->SOCLOCK.SYSOSCCFG &= ~(SYSCTL_SYSOSCCFG_BLOCKASYNCALL_ENABLE);
+}
+
+/**
+ *  @brief  Generates an asynchronous fast clock request upon any IRQ request to CPU.
+ *
+ *  Provides lowest latency interrupt handling regardless of system clock speed.
+ *  Blockable by @ref DL_SYSCTL_blockAllAsyncFastClockRequests
+ *
+ *  @sa DL_SYSCTL_blockAllAsyncFastClockRequests
+ */
+__STATIC_INLINE void DL_SYSCTL_enableFastCPUEventHandling(void)
+{
+    SYSCTL->SOCLOCK.SYSOSCCFG |= SYSCTL_SYSOSCCFG_FASTCPUEVENT_ENABLE;
+}
+
+/**
+ *  @brief  Maintains current system clock speed for IRQ request to CPU.
+ *
+ *  Latency for interrupt handling will be higher at lower system clock speeds.
+ */
+__STATIC_INLINE void DL_SYSCTL_disableFastCPUEventHandling(void)
+{
+    SYSCTL->SOCLOCK.SYSOSCCFG &= ~(SYSCTL_SYSOSCCFG_FASTCPUEVENT_ENABLE);
+}
+
+/**
+ *  @brief  Set the SRAM boundary address to act as partition for read-execute
+ *          permission
+ *
+ *  Specify the SRAM partition address to protect the code region of SRAM from
+ *  being written to, and prevent the RW ("data") region of SRAM from being
+ *  used for code execution.
+ *  The SRAM partition address creates lower and higher partitions:
+ *      - Lower partition is Read-Write only, no execute
+ *      - Upper partition is Read-Execute only, no write
+ *  A partition address of 0x0 is a special case and indicates that all SRAM is
+ *  configured with RWX (read-write-execute) permissions. This is the default
+ *  value.
+ *
+ *  The address is set with a 32-byte resolution. The address written is the
+ *  system memory map address of the partition (0x200X_XXXX).
+ *
+ *  @param[in]  address   Address to act as the SRAM partition address. Value is
+ *                        a valid 32-bit SRAM address. Only address bits [19:5]
+ *                        i.e. bit 5 to bit 19 are used for the boundary address
+ */
+__STATIC_INLINE void DL_SYSCTL_setSRAMBoundaryAddress(uint32_t address)
+{
+    SYSCTL->SOCLOCK.SRAMBOUNDARY =
+        (((uint32_t) address) & SYSCTL_SRAMBOUNDARY_ADDR_MASK);
+}
+
+/**
+ *  @brief  Get the SRAM boundary address
+ *
+ *  Get the SRAM partition address
+ *  The SRAM partition address creates lower and higher partitions:
+ *      - Lower partition is Read-Write only, no execute
+ *      - Upper partition is Read-Execute only, no write
+ *  A partition address of 0x0 is a special case and indicates that all SRAM is
+ *  configured with RWX (read-write-execute) permissions.
+ *
+ *  The address is set with a 32-byte granularity. The address written is the
+ *  system memory map address of the partition (0x200X_XXXX).
+ *
+ *  @return     The SRAM partition address offset from the SRAM base address
+ *
+ *  @retval     Value is range in [0x0, 0x000FFFE0]
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getSRAMBoundaryAddress(void)
+{
+    return (SYSCTL->SOCLOCK.SRAMBOUNDARY);
+}
+
+/**
+ *  @brief  Set flash wait state
+ *
+ *  @note Flash wait states are managed automatically by SYSCTL when MCLK is
+ *  running from SYSOSC or LFCLK.
+ *  @note This wait state is only applied if MCLK running from SYSPLL, HFXT,
+ *  or HFCLK_IN.
+ *
+ *  Consult device specific datasheet for proper values.
+ *
+ *  @param[in]  waitState  Desired number of flash wait states. One of
+ *  @ref DL_SYSCTL_FLASH_WAIT_STATE.
+ */
+__STATIC_INLINE void DL_SYSCTL_setFlashWaitState(
+    DL_SYSCTL_FLASH_WAIT_STATE waitState)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.MCLKCFG, (uint32_t) waitState,
+        SYSCTL_MCLKCFG_FLASHWAIT_MASK);
+}
+
+/**
+ *  @brief  Get flash wait state
+ *
+ *  @note Flash wait states are managed automatically by SYSCTL when MCLK is
+ *  running from SYSOSC or LFCLK.
+ *  @note This wait state is only applied if MCLK running from SYSPLL, HFXT,
+ *  or HFCLK_IN.
+ *
+ *  Consult device specific datasheet for proper values.
+ *
+ *  @return Number of flash wait states. One of @ref DL_SYSCTL_FLASH_WAIT_STATE.
+ */
+__STATIC_INLINE DL_SYSCTL_FLASH_WAIT_STATE DL_SYSCTL_getFlashWaitState(void)
+{
+    uint32_t waitState =
+        SYSCTL->SOCLOCK.MCLKCFG & SYSCTL_MCLKCFG_FLASHWAIT_MASK;
+
+    return (DL_SYSCTL_FLASH_WAIT_STATE)(waitState);
+}
+
+/**
+ *  @brief  Read Frequency Clock Counter (FCC)
+ *  @return  22-bit value of Frequency Clock Counter (FCC)
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_readFCC(void)
+{
+    return (SYSCTL->SOCLOCK.FCC);
+}
+
+/**
+ *  @brief  Start Frequency Clock Counter (FCC)
+ *
+ *  If FCC_IN is already logic high, counting starts immediately.
+ *  When using level trigger, FCC_IN should be low when GO is set, and trigger
+ *  pulse should be sent to FCC_IN after starting FCC.
+ */
+__STATIC_INLINE void DL_SYSCTL_startFCC(void)
+{
+    SYSCTL->SOCLOCK.FCCCMD = (SYSCTL_FCCCMD_KEY_VALUE | SYSCTL_FCCCMD_GO_TRUE);
+}
+
+/**
+ *  @brief  Returns whether FCC is done capturing
+ *
+ *  When capture completes, FCCDONE is set by hardware.
+ *  FCCDONE is read-only and is automatically cleared by hardware when a new
+ *  capture is started.
+ *
+ *  @return Whether FCC is done or not
+ *  @retval true or false (boolean)
+ */
+__STATIC_INLINE bool DL_SYSCTL_isFCCDone(void)
+{
+    return (DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_FCCDONE_DONE) ==
+           SYSCTL_CLKSTATUS_FCCDONE_DONE;
+}
+
+/**
+ *  @brief     Configure the Frequency Clock Counter (FCC)
+ *
+ *  FCC enables flexible in-system testing and calibration of a variety of oscillators
+ *  and clocks on the device. The FCC counts the number of clock periods seen on the
+ *  selected clock source within a known fixed trigger period (derived from a secondary
+ *  reference source) to provide an estimation of the frequency of the source clock.
+ *
+ *  @param[in] trigLvl  Determines if active high level trigger or rising-edge
+ *                      to rising-edge. One of @ref DL_SYSCTL_FCC_TRIG_TYPE.
+ *                      @sa DL_SYSCTL_setFCCPeriods must be called to configure
+ *                      number of rising-edge to rising-edge periods when
+ *                      DL_SYSCTL_FCC_TRIG_TYPE_RISE_RISE is selected.
+ *  @param[in] trigSrc  Determines which clock source to trigger FCC from. One of
+ *                      @ref DL_SYSCTL_FCC_TRIG_SOURCE.
+ *  @param[in] clkSrc   Which clock source to capture and measure frequency of. One of
+ *                      @ref DL_SYSCTL_FCC_CLOCK_SOURCE.
+ */
+void DL_SYSCTL_configFCC(DL_SYSCTL_FCC_TRIG_TYPE trigLvl,
+    DL_SYSCTL_FCC_TRIG_SOURCE trigSrc, DL_SYSCTL_FCC_CLOCK_SOURCE clkSrc);
+
+/**
+ *  @brief     Sets number of rising-edge to rising-edge period for Frequency
+ *             Clock Counter (FCC)
+ *
+ *  Set the number of rising-edge to rising-edge period for Frequency
+ *             Clock Counter (FCC)
+ *
+ *  @param[in] periods  One of @ref DL_SYSCTL_FCC_TRIG_CNT
+ */
+__STATIC_INLINE void DL_SYSCTL_setFCCPeriods(DL_SYSCTL_FCC_TRIG_CNT periods)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.GENCLKCFG, (uint32_t) periods,
+        SYSCTL_GENCLKCFG_FCCTRIGCNT_MASK);
+}
+
+/**
+ *  @brief     Gets number of rising-edge to rising-edge period for Frequency
+ *             Clock Counter (FCC)
+ *
+ *  @return     One of @ref DL_SYSCTL_FCC_TRIG_CNT
+ */
+__STATIC_INLINE DL_SYSCTL_FCC_TRIG_CNT DL_SYSCTL_getFCCPeriods(void)
+{
+    uint32_t periods =
+        SYSCTL->SOCLOCK.GENCLKCFG & SYSCTL_GENCLKCFG_FCCTRIGCNT_MASK;
+
+    return (DL_SYSCTL_FCC_TRIG_CNT)(periods);
+}
+
+/**
+ *  @brief  Enable Frequency Correction Loop (FCL)
+ *
+ *  Used to increase SYSOSC accuracy. An ROSC reference resistor which is suitable
+ *  to meet application accuracy reqiurements must be placed between ROSC pin and
+ *  device ground (VSS).
+ *
+ *  Once FCL is enable, it cannot be disabled by software. A BOOTRST is required.
+ *
+ *  Power consumption of SYSOSC will be marginally higher with FCL enabled due to
+ *  reference current which flows through ROSC.
+ *  Settling time from startup to specified accuracy may also be longer.
+ *  See device-specific datasheet for startup times.
+ */
+__STATIC_INLINE void DL_SYSCTL_enableSYSOSCFCL(void)
+{
+    SYSCTL->SOCLOCK.SYSOSCFCLCTL =
+        (SYSCTL_SYSOSCFCLCTL_KEY_VALUE | SYSCTL_SYSOSCFCLCTL_SETUSEFCL_TRUE);
+}
+
+/**
+ *  @brief  Enable write protection of selected SYSCTL registers
+ *
+ *  Protecting writes to configuration registers in SYSCTL can add a layer of
+ *  robustness against unintended changes during runtime.
+ *
+ *  @note Does not protect all SYSCTL registers, see TRM for more detail.
+ */
+__STATIC_INLINE void DL_SYSCTL_enableWriteLock(void)
+{
+    SYSCTL->SOCLOCK.WRITELOCK = SYSCTL_WRITELOCK_ACTIVE_ENABLE;
+}
+
+/**
+ *  @brief  Disable write protection of selected SYSCTL registers
+ *
+ *  Protecting writes to configuration registers in SYSCTL can add a layer of
+ *  robustness against unintended changes during runtime.
+ *
+ *  @note Does not protect all SYSCTL registers, see TRM for more detail.
+ */
+__STATIC_INLINE void DL_SYSCTL_disableWriteLock(void)
+{
+    SYSCTL->SOCLOCK.WRITELOCK = SYSCTL_WRITELOCK_ACTIVE_DISABLE;
+}
+
+/**
+ *  @brief  Sets operating mode of VBOOST (analog charge pump)
+ *
+ *  Active VBOOST circuitry is needed for COMP/OPA/GPAMP (if present on device).
+ *  VBOOST has a startup time, so consider power consumption versus desired startup time.
+ *
+ *  @note Although VBOOST clock source is automatically managed, it is up to
+ *  application software to ensure certain cases, or else ANACLKERR occurs.
+ *  See VBOOST section of TRM for more details.
+ *  @param[in] setting   One of @ref DL_SYSCTL_VBOOST.
+ */
+__STATIC_INLINE void DL_SYSCTL_setVBOOSTConfig(DL_SYSCTL_VBOOST setting)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.GENCLKCFG, (uint32_t) setting,
+        SYSCTL_GENCLKCFG_ANACPUMPCFG_MASK);
+}
+
+/**
+ *  @brief  Gets operating mode of VBOOST (analog charge pump)
+ *
+ *  Active VBOOST circuitry is needed for COMP/OPA/GPAMP (if present on device).
+ *  VBOOST has a startup time, so consider power consumption versus desired startup time.
+ *
+ *  @note Although VBOOST clock source is automatically managed, it is up to
+ *  application software to ensure certain cases, or else ANACLKERR occurs.
+ *  See VBOOST section of TRM for more details.
+ *  @return One of @ref DL_SYSCTL_VBOOST.
+ */
+__STATIC_INLINE DL_SYSCTL_VBOOST DL_SYSCTL_getVBOOSTConfig(void)
+{
+    uint32_t setting =
+        SYSCTL->SOCLOCK.GENCLKCFG & SYSCTL_GENCLKCFG_ANACPUMPCFG_MASK;
+
+    return (DL_SYSCTL_VBOOST)(setting);
+}
+
+/**
+ *  @brief  Return byte that was saved through SHUTDOWN
+ *
+ *  Shutdown memory persists beyond BOR, BOOTRST, and SYSRST.
+ *
+ *  @note Parity bits and parity fault checking is done by hardware.
+ *
+ *  @param[in] index   One of @ref DL_SYSCTL_SHUTDOWN_STORAGE_BYTE.
+ *
+ *  @return 8-bit value of Shutdown Storage Byte.
+ */
+__STATIC_INLINE uint8_t DL_SYSCTL_getShutdownStorageByte(
+    DL_SYSCTL_SHUTDOWN_STORAGE_BYTE index)
+{
+    const volatile uint32_t *pReg = &SYSCTL->SOCLOCK.SHUTDNSTORE0;
+
+    return (uint8_t)(
+        *(pReg + (uint32_t) index) & SYSCTL_SHUTDNSTORE0_DATA_MASK);
+}
+
+/**
+ *  @brief  Save a byte to SHUTDOWN memory
+ *
+ *  Shutdown memory persists beyond BOR, BOOTRST, and SYSRST.
+ *
+ *  @note Parity bits and parity fault checking is done by hardware.
+ *
+ *  @param[in] index   One of @ref DL_SYSCTL_SHUTDOWN_STORAGE_BYTE.
+ *  @param[in] data    8-bit data to save in memory
+ */
+__STATIC_INLINE void DL_SYSCTL_setShutdownStorageByte(
+    DL_SYSCTL_SHUTDOWN_STORAGE_BYTE index, uint8_t data)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SHUTDNSTORE0 + (uint32_t) index, data,
+        SYSCTL_SHUTDNSTORE0_DATA_MASK);
+}
+
+/**
+ *  @brief  Enable SHUTDOWN IO Release
+ *
+ *  After shutdown, IO is locked in previous state.
+ *
+ *  @note Release IO after re-configuring IO to their proper state.
+ */
+__STATIC_INLINE void DL_SYSCTL_releaseShutdownIO(void)
+{
+    SYSCTL->SOCLOCK.SHDNIOREL =
+        (SYSCTL_SHDNIOREL_KEY_VALUE | SYSCTL_SHDNIOREL_RELEASE_TRUE);
+}
+
+/**
+ *  @brief  Disable the reset functionality of the NRST pin
+ *
+ *  Disabling the NRST pin allows the pin to be configured as a GPIO.
+ *  Once disabled, the reset functionality can only be re-enabled by a POR.
+ *
+ *  @note The register is write-only, so the EXRSTPIN register
+ *        will always appear as "Disabled" in the debugger
+ */
+__STATIC_INLINE void DL_SYSCTL_disableNRSTPin(void)
+{
+    SYSCTL->SOCLOCK.EXRSTPIN =
+        (SYSCTL_EXRSTPIN_KEY_VALUE | SYSCTL_EXRSTPIN_DISABLE_TRUE);
+}
+
+/**
+ *  @brief  Disable Serial Wire Debug (SWD) functionality
+ *
+ *  SWD pins are enabled by default after cold start to allow a debug connection.
+ *  It is possible to disable SWD on these pins to use for other functionality.
+ *
+ *  @post SWD is disabled, but pins must be re-configured separately.
+ *
+ *  @note Cannot debug the device after disabling SWD. Only re-enabled by POR.
+ */
+__STATIC_INLINE void DL_SYSCTL_disableSWD(void)
+{
+    SYSCTL->SOCLOCK.SWDCFG =
+        (SYSCTL_SWDCFG_KEY_VALUE | SYSCTL_SWDCFG_DISABLE_TRUE);
+}
+
+/**
+ *  @brief  Return byte that is stored in RSTCAUSE.
+ *
+ *  @return The cause of reset. One of @ref DL_SYSCTL_RESET_CAUSE
+ */
+__STATIC_INLINE DL_SYSCTL_RESET_CAUSE DL_SYSCTL_getResetCause(void)
+{
+    uint32_t resetCause = SYSCTL->SOCLOCK.RSTCAUSE & SYSCTL_RSTCAUSE_ID_MASK;
+
+    return (DL_SYSCTL_RESET_CAUSE)(resetCause);
+}
+
+/**
+ *  @brief     Set the HFXT startup time
+ *
+ * Specify the HFXT startup time in 64us resolution. If the HFCLK startup
+ * monitor is enabled (HFCLKFLTCHK), HFXT will be checked after this time
+ * expires.
+ *
+ *  @param[in]  startupTime  The HFXT startup time to set in ~64us steps.
+ *                           Value between [0x0 (~0s), 0xFF (~16.32ms)].
+ */
+__STATIC_INLINE void DL_SYSCTL_setHFXTStartupTime(uint32_t startupTime)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.HFCLKCLKCFG, startupTime,
+        SYSCTL_HFCLKCLKCFG_HFXTTIME_MASK);
+}
+
+/**
+ *  @brief   Get the HFXT startup time
+ *
+ *  @return  Returns the HFXT startup time in ~64us steps
+ *
+ *  @retval  Value between [0x0 (~0s), 0xFF (~16.32ms)]
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getHFXTStartupTime(void)
+{
+    return (SYSCTL->SOCLOCK.HFCLKCLKCFG & SYSCTL_HFCLKCLKCFG_HFXTTIME_MASK);
+}
+
+/**
+ *  @brief     Set the HFXT frequency range
+ *
+ * The high frequency crystal oscillator (HFXT) can be used with standard
+ * crystals and resonators in the 4-48MHz range to generate a stable high-speed
+ * reference clock for the system.
+ *
+ *  @param[in]  range  One of @ref DL_SYSCTL_HFXT_RANGE
+ */
+__STATIC_INLINE void DL_SYSCTL_setHFXTFrequencyRange(
+    DL_SYSCTL_HFXT_RANGE range)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.HFCLKCLKCFG, ((uint32_t) range),
+        SYSCTL_HFCLKCLKCFG_HFXTRSEL_MASK);
+}
+
+/**
+ *  @brief   Get the HFXT frequency range
+ *
+ *  @return  Returns the HFXT frequency range
+ *
+ *  @retval  One of @ref DL_SYSCTL_HFXT_RANGE
+ */
+__STATIC_INLINE DL_SYSCTL_HFXT_RANGE DL_SYSCTL_getHFXTFrequencyRange(void)
+{
+    uint32_t range =
+        (SYSCTL->SOCLOCK.HFCLKCLKCFG & SYSCTL_HFCLKCLKCFG_HFXTRSEL_MASK) >>
+        SYSCTL_HFCLKCLKCFG_HFXTRSEL_OFS;
+
+    return (DL_SYSCTL_HFXT_RANGE)(range);
+}
+
+/**
+ *  @brief  Enable the HFCLK startup monitor
+ *
+ * The HFXT takes time to start after being enabled. A startup monitor is
+ * provided to indicate to the application software if the HFXT has successfully
+ * started, at which point the HFCLK can be selected to source a variety of
+ * system functions. The HFCLK startup monitor also supports checking the
+ * HFCLK_IN digital clock input for a clock stuck fault.
+ *
+ */
+__STATIC_INLINE void DL_SYSCTL_enableHFCLKStartupMonitor(void)
+{
+    SYSCTL->SOCLOCK.HFCLKCLKCFG |= SYSCTL_HFCLKCLKCFG_HFCLKFLTCHK_ENABLE;
+}
+
+/**
+ *  @brief  Disable the HFCLK startup monitor
+ */
+__STATIC_INLINE void DL_SYSCTL_disableHFCLKStartupMonitor(void)
+{
+    SYSCTL->SOCLOCK.HFCLKCLKCFG &= ~(SYSCTL_HFCLKCLKCFG_HFCLKFLTCHK_MASK);
+}
+
+/**
+ *  @brief  Retrieves the calibration constant of the temperature sensor to be
+ *          used in temperature calculation.
+ *
+ *  @retval Temperature sensor calibration data
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getTempCalibrationConstant(void)
+{
+    // TODO replace hard coded temp cal address once available in device header file
+    return (*((uint32_t *) 0x41C4003C));
+}
+
+/**
+ *  @brief  Checks if Flash Bank swapping is enabled
+ *
+ *  @return Whether Flash Bank swap is enabled
+ *
+ *  @retval  false  This is not a multi-bank device
+ */
+__STATIC_INLINE bool DL_SYSCTL_isFlashBankSwapEnabled(void)
+{
+    return false;
+}
+
+/**
+ *  @brief  Checks if executing from upper flash bank
+ *
+ *  @return Whether executing from upper flash bank
+ *
+ *  @retval  false  This is not a multi-bank device.
+ */
+__STATIC_INLINE bool DL_SYSCTL_isExecuteFromUpperFlashBank(void)
+{
+    return false;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_dl_m0p_dl_sysctl_sysctl__include */
+/** @}*/

--- a/mspm0/source/ti/driverlib/m0p/sysctl/dl_sysctl_mspm0l122x_l222x.c
+++ b/mspm0/source/ti/driverlib/m0p/sysctl/dl_sysctl_mspm0l122x_l222x.c
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <ti/devices/DeviceFamily.h>
+
+#if (DeviceFamily_PARENT == DeviceFamily_PARENT_MSPM0L122X_L222X)
+
+#include <ti/driverlib/m0p/sysctl/dl_sysctl_mspm0l122x_l222x.h>
+
+bool DL_SYSCTL_initReadExecuteProtectFirewall(
+    uint32_t startAddr, uint32_t endAddr)
+{
+    bool status = false;
+    if (!DL_SYSCTL_isINITDONEIssued()) {
+        DL_SYSCTL_setReadExecuteProtectFirewallAddrStart(startAddr);
+        DL_SYSCTL_setReadExecuteProtectFirewallAddrEnd(endAddr);
+        DL_SYSCTL_enableReadExecuteProtectFirewall();
+        status = true;
+    }
+    return status;
+}
+
+bool DL_SYSCTL_initIPProtectFirewall(uint32_t startAddr, uint32_t endAddr)
+{
+    bool status = false;
+    if (!DL_SYSCTL_isINITDONEIssued()) {
+        DL_SYSCTL_setIPProtectFirewallAddrStart(startAddr);
+        DL_SYSCTL_setIPProtectFirewallAddrEnd(endAddr);
+        DL_SYSCTL_enableIPProtectFirewall();
+        status = true;
+    }
+    return status;
+}
+
+void DL_SYSCTL_setLFCLKSourceLFXT(DL_SYSCTL_LFCLKConfig *config)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.LFCLKCFG,
+        ((uint32_t) config->lowCap << SYSCTL_LFCLKCFG_LOWCAP_OFS) |
+            (uint32_t) config->xt1Drive,
+        (SYSCTL_LFCLKCFG_XT1DRIVE_MASK | SYSCTL_LFCLKCFG_LOWCAP_MASK));
+    // start the LFXT oscillator
+    SYSCTL->SOCLOCK.LFXTCTL =
+        (SYSCTL_LFXTCTL_KEY_VALUE | SYSCTL_LFXTCTL_STARTLFXT_TRUE);
+    // wait until LFXT oscillator is stable
+    // if it does not stabilize, check the hardware/IOMUX settings
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_LFXTGOOD_MASK) !=
+           DL_SYSCTL_CLK_STATUS_LFXT_GOOD) {
+        ;
+    }
+    if (config->monitor) {
+        // set the LFCLK monitor
+        SYSCTL->SOCLOCK.LFCLKCFG |= SYSCTL_LFCLKCFG_MONITOR_ENABLE;
+    }
+
+    // switch LFCLK source from LFOSC to LFXT
+    SYSCTL->SOCLOCK.LFXTCTL =
+        (SYSCTL_LFXTCTL_KEY_VALUE | SYSCTL_LFXTCTL_SETUSELFXT_TRUE);
+}
+
+void DL_SYSCTL_switchMCLKfromSYSOSCtoLFCLK(bool disableSYSOSC)
+{
+    // Set SYSOSC back to base frequency if left enabled
+    if (disableSYSOSC == false) {
+        DL_SYSCTL_setSYSOSCFreq(DL_SYSCTL_SYSOSC_FREQ_BASE);
+        // Do not set both bits
+        SYSCTL->SOCLOCK.SYSOSCCFG &= ~SYSCTL_SYSOSCCFG_DISABLE_ENABLE;
+        SYSCTL->SOCLOCK.MCLKCFG |= SYSCTL_MCLKCFG_USELFCLK_ENABLE;
+    } else {
+        // Do not set both bits
+        SYSCTL->SOCLOCK.MCLKCFG &= ~SYSCTL_MCLKCFG_USELFCLK_ENABLE;
+        SYSCTL->SOCLOCK.SYSOSCCFG |= SYSCTL_SYSOSCCFG_DISABLE_ENABLE;
+    }
+
+    // Verify LFCLK -> MCLK
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_CURMCLKSEL_MASK) !=
+           DL_SYSCTL_CLK_STATUS_MCLK_SOURCE_LFCLK) {
+        ;
+    }
+}
+
+void DL_SYSCTL_switchMCLKfromLFCLKtoSYSOSC(void)
+{
+    // Only one should have been set, but clear both because unknown incoming state
+    // Clear SYSOSCCFG.DISABLE to get SYSOSC running again
+    // Clear MCLKCFG.USELFCLK to switch MCLK source from LFCLK to SYSOSC
+    SYSCTL->SOCLOCK.SYSOSCCFG &= ~SYSCTL_SYSOSCCFG_DISABLE_ENABLE;
+    SYSCTL->SOCLOCK.MCLKCFG &= ~SYSCTL_MCLKCFG_USELFCLK_ENABLE;
+
+    // Verify SYSOSC -> MCLK
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_CURMCLKSEL_MASK) ==
+           DL_SYSCTL_CLK_STATUS_MCLK_SOURCE_LFCLK) {
+        ;
+    }
+}
+
+void DL_SYSCTL_switchMCLKfromSYSOSCtoHSCLK(DL_SYSCTL_HSCLK_SOURCE source)
+{
+    // Assume desired HS sources already enabled per their requirements (SYSPLL, HFXT, HFCLK_IN)
+    // Selected desired HSCLK source
+    DL_SYSCTL_setHSCLKSource(source);
+
+    // Verify HSCLK source is valid
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_HSCLKGOOD_MASK) !=
+           DL_SYSCTL_CLK_STATUS_HSCLK_GOOD) {
+        ;
+    }
+
+    // Switch MCLK to HSCLK
+    SYSCTL->SOCLOCK.MCLKCFG |= SYSCTL_MCLKCFG_USEHSCLK_ENABLE;
+
+    // Verify HSCLK -> MCLK
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_HSCLKMUX_MASK) !=
+           DL_SYSCTL_CLK_STATUS_MCLK_SOURCE_HSCLK) {
+        ;
+    }
+}
+
+void DL_SYSCTL_switchMCLKfromHSCLKtoSYSOSC(void)
+{
+    // Switch MCLK to SYSOSC
+    SYSCTL->SOCLOCK.MCLKCFG &= ~SYSCTL_MCLKCFG_USEHSCLK_ENABLE;
+
+    // Verify SYSOSC -> MCLK
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_HSCLKMUX_MASK) ==
+           DL_SYSCTL_CLK_STATUS_MCLK_SOURCE_HSCLK) {
+        ;
+    }
+}
+
+void DL_SYSCTL_setHFCLKSourceHFXT(DL_SYSCTL_HFXT_RANGE range)
+{
+    DL_SYSCTL_setHFXTFrequencyRange(range);
+    /* Set startup time to ~0.512ms based on TYP datasheet recommendation */
+    DL_SYSCTL_setHFXTStartupTime(8);
+    SYSCTL->SOCLOCK.HSCLKEN |= SYSCTL_HSCLKEN_HFXTEN_ENABLE;
+    DL_SYSCTL_enableHFCLKStartupMonitor();
+    /* Wait until HFXT oscillator is stable. If it does not stabilize, check the
+     hardware/IOMUX settings */
+    while ((DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_HFCLKGOOD_MASK) !=
+           DL_SYSCTL_CLK_STATUS_HFCLK_GOOD) {
+        ;
+    }
+}
+
+void DL_SYSCTL_setHFCLKSourceHFXTParams(
+    DL_SYSCTL_HFXT_RANGE range, uint32_t startupTime, bool monitorEnable)
+{
+    DL_SYSCTL_setHFXTFrequencyRange(range);
+    DL_SYSCTL_setHFXTStartupTime(startupTime);
+    SYSCTL->SOCLOCK.HSCLKEN |= SYSCTL_HSCLKEN_HFXTEN_ENABLE;
+
+    if (monitorEnable == true) {
+        DL_SYSCTL_enableHFCLKStartupMonitor();
+        /* Wait until HFXT oscillator is stable. If it does not stabilize, check the
+        hardware/IOMUX settings */
+        while (
+            (DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_HFCLKGOOD_MASK) !=
+            DL_SYSCTL_CLK_STATUS_HFCLK_GOOD) {
+            ;
+        }
+    } else {
+        DL_SYSCTL_disableHFCLKStartupMonitor();
+    }
+}
+
+void DL_SYSCTL_configFCC(DL_SYSCTL_FCC_TRIG_TYPE trigLvl,
+    DL_SYSCTL_FCC_TRIG_SOURCE trigSrc, DL_SYSCTL_FCC_CLOCK_SOURCE clkSrc)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.GENCLKCFG,
+        (uint32_t) trigLvl | (uint32_t) trigSrc | (uint32_t) clkSrc,
+        SYSCTL_GENCLKCFG_FCCLVLTRIG_MASK | SYSCTL_GENCLKCFG_FCCTRIGSRC_MASK |
+            SYSCTL_GENCLKCFG_FCCSELCLK_MASK);
+}
+
+DL_SYSCTL_POWER_POLICY_RUN_SLEEP DL_SYSCTL_getPowerPolicyRUNSLEEP(void)
+{
+    DL_SYSCTL_POWER_POLICY_RUN_SLEEP policy =
+        DL_SYSCTL_POWER_POLICY_RUN_SLEEP_NOT_ENABLED;
+
+    // Check if SLEEP is enabled
+    if ((SCB->SCR & SCB_SCR_SLEEPDEEP_Msk) != SCB_SCR_SLEEPDEEP_Msk) {
+        // Check which policy is enabled
+        if ((SYSCTL->SOCLOCK.MCLKCFG & SYSCTL_MCLKCFG_USELFCLK_MASK) ==
+            SYSCTL_MCLKCFG_USELFCLK_ENABLE) {
+            policy = DL_SYSCTL_POWER_POLICY_RUN_SLEEP1;
+        } else if ((SYSCTL->SOCLOCK.SYSOSCCFG &
+                       SYSCTL_SYSOSCCFG_DISABLESTOP_MASK) ==
+                   SYSCTL_SYSOSCCFG_DISABLESTOP_ENABLE) {
+            policy = DL_SYSCTL_POWER_POLICY_RUN_SLEEP2;
+        } else {
+            policy = DL_SYSCTL_POWER_POLICY_RUN_SLEEP0;
+        }
+    }
+    return policy;
+}
+
+DL_SYSCTL_POWER_POLICY_STOP DL_SYSCTL_getPowerPolicySTOP(void)
+{
+    DL_SYSCTL_POWER_POLICY_STOP policy =
+        DL_SYSCTL_POWER_POLICY_STOP_NOT_ENABLED;
+
+    // Check if STOP is enabled
+    if ((SYSCTL->SOCLOCK.PMODECFG == SYSCTL_PMODECFG_DSLEEP_STOP) &&
+        (SCB->SCR & SCB_SCR_SLEEPDEEP_Msk) == SCB_SCR_SLEEPDEEP_Msk) {
+        // Check which policy is enabled
+        if ((SYSCTL->SOCLOCK.SYSOSCCFG & SYSCTL_SYSOSCCFG_USE4MHZSTOP_MASK) ==
+            SYSCTL_SYSOSCCFG_USE4MHZSTOP_ENABLE) {
+            policy = DL_SYSCTL_POWER_POLICY_STOP1;
+        } else if ((SYSCTL->SOCLOCK.SYSOSCCFG &
+                       SYSCTL_SYSOSCCFG_DISABLESTOP_MASK) ==
+                   SYSCTL_SYSOSCCFG_DISABLESTOP_ENABLE) {
+            policy = DL_SYSCTL_POWER_POLICY_STOP2;
+        } else {
+            policy = DL_SYSCTL_POWER_POLICY_STOP0;
+        }
+    }
+    return policy;
+}
+
+DL_SYSCTL_POWER_POLICY_STANDBY DL_SYSCTL_getPowerPolicySTANDBY(void)
+{
+    DL_SYSCTL_POWER_POLICY_STANDBY policy =
+        DL_SYSCTL_POWER_POLICY_STANDBY_NOT_ENABLED;
+
+    // Check if STOP is enabled
+    if ((SYSCTL->SOCLOCK.PMODECFG == SYSCTL_PMODECFG_DSLEEP_STANDBY) &&
+        (SCB->SCR & SCB_SCR_SLEEPDEEP_Msk) == SCB_SCR_SLEEPDEEP_Msk) {
+        // Check which policy is enabled
+        if ((SYSCTL->SOCLOCK.MCLKCFG & SYSCTL_MCLKCFG_STOPCLKSTBY_MASK) ==
+            SYSCTL_MCLKCFG_STOPCLKSTBY_ENABLE) {
+            policy = DL_SYSCTL_POWER_POLICY_STANDBY1;
+        } else {
+            policy = DL_SYSCTL_POWER_POLICY_STANDBY0;
+        }
+    }
+    return policy;
+}
+
+#endif /* DeviceFamily_PARENT_MSPM0L122X_L222X */

--- a/mspm0/source/ti/driverlib/m0p/sysctl/dl_sysctl_mspm0l122x_l222x.h
+++ b/mspm0/source/ti/driverlib/m0p/sysctl/dl_sysctl_mspm0l122x_l222x.h
@@ -1,0 +1,2920 @@
+/*
+ * Copyright (c) 2020, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*!****************************************************************************
+ *  @file       dl_sysctl_mspm0l122x_l222x.h
+ *  @brief      System Control (SysCtl)
+ *  @defgroup   SYSCTL_MSPM0L122X_L222X MSPM0L122X_L222X System Control (SYSCTL)
+ *
+ *  @anchor ti_dl_m0p_mspm0l122x_l222x_dl_sysctl_Overview
+ *  # Overview
+ *
+ *  The System Control (SysCtl) module enables control over system wide
+ *  settings like clocks and power management.
+ *
+ *  <hr>
+ *
+ ******************************************************************************
+ */
+/** @addtogroup SYSCTL_MSPM0L122X_L222X
+ * @{
+ */
+#ifndef ti_dl_m0p_dl_sysctl_sysctl__include
+#define ti_dl_m0p_dl_sysctl_sysctl__include
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ti/devices/msp/msp.h>
+#include <ti/driverlib/dl_common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* clang-format off */
+
+/** @addtogroup DL_SYSCTL_RESET
+ *  @{
+ */
+/*!
+ * @brief Perform a CPU reset
+ *
+ * This clears the state of the CPU logic. Peripheral states are not affected
+ */
+ #define DL_SYSCTL_RESET_CPU                       (SYSCTL_RESETLEVEL_LEVEL_CPU)
+
+/*!
+ * @brief Perform a Boot reset
+ *
+ * This triggers execution of the device boot configuration routine and resets
+ * the majority of the core logic while also power cycling the SRAM
+ */
+ #define DL_SYSCTL_RESET_BOOT                     (SYSCTL_RESETLEVEL_LEVEL_BOOT)
+
+/*!
+ * @brief Perform a POR reset
+ *
+ * This performas a POR reset which is a complete device reset
+ */
+ #define DL_SYSCTL_RESET_POR                       (SYSCTL_RESETLEVEL_LEVEL_POR)
+
+/*!
+ * @brief Perform system reset and exit bootloader to the application
+ */
+ #define DL_SYSCTL_RESET_BOOTLOADER_EXIT                                       \
+                                        (SYSCTL_RESETLEVEL_LEVEL_BOOTLOADEREXIT)
+
+ /*!
+ * @brief Perform system reset and run bootloader
+ */
+ #define DL_SYSCTL_RESET_BOOTLOADER_ENTRY                                      \
+                                       (SYSCTL_RESETLEVEL_LEVEL_BOOTLOADERENTRY)
+
+/** @}*/
+
+/** @addtogroup DL_SYSCTL_INTERRUPT
+ *  @{
+ */
+/*! @brief  Low Frequency Oscillator is stabilized and ready to use */
+#define DL_SYSCTL_INTERRUPT_LFOSC_GOOD           (SYSCTL_IMASK_LFOSCGOOD_ENABLE)
+/*! @brief  Analog clocking consistency error */
+#define DL_SYSCTL_INTERRUPT_ANALOG_CLOCK_ERROR   (SYSCTL_IMASK_ANACLKERR_ENABLE)
+
+/** @}*/
+
+/*! @enum DL_SYSCTL_IIDX */
+typedef enum {
+    /*! @brief  Low Frequency Oscillator is stabilized and ready to use */
+    DL_SYSCTL_IIDX_LFOSC_GOOD = SYSCTL_IIDX_STAT_LFOSCGOOD,
+    /*! @brief  Analog clocking consistency error */
+    DL_SYSCTL_IIDX_ANALOG_CLOCK_ERROR = SYSCTL_IIDX_STAT_ANACLKERR,
+} DL_SYSCTL_IIDX;
+
+
+/** @addtogroup DL_SYSCTL_NMI
+ *  @{
+ */
+/*! @brief  Non-maskable interrupt for Watchdog 0 Fault */
+#define DL_SYSCTL_NMI_WWDT0_FAULT                     (SYSCTL_NMIISET_WWDT0_SET)
+/*! @brief  Non-maskable interrupt for early BOR */
+#define DL_SYSCTL_NMI_BORLVL                         (SYSCTL_NMIISET_BORLVL_SET)
+/** @}*/
+
+/** @addtogroup DL_SYSCTL_CLK_STATUS
+ *  @{
+ */
+/*! @brief Writes to HFCLKCLKCFG are blocked */
+#define DL_SYSCTL_CLK_STATUS_HFCLK_CONFIG_BLOCKED                              \
+                                             (SYSCTL_CLKSTATUS_HFCLKBLKUPD_TRUE)
+/*! @brief SYSOSC Frequency Correcting Loop Mode ON */
+#define DL_SYSCTL_CLK_STATUS_FCL_ON           (SYSCTL_CLKSTATUS_FCLMODE_ENABLED)
+/*! @brief Clock Fail for LFXT or EXLF clock source */
+#define DL_SYSCTL_CLK_STATUS_LFCLK_FAIL        (SYSCTL_CLKSTATUS_LFCLKFAIL_TRUE)
+/*! @brief High Speed Clock Good */
+#define DL_SYSCTL_CLK_STATUS_HSCLK_GOOD        (SYSCTL_CLKSTATUS_HSCLKGOOD_TRUE)
+/*! @brief High Speed Clock Stuck Fault */
+#define DL_SYSCTL_CLK_STATUS_HSCLK_FAULT       (SYSCTL_CLKSTATUS_HSCLKDEAD_TRUE)
+/*! @brief HFCLKs is OFF or DEAD */
+#define DL_SYSCTL_CLK_STATUS_HFCLK_OFF          (SYSCTL_CLKSTATUS_HFCLKOFF_TRUE)
+/*! @brief All HFCLKs are OFF or DEAD */
+#define DL_SYSCTL_CLK_STATUS_HSCLK_OFF         (SYSCTL_CLKSTATUS_HSCLKSOFF_TRUE)
+/*! @brief LFOSC is Valid */
+#define DL_SYSCTL_CLK_STATUS_LFOSC_GOOD        (SYSCTL_CLKSTATUS_LFOSCGOOD_TRUE)
+/*! @brief LFXT is Valid */
+#define DL_SYSCTL_CLK_STATUS_LFXT_GOOD          (SYSCTL_CLKSTATUS_LFXTGOOD_TRUE)
+/*! @brief High Frequency Clock ON */
+#define DL_SYSCTL_CLK_STATUS_HFCLK_GOOD        (SYSCTL_CLKSTATUS_HFCLKGOOD_TRUE)
+/*! @brief MCLK now sourced from HSCLK, otherwise SYSOSC */
+#define DL_SYSCTL_CLK_STATUS_MCLK_SOURCE_HSCLK (SYSCTL_CLKSTATUS_HSCLKMUX_HSCLK)
+/*! @brief MCLK now sourced from LFCLK */
+#define DL_SYSCTL_CLK_STATUS_MCLK_SOURCE_LFCLK                                 \
+                                             (SYSCTL_CLKSTATUS_CURMCLKSEL_LFCLK)
+/*! @brief Analog clocking error */
+#define DL_SYSCTL_CLK_STATUS_ANALOG_CLOCK_ERROR                                \
+                                               (SYSCTL_CLKSTATUS_ANACLKERR_TRUE)
+/*! @brief Frequency Clock Counter (FCC) done */
+#define DL_SYSCTL_CLK_STATUS_FCC_DONE            (SYSCTL_CLKSTATUS_FCCDONE_DONE)
+/*! @brief = LFCLK sourced from the LFXT (crystal) */
+#define DL_SYSCTL_CLK_STATUS_LFCLK_SOURCE_LFXT  (SYSCTL_CLKSTATUS_LFCLKMUX_LFXT)
+/*! @brief = LFCLK sourced from LFCLK_IN (external digital clock input) */
+#define DL_SYSCTL_CLK_STATUS_LFCLK_SOURCE_EXLF  (SYSCTL_CLKSTATUS_LFCLKMUX_EXLF)
+/*! @brief = SYSOSC is at low frequency (4MHz) */
+#define DL_SYSCTL_CLK_STATUS_SYSOSC_4MHZ  (SYSCTL_CLKSTATUS_SYSOSCFREQ_SYSOSC4M)
+/*! @brief = SYSOSC is at the user-trimmed frequency (16 or 24MHz) */
+#define DL_SYSCTL_CLK_STATUS_SYSOSC_USERTRIM_FREQ                              \
+                                        (SYSCTL_CLKSTATUS_SYSOSCFREQ_SYSOSCUSER)
+/** @}*/
+
+/** @addtogroup DL_SYSCTL_STATUS
+ *  @{
+ */
+
+/*! @brief IO is locked due to SHUTDOWN */
+#define DL_SYSCTL_STATUS_SHUTDOWN_IO_LOCK_TRUE                                 \
+                                              (SYSCTL_SYSSTATUS_SHDNIOLOCK_TRUE)
+/*! @brief User has disabled external reset pin */
+#define DL_SYSCTL_STATUS_EXT_RESET_PIN_DISABLED                                \
+                                            (SYSCTL_SYSSTATUS_EXTRSTPINDIS_TRUE)
+/*! @brief User has disabled SWD port  */
+#define DL_SYSCTL_STATUS_SWD_DISABLED          (SYSCTL_SYSSTATUS_SWDCFGDIS_TRUE)
+
+/*! @brief PMU IFREF good */
+#define DL_SYSCTL_STATUS_PMU_IFREF_GOOD      (SYSCTL_SYSSTATUS_PMUIREFGOOD_TRUE)
+/*! @brief VBOOST (Analog Charge Pump) started up properly */
+#define DL_SYSCTL_STATUS_VBOOST_GOOD        (SYSCTL_SYSSTATUS_ANACPUMPGOOD_TRUE)
+/*! @brief Brown Out Reset event status indicator */
+#define DL_SYSCTL_STATUS_BOR_EVENT                (SYSCTL_SYSSTATUS_BORLVL_TRUE)
+/*! @brief MCAN0 ready */
+#define DL_SYSCTL_STATUS_MCAN0_READY          (SYSCTL_SYSSTATUS_MCAN0READY_TRUE)
+/*! @brief Double Error Detect on Flash */
+#define DL_SYSCTL_STATUS_FLASH_DED              (SYSCTL_SYSSTATUS_FLASHDED_TRUE)
+/*! @brief Single Error Correction on Flash */
+#define DL_SYSCTL_STATUS_FLASH_SEC              (SYSCTL_SYSSTATUS_FLASHSEC_TRUE)
+/*! @brief Current Brown Out Reset minimum level */
+#define DL_SYSCTL_STATUS_BOR_LEVEL0                                            \
+                                  (SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVELMIN)
+/*! @brief Current Brown Out Reset level 1 */
+#define DL_SYSCTL_STATUS_BOR_LEVEL1 (SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVEL1)
+/*! @brief Current Brown Out Reset level 2 */
+#define DL_SYSCTL_STATUS_BOR_LEVEL2 (SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVEL2)
+/*! @brief Current Brown Out Reset level 3 */
+#define DL_SYSCTL_STATUS_BOR_LEVEL3 (SYSCTL_SYSSTATUS_BORCURTHRESHOLD_BORLEVEL3)
+/** @}*/
+
+/* clang-format on */
+
+/*! @enum DL_SYSCTL_NMI_IIDX */
+typedef enum {
+    /*! @brief  NMI interrupt index for VBAT power on */
+    DL_SYSCTL_NMI_IIDX_VBAT_ON = SYSCTL_NMIIIDX_STAT_VBATUP,
+    /*! @brief  NMI interrupt index for VBAT power off  */
+    DL_SYSCTL_NMI_IIDX_VBAT_OFF = SYSCTL_NMIIIDX_STAT_VBATDN,
+
+    /*! @brief  NMI interrupt index for SRAM Double Error Detect */
+    DL_SYSCTL_NMI_IIDX_SRAM_DED = SYSCTL_NMIIIDX_STAT_SRAMDED,
+    /*! @brief  NMI interrupt index for Flash Double Error Detect */
+    DL_SYSCTL_NMI_IIDX_FLASH_DED = SYSCTL_NMIIIDX_STAT_FLASHDED,
+    /*! @brief  NMI interrupt index for LFCLK Monitor Fail */
+    DL_SYSCTL_NMI_IIDX_LFCLK_FAIL = SYSCTL_NMIIIDX_STAT_LFCLKFAIL,
+    /*! @brief  NMI interrupt index for Watchdog 0 Fault */
+    DL_SYSCTL_NMI_IIDX_WWDT0_FAULT = SYSCTL_NMIIIDX_STAT_WWDT0,
+    /*! @brief  NMI interrupt index for early BOR */
+    DL_SYSCTL_NMI_IIDX_BORLVL = SYSCTL_NMIIIDX_STAT_BORLVL,
+    /*! @brief  NMI interrupt index for no interrupt pending */
+    DL_SYSCTL_NMI_IIDX_NO_INT = SYSCTL_NMIIIDX_STAT_NO_INTR,
+} DL_SYSCTL_NMI_IIDX;
+
+/*! @enum DL_SYSCTL_ERROR_BEHAVIOR */
+typedef enum {
+    /*! @brief  The error event will trigger a SYSRST */
+    DL_SYSCTL_ERROR_BEHAVIOR_RESET = 0x0,
+    /*! @brief  The error event will trigger an NMI */
+    DL_SYSCTL_ERROR_BEHAVIOR_NMI = 0x1,
+
+} DL_SYSCTL_ERROR_BEHAVIOR;
+
+/*! @enum DL_SYSCTL_SYSOSC_FREQ */
+typedef enum {
+    /*! Use 4MHz for System Oscillator (SYSOSC) */
+    DL_SYSCTL_SYSOSC_FREQ_4M = (SYSCTL_SYSOSCCFG_FREQ_SYSOSC4M),
+    /*! Use BASE (32MHz) for System Oscillator (SYSOSC) */
+    DL_SYSCTL_SYSOSC_FREQ_BASE = (SYSCTL_SYSOSCCFG_FREQ_SYSOSCBASE),
+    /*! User will trim the System Oscillator (SYSOSC) to 16MHz or 24MHz */
+    DL_SYSCTL_SYSOSC_FREQ_USERTRIM = (SYSCTL_SYSOSCCFG_FREQ_SYSOSCUSER),
+} DL_SYSCTL_SYSOSC_FREQ;
+
+/** @enum DL_SYSCTL_SYSOSC_USERTRIM_FREQ */
+typedef enum {
+    /*! Set SYSOSC user trim frequency target to 16MHz */
+    DL_SYSCTL_SYSOSC_USERTRIM_FREQ_16M =
+        (SYSCTL_SYSOSCTRIMUSER_FREQ_SYSOSC16M),
+    /*! Set SYSOSC user trim frequency target to 24MHz */
+    DL_SYSCTL_SYSOSC_USERTRIM_FREQ_24M =
+        (SYSCTL_SYSOSCTRIMUSER_FREQ_SYSOSC24M),
+} DL_SYSCTL_SYSOSC_USERTRIM_FREQ;
+
+/*! @brief  Configuration struct for @ref DL_SYSCTL_configSYSOSCUserTrim. */
+typedef struct {
+    /*! Frequency Correcting Loop resistor divide value [0x0, 0x1FF] */
+    uint32_t rDiv;
+    /*! Resistor fine trim [0x0, 0xF] */
+    uint32_t resistorFine;
+    /*! Resistor coarse trim [0x0, 0x3F] */
+    uint32_t resistorCoarse;
+    /*! Capacitor trim [0x0, 0x7] */
+    uint32_t capacitor;
+    /*! SYSOSC user trim frequency target */
+    DL_SYSCTL_SYSOSC_USERTRIM_FREQ freq;
+} DL_SYSCTL_SYSOSCUserTrimConfig;
+
+/** @enum DL_SYSCTL_LFXT_DRIVE_STRENGTH */
+typedef enum {
+    /*! Lowest Drive and Current */
+    DL_SYSCTL_LFXT_DRIVE_STRENGTH_LOWEST =
+        (SYSCTL_LFCLKCFG_XT1DRIVE_LOWESTDRV),
+    /*! Lower Drive and Current */
+    DL_SYSCTL_LFXT_DRIVE_STRENGTH_LOWER = (SYSCTL_LFCLKCFG_XT1DRIVE_LOWERDRV),
+    /*! Higher Drive and Current */
+    DL_SYSCTL_LFXT_DRIVE_STRENGTH_HIGHER =
+        (SYSCTL_LFCLKCFG_XT1DRIVE_HIGHERDRV),
+    /*! Highest Drive and Current */
+    DL_SYSCTL_LFXT_DRIVE_STRENGTH_HIGHEST =
+        (SYSCTL_LFCLKCFG_XT1DRIVE_HIGHESTDRV),
+} DL_SYSCTL_LFXT_DRIVE_STRENGTH;
+
+/*! @brief  Configuration struct for @ref DL_SYSCTL_LFCLKConfig. */
+typedef struct {
+    /*! Enable if CAP is less than 3pF to reduce power consumption */
+    bool lowCap;
+    /*! Enable to use monitor for LFXT, EXLF failure */
+    bool monitor;
+    /*! Drive strength and power consumption option */
+    DL_SYSCTL_LFXT_DRIVE_STRENGTH xt1Drive;
+} DL_SYSCTL_LFCLKConfig;
+
+/** @enum DL_SYSCTL_HFXT_RANGE */
+typedef enum {
+    /*! HFXT frequency range between 4 and 8 MHz */
+    DL_SYSCTL_HFXT_RANGE_4_8_MHZ = SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE4TO8,
+    /*! HFXT frequency range between 8.01 and 16 MHz */
+    DL_SYSCTL_HFXT_RANGE_8_16_MHZ = SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE8TO16,
+    /*! HFXT frequency range between 16.01 and 32 MHz */
+    DL_SYSCTL_HFXT_RANGE_16_32_MHZ = SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE16TO32,
+    /*! HFXT frequency range between 32.01 and 48 MHz */
+    DL_SYSCTL_HFXT_RANGE_32_48_MHZ = SYSCTL_HFCLKCLKCFG_HFXTRSEL_RANGE32TO48,
+} DL_SYSCTL_HFXT_RANGE;
+
+/*! @enum DL_SYSCTL_HSCLK_SOURCE */
+typedef enum {
+    /*! Invalid source for HSCLK */
+    DL_SYSCTL_HSCLK_SOURCE_INVALID = 0x0,
+    /*! Use HFLK as input source for HSCLK */
+    DL_SYSCTL_HSCLK_SOURCE_HFCLK = SYSCTL_HSCLKCFG_HSCLKSEL_HFCLKCLK,
+} DL_SYSCTL_HSCLK_SOURCE;
+
+/** @enum DL_SYSCTL_MCLK_SOURCE */
+typedef enum {
+    /*! Use System Oscillator (SYSOSC) as MCLK source (default after reset) */
+    DL_SYSCTL_MCLK_SOURCE_SYSOSC = SYSCTL_MCLKCFG_USEHSCLK_DISABLE,
+    /*! Use High Speed Clock (HSCLK) as MCLK source (HFCLK, ...) */
+    DL_SYSCTL_MCLK_SOURCE_HSCLK = SYSCTL_MCLKCFG_USEHSCLK_ENABLE,
+    /*! Use the Low Frequency Clock (LFCLK) as the clock source */
+    DL_SYSCTL_MCLK_SOURCE_LFCLK = SYSCTL_MCLKCFG_USELFCLK_ENABLE,
+} DL_SYSCTL_MCLK_SOURCE;
+
+/** @enum DL_SYSCTL_MCLK_DIVIDER */
+typedef enum {
+    /*! Disable MCLK divider. Change SYSOSC freq only when MDIV is disabled */
+    DL_SYSCTL_MCLK_DIVIDER_DISABLE = 0x0,
+    /*! Divide MCLK frequency by 2 */
+    DL_SYSCTL_MCLK_DIVIDER_2 = 0x1,
+    /*! Divide MCLK frequency by 3 */
+    DL_SYSCTL_MCLK_DIVIDER_3 = 0x2,
+    /*! Divide MCLK frequency by 4 */
+    DL_SYSCTL_MCLK_DIVIDER_4 = 0x3,
+    /*! Divide MCLK frequency by 5 */
+    DL_SYSCTL_MCLK_DIVIDER_5 = 0x4,
+    /*! Divide MCLK frequency by 6 */
+    DL_SYSCTL_MCLK_DIVIDER_6 = 0x5,
+    /*! Divide MCLK frequency by 7 */
+    DL_SYSCTL_MCLK_DIVIDER_7 = 0x6,
+    /*! Divide MCLK frequency by 8 */
+    DL_SYSCTL_MCLK_DIVIDER_8 = 0x7,
+    /*! Divide MCLK frequency by 9 */
+    DL_SYSCTL_MCLK_DIVIDER_9 = 0x8,
+    /*! Divide MCLK frequency by 10 */
+    DL_SYSCTL_MCLK_DIVIDER_10 = 0x9,
+    /*! Divide MCLK frequency by 11 */
+    DL_SYSCTL_MCLK_DIVIDER_11 = 0xA,
+    /*! Divide MCLK frequency by 12 */
+    DL_SYSCTL_MCLK_DIVIDER_12 = 0xB,
+    /*! Divide MCLK frequency by 13 */
+    DL_SYSCTL_MCLK_DIVIDER_13 = 0xC,
+    /*! Divide MCLK frequency by 14 */
+    DL_SYSCTL_MCLK_DIVIDER_14 = 0xD,
+    /*! Divide MCLK frequency by 15 */
+    DL_SYSCTL_MCLK_DIVIDER_15 = 0xE,
+    /*! Divide MCLK frequency by 16 */
+    DL_SYSCTL_MCLK_DIVIDER_16 = 0xF,
+} DL_SYSCTL_MCLK_DIVIDER;
+
+/** @enum DL_SYSCTL_CLK_OUT_SOURCE */
+typedef enum {
+    /*! Use System Oscillator (SYSOSC) as CLK_OUT source */
+    DL_SYSCTL_CLK_OUT_SOURCE_SYSOSC = SYSCTL_GENCLKCFG_EXCLKSRC_SYSOSC,
+    /*! Use Ultra Low Power Clock (ULPCLK) as CLK_OUT source.
+      * @ref DL_SYSCTL_CLK_OUT_DIVIDE_DISABLE must not be selected for this
+      * configuration. */
+    DL_SYSCTL_CLK_OUT_SOURCE_ULPCLK = SYSCTL_GENCLKCFG_EXCLKSRC_ULPCLK,
+    /*! Use Low Frequency Clock (LFCLK) as CLK_OUT source */
+    DL_SYSCTL_CLK_OUT_SOURCE_LFCLK = SYSCTL_GENCLKCFG_EXCLKSRC_LFCLK,
+    /*! Use Middle Frequency Precision Clock (MFPCLK) as CLK_OUT source.
+      * @ref DL_SYSCTL_CLK_OUT_DIVIDE_DISABLE must not be selected for this
+      * configuration. */
+    DL_SYSCTL_CLK_OUT_SOURCE_MFPCLK = SYSCTL_GENCLKCFG_EXCLKSRC_MFPCLK,
+    /*! Use High Frequency Clock (HFCLK) as CLK_OUT source */
+    DL_SYSCTL_CLK_OUT_SOURCE_HFCLK = SYSCTL_GENCLKCFG_EXCLKSRC_HFCLK,
+} DL_SYSCTL_CLK_OUT_SOURCE;
+
+/** @enum DL_SYSCTL_CLK_OUT_DIVIDE */
+typedef enum {
+    /*! Disable the External Clock (CLK_OUT) output divider */
+    DL_SYSCTL_CLK_OUT_DIVIDE_DISABLE = SYSCTL_GENCLKCFG_EXCLKDIVEN_PASSTHRU,
+    /*! Divide External Clock (CLK_OUT) output by 2 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_2 =
+        SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE | SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV2,
+    /*! Divide External Clock (CLK_OUT) output by 4 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_4 =
+        SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE | SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV4,
+    /*! Divide External Clock (CLK_OUT) output by 6 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_6 =
+        SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE | SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV6,
+    /*! Divide External Clock (CLK_OUT) output by 8 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_8 =
+        SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE | SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV8,
+    /*! Divide External Clock (CLK_OUT) output by 10 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_10 = SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE |
+                                  SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV10,
+    /*! Divide External Clock (CLK_OUT) output by 12 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_12 = SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE |
+                                  SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV12,
+    /*! Divide External Clock (CLK_OUT) output by 14 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_14 = SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE |
+                                  SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV14,
+    /*! Divide External Clock (CLK_OUT) output by 16 */
+    DL_SYSCTL_CLK_OUT_DIVIDE_16 = SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE |
+                                  SYSCTL_GENCLKCFG_EXCLKDIVVAL_DIV16,
+} DL_SYSCTL_CLK_OUT_DIVIDE;
+
+/** @enum DL_SYSCTL_MFPCLK_SOURCE */
+typedef enum {
+    /*! Use System Oscillator (SYSOSC) as MFPCLK source */
+    DL_SYSCTL_MFPCLK_SOURCE_SYSOSC = SYSCTL_GENCLKCFG_MFPCLKSRC_SYSOSC,
+    /*! Use High Frequency Clock (HFCLK) as MFPCLK source */
+    DL_SYSCTL_MFPCLK_SOURCE_HFCLK = SYSCTL_GENCLKCFG_MFPCLKSRC_HFCLK,
+} DL_SYSCTL_MFPCLK_SOURCE;
+
+/** @enum DL_SYSCTL_HFCLK_MFPCLK_DIVIDER */
+typedef enum {
+    /*! HFCLK is not divided before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_DISABLE = 0x0,
+    /*! Divide HFCLK by 2 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_2 = 0x1,
+    /*! Divide HFCLK by 3 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_3 = 0x2,
+    /*! Divide HFCLK by 4 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_4 = 0x3,
+    /*! Divide HFCLK by 5 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_5 = 0x4,
+    /*! Divide HFCLK by 6 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_6 = 0x5,
+    /*! Divide HFCLK by 7 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_7 = 0x6,
+    /*! Divide HFCLK by 8 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_8 = 0x7,
+    /*! Divide HFCLK by 9 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_9 = 0x8,
+    /*! Divide HFCLK by 10 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_10 = 0x9,
+    /*! Divide HFCLK by 11 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_11 = 0xA,
+    /*! Divide HFCLK by 12 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_12 = 0xB,
+    /*! Divide HFCLK by 13 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_13 = 0xC,
+    /*! Divide HFCLK by 14 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_14 = 0xD,
+    /*! Divide HFCLK by 15 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_15 = 0xE,
+    /*! Divide HFCLK by 16 before being used for MFPCLK */
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER_16 = 0xF,
+} DL_SYSCTL_HFCLK_MFPCLK_DIVIDER;
+
+/** @enum DL_SYSCTL_FCC_TRIG_TYPE */
+typedef enum {
+    /*! FCC trigger is rising-edge to rising-edge pulse */
+    DL_SYSCTL_FCC_TRIG_TYPE_RISE_RISE = SYSCTL_GENCLKCFG_FCCLVLTRIG_RISE2RISE,
+    /*! FCC trigger is active-high pulse level */
+    DL_SYSCTL_FCC_TRIG_TYPE_LEVEL = SYSCTL_GENCLKCFG_FCCLVLTRIG_LEVEL,
+} DL_SYSCTL_FCC_TRIG_TYPE;
+
+/** @enum DL_SYSCTL_FCC_TRIG_SOURCE */
+typedef enum {
+    /*! FCC trigger source is FCC_IN external pin */
+    DL_SYSCTL_FCC_TRIG_SOURCE_FCC_IN = SYSCTL_GENCLKCFG_FCCTRIGSRC_EXTPIN,
+    /*! FCC trigger source is LFCLK */
+    DL_SYSCTL_FCC_TRIG_SOURCE_LFCLK = SYSCTL_GENCLKCFG_FCCTRIGSRC_LFCLK,
+} DL_SYSCTL_FCC_TRIG_SOURCE;
+
+/** @enum DL_SYSCTL_FCC_CLOCK_SOURCE */
+typedef enum {
+    /*! FCC clock source to capture is MCLK */
+    DL_SYSCTL_FCC_CLOCK_SOURCE_MCLK = SYSCTL_GENCLKCFG_FCCSELCLK_MCLK,
+    /*! FCC clock source to capture is SYSOSC */
+    DL_SYSCTL_FCC_CLOCK_SOURCE_SYSOSC = SYSCTL_GENCLKCFG_FCCSELCLK_SYSOSC,
+    /*! FCC clock source to capture is HFCLK */
+    DL_SYSCTL_FCC_CLOCK_SOURCE_HFCLK = SYSCTL_GENCLKCFG_FCCSELCLK_HFCLK,
+    /*! FCC clock source to capture is CLK_OUT */
+    DL_SYSCTL_FCC_CLOCK_SOURCE_CLK_OUT = SYSCTL_GENCLKCFG_FCCSELCLK_EXTCLK,
+    /*! FCC clock source to capture is FCC_IN */
+    DL_SYSCTL_FCC_CLOCK_SOURCE_FCC_IN = SYSCTL_GENCLKCFG_FCCSELCLK_FCCIN,
+} DL_SYSCTL_FCC_CLOCK_SOURCE;
+
+/** @enum DL_SYSCTL_FCC_TRIG_CNT */
+typedef enum {
+    /*! One monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_01 =
+        ((uint32_t) 0 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Two monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_02 =
+        ((uint32_t) 1 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Three monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_03 =
+        ((uint32_t) 2 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Four monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_04 =
+        ((uint32_t) 3 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Five monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_05 =
+        ((uint32_t) 4 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Six monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_06 =
+        ((uint32_t) 5 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Seven monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_07 =
+        ((uint32_t) 6 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Eight monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_08 =
+        ((uint32_t) 7 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Nine monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_09 =
+        ((uint32_t) 8 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Ten monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_10 =
+        ((uint32_t) 9 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Eleven monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_11 =
+        ((uint32_t) 10 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twelve monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_12 =
+        ((uint32_t) 11 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Thirteen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_13 =
+        ((uint32_t) 12 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Fourteen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_14 =
+        ((uint32_t) 13 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Fifteen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_15 =
+        ((uint32_t) 14 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Sixteen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_16 =
+        ((uint32_t) 15 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Seventeen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_17 =
+        ((uint32_t) 16 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Eighteen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_18 =
+        ((uint32_t) 17 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Nineteen monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_19 =
+        ((uint32_t) 18 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_20 =
+        ((uint32_t) 19 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-one monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_21 =
+        ((uint32_t) 20 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-two monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_22 =
+        ((uint32_t) 21 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-three monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_23 =
+        ((uint32_t) 22 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-four monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_24 =
+        ((uint32_t) 23 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-five monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_25 =
+        ((uint32_t) 24 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-six monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_26 =
+        ((uint32_t) 25 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-seven monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_27 =
+        ((uint32_t) 26 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-eight monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_28 =
+        ((uint32_t) 27 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Twenty-nine monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_29 =
+        ((uint32_t) 28 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Thirty monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_30 =
+        ((uint32_t) 29 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Thirty-one monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_31 =
+        ((uint32_t) 30 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+    /*! Thirty-two monitoring period */
+    DL_SYSCTL_FCC_TRIG_CNT_32 =
+        ((uint32_t) 31 << SYSCTL_GENCLKCFG_FCCTRIGCNT_OFS),
+} DL_SYSCTL_FCC_TRIG_CNT;
+
+/** @enum DL_SYSCTL_VBOOST */
+typedef enum {
+    /*! VBOOST enabled only when COMP/OPA/GPAMP is enabled */
+    DL_SYSCTL_VBOOST_ONDEMAND = SYSCTL_GENCLKCFG_ANACPUMPCFG_ONDEMAND,
+    /*! VBOOST enabled in RUN/SLEEP, and in STOP/STANDBY if COMP/OPA/GPAMP is enabled */
+    DL_SYSCTL_VBOOST_ONACTIVE = SYSCTL_GENCLKCFG_ANACPUMPCFG_ONACTIVE,
+    /*! VBOOST enabled in all power modes except SHUTDOWN for fastest startup */
+    DL_SYSCTL_VBOOST_ONALWAYS = SYSCTL_GENCLKCFG_ANACPUMPCFG_ONALWAYS,
+} DL_SYSCTL_VBOOST;
+
+/** @enum DL_SYSCTL_FLASH_WAIT_STATE */
+typedef enum {
+    /*! 0 flash wait states */
+    DL_SYSCTL_FLASH_WAIT_STATE_0 = ((uint32_t) 0x00000000U),
+    /*! 1 flash wait states */
+    DL_SYSCTL_FLASH_WAIT_STATE_1 = ((uint32_t) 0x00000100U),
+    /*! 2 flash wait states */
+    DL_SYSCTL_FLASH_WAIT_STATE_2 = ((uint32_t) 0x00000200U),
+} DL_SYSCTL_FLASH_WAIT_STATE;
+
+/** @enum DL_SYSCTL_POWER_POLICY_RUN_SLEEP */
+typedef enum {
+    /*! RUN/SLEEP power policy is not enabled */
+    DL_SYSCTL_POWER_POLICY_RUN_SLEEP_NOT_ENABLED = 0x0,
+    /*! Enable RUN0/SLEEP0 power mode policy. */
+    DL_SYSCTL_POWER_POLICY_RUN_SLEEP0 = 0x1,
+    /*! Enable the RUN1/SLEEP1 power mode policy */
+    DL_SYSCTL_POWER_POLICY_RUN_SLEEP1 = 0x2,
+    /*! Enable the RUN2/SLEEP2 power mode policy */
+    DL_SYSCTL_POWER_POLICY_RUN_SLEEP2 = 0x3,
+} DL_SYSCTL_POWER_POLICY_RUN_SLEEP;
+
+/** @enum DL_SYSCTL_POWER_POLICY_STOP */
+typedef enum {
+    /*! STOP power policy is not enabled */
+    DL_SYSCTL_POWER_POLICY_STOP_NOT_ENABLED = 0x0,
+    /*! Enable the STOP0 power mode policy */
+    DL_SYSCTL_POWER_POLICY_STOP0 = 0x1,
+    /*! Enable the STOP1 power mode policy */
+    DL_SYSCTL_POWER_POLICY_STOP1 = 0x2,
+    /*! Enable the STOP2 power mode policy */
+    DL_SYSCTL_POWER_POLICY_STOP2 = 0x3,
+} DL_SYSCTL_POWER_POLICY_STOP;
+
+/** @enum DL_SYSCTL_POWER_POLICY_STANDBY */
+typedef enum {
+    /*! STANDBY power policy is not enabled */
+    DL_SYSCTL_POWER_POLICY_STANDBY_NOT_ENABLED = 0x0,
+    /*! Enable the STANDBY0 power mode policy */
+    DL_SYSCTL_POWER_POLICY_STANDBY0 = 0x1,
+    /*! Enable the STANDBY1 power mode policy */
+    DL_SYSCTL_POWER_POLICY_STANDBY1 = 0x2,
+} DL_SYSCTL_POWER_POLICY_STANDBY;
+
+/** @enum DL_SYSCTL_BOR_THRESHOLD_LEVEL */
+typedef enum {
+    /*! BOR0 threshold level. This is the minimum allowed threshold.
+     * A BOR0- violation will force a re-boot. */
+    DL_SYSCTL_BOR_THRESHOLD_LEVEL_0 = SYSCTL_BORTHRESHOLD_LEVEL_BORMIN,
+    /*! BOR1 threshold level. A BOR1- violation generates an interrupt */
+    DL_SYSCTL_BOR_THRESHOLD_LEVEL_1 = SYSCTL_BORTHRESHOLD_LEVEL_BORLEVEL1,
+    /*! BOR2 threshold level. A BOR2- violation generates an interrupt */
+    DL_SYSCTL_BOR_THRESHOLD_LEVEL_2 = SYSCTL_BORTHRESHOLD_LEVEL_BORLEVEL2,
+    /*! BOR3 threshold level. A BOR3- violation generates an interrupt */
+    DL_SYSCTL_BOR_THRESHOLD_LEVEL_3 = SYSCTL_BORTHRESHOLD_LEVEL_BORLEVEL3,
+} DL_SYSCTL_BOR_THRESHOLD_LEVEL;
+
+/** @enum DL_SYSCTL_SHUTDOWN_STORAGE_BYTE */
+typedef enum {
+    /*! Shutdown Storage Byte 0 */
+    DL_SYSCTL_SHUTDOWN_STORAGE_BYTE_0 = 0x0,
+    /*! Shutdown Storage Byte 1 */
+    DL_SYSCTL_SHUTDOWN_STORAGE_BYTE_1 = 0x1,
+    /*! Shutdown Storage Byte 2 */
+    DL_SYSCTL_SHUTDOWN_STORAGE_BYTE_2 = 0x2,
+    /*! Shutdown Storage Byte 3 */
+    DL_SYSCTL_SHUTDOWN_STORAGE_BYTE_3 = 0x3,
+} DL_SYSCTL_SHUTDOWN_STORAGE_BYTE;
+
+/** @enum DL_SYSCTL_RESET_CAUSE */
+typedef enum {
+    /*! No Reset Since Last Read */
+    DL_SYSCTL_RESET_CAUSE_NO_RESET = SYSCTL_RSTCAUSE_ID_NORST,
+    /*! (VDD < POR- violation) or (PMU trim parity fault) or (SHUTDNSTOREx parity fault) */
+    DL_SYSCTL_RESET_CAUSE_POR_HW_FAILURE = SYSCTL_RSTCAUSE_ID_PORHWFAIL,
+    /*! NRST pin reset (>1s) */
+    DL_SYSCTL_RESET_CAUSE_POR_EXTERNAL_NRST = SYSCTL_RSTCAUSE_ID_POREXNRST,
+    /*! Software-triggered POR */
+    DL_SYSCTL_RESET_CAUSE_POR_SW_TRIGGERED = SYSCTL_RSTCAUSE_ID_PORSW,
+    /*! VDD < BOR- violation */
+    DL_SYSCTL_RESET_CAUSE_BOR_SUPPLY_FAILURE = SYSCTL_RSTCAUSE_ID_BORSUPPLY,
+    /*! Wake from SHUTDOWN */
+    DL_SYSCTL_RESET_CAUSE_BOR_WAKE_FROM_SHUTDOWN =
+        SYSCTL_RSTCAUSE_ID_BORWAKESHUTDN,
+    /*! Non-PMU trim parity fault */
+    DL_SYSCTL_RESET_CAUSE_BOOTRST_NON_PMU_PARITY_FAULT =
+        SYSCTL_RSTCAUSE_ID_BOOTNONPMUPARITY,
+    /*! Fatal clock fault */
+    DL_SYSCTL_RESET_CAUSE_BOOTRST_CLOCK_FAULT = SYSCTL_RSTCAUSE_ID_BOOTCLKFAIL,
+    /*! Software-triggered BOOTRST */
+    DL_SYSCTL_RESET_CAUSE_BOOTRST_SW_TRIGGERED = SYSCTL_RSTCAUSE_ID_BOOTSW,
+    /*! NRST pin reset (<1s) */
+    DL_SYSCTL_RESET_CAUSE_BOOTRST_EXTERNAL_NRST =
+        SYSCTL_RSTCAUSE_ID_BOOTEXNRST,
+    /*! BSL exit */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_BSL_EXIT = SYSCTL_RSTCAUSE_ID_SYSBSLEXIT,
+    /*! BSL entry */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_BSL_ENTRY = SYSCTL_RSTCAUSE_ID_SYSBSLENTRY,
+    /*! WWDT0 violation */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_WWDT0_VIOLATION = SYSCTL_RSTCAUSE_ID_SYSWWDT0,
+    /*! WWDT1 violation */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_WWDT1_VIOLATION = SYSCTL_RSTCAUSE_ID_SYSWWDT1,
+    /*! Uncorrectable flash ECC error */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_FLASH_ECC_ERROR =
+        SYSCTL_RSTCAUSE_ID_SYSFLASHECC,
+    /*! CPULOCK violation */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_CPU_LOCKUP_VIOLATION =
+        SYSCTL_RSTCAUSE_ID_SYSCPULOCK,
+    /*! Debug-triggered SYSRST */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_DEBUG_TRIGGERED = SYSCTL_RSTCAUSE_ID_SYSDBG,
+    /*! Software-triggered SYSRST */
+    DL_SYSCTL_RESET_CAUSE_SYSRST_SW_TRIGGERED = SYSCTL_RSTCAUSE_ID_SYSSW,
+    /*! Debug-triggered CPURST */
+    DL_SYSCTL_RESET_CAUSE_CPURST_DEBUG_TRIGGERED = SYSCTL_RSTCAUSE_ID_CPUDBG,
+    /*! Software-triggered CPURST */
+    DL_SYSCTL_RESET_CAUSE_CPURST_SW_TRIGGERED = SYSCTL_RSTCAUSE_ID_CPUSW,
+} DL_SYSCTL_RESET_CAUSE;
+
+/**
+ *  @brief  Enable sleep on exit
+ *
+ *  Enables sleep on exit when the CPU moves from handler mode to thread mode.
+ *  By enabling, allows an interrupt driven application to avoid returning to
+ *  an empty main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_enableSleepOnExit(void)
+{
+    SCB->SCR |= SCB_SCR_SLEEPONEXIT_Msk;
+}
+
+/**
+ *  @brief  Disable sleep on exit
+ *
+ *  Disables sleep on exit when the CPU moves from handler mode to thread mode.
+ */
+__STATIC_INLINE void DL_SYSCTL_disableSleepOnExit(void)
+{
+    SCB->SCR &= ~(SCB_SCR_SLEEPONEXIT_Msk);
+}
+
+/**
+ *  @brief  Check if sleep on exit is enabled
+ */
+__STATIC_INLINE bool DL_SYSCTL_isSleepOnExitEnabled(void)
+{
+    return ((SCB->SCR & SCB_SCR_SLEEPONEXIT_Msk) == SCB_SCR_SLEEPONEXIT_Msk);
+}
+
+/**
+ *  @brief  Enable send event on pending bit
+ *
+ *  When enabled, any enabled event and all interrupts (including disabled
+ *  interrupts) can wakeup the processor.
+ */
+__STATIC_INLINE void DL_SYSCTL_enableEventOnPend(void)
+{
+    SCB->SCR |= SCB_SCR_SEVONPEND_Msk;
+}
+
+/**
+ *  @brief  Disable send event on pending bit
+ *
+ *  When disabled, only enabled interrupts or events can wake up the processor.
+ *  Disabled interrupts are excluded.
+ */
+__STATIC_INLINE void DL_SYSCTL_disableEventOnPend(void)
+{
+    SCB->SCR &= ~(SCB_SCR_SEVONPEND_Msk);
+}
+
+/**
+ *  @brief   Check if send event on pending bit is enabled
+ *
+ *  @return  Returns the enabled status of the send event on pending bit
+ *
+ *  @retval  true  Send event on pending bit is enabled
+ *  @retval  false Send event on pending bit is disabled
+ */
+__STATIC_INLINE bool DL_SYSCTL_isEventOnPendEnabled(void)
+{
+    return ((SCB->SCR & SCB_SCR_SEVONPEND_Msk) == SCB_SCR_SEVONPEND_Msk);
+}
+
+/*!
+ *  @brief  Change MCLK source
+ *
+ *  To ensure good clocking behavior, these are the recommended steps for transition.
+ *  Valid sources and destinations: LFCLK, SYSOSC, HSCLK
+ *
+ *  Depending on current MCLK source, steps to switch to next MCLK source can vary.
+ *  This is a macro that redirects to the different possible transitions.
+ *
+ *  Only valid for RUN modes. In low power modes, MCLK transitions are handled by hardware.
+ *
+ *  @note Different transition APIs may require different input parameters
+ *  Transitions between LFCLK and HSCLK requires going through SYSOSC.
+ *
+ *  @sa DL_SYSCTL_switchMCLKfromSYSOSCtoLFCLK
+ *  @sa DL_SYSCTL_switchMCLKfromLFCLKtoSYSOSC
+ *  @sa DL_SYSCTL_switchMCLKfromSYSOSCtoHSCLK
+ *  @sa DL_SYSCTL_switchMCLKfromHSCLKtoSYSOSC
+ */
+#define DL_SYSCTL_setMCLKSource(current, next, ...) \
+    DL_SYSCTL_switchMCLKfrom##current##to##next(__VA_ARGS__);
+
+/**
+ *  @brief  Change MCLK source from SYSOSC to LFCLK
+ *
+ *  @pre    If disabling SYSOSC, high speed oscillators (HFXT,...) must be disabled beforehand.
+ *  @post   MCLK source is switched to LFCLK, function will busy-wait until confirmed.
+ *
+ *  @param[in] disableSYSOSC   Whether to leave SYSOSC running or not
+ */
+void DL_SYSCTL_switchMCLKfromSYSOSCtoLFCLK(bool disableSYSOSC);
+
+/**
+ *  @brief  Change MCLK source from LFCLK to SYSOSC
+ *
+ *  @post   MCLK source is switched to SYSOSC, function will busy-wait until confirmed.
+ */
+void DL_SYSCTL_switchMCLKfromLFCLKtoSYSOSC(void);
+
+/**
+ *  @brief  Change MCLK source from SYSOSC to HSCLK
+ *
+ *  @pre    The desired HSCLK source is enabled beforehand (HFXT, HFCLK_IN).
+ *  @post   MCLK source is switched to HSCLK, function will busy-wait until confirmed.
+ *
+ *  @param[in] source   Desired high-speed clock source
+ */
+void DL_SYSCTL_switchMCLKfromSYSOSCtoHSCLK(DL_SYSCTL_HSCLK_SOURCE source);
+
+/**
+ *  @brief  Change MCLK source from HSCLK to SYSOSC
+ *
+ *  @pre    MCLK is sourced from a valid, running HSCLK source (HFXT, HFCLK_IN)
+ *  @post   MCLK source is switched to SYSOSC, function will busy-wait until confirmed.
+ *
+ *  @note   No HSCLK sources are disabled by this function
+ */
+void DL_SYSCTL_switchMCLKfromHSCLKtoSYSOSC(void);
+
+/**
+ *  @brief     Set the RUN/SLEEP mode power policy to RUN0/SLEEP0
+ *
+ * In RUN0, the MCLK and the CPUCLK run from a fast clock source (SYSOSC, or
+ * HFCLK).
+ *
+ * Setting the RUN power policy will also set the SLEEP power policy.
+ * The SLEEP mode behavior is always identical to RUN mode, just with the
+ * CPUCLK disabled. As such, the SLEEP behavior is determined by the
+ * configuration of the RUN mode. To actually enter SLEEP mode, you must call
+ * `__WFI()` to wait for interrupts or `__WFE()` to wait for ARM events.
+ * `__WFI()` is used in interrupt-driven applications, and `__WFE()` is used
+ * for interactions between the interrupt handler and main application.
+ *
+ * There are three RUN/SLEEP mode policy options: RUN0/SLEEP0, RUN1/SLEEP1,
+ * and RUN2/SLEEP2. Refer to the device TRM for more information on each policy
+ *
+ * @sa DL_SYSCTL_setMCLKSource
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicyRUN0SLEEP0(void)
+{
+    DL_SYSCTL_setMCLKSource(LFCLK, SYSOSC);
+    SCB->SCR &= ~(SCB_SCR_SLEEPDEEP_Msk);
+}
+
+/**
+ *  @brief     Set the RUN/SLEEP mode power policy to RUN1/SLEEP1
+ *
+ * In RUN1, the MCLK and the CPUCLK run from LFCLK (at 32kHz) to reduce active
+ * power, but SYSOSC is left enabled to service analog modules such as an ADC,
+ * DAC, OPA, or COMP (in HS mode).
+ *
+ * Setting the RUN power policy will also set the SLEEP power policy.
+ * The SLEEP mode behavior is always identical to RUN mode, just with the
+ * CPUCLK disabled. As such, the SLEEP behavior is determined by the
+ * configuration of the RUN mode. To actually enter SLEEP mode, you must call
+ * `__WFI()` to wait for interrupts or `__WFE()` to wait for ARM events.
+ * `__WFI()` is used in interrupt-driven applications, and `__WFE()` is used
+ * for interactions between the interrupt handler and main application.
+ *
+ * There are three RUN/SLEEP mode policy options: RUN0/SLEEP0, RUN1/SLEEP1,
+ * and RUN2/SLEEP2. Refer to the device TRM for more information on each policy
+ *
+ * @sa DL_SYSCTL_setMCLKSource
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicyRUN1SLEEP1(void)
+{
+    DL_SYSCTL_setMCLKSource(SYSOSC, LFCLK, (bool) false);
+    SCB->SCR &= ~(SCB_SCR_SLEEPDEEP_Msk);
+}
+
+/**
+ *  @brief     Set the RUN/SLEEP mode power policy to RUN2/SLEEP2
+ *
+ * In RUN2, the MCLK and the CPUCLK run from LFCLK (at 32kHz), and SYSOSC is
+ * completely disabled to save power. This is the lowest power state with
+ * the CPU running
+ *
+ * Setting the RUN power policy will also set the SLEEP power policy.
+ * The SLEEP mode behavior is always identical to RUN mode, just with the
+ * CPUCLK disabled. As such, the SLEEP behavior is determined by the
+ * configuration of the RUN mode. To actually enter SLEEP mode, you must call
+ * `__WFI()` to wait for interrupts or `__WFE()` to wait for ARM events.
+ * `__WFI()` is used in interrupt-driven applications, and `__WFE()` is used
+ * for interactions between the interrupt handler and main application.
+ *
+ * There are three RUN/SLEEP mode policy options: RUN0/SLEEP0, RUN1/SLEEP1,
+ * and RUN2/SLEEP2. Refer to the device TRM for more information on each policy
+ *
+ * @note Since this turns off SYSOSC, HSCLK sources MUST be disabled before calling
+ *
+ * @sa DL_SYSCTL_setMCLKSource
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicyRUN2SLEEP2(void)
+{
+    DL_SYSCTL_setMCLKSource(SYSOSC, LFCLK, (bool) true);
+    SCB->SCR &= ~(SCB_SCR_SLEEPDEEP_Msk);
+}
+
+/**
+ *  @brief     Get the RUN/SLEEP mode power policy
+ *
+ * Get which RUN/SLEEP power policy has been set.
+ *
+ * The SLEEP mode behavior is always identical to RUN mode, just with the
+ * CPUCLK disabled. As such, the SLEEP behavior is determined by the
+ * configuration of the RUN mode.
+ *
+ *  @return  Returns the current RUN/SLEEP mode power policy
+ *
+ *  @retval  One of @ref DL_SYSCTL_POWER_POLICY_RUN_SLEEP
+
+ */
+DL_SYSCTL_POWER_POLICY_RUN_SLEEP DL_SYSCTL_getPowerPolicyRUNSLEEP(void);
+
+/**
+ *  @brief     Set the STOP mode power policy to STOP0
+ *
+ * In STOP0, the SYSOSC is left running at the current frequency when entering
+ * STOP mode (either 32MHz, 24MHz, 16MHz, or 4MHz). ULPCLK is always limited
+ * to 4MHz automatically by hardware, but SYSOSC is not disturbed to support
+ * consistent operation of analog peripherals such as the ADC, OPA, or COMP.
+ *
+ * There are three STOP mode policy options: STOP0, STOP1, and STOP2.
+ * Refer to the device TRM for more information on each policy.
+ *
+ * @post This API does not actually enter STOP mode. After using this API to
+ * set the power policy, to enter STOP mode you must call `__WFI()` to
+ * wait for interrupts or `__WFE()` to wait for ARM events. `__WFI()` is used
+ * in interrupt-driven applications, and `__WFE()` is used for interactions
+ * between the interrupt handler and main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicySTOP0(void)
+{
+    SYSCTL->SOCLOCK.PMODECFG = SYSCTL_PMODECFG_DSLEEP_STOP;
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+    SYSCTL->SOCLOCK.SYSOSCCFG &= ~(
+        SYSCTL_SYSOSCCFG_USE4MHZSTOP_MASK | SYSCTL_SYSOSCCFG_DISABLESTOP_MASK);
+    SYSCTL->SOCLOCK.MCLKCFG &= ~(SYSCTL_MCLKCFG_USELFCLK_MASK);
+}
+
+/**
+ *  @brief     Set the STOP mode power policy to STOP1
+ *
+ * In STOP1, the SYSOSC is gear shifted from its current frequency to 4MHz for
+ * the lowest power consumption in STOP mode with SYSOSC running. SYSOSC and
+ * ULPCLK both run at 4MHz.
+ *
+ * There are three STOP mode policy options: STOP0, STOP1, and STOP2.
+ * Refer to the device TRM for more information on each policy.
+ *
+ * @post This API does not actually enter STOP mode. After using this API to
+ * set the power policy, to enter STOP mode you must call `__WFI()` to
+ * wait for interrupts or `__WFE()` to wait for ARM events. `__WFI()` is used
+ * in interrupt-driven applications, and `__WFE()` is used for interactions
+ * between the interrupt handler and main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicySTOP1(void)
+{
+    SYSCTL->SOCLOCK.PMODECFG = SYSCTL_PMODECFG_DSLEEP_STOP;
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+    SYSCTL->SOCLOCK.SYSOSCCFG |= SYSCTL_SYSOSCCFG_USE4MHZSTOP_MASK;
+    SYSCTL->SOCLOCK.SYSOSCCFG &= ~(SYSCTL_SYSOSCCFG_DISABLESTOP_MASK);
+    SYSCTL->SOCLOCK.MCLKCFG &= ~(SYSCTL_MCLKCFG_USELFCLK_MASK);
+}
+
+/**
+ *  @brief     Set the STOP mode power policy to STOP2
+ *
+ * In STOP2, the SYSOSC is disabled and the ULPCLK is sourced from LFCLK at
+ * 32kHz. This is the lowest power state in STOP mode.
+ *
+ * There are three STOP mode policy options: STOP0, STOP1, and STOP2.
+ * Refer to the device TRM for more information on each policy.
+ *
+ * @post This API does not actually enter STOP mode. After using this API to
+ * set the power policy, to enter STOP mode you must call `__WFI()` to
+ * wait for interrupts or `__WFE()` to wait for ARM events. `__WFI()` is used
+ * in interrupt-driven applications, and `__WFE()` is used for interactions
+ * between the interrupt handler and main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicySTOP2(void)
+{
+    SYSCTL->SOCLOCK.PMODECFG = SYSCTL_PMODECFG_DSLEEP_STOP;
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+    SYSCTL->SOCLOCK.SYSOSCCFG &= ~(SYSCTL_SYSOSCCFG_USE4MHZSTOP_MASK);
+    SYSCTL->SOCLOCK.SYSOSCCFG |= SYSCTL_SYSOSCCFG_DISABLESTOP_MASK;
+}
+
+/**
+ *  @brief     Get the STOP mode power policy
+ *
+ * Get which STOP power policy has been set.
+ *
+ *  @return  Returns the current STOP mode power policy
+ *
+ *  @retval  One of @ref DL_SYSCTL_POWER_POLICY_STOP if a STOP power policy
+ */
+DL_SYSCTL_POWER_POLICY_STOP DL_SYSCTL_getPowerPolicySTOP(void);
+
+/**
+ *  @brief     Set the STANDBY mode power policy to STANDBY0
+ *
+ * In STANDBY0, all PD0 peripherals receive the ULPCLK and LFCLK, and the RTC
+ * receives RTCCLK.
+ *
+ * There are two STANDBY mode policy options: STANDBY0 and STANDBY1.
+ *
+ * @post This API does not actually enter STANDBY mode. After using this API to
+ * set the power policy, to enter STANDBY mode you must call `__WFI()` to
+ * wait for interrupts or `__WFE()` to wait for ARM events. `__WFI()` is used
+ * in interrupt-driven applications, and `__WFE()` is used for interactions
+ * between the interrupt handler and main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicySTANDBY0(void)
+{
+    SYSCTL->SOCLOCK.PMODECFG = SYSCTL_PMODECFG_DSLEEP_STANDBY;
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+    SYSCTL->SOCLOCK.MCLKCFG &= ~(SYSCTL_MCLKCFG_STOPCLKSTBY_MASK);
+}
+
+/**
+ *  @brief     Set the STANDBY mode power policy to STANDBY1
+ *
+ * In STANDBY1, only TIMG0 and TIMG1 receive ULPCLK/LFCLK. The RTC continues
+ * to receive RTCCLK. A TIMG0/1 interrupt, RTC interrupt, or ADC trigger in
+ * STANDBY1 always triggers an asynchronous fast clock request to wake the
+ * system. Other PD0 peripherals (such as UART, I2C, GPIO, and COMP) can also
+ * wake the system upon an external event through an asynchronous fast clock
+ * request, but they are not actively clocked in STANDBY1.
+ *
+ * There are two STANDBY mode policy options: STANDBY0 and STANDBY1.
+ *
+ * @post This API does not actually enter STANDBY mode. After using this API to
+ * set the power policy, to enter STANDBY mode you must call `__WFI()` to
+ * wait for interrupts or `__WFE()` to wait for ARM events. `__WFI()` is used
+ * in interrupt-driven applications, and `__WFE()` is used for interactions
+ * between the interrupt handler and main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicySTANDBY1(void)
+{
+    SYSCTL->SOCLOCK.PMODECFG = SYSCTL_PMODECFG_DSLEEP_STANDBY;
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+    SYSCTL->SOCLOCK.MCLKCFG |= SYSCTL_MCLKCFG_STOPCLKSTBY_MASK;
+}
+
+/**
+ *  @brief     Get the STANDBY mode power policy
+ *
+ * Get which STANDBY power policy has been set.
+ *
+ *  @return  Returns the current STANDBY mode power policy
+ *
+ *  @retval  One of @ref DL_SYSCTL_POWER_POLICY_STANDBY
+ */
+DL_SYSCTL_POWER_POLICY_STANDBY DL_SYSCTL_getPowerPolicySTANDBY(void);
+
+/**
+ *  @brief     Set power policy to SHUTDOWN mode
+ *
+ * In SHUTDOWN mode, no clocks are available. The core regulator is completely
+ * disabled and all SRAM and register contents are lost, with the exception of
+ * the 4 bytes of general purpose memory in SYSCTL which may be used to store
+ * state information. The BOR and bandgap circuit are disabled. The device may
+ * wake up via a wake-up capable IO, a debug connection, or NRST. SHUTDOWN mode
+ * has the lowest current consumption of any operating mode. Exiting SHUTDOWN
+ * mode triggers a BOR.
+ *
+ * There is only one SHUTDOWN mode policy option: SHUTDOWN.
+ *
+ * @post This API does not actually enter SHUTDOWN mode. After using this API
+ * to enable SHUTDOWN mode, to enter SHUTDOWN mode you must call `__WFI()` to
+ * wait for interrupts or `__WFE()` to wait for ARM events. `__WFI()` is used
+ * in interrupt-driven applications, and `__WFE()` is used for interactions
+ * between the interrupt handler and main application.
+ */
+__STATIC_INLINE void DL_SYSCTL_setPowerPolicySHUTDOWN(void)
+{
+    SYSCTL->SOCLOCK.PMODECFG = SYSCTL_PMODECFG_DSLEEP_SHUTDOWN;
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+}
+
+/**
+ *  @brief     Set the brown-out reset (BOR) threshold level
+ *
+ *  Note that this API does NOT activate the BOR threshold. After setting the
+ *  threshold level with this API, call @ref DL_SYSCTL_activateBORThreshold
+ *  to actually activate the new threshold.
+ *
+ * During startup, the BOR threshold defaults to BOR0 (the lowet value) to
+ * ensure the device always starts at the specified VDD minimum. After boot,
+ * the BOR threshold level can be configured to a different level. When the
+ * BOR threshold is BOR0, a BOR0- violation always generates a BOR- violation
+ * signal to SYSCTL, generating a BOR level reset. When the BOR threshold is
+ * re-configured to BOR1, BOR2, or BOR3 the BOR circuit will generate a SYSCTL
+ * interrupt rather than asserting a BOR- violation. This may be used to give
+ * the application an indication that the supply has dropped below a certain
+ * level without causing a reset. If the BOR is in interrupt mode (threshold
+ * level of BOR1-3), and VDD drops below the respective BORx- level, an
+ * interrupt will be generated and the BOR circuit will automatically switch
+ * the BOR threshold level to BOR0 to ensure that a BOR- violation is
+ * asserted if VDD drops below BOR0-.
+ *
+ *  @param[in]  thresholdLevel  The BOR threshold level to set.
+ *                              One of @ref DL_SYSCTL_BOR_THRESHOLD_LEVEL.
+ *
+ *  @post       DL_SYSCTL_activateBORThreshold
+ */
+__STATIC_INLINE void DL_SYSCTL_setBORThreshold(
+    DL_SYSCTL_BOR_THRESHOLD_LEVEL thresholdLevel)
+{
+    SYSCTL->SOCLOCK.BORTHRESHOLD = (uint32_t) thresholdLevel;
+}
+
+/**
+ *  @brief   Get the brown-out reset (BOR) threshold level
+ *
+ *  @return  Returns the current BOR threshold level.
+ *
+ *  @retval  One of @ref DL_SYSCTL_BOR_THRESHOLD_LEVEL
+ */
+__STATIC_INLINE DL_SYSCTL_BOR_THRESHOLD_LEVEL DL_SYSCTL_getBORThreshold(void)
+{
+    return (DL_SYSCTL_BOR_THRESHOLD_LEVEL)(SYSCTL->SOCLOCK.BORTHRESHOLD);
+}
+
+/**
+ *  @brief      Activate the BOR threshold level
+ *
+ *  Attempts to change the active BOR mode to the BOR threshold that was set
+ *  via @ref DL_SYSCTL_setBORThreshold.
+ *
+ *  Setting this bit also clears any prior BOR violation status indications.
+ *
+ *  After calling this API, the change can be validated by calling
+ *  @ref DL_SYSCTL_getStatus and checking the return value.
+ *
+ *  @pre        DL_SYSCTL_setBORThreshold
+ */
+__STATIC_INLINE void DL_SYSCTL_activateBORThreshold(void)
+{
+    SYSCTL->SOCLOCK.BORCLRCMD =
+        SYSCTL_BORCLRCMD_KEY_VALUE | SYSCTL_BORCLRCMD_GO_TRUE;
+}
+
+/**
+ *  @brief      Resets the device
+ *
+ *  Resets the device using the type of reset selected. This function does not
+ *  return, the reset will happen immediately.
+ *
+ *  @param[in]  resetType  Type of reset to perform. One of @ref
+ *                         DL_SYSCTL_RESET.
+ */
+__STATIC_INLINE void DL_SYSCTL_resetDevice(uint32_t resetType)
+{
+    SYSCTL->SOCLOCK.RESETLEVEL = resetType;
+    SYSCTL->SOCLOCK.RESETCMD =
+        SYSCTL_RESETCMD_KEY_VALUE | SYSCTL_RESETCMD_GO_TRUE;
+}
+
+/**
+ *  @brief      Enable SYSCTL interrupts
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_SYSCTL_INTERRUPT.
+ */
+__STATIC_INLINE void DL_SYSCTL_enableInterrupt(uint32_t interruptMask)
+{
+    SYSCTL->SOCLOCK.IMASK |= interruptMask;
+}
+
+/**
+ *  @brief      Disable SYSCTL interrupts
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to enable. Bitwise OR of
+ *                             @ref DL_SYSCTL_INTERRUPT.
+ */
+__STATIC_INLINE void DL_SYSCTL_disableInterrupt(uint32_t interruptMask)
+{
+    SYSCTL->SOCLOCK.IMASK &= ~(interruptMask);
+}
+
+/**
+ *  @brief      Check which SYSCTL interrupts are enabled
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SYSCTL_INTERRUPT.
+ *
+ *  @return     Which of the requested SYSCTL interrupts are enabled
+ *
+ *  @retval     Bitwise OR of @ref DL_SYSCTL_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getEnabledInterrupts(uint32_t interruptMask)
+{
+    return (SYSCTL->SOCLOCK.IMASK & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of enabled SYSCTL interrupts
+ *
+ *  Checks if any of the SYSCTL interrupts that were previously enabled are
+ *  pending.
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SYSCTL_INTERRUPT.
+ *
+ *  @return     Which of the requested SYSCTL interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_SYSCTL_INTERRUPT values
+ *
+ *  @sa         DL_SYSCTL_enableInterrupt
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getEnabledInterruptStatus(
+    uint32_t interruptMask)
+{
+    return (SYSCTL->SOCLOCK.MIS & interruptMask);
+}
+
+/**
+ *  @brief      Check interrupt flag of any SYSCTL interrupt
+ *
+ *  Checks if any of the SYSCTL interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SYSCTL_INTERRUPT.
+ *
+ *  @return     Which of the requested SYSCTL interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_SYSCTL_INTERRUPT values
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getRawInterruptStatus(
+    uint32_t interruptMask)
+{
+    return (SYSCTL->SOCLOCK.RIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending SYSCTL interrupt
+ *
+ *  Checks if any of the SYSCTL interrupts are pending. Interrupts do not have to
+ *  be previously enabled.
+ *
+ *  @return     The highest priority pending SYSCTL interrupt
+ *
+ *  @retval     One of @ref DL_SYSCTL_IIDX values
+ */
+__STATIC_INLINE DL_SYSCTL_IIDX DL_SYSCTL_getPendingInterrupt(void)
+{
+    return (DL_SYSCTL_IIDX)(SYSCTL->SOCLOCK.IIDX);
+}
+
+/**
+ *  @brief      Clear pending SYSCTL interrupts
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_SYSCTL_INTERRUPT.
+ */
+__STATIC_INLINE void DL_SYSCTL_clearInterruptStatus(uint32_t interruptMask)
+{
+    SYSCTL->SOCLOCK.ICLR = interruptMask;
+}
+
+/**
+ *  @brief      Check interrupt flag of any SYSCTL non-maskable interrupt
+ *
+ *  Checks if any of the SYSCTL non-maskable interrupts are pending. Interrupts
+ *  do not have to be previously enabled.
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to check. Bitwise OR of
+ *                             @ref DL_SYSCTL_NMI.
+ *
+ *  @return     Which of the requested SYSCTL non-maskable interrupts are pending
+ *
+ *  @retval     Bitwise OR of @ref DL_SYSCTL_NMI values
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getRawNonMaskableInterruptStatus(
+    uint32_t interruptMask)
+{
+    return (SYSCTL->SOCLOCK.NMIRIS & interruptMask);
+}
+
+/**
+ *  @brief      Get highest priority pending SYSCTL non-maskable interrupt
+ *
+ *  Checks if any of the SYSCTL non-maskable interrupts are pending. Interrupts
+ *  do not have to be previously enabled.
+ *
+ *  @return     The highest priority pending SYSCTL non-maskable interrupt
+ *
+ *  @retval     One of @ref DL_SYSCTL_NMI_IIDX values
+ */
+__STATIC_INLINE DL_SYSCTL_NMI_IIDX DL_SYSCTL_getPendingNonMaskableInterrupt(
+    void)
+{
+    return (DL_SYSCTL_NMI_IIDX)(SYSCTL->SOCLOCK.NMIIIDX);
+}
+
+/**
+ *  @brief      Clear pending SYSCTL non-maskable interrupts
+ *
+ *  @param[in]  interruptMask  Bit mask of interrupts to clear. Bitwise OR of
+ *                             @ref DL_SYSCTL_NMI.
+ */
+__STATIC_INLINE void DL_SYSCTL_clearNonMaskableInterruptStatus(
+    uint32_t interruptMask)
+{
+    SYSCTL->SOCLOCK.NMIICLR = interruptMask;
+}
+
+/**
+ *  @brief  Set the behavior when a WWDT0 error occurs
+ *
+ *  Configures whether a WWDT0 error will trigger a BOOTRST or an NMI
+ * (non-maskable interrupt). By default, this error will trigger a BOOTRST.
+ *
+ *  @param[in] behavior The behavior when a Flash ECC DED occurrs
+ *
+ *  @sa        DL_SYSCTL_enableNonMaskableInterrupt
+ */
+__STATIC_INLINE void DL_SYSCTL_setWWDT0ErrorBehavior(
+    DL_SYSCTL_ERROR_BEHAVIOR behavior)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SYSTEMCFG,
+        (((uint32_t) behavior << SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_OFS)) |
+            SYSCTL_SYSTEMCFG_KEY_VALUE,
+        (SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_MASK | SYSCTL_SYSTEMCFG_KEY_MASK));
+}
+
+/**
+ *  @brief  Get the behavior when a WWDT0 error occurs
+ *
+ *  By default, this error will trigger a BOOTRST.
+ *
+ *  @return The behavior when a WWDT0 error occurs
+ *
+ *  @retval One of @ref DL_SYSCTL_ERROR_BEHAVIOR
+ */
+__STATIC_INLINE DL_SYSCTL_ERROR_BEHAVIOR DL_SYSCTL_getWWDT0ErrorBehavior(void)
+{
+    uint32_t behavior =
+        (SYSCTL->SOCLOCK.SYSTEMCFG & SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_MASK) >>
+        SYSCTL_SYSTEMCFG_WWDTLP0RSTDIS_OFS;
+
+    return (DL_SYSCTL_ERROR_BEHAVIOR)(behavior);
+}
+
+/**
+ *  @brief Set the Main Clock (MCLK) divider (MDIV)
+ *
+ *  Additionally, can use this function to disable MDIV. MDIV must be disabled
+ *  before changing SYSOSC frequency.
+ *
+ *  MDIV is not valid if MCLK source is HSCLK.
+ *  MDIV is not used if MCLK source if LFCLK.
+ *
+ *  @param[in] divider Should be DL_SYSCTL_MCLK_DIVIDER_DISABLE if source is
+ *  HSCLK, a don't care if LFCLK, and one of DL_SYSCTL_MCLK_DIVIDER if SYSOSC.
+ */
+__STATIC_INLINE void DL_SYSCTL_setMCLKDivider(DL_SYSCTL_MCLK_DIVIDER divider)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.MCLKCFG, (uint32_t) divider,
+        SYSCTL_MCLKCFG_MDIV_MASK);
+}
+/**
+ *  @brief Get the Main Clock (MCLK) divider (MDIV)
+ *
+ *  @return The value of the Main Clock (MCLK) divider (MDIV)
+ *
+ *  @retval Should be DL_SYSCTL_MCLK_DIVIDER_DISABLE if source is HSCLK, a
+ *  don't care if LFCLK, and one of DL_SYSCTL_MCLK_DIVIDER if SYSOSC.
+ */
+__STATIC_INLINE DL_SYSCTL_MCLK_DIVIDER DL_SYSCTL_getMCLKDivider(void)
+{
+    uint32_t divider = SYSCTL->SOCLOCK.MCLKCFG & SYSCTL_MCLKCFG_MDIV_MASK;
+
+    return (DL_SYSCTL_MCLK_DIVIDER)(divider);
+}
+
+/**
+ *  @brief   Get the source for the Main Clock (MCLK)
+ *
+ *  @return  The source for the Main Clock (MCLK)
+ *
+ *  @retval  One of @ref DL_SYSCTL_MCLK_SOURCE
+ */
+__STATIC_INLINE DL_SYSCTL_MCLK_SOURCE DL_SYSCTL_getMCLKSource(void)
+{
+    uint32_t source =
+        SYSCTL->SOCLOCK.MCLKCFG &
+        (SYSCTL_MCLKCFG_USEHSCLK_MASK | SYSCTL_MCLKCFG_USELFCLK_MASK);
+
+    return (DL_SYSCTL_MCLK_SOURCE)(source);
+}
+
+/**
+ *  @brief     Set the target frequency of the System Oscillator (SYSOSC)
+ *
+ *  Target/desired SYSOSC frequency may be different than current/actual SYSOSC
+ *  frequency during gear shift and other operations.
+ *
+ *  The System Oscillator (SYSOSC) is an on-chip, accurate, configurable
+ *  oscillator with factory trimmed support for 32MHz (base frequency) and 4MHz
+ *  (low frequency) operation.
+ *  It can also operate at 16MHz or 24MHz by using the
+ *  @ref DL_SYSCTL_configSYSOSCUserTrim function instead.
+ *
+ *  SYSOSC provides a flexible high-speed clock source for the system in cases
+ *  where the HFXT is either not present or not used.
+ *
+ *  MDIV must be disabled before changing SYSOSC freq. See @ref DL_SYSCTL_setMCLKDivider.
+ *
+ *  @param[in] freq  Target frequency to use for the System Oscillator (SYSOSC).
+ *                  @ref DL_SYSCTL_SYSOSC_FREQ_4M or @ref DL_SYSCTL_SYSOSC_FREQ_BASE.
+ *
+ *  @sa DL_SYSCTL_configSYSOSCUserTrim
+ *  @sa DL_SYSCTL_setMCLKDivider
+ */
+__STATIC_INLINE void DL_SYSCTL_setSYSOSCFreq(DL_SYSCTL_SYSOSC_FREQ freq)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SYSOSCCFG, (uint32_t) freq,
+        SYSCTL_SYSOSCCFG_FREQ_MASK);
+}
+
+/**
+ *  @brief     Trim the System Oscillator (SYSOSC) to 16MHz or 24MHz
+ *
+ *  The trim values supplied in the config struct must be determined by
+ *  experimentation. Please refer to the "SYSOSC User Trim Procedure" section
+ *  in the CKM Technical Reference Manual.
+ *  Each device must be trimmed individually for accuracy.
+ *
+ *  MDIV must be disabled before changing SYSOSC freq. See @ref DL_SYSCTL_setMCLKDivider.
+ *
+ *  @param[in]  config         Pointer to the SYSOSC user trim configuration struct
+ *                             @ref DL_SYSCTL_SYSOSCUserTrimConfig.
+ *
+ *  @sa DL_SYSCTL_setSYSOSCFreq
+ *  @sa DL_SYSCTL_setMCLKDivider
+ */
+__STATIC_INLINE void DL_SYSCTL_configSYSOSCUserTrim(
+    DL_SYSCTL_SYSOSCUserTrimConfig *config)
+{
+    SYSCTL->SOCLOCK.SYSOSCTRIMUSER =
+        ((config->rDiv << SYSCTL_SYSOSCTRIMUSER_RDIV_OFS) &
+            SYSCTL_SYSOSCTRIMUSER_RDIV_MASK) |
+        ((config->resistorFine << SYSCTL_SYSOSCTRIMUSER_RESFINE_OFS) &
+            SYSCTL_SYSOSCTRIMUSER_RESFINE_MASK) |
+        ((config->resistorCoarse << SYSCTL_SYSOSCTRIMUSER_RESCOARSE_OFS) &
+            SYSCTL_SYSOSCTRIMUSER_RESCOARSE_MASK) |
+        (config->capacitor << SYSCTL_SYSOSCTRIMUSER_CAP_OFS) |
+        ((uint32_t) config->freq);
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SYSOSCCFG,
+        SYSCTL_SYSOSCCFG_FREQ_SYSOSCUSER, SYSCTL_SYSOSCCFG_FREQ_MASK);
+}
+
+/**
+ *  @brief   Get the target frequency of the System Oscillator (SYSOSC)
+ *  Target/desired SYSOSC frequency may be different than current/actual SYSOSC
+ *  frequency during gear shift and other operations.
+ *  This function matches what is input by @ref DL_SYSCTL_setSYSOSCFreq.
+ *
+ *  @return  The target frequency of System Oscillator (SYSOSC). One of
+ *           @ref DL_SYSCTL_SYSOSC_FREQ.
+ */
+__STATIC_INLINE DL_SYSCTL_SYSOSC_FREQ DL_SYSCTL_getTargetSYSOSCFreq(void)
+{
+    uint32_t freq = SYSCTL->SOCLOCK.SYSOSCCFG & SYSCTL_SYSOSCCFG_FREQ_MASK;
+
+    return (DL_SYSCTL_SYSOSC_FREQ)(freq);
+}
+
+/**
+ *  @brief   Get the current frequency of the System Oscillator (SYSOSC)
+ *  Current/actual SYSOSC frequency may be different than target/desired SYSOSC
+ *  frequency during gear shift and other operations.
+ *
+ *  @return  The current frequency of System Oscillator (SYSOSC). One of
+ *           @ref DL_SYSCTL_SYSOSC_FREQ.
+ */
+__STATIC_INLINE DL_SYSCTL_SYSOSC_FREQ DL_SYSCTL_getCurrentSYSOSCFreq(void)
+{
+    uint32_t freq =
+        SYSCTL->SOCLOCK.CLKSTATUS & SYSCTL_CLKSTATUS_SYSOSCFREQ_MASK;
+
+    return (DL_SYSCTL_SYSOSC_FREQ)(freq);
+}
+
+/**
+ *  @brief   Returns status of the different clocks in CKM
+ *
+ *  @return  Full status of all clock selections
+ *
+ *  @retval  Bitwise OR of @ref DL_SYSCTL_CLK_STATUS.
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getClockStatus(void)
+{
+    return (SYSCTL->SOCLOCK.CLKSTATUS);
+}
+
+/**
+ *  @brief   Returns general status of SYSCTL
+ *
+ *  @return  Full status of all general conditions in SYSCTL
+ *
+ *  @retval  Bitwise OR of @ref DL_SYSCTL_STATUS.
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getStatus(void)
+{
+    return (SYSCTL->SOCLOCK.SYSSTATUS);
+}
+
+/**
+ *  @brief   Clear the ECC error bits in SYSSTATUS
+ *
+ *  The ECC error bits in SYSSTATUS are sticky (they remain set when an ECC
+ *  error occurs even if future reads do not have errors), and can be
+ *  cleared through this API.
+ */
+__STATIC_INLINE void DL_SYSCTL_clearECCErrorStatus(void)
+{
+    SYSCTL->SOCLOCK.SYSSTATUSCLR =
+        (SYSCTL_SYSSTATUSCLR_ALLECC_CLEAR | SYSCTL_SYSSTATUSCLR_KEY_VALUE);
+}
+
+/**
+ *  @brief Change LFCLK source to external crystal LFXT
+ *
+ * LFOSC is the internal 32kHz oscillator and default LFCLK source after a BOR.
+ * Once LFCLK source is changed, the change is locked, LFOSC is disabled to
+ * save power, and LFCLK source cannot be selected again without BOR.
+ *
+ * LFXT is an ultra-low power crystal oscillator which supports driving a
+ * standard 32.768kHz watch crystal.
+ *
+ * To use the LFXT, a watch crystal must be populated between LFXIN and LFXOUT
+ * pins. Find more info in LFXT section of CKM Technical Reference Manual.
+ *
+ * GPIO/IOMUX must be configure LFXT functionality for LFXIN and LFXOUT before
+ * calling this function.
+ *
+ * This basic implementation will busy-wait until LFXT oscillator is stabilized.
+ * But a more advanced implementation can do other things while the LFXT is
+ * stabilizing. You can enable LFXTGOOD interrupt, or check CLKSTATUS.LFXTGOOD
+ * when convenient, as long as you do not switch the source via
+ * SETUSELFXT until LFXTGOOD is set.
+ *
+ * LFCLK_IN and LFXT are mutually exclusive.
+ * This function assumes LFCLK_IN is disabled (default).
+ *
+ *  @param[in]  config         Pointer to the LFCLK configuration struct
+ *                             @ref DL_SYSCTL_LFCLKConfig.
+ */
+void DL_SYSCTL_setLFCLKSourceLFXT(DL_SYSCTL_LFCLKConfig *config);
+
+/**
+ *  @brief Change LFCLK source to external digital LFCLK_IN
+ *
+ * LFOSC is the internal 32kHz oscillator and default LFCLK source after a BOR.
+ * Once LFCLK source is changed, the change is locked, LFOSC is disabled to
+ * save power, and LFCLK source cannot be selected again without BOR.
+ *
+ * LFCLK_IN is a low frequency digital clock input compatible with 32.768kHz
+ * typical frequency digital square wave CMOS clock inputs (typical duty
+ * cycle of 50%).
+ *
+ * Digital clock input must be valid and GPIO/IOMUX must be configured
+ * separately on the appropriate pin before calling this function to enable
+ * LFCLK_IN.
+ *
+ * LFCLK_IN and LFXT are mutually exclusive.
+ * This function assumes LFXT is disabled (default).
+ */
+__STATIC_INLINE void DL_SYSCTL_setLFCLKSourceEXLF(void)
+{
+    SYSCTL->SOCLOCK.EXLFCTL =
+        (SYSCTL_EXLFCTL_KEY_VALUE | SYSCTL_EXLFCTL_SETUSEEXLF_TRUE);
+}
+
+/**
+ *  @brief Change HFCLK source to external crystal HFXT with default parameters
+ *
+ * HFXT is a high frequency crystal oscillator which supports standard crystals
+ * and resonators in the 4-48MHz range to generate a stable high-speed
+ * reference clock for the system.
+ *
+ * To use the HFXT, a crystal or resonator must be populated between HFXIN and HFXOUT
+ * pins. Find more info in HFXT section of CKM Technical Reference Manual.
+ *
+ * GPIO/IOMUX must be configure HFXT functionality for HFXIN and HFXOUT before
+ * calling this function.
+ *
+ * The HFXT startup time is set to ~0.512ms based on the TYP datasheet
+ * recommendation. Additionally, the HFCLK startup monitor is enabled.
+ *
+ * This basic implementation will busy-wait until HFXT oscillator is stabilized.
+ * But a more advanced implementation can do other things while the HFXT is
+ * stabilizing. You can enable HFCLKGOOD interrupt, or check CLKSTATUS.HFCLKGOOD
+ * when convenient, as long as you do not switch the source before HFCLKGOOD is set.
+ *
+ * To modify the default HFXT startup time or disable the startup monitor, use
+ * @ref DL_SYSCTL_setHFCLKSourceHFXTParams instead of this API.
+ *
+ *  @param[in]  range   HFXT frequency range
+ */
+void DL_SYSCTL_setHFCLKSourceHFXT(DL_SYSCTL_HFXT_RANGE range);
+
+/**
+ *  @brief Change HFCLK source to external crystal HFXT with custom parameters
+ *
+ * HFXT is a high frequency crystal oscillator which supports standard crystals
+ * and resonators in the 4-48MHz range to generate a stable high-speed
+ * reference clock for the system.
+ *
+ * To use the HFXT, a crystal or resonator must be populated between HFXIN and HFXOUT
+ * pins. Find more info in HFXT section of CKM Technical Reference Manual.
+ *
+ * GPIO/IOMUX must be configure HFXT functionality for HFXIN and HFXOUT before
+ * calling this function.
+ *
+ * If the HFCLK startup monitor is enabled, then the HFXT will be checked after
+ * the amount of time specified by the startupTime parameter.
+ * This basic implementation will busy-wait until HFXT oscillator is stabilized.
+ * But a more advanced implementation can do other things while the HFXT is
+ * stabilizing. You can enable HFCLKGOOD interrupt, or check CLKSTATUS.HFCLKGOOD
+ * when convenient, as long as you do not switch the source before HFCLKGOOD is set.
+ *
+ * If the HFCLK startup monitor is disabled, then this implementation will not
+ * check if the HFXT oscillator is stabilized.
+ *
+ *  @param[in]  range           HFXT frequency range
+ *  @param[in]  startupTime     HFXT startup time
+ *  @param[in]  monitorEnable   Whether to enable the HFCLK startup monitor
+
+ */
+void DL_SYSCTL_setHFCLKSourceHFXTParams(
+    DL_SYSCTL_HFXT_RANGE range, uint32_t startupTime, bool monitorEnable);
+
+/**
+ *  @brief Change HFCLK source to external digital HFCLK_IN
+ *
+ * HFCLK_IN can be used to bypass the HFXT circuit and bring 4-48MHz typical
+ * frequency digital clock into the devce as HFCLK source instead of HFXT.
+ *
+ * HFCLK_IN is a digital clock input compatible with digital square wave CMOS
+ * clock inputs and should have typical duty cycle of 50%.
+ *
+ * Digital clock input must be valid and GPIO/IOMUX must be configured
+ * separately on the appropriate pin before calling this function to enable
+ * HFCLK_IN.
+ */
+__STATIC_INLINE void DL_SYSCTL_setHFCLKSourceHFCLKIN(void)
+{
+    SYSCTL->SOCLOCK.HSCLKEN |= SYSCTL_HSCLKEN_USEEXTHFCLK_ENABLE;
+}
+
+/**
+ *  @brief      Disable the HFXT
+ *
+ *  If HFXT is already enabled, application software must verify that either an
+ *  HFCLKGOOD indication or an HFCLKOFF (off/dead) indication in the CLKSTATUS
+ *  register was asserted by hardware before attempting to disable the HFXT
+ *  by clearing HFXTEN. When disabling the HFXT by clearing HFXTEN, the HFXT
+ *  must not be re-enabled again until the HFCLKOFF bit in the CLKSTATUS
+ *  register is set by hardware.
+ *
+ *  @sa DL_SYSCTL_getClockStatus
+ */
+__STATIC_INLINE void DL_SYSCTL_disableHFXT(void)
+{
+    SYSCTL->SOCLOCK.HSCLKEN &= ~(SYSCTL_HSCLKEN_HFXTEN_MASK);
+}
+
+/**
+ *  @brief   Get the source of High Speed Clock (HSCLK)
+ *
+ * HSCLK can be sourced by HFCLK.
+ * HSCLK is an optional source for MCLK alongside SYSOSC or LFCLK.
+ *
+ *  @return  The source of HSCLK. One of @ref DL_SYSCTL_HSCLK_SOURCE.
+ */
+__STATIC_INLINE DL_SYSCTL_HSCLK_SOURCE DL_SYSCTL_getHSCLKSource(void)
+{
+    uint32_t source = SYSCTL->SOCLOCK.HSCLKCFG & SYSCTL_HSCLKCFG_HSCLKSEL_MASK;
+
+    return (DL_SYSCTL_HSCLK_SOURCE)(source);
+}
+
+/**
+ *  @brief   Set the source of High Speed Clock (HSCLK)
+ *
+ * HSCLK can be sourced by HFCLK.
+ * HSCLK is an optional source for MCLK alongside SYSOSC or LFCLK.
+ *
+ *  @param[in]  source  The source of HSCLK. One of @ref DL_SYSCTL_HSCLK_SOURCE.
+ */
+__STATIC_INLINE void DL_SYSCTL_setHSCLKSource(DL_SYSCTL_HSCLK_SOURCE source)
+{
+    SYSCTL->SOCLOCK.HSCLKCFG = (uint32_t) source;
+}
+
+/**
+ *  @brief   Get the source of Middle Frequency Precision Clock (MFPCLK)
+ *
+ *  MFPCLK is a continuous 4MHz to DAC module in RUN/SLEEP/STOP mode.
+ *  Unlike MFCLK, MFPCLK is async to MCLK/ULPCLK, providing higher DAC precision and performance.
+ *  MFPCLK is the only clock source for DAC.
+ *
+ *  @return  The source of MFPCLK. One of @ref DL_SYSCTL_MFPCLK_SOURCE.
+ */
+__STATIC_INLINE DL_SYSCTL_MFPCLK_SOURCE DL_SYSCTL_getMFPCLKSource(void)
+{
+    uint32_t source =
+        SYSCTL->SOCLOCK.GENCLKCFG & SYSCTL_GENCLKCFG_MFPCLKSRC_MASK;
+
+    return (DL_SYSCTL_MFPCLK_SOURCE)(source);
+}
+
+/**
+ *  @brief   Set the source of Middle Frequency Precision Clock (MFPCLK)
+ *
+ *  MFPCLK is a continuous 4MHz to DAC module in RUN/SLEEP/STOP mode.
+ *  Unlike MFCLK, MFPCLK is async to MCLK/ULPCLK, providing higher DAC precision and performance.
+ *  MFPCLK is the only clock source for DAC.
+ *
+ *  @param[in]  source  The source of MFPCLK. One of @ref DL_SYSCTL_MFPCLK_SOURCE.
+ */
+__STATIC_INLINE void DL_SYSCTL_setMFPCLKSource(DL_SYSCTL_MFPCLK_SOURCE source)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.GENCLKCFG, (uint32_t) source,
+        SYSCTL_GENCLKCFG_MFPCLKSRC_MASK);
+}
+
+/**
+ *  @brief  Enable the Medium Frequency Clock (MFCLK)
+ *
+ *  MFCLK provides a continuous 4MHz clock to drive certain peripherals on the system.
+ *  The 4MHz rate is always derived from SYSOSC, and the divider is automatically
+ *  applied to maintain the 4MHz rate regardless of SYSOSC frequency.
+ *  MCLK is ideal for timers and serial interfaces which require a constant
+ *  clock source in RUN/SLEEP/STOP power modes.
+ *
+ *  MFCLK can only run if 3 conditions are met:
+ *
+ *  1) Power mode must be RUN, SLEEP, or STOP.
+ *  2) USEMFTICK register bit is set, which this function does
+ *  3) MDIV must be set to @ref DL_SYSCTL_MCLK_DIVIDER_DISABLE by @ref DL_SYSCTL_setMCLKDivider.
+ *
+ *  If MCLK source is not SYSOSC, MCLK frequency must be >=32MHz for correct operation of MFCLK.
+ *
+ *  @sa DL_SYSCTL_setMCLKDivider
+ *  @sa DL_SYSCTL_getMCLKSource
+ *  @sa DL_SYSCTL_getMCLKFreq
+ */
+__STATIC_INLINE void DL_SYSCTL_enableMFCLK(void)
+{
+    SYSCTL->SOCLOCK.MCLKCFG |= SYSCTL_MCLKCFG_USEMFTICK_ENABLE;
+}
+
+/**
+ *  @brief  Disable the Medium Frequency Clock (MFCLK)
+ */
+__STATIC_INLINE void DL_SYSCTL_disableMFCLK(void)
+{
+    SYSCTL->SOCLOCK.MCLKCFG &= ~(SYSCTL_MCLKCFG_USEMFTICK_ENABLE);
+}
+
+/**
+ *  @brief  Enable the Middle Frequency Precision Clock (MFPCLK)
+ *
+ *  MFPCLK provides a continuous 4MHz clock to the DAC.
+ *
+ *  MFPCLK can be sources from either SYSOSC or HFCLK (HFXT or HFCLK_IN).
+ *
+ *  The DAC does not have a clock selection mux. Its clock source is selected
+ *  by configuring MFPCLK.
+ *
+ *  @sa DL_SYSCTL_disableMFPCLK
+ */
+__STATIC_INLINE void DL_SYSCTL_enableMFPCLK(void)
+{
+    SYSCTL->SOCLOCK.GENCLKEN |= SYSCTL_GENCLKEN_MFPCLKEN_ENABLE;
+}
+
+/**
+ *  @brief  Disable the Middle Frequency Precision Clock (MFPCLK)
+ *  @sa DL_SYSCTL_enableMFPCLK
+ */
+__STATIC_INLINE void DL_SYSCTL_disableMFPCLK(void)
+{
+    SYSCTL->SOCLOCK.GENCLKEN &= ~(SYSCTL_GENCLKEN_MFPCLKEN_ENABLE);
+}
+
+/**
+ *  @brief  Set the divider for HFCLK when HFCLK is used as the MFPCLK source
+ *
+ *  @param[in] divider   The divider of HFCLK for MFPCLK
+ *                       One of @ref DL_SYSCTL_HFCLK_MFPCLK_DIVIDER.
+ */
+__STATIC_INLINE void DL_SYSCTL_setHFCLKDividerForMFPCLK(
+    DL_SYSCTL_HFCLK_MFPCLK_DIVIDER divider)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.GENCLKCFG,
+        ((uint32_t) divider << SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_OFS),
+        SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_MASK);
+}
+
+/**
+ *  @brief   Get the divider for HFCLK when HFCLK is used as the MFPCLK source
+ *
+ *  @return  Returns the divider for HFCLK for MFPCLK
+ *
+ *  @retval  One of @ref DL_SYSCTL_HFCLK_MFPCLK_DIVIDER
+ */
+__STATIC_INLINE DL_SYSCTL_HFCLK_MFPCLK_DIVIDER
+DL_SYSCTL_getHFCLKDividerForMFPCLK(void)
+{
+    uint32_t divider =
+        (SYSCTL->SOCLOCK.GENCLKCFG & SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_MASK) >>
+        SYSCTL_GENCLKCFG_HFCLK4MFPCLKDIV_OFS;
+
+    return (DL_SYSCTL_HFCLK_MFPCLK_DIVIDER)(divider);
+}
+
+/**
+ *  @brief  Enable the External Clock (CLK_OUT)
+ *
+ *  CLK_OUT is provided for pushing out digital clocks to external circuits, such
+ *  as an external ADC which does not have its own clock source.
+ *
+ *  IOMUX setting for CLK_OUT must be configured before using this function.
+ *
+ *  CLK_OUT has a typical duty cycle of 50% if clock source is HFCLK,
+ *  SYSOSC, or LFCLK. If source is MCLK, ULPCLK, or MFCLK, duty cycle is not
+ *  guaranteed to be 50%.
+ *
+ *  This function performs multiple operations:
+ *  1) Sets the CLK_OUT source
+ *  2) Sets the CLK_OUT divider value
+ *  3) Enables the CLK_OUT divider, which can be disabled by @ref DL_SYSCTL_disableExternalClockDivider
+ *  4) Enables the CLK_OUT, which can be disabled by @ref DL_SYSCTL_disableExternalClock
+ *
+ *  @param[in]  source  The source of CLK_OUT. One of @ref DL_SYSCTL_CLK_OUT_SOURCE.
+ *  @param[in]  divider The divider of CLK_OUT. One of @ref DL_SYSCTL_CLK_OUT_DIVIDE.
+ *
+ *  @sa DL_SYSCTL_disableExternalClock
+ *  @sa DL_SYSCTL_disableExternalClockDivider
+ */
+__STATIC_INLINE void DL_SYSCTL_enableExternalClock(
+    DL_SYSCTL_CLK_OUT_SOURCE source, DL_SYSCTL_CLK_OUT_DIVIDE divider)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.GENCLKCFG,
+        (uint32_t) divider | (uint32_t) source,
+        SYSCTL_GENCLKCFG_EXCLKDIVEN_MASK | SYSCTL_GENCLKCFG_EXCLKDIVVAL_MASK |
+            SYSCTL_GENCLKCFG_EXCLKSRC_MASK);
+    SYSCTL->SOCLOCK.GENCLKEN |= SYSCTL_GENCLKEN_EXCLKEN_ENABLE;
+}
+
+/**
+ *  @brief  Disable the External Clock (CLK_OUT)
+ *  @sa DL_SYSCTL_enableExternalClock
+ */
+__STATIC_INLINE void DL_SYSCTL_disableExternalClock(void)
+{
+    SYSCTL->SOCLOCK.GENCLKEN &= ~(SYSCTL_GENCLKEN_EXCLKEN_ENABLE);
+}
+
+/**
+ *  @brief  Disable the External Clock (CLK_OUT) Divider
+ *  @sa DL_SYSCTL_enableExternalClock
+ */
+__STATIC_INLINE void DL_SYSCTL_disableExternalClockDivider(void)
+{
+    SYSCTL->SOCLOCK.GENCLKCFG &= ~(SYSCTL_GENCLKCFG_EXCLKDIVEN_ENABLE);
+}
+
+/**
+ *  @brief  Blocks all asynchronous fast clock requests
+ *
+ *  To block specific async fast clock requests on certain IP, refer to their
+ *  individual driverlib. Examples include: RTC, UART, SPI, I2C.
+ */
+__STATIC_INLINE void DL_SYSCTL_blockAllAsyncFastClockRequests(void)
+{
+    SYSCTL->SOCLOCK.SYSOSCCFG |= SYSCTL_SYSOSCCFG_BLOCKASYNCALL_ENABLE;
+}
+
+/**
+ *  @brief  Allows all asynchronous fast clock requests
+ *
+ *  Although this allows all async fast clock requests, individual IPs may still
+ *  be blocking theirs.
+ *
+ *  To allow specific async fast clock requests on certain IP, refer to their
+ *  individual driverlib. Examples include: RTC, UART, SPI, I2C, GPIO.
+ */
+__STATIC_INLINE void DL_SYSCTL_allowAllAsyncFastClockRequests(void)
+{
+    SYSCTL->SOCLOCK.SYSOSCCFG &= ~(SYSCTL_SYSOSCCFG_BLOCKASYNCALL_ENABLE);
+}
+
+/**
+ *  @brief  Generates an asynchronous fast clock request upon any IRQ request to CPU.
+ *
+ *  Provides lowest latency interrupt handling regardless of system clock speed.
+ *  Blockable by @ref DL_SYSCTL_blockAllAsyncFastClockRequests
+ *
+ *  @sa DL_SYSCTL_blockAllAsyncFastClockRequests
+ */
+__STATIC_INLINE void DL_SYSCTL_enableFastCPUEventHandling(void)
+{
+    SYSCTL->SOCLOCK.SYSOSCCFG |= SYSCTL_SYSOSCCFG_FASTCPUEVENT_ENABLE;
+}
+
+/**
+ *  @brief  Maintains current system clock speed for IRQ request to CPU.
+ *
+ *  Latency for interrupt handling will be higher at lower system clock speeds.
+ */
+__STATIC_INLINE void DL_SYSCTL_disableFastCPUEventHandling(void)
+{
+    SYSCTL->SOCLOCK.SYSOSCCFG &= ~(SYSCTL_SYSOSCCFG_FASTCPUEVENT_ENABLE);
+}
+
+/**
+ *  @brief  Set the SRAM boundary address to act as partition for read-execute
+ *          permission
+ *
+ *  Specify the SRAM partition address to protect the code region of SRAM from
+ *  being written to, and prevent the RW ("data") region of SRAM from being
+ *  used for code execution.
+ *  The SRAM partition address creates lower and higher partitions:
+ *      - Lower partition is Read-Write only, no execute
+ *      - Upper partition is Read-Execute only, no write
+ *  A partition address of 0x0 is a special case and indicates that all SRAM is
+ *  configured with RWX (read-write-execute) permissions. This is the default
+ *  value.
+ *
+ *  The address is set with a 32-byte resolution. The address written is the
+ *  system memory map address of the partition (0x200X_XXXX).
+ *
+ *  @param[in]  address   Address to act as the SRAM partition address. Value is
+ *                        a valid 32-bit SRAM address. Only address bits [19:5]
+ *                        i.e. bit 5 to bit 19 are used for the boundary address
+ */
+__STATIC_INLINE void DL_SYSCTL_setSRAMBoundaryAddress(uint32_t address)
+{
+    SYSCTL->SOCLOCK.SRAMBOUNDARY =
+        (((uint32_t) address) & SYSCTL_SRAMBOUNDARY_ADDR_MASK);
+}
+
+/**
+ *  @brief  Get the SRAM boundary address
+ *
+ *  Get the SRAM partition address
+ *  The SRAM partition address creates lower and higher partitions:
+ *      - Lower partition is Read-Write only, no execute
+ *      - Upper partition is Read-Execute only, no write
+ *  A partition address of 0x0 is a special case and indicates that all SRAM is
+ *  configured with RWX (read-write-execute) permissions.
+ *
+ *  The address is set with a 32-byte granularity. The address written is the
+ *  system memory map address of the partition (0x200X_XXXX).
+ *
+ *  @return     The SRAM partition address offset from the SRAM base address
+ *
+ *  @retval     Value is range in [0x0, 0x000FFFE0]
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getSRAMBoundaryAddress(void)
+{
+    return (SYSCTL->SOCLOCK.SRAMBOUNDARY);
+}
+
+/**
+ *  @brief  Set flash wait state
+ *
+ *  @note Flash wait states are managed automatically by SYSCTL when MCLK is
+ *  running from SYSOSC or LFCLK.
+ *  @note This wait state is only applied if MCLK running from HFXT,
+ *  or HFCLK_IN.
+ *
+ *  Consult device specific datasheet for proper values.
+ *
+ *  @param[in]  waitState  Desired number of flash wait states. One of
+ *  @ref DL_SYSCTL_FLASH_WAIT_STATE.
+ */
+__STATIC_INLINE void DL_SYSCTL_setFlashWaitState(
+    DL_SYSCTL_FLASH_WAIT_STATE waitState)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.MCLKCFG, (uint32_t) waitState,
+        SYSCTL_MCLKCFG_FLASHWAIT_MASK);
+}
+
+/**
+ *  @brief  Get flash wait state
+ *
+ *  @note Flash wait states are managed automatically by SYSCTL when MCLK is
+ *  running from SYSOSC or LFCLK.
+ *  @note This wait state is only applied if MCLK running from HFXT,
+ *  or HFCLK_IN.
+ *
+ *  Consult device specific datasheet for proper values.
+ *
+ *  @return Number of flash wait states. One of @ref DL_SYSCTL_FLASH_WAIT_STATE.
+ */
+__STATIC_INLINE DL_SYSCTL_FLASH_WAIT_STATE DL_SYSCTL_getFlashWaitState(void)
+{
+    uint32_t waitState =
+        SYSCTL->SOCLOCK.MCLKCFG & SYSCTL_MCLKCFG_FLASHWAIT_MASK;
+
+    return (DL_SYSCTL_FLASH_WAIT_STATE)(waitState);
+}
+
+/**
+ *  @brief  Read Frequency Clock Counter (FCC)
+ *  @return  22-bit value of Frequency Clock Counter (FCC)
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_readFCC(void)
+{
+    return (SYSCTL->SOCLOCK.FCC);
+}
+
+/**
+ *  @brief  Start Frequency Clock Counter (FCC)
+ *
+ *  If FCC_IN is already logic high, counting starts immediately.
+ *  When using level trigger, FCC_IN should be low when GO is set, and trigger
+ *  pulse should be sent to FCC_IN after starting FCC.
+ */
+__STATIC_INLINE void DL_SYSCTL_startFCC(void)
+{
+    SYSCTL->SOCLOCK.FCCCMD = (SYSCTL_FCCCMD_KEY_VALUE | SYSCTL_FCCCMD_GO_TRUE);
+}
+
+/**
+ *  @brief  Returns whether FCC is done capturing
+ *
+ *  When capture completes, FCCDONE is set by hardware.
+ *  FCCDONE is read-only and is automatically cleared by hardware when a new
+ *  capture is started.
+ *
+ *  @return Whether FCC is done or not
+ *  @retval true or false (boolean)
+ */
+__STATIC_INLINE bool DL_SYSCTL_isFCCDone(void)
+{
+    return (DL_SYSCTL_getClockStatus() & SYSCTL_CLKSTATUS_FCCDONE_DONE) ==
+           SYSCTL_CLKSTATUS_FCCDONE_DONE;
+}
+
+/**
+ *  @brief     Configure the Frequency Clock Counter (FCC)
+ *
+ *  FCC enables flexible in-system testing and calibration of a variety of oscillators
+ *  and clocks on the device. The FCC counts the number of clock periods seen on the
+ *  selected clock source within a known fixed trigger period (derived from a secondary
+ *  reference source) to provide an estimation of the frequency of the source clock.
+ *
+ *  @param[in] trigLvl  Determines if active high level trigger or rising-edge
+ *                      to rising-edge. One of @ref DL_SYSCTL_FCC_TRIG_TYPE .
+ *  @param[in] trigSrc  Determines which clock source to trigger FCC from. One of
+ *                      @ref DL_SYSCTL_FCC_TRIG_SOURCE.
+ *  @param[in] clkSrc   Which clock source to capture and measure frequency of. One of
+ *                      @ref DL_SYSCTL_FCC_CLOCK_SOURCE.
+ */
+void DL_SYSCTL_configFCC(DL_SYSCTL_FCC_TRIG_TYPE trigLvl,
+    DL_SYSCTL_FCC_TRIG_SOURCE trigSrc, DL_SYSCTL_FCC_CLOCK_SOURCE clkSrc);
+
+/**
+ *  @brief     Sets number of rising-edge to rising-edge period for Frequency
+ *             Clock Counter (FCC)
+ *
+ *  Set the number of rising-edge to rising-edge period for Frequency
+ *             Clock Counter (FCC)
+ *
+ *  @param[in] periods  One of @ref DL_SYSCTL_FCC_TRIG_CNT
+ */
+__STATIC_INLINE void DL_SYSCTL_setFCCPeriods(DL_SYSCTL_FCC_TRIG_CNT periods)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.GENCLKCFG, (uint32_t) periods,
+        SYSCTL_GENCLKCFG_FCCTRIGCNT_MASK);
+}
+
+/**
+ *  @brief     Gets number of rising-edge to rising-edge period for Frequency
+ *             Clock Counter (FCC)
+ *
+ *  @return     One of @ref DL_SYSCTL_FCC_TRIG_CNT
+ */
+__STATIC_INLINE DL_SYSCTL_FCC_TRIG_CNT DL_SYSCTL_getFCCPeriods(void)
+{
+    uint32_t periods =
+        SYSCTL->SOCLOCK.GENCLKCFG & SYSCTL_GENCLKCFG_FCCTRIGCNT_MASK;
+
+    return (DL_SYSCTL_FCC_TRIG_CNT)(periods);
+}
+
+/**
+ *  @brief  Enable Frequency Correction Loop (FCL)
+ *
+ *  Used to increase SYSOSC accuracy. An ROSC reference resistor which is suitable
+ *  to meet application accuracy reqiurements must be placed between ROSC pin and
+ *  device ground (VSS).
+ *
+ *  Once FCL is enable, it cannot be disabled by software. A BOOTRST is required.
+ *
+ *  Power consumption of SYSOSC will be marginally higher with FCL enabled due to
+ *  reference current which flows through ROSC.
+ *  Settling time from startup to specified accuracy may also be longer.
+ *  See device-specific datasheet for startup times.
+ */
+__STATIC_INLINE void DL_SYSCTL_enableSYSOSCFCL(void)
+{
+    SYSCTL->SOCLOCK.SYSOSCFCLCTL =
+        (SYSCTL_SYSOSCFCLCTL_KEY_VALUE | SYSCTL_SYSOSCFCLCTL_SETUSEFCL_TRUE);
+}
+
+/**
+ *  @brief  Enable write protection of selected SYSCTL registers
+ *
+ *  Protecting writes to configuration registers in SYSCTL can add a layer of
+ *  robustness against unintended changes during runtime.
+ *
+ *  @note Does not protect all SYSCTL registers, see TRM for more detail.
+ */
+__STATIC_INLINE void DL_SYSCTL_enableWriteLock(void)
+{
+    SYSCTL->SOCLOCK.WRITELOCK = SYSCTL_WRITELOCK_ACTIVE_ENABLE;
+}
+
+/**
+ *  @brief  Disable write protection of selected SYSCTL registers
+ *
+ *  Protecting writes to configuration registers in SYSCTL can add a layer of
+ *  robustness against unintended changes during runtime.
+ *
+ *  @note Does not protect all SYSCTL registers, see TRM for more detail.
+ */
+__STATIC_INLINE void DL_SYSCTL_disableWriteLock(void)
+{
+    SYSCTL->SOCLOCK.WRITELOCK = SYSCTL_WRITELOCK_ACTIVE_DISABLE;
+}
+
+/**
+ *  @brief  Sets operating mode of VBOOST (analog charge pump)
+ *
+ *  Active VBOOST circuitry is needed for COMP/OPA/GPAMP (if present on device).
+ *  VBOOST has a startup time, so consider power consumption versus desired startup time.
+ *
+ *  @note Although VBOOST clock source is automatically managed, it is up to
+ *  application software to ensure certain cases, or else ANACLKERR occurs.
+ *  See VBOOST section of TRM for more details.
+ *  @param[in] setting   One of @ref DL_SYSCTL_VBOOST.
+ */
+__STATIC_INLINE void DL_SYSCTL_setVBOOSTConfig(DL_SYSCTL_VBOOST setting)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.GENCLKCFG, (uint32_t) setting,
+        SYSCTL_GENCLKCFG_ANACPUMPCFG_MASK);
+}
+
+/**
+ *  @brief  Gets operating mode of VBOOST (analog charge pump)
+ *
+ *  Active VBOOST circuitry is needed for COMP/OPA/GPAMP (if present on device).
+ *  VBOOST has a startup time, so consider power consumption versus desired startup time.
+ *
+ *  @note Although VBOOST clock source is automatically managed, it is up to
+ *  application software to ensure certain cases, or else ANACLKERR occurs.
+ *  See VBOOST section of TRM for more details.
+ *  @return One of @ref DL_SYSCTL_VBOOST.
+ */
+__STATIC_INLINE DL_SYSCTL_VBOOST DL_SYSCTL_getVBOOSTConfig(void)
+{
+    uint32_t setting =
+        SYSCTL->SOCLOCK.GENCLKCFG & SYSCTL_GENCLKCFG_ANACPUMPCFG_MASK;
+
+    return (DL_SYSCTL_VBOOST)(setting);
+}
+
+/**
+ *  @brief  Return byte that was saved through SHUTDOWN
+ *
+ *  Shutdown memory persists beyond BOR, BOOTRST, and SYSRST.
+ *
+ *  @note Parity bits and parity fault checking is done by hardware.
+ *
+ *  @param[in] index   One of @ref DL_SYSCTL_SHUTDOWN_STORAGE_BYTE.
+ *
+ *  @return 8-bit value of Shutdown Storage Byte.
+ */
+__STATIC_INLINE uint8_t DL_SYSCTL_getShutdownStorageByte(
+    DL_SYSCTL_SHUTDOWN_STORAGE_BYTE index)
+{
+    const volatile uint32_t *pReg = &SYSCTL->SOCLOCK.SHUTDNSTORE0;
+
+    return (uint8_t)(
+        *(pReg + (uint32_t) index) & SYSCTL_SHUTDNSTORE0_DATA_MASK);
+}
+
+/**
+ *  @brief  Save a byte to SHUTDOWN memory
+ *
+ *  Shutdown memory persists beyond BOR, BOOTRST, and SYSRST.
+ *
+ *  @note Parity bits and parity fault checking is done by hardware.
+ *
+ *  @param[in] index   One of @ref DL_SYSCTL_SHUTDOWN_STORAGE_BYTE.
+ *  @param[in] data    8-bit data to save in memory
+ */
+__STATIC_INLINE void DL_SYSCTL_setShutdownStorageByte(
+    DL_SYSCTL_SHUTDOWN_STORAGE_BYTE index, uint8_t data)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.SHUTDNSTORE0 + (uint32_t) index, data,
+        SYSCTL_SHUTDNSTORE0_DATA_MASK);
+}
+
+/**
+ *  @brief  Enable SHUTDOWN IO Release
+ *
+ *  After shutdown, IO is locked in previous state.
+ *
+ *  @note Release IO after re-configuring IO to their proper state.
+ */
+__STATIC_INLINE void DL_SYSCTL_releaseShutdownIO(void)
+{
+    SYSCTL->SOCLOCK.SHDNIOREL =
+        (SYSCTL_SHDNIOREL_KEY_VALUE | SYSCTL_SHDNIOREL_RELEASE_TRUE);
+}
+
+/**
+ *  @brief  Disable the reset functionality of the NRST pin
+ *
+ *  Disabling the NRST pin allows the pin to be configured as a GPIO.
+ *  Once disabled, the reset functionality can only be re-enabled by a POR.
+ *
+ *  @note The register is write-only, so the EXRSTPIN register
+ *        will always appear as "Disabled" in the debugger
+ */
+__STATIC_INLINE void DL_SYSCTL_disableNRSTPin(void)
+{
+    SYSCTL->SOCLOCK.EXRSTPIN =
+        (SYSCTL_EXRSTPIN_KEY_VALUE | SYSCTL_EXRSTPIN_DISABLE_TRUE);
+}
+
+/**
+ *  @brief  Disable Serial Wire Debug (SWD) functionality
+ *
+ *  SWD pins are enabled by default after cold start to allow a debug connection.
+ *  It is possible to disable SWD on these pins to use for other functionality.
+ *
+ *  @post SWD is disabled, but pins must be re-configured separately.
+ *
+ *  @note Cannot debug the device after disabling SWD. Only re-enabled by POR.
+ */
+__STATIC_INLINE void DL_SYSCTL_disableSWD(void)
+{
+    SYSCTL->SOCLOCK.SWDCFG =
+        (SYSCTL_SWDCFG_KEY_VALUE | SYSCTL_SWDCFG_DISABLE_TRUE);
+}
+
+/**
+ *  @brief  Return byte that is stored in RSTCAUSE.
+ *
+ *  @return The cause of reset. One of @ref DL_SYSCTL_RESET_CAUSE
+ */
+__STATIC_INLINE DL_SYSCTL_RESET_CAUSE DL_SYSCTL_getResetCause(void)
+{
+    uint32_t resetCause = SYSCTL->SOCLOCK.RSTCAUSE & SYSCTL_RSTCAUSE_ID_MASK;
+
+    return (DL_SYSCTL_RESET_CAUSE)(resetCause);
+}
+
+/**
+ *  @brief     Set the HFXT startup time
+ *
+ * Specify the HFXT startup time in 64us resolution. If the HFCLK startup
+ * monitor is enabled (HFCLKFLTCHK), HFXT will be checked after this time
+ * expires.
+ *
+ *  @param[in]  startupTime  The HFXT startup time to set in ~64us steps.
+ *                           Value between [0x0 (~0s), 0xFF (~16.32ms)].
+ */
+__STATIC_INLINE void DL_SYSCTL_setHFXTStartupTime(uint32_t startupTime)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.HFCLKCLKCFG, startupTime,
+        SYSCTL_HFCLKCLKCFG_HFXTTIME_MASK);
+}
+
+/**
+ *  @brief   Get the HFXT startup time
+ *
+ *  @return  Returns the HFXT startup time in ~64us steps
+ *
+ *  @retval  Value between [0x0 (~0s), 0xFF (~16.32ms)]
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getHFXTStartupTime(void)
+{
+    return (SYSCTL->SOCLOCK.HFCLKCLKCFG & SYSCTL_HFCLKCLKCFG_HFXTTIME_MASK);
+}
+
+/**
+ *  @brief     Set the HFXT frequency range
+ *
+ * The high frequency crystal oscillator (HFXT) can be used with standard
+ * crystals and resonators in the 4-48MHz range to generate a stable high-speed
+ * reference clock for the system.
+ *
+ *  @param[in]  range  One of @ref DL_SYSCTL_HFXT_RANGE
+ */
+__STATIC_INLINE void DL_SYSCTL_setHFXTFrequencyRange(
+    DL_SYSCTL_HFXT_RANGE range)
+{
+    DL_Common_updateReg(&SYSCTL->SOCLOCK.HFCLKCLKCFG, ((uint32_t) range),
+        SYSCTL_HFCLKCLKCFG_HFXTRSEL_MASK);
+}
+
+/**
+ *  @brief   Get the HFXT frequency range
+ *
+ *  @return  Returns the HFXT frequency range
+ *
+ *  @retval  One of @ref DL_SYSCTL_HFXT_RANGE
+ */
+__STATIC_INLINE DL_SYSCTL_HFXT_RANGE DL_SYSCTL_getHFXTFrequencyRange(void)
+{
+    uint32_t range =
+        (SYSCTL->SOCLOCK.HFCLKCLKCFG & SYSCTL_HFCLKCLKCFG_HFXTRSEL_MASK) >>
+        SYSCTL_HFCLKCLKCFG_HFXTRSEL_OFS;
+
+    return (DL_SYSCTL_HFXT_RANGE)(range);
+}
+
+/**
+ *  @brief  Enable the HFCLK startup monitor
+ *
+ * The HFXT takes time to start after being enabled. A startup monitor is
+ * provided to indicate to the application software if the HFXT has successfully
+ * started, at which point the HFCLK can be selected to source a variety of
+ * system functions. The HFCLK startup monitor also supports checking the
+ * HFCLK_IN digital clock input for a clock stuck fault.
+ *
+ */
+__STATIC_INLINE void DL_SYSCTL_enableHFCLKStartupMonitor(void)
+{
+    SYSCTL->SOCLOCK.HFCLKCLKCFG |= SYSCTL_HFCLKCLKCFG_HFCLKFLTCHK_ENABLE;
+}
+
+/**
+ *  @brief  Disable the HFCLK startup monitor
+ */
+__STATIC_INLINE void DL_SYSCTL_disableHFCLKStartupMonitor(void)
+{
+    SYSCTL->SOCLOCK.HFCLKCLKCFG &= ~(SYSCTL_HFCLKCLKCFG_HFCLKFLTCHK_MASK);
+}
+
+/**
+ *  @brief  Retrieves the calibration constant of the temperature sensor to be
+ *          used in temperature calculation.
+ *
+ *  @retval Temperature sensor calibration data
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getTempCalibrationConstant(void)
+{
+    // TODO replace hard coded temp cal address once available in device header file
+    return (*((uint32_t *) 0x41C4003C));
+}
+
+/**
+ *  @brief  Initializes the Read Execute (RX) Protect Firewall
+ *
+ *  The firewall security configuration can only be configured if INITDONE has
+ *  not been issued by the CSC.
+ *  This API checks if INITDONE has been issued. If it has not been issued,
+ *  then the start and end addresses are set, and then it enables the firewall.
+ *  If INITDONE has been issused, then the API immediately returns.
+ *
+ *  @param[in] startAddr  The start address of the read execute protect firewall
+ *  @param[in] endAddr    The end address of the read execute protect firewall
+ *
+ *  @return  If the Read Execute Protect Firewall was configured
+ *
+ *  @retval  true  If INITDONE was not issued and the firewall was configured
+ *  @retval  false If INITDONE was issued and the firewall was not configured
+ */
+bool DL_SYSCTL_initReadExecuteProtectFirewall(
+    uint32_t startAddr, uint32_t endAddr);
+
+/**
+ *  @brief  Initializes the IP Protect Firewall
+ *
+ *  The firewall security configuration can only be configured if INITDONE has
+ *  not been issued by the CSC.
+ *  This API checks if INITDONE has been issued. If it has not been issued,
+ *  then the start and end addresses are set, and then it enables the firewall.
+ *  If INITDONE has been issused, then the API immediately returns.
+ *
+ *  @param[in] startAddr  The start address of the IP protect firewall
+ *  @param[in] endAddr    The end address of the IP protect firewall
+ *
+ *  @return  If the IP Protect Firewall was configured
+ *
+ *  @retval  true  If INITDONE was not issued and the firewall was configured
+ *  @retval  false If INITDONE was issued and the firewall was not configured
+ */
+bool DL_SYSCTL_initIPProtectFirewall(uint32_t startAddr, uint32_t endAddr);
+
+/**
+ *  @brief  Set the address range of the Write Protect Firewall
+ *
+ *  Set Write Protection starting at 0x0 of flash, for the first
+ *  32KB at 1KB granularity.
+ *  Setting a bit to 1 enables write protection, and setting a bit to 0
+ *  allows write.
+ *
+ *  @note This bit can be written only before INITDONE. At INITDONE, this
+ *        configuration gets locked and stays locked until the next BOOTRST.
+ *
+ *  @param[in] addrMask The mask to set the address range for the Write Protect
+ *                      Firewall
+ */
+__STATIC_INLINE void DL_SYSCTL_setWriteProtectFirewallAddrRange(
+    uint32_t addrMask)
+{
+    SYSCTL->SECCFG.FWEPROTMAIN = addrMask;
+}
+
+/**
+ *  @brief  Get the address range of the Write Protect Firewall
+ *
+ *  @retval The address range for the Write Protect Firewall
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getWriteProtectFirewallAddrRange(void)
+{
+    return (SYSCTL->SECCFG.FWEPROTMAIN);
+}
+
+/**
+ *  @brief  Set the start address of the Read Execute (RX) Protect Firewall
+ *
+ *  Set the start of the range of Flash MAIN memory that needs to be guarded
+ *  from both read and execute accesses. The firewall is configured as an
+ *  address range.
+ *
+ *  The start and end addresses are specified at 64B sector granularity, so
+ *  the 6 LSBs are don't cares.
+ *  If the start address is equal to the end address, then one sector is RX
+ *  protected. If the end address is equal to the start address + 1, then two
+ *  sectors are protected, and so on. If the end address is less than the start
+ *  address, the no sectors are RX protected. The hardware does not perform any
+ *  checks on the addresses.
+ *
+ *  @note This bit can be written only before INITDONE. At INITDONE, this
+ *        configuration gets locked and stays locked until the next BOOTRST.
+ *
+ *  @param[in] startAddr  The start address of the read execute protect
+ *                        firewall. The 6 LSBs are don't cares.
+ */
+__STATIC_INLINE void DL_SYSCTL_setReadExecuteProtectFirewallAddrStart(
+    uint32_t startAddr)
+{
+    SYSCTL->SECCFG.FRXPROTMAINSTART =
+        (startAddr & SYSCTL_FRXPROTMAINSTART_ADDR_MASK);
+}
+
+/**
+ *  @brief  Get the start address of the Read Execute (RX) Protect Firewall
+ *
+ *  The start and end addresses are specified at 64B sector granularity, so
+ *  the 6 LSBs are don't cares.
+ *
+ *  @return  The start address of the read execute protect firewall
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getReadExecuteProtectFirewallAddrStart(void)
+{
+    return (SYSCTL->SECCFG.FRXPROTMAINSTART);
+}
+
+/**
+ *  @brief  Set the end address of the Read Execute (RX) Protect Firewall
+ *
+ *  Set the end of the range of Flash MAIN memory that needs to be guarded
+ *  from both read and execute accesses. The firewall is configured as an
+ *  address range.
+ *
+ *  The start and end addresses are specified at 64B sector granularity, so
+ *  the 6 LSBs are don't cares.
+ *  If the start address is equal to the end address, then one sector is RX
+ *  protected. If the end address is equal to the start address + 1, then two
+ *  sectors are protected, and so on. If the end address is less than the start
+ *  address, the no sectors are RX protected. The hardware does not perform any
+ *  checks on the addresses.
+ *
+ *  @note This bit can be written only before INITDONE. At INITDONE, this
+ *        configuration gets locked and stays locked until the next BOOTRST.
+ *
+ *  @param[in] endAddr  The end address of the read execute protect firewall.
+ *                      The 6 LSBs are don't cares.
+ */
+__STATIC_INLINE void DL_SYSCTL_setReadExecuteProtectFirewallAddrEnd(
+    uint32_t endAddr)
+{
+    SYSCTL->SECCFG.FRXPROTMAINEND =
+        (endAddr & SYSCTL_FRXPROTMAINEND_ADDR_MASK);
+}
+
+/**
+ *  @brief  Get the end address of the Read Execute (RX) Protect Firewall
+ *
+ *  The start and end addresses are specified at 64B sector granularity, so
+ *  the 6 LSBs are don't cares.
+ *
+ *  @return  The end address of the Read Execute Protect Firewall
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getReadExecuteProtectFirewallAddrEnd(void)
+{
+    return (SYSCTL->SECCFG.FRXPROTMAINEND);
+}
+
+/**
+ *  @brief  Set the start address of the IP Protect Firewall
+ *
+ *  Set the end of the range of Flash MAIN memory that needs to be guarded
+ *  from read access, allowing only execute accesses. The firewall is configured
+ *  as an address range.
+ *
+ *  The start and end addresses are specified at 64B sector granularity, so
+ *  the 6 LSBs are don't cares.
+ *  If the start address is equal to the end address, then one sector is IP
+ *  protected. If the end address is equal to the start address + 1, then two
+ *  sectors are protected, and so on. If the end address is less than the start
+ *  address, the no sectors are IP protected. The hardware does not perform any
+ *  checks on the addresses.
+ *
+ *  @note This bit can be written only before INITDONE. At INITDONE, this
+ *        configuration gets locked and stays locked until the next BOOTRST.
+ *
+ *  @param[in] startAddr  The start address of the IP Protect Firewall
+ */
+__STATIC_INLINE void DL_SYSCTL_setIPProtectFirewallAddrStart(
+    uint32_t startAddr)
+{
+    SYSCTL->SECCFG.FIPPROTMAINSTART =
+        (startAddr & SYSCTL_FIPPROTMAINSTART_ADDR_MASK);
+}
+
+/**
+ *  @brief  Get the start address of the IP Protect Firewall
+ *
+ *  @return  The start address of the IP Protect Firewall
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getIPProtectFirewallAddrStart(void)
+{
+    return (SYSCTL->SECCFG.FIPPROTMAINSTART);
+}
+
+/**
+ *  @brief  Set the end address of the IP Protect firewall
+ *
+ *  Set the end of the range of Flash MAIN memory that needs to be guarded
+ *  from read access, allowing only execute accesses. The firewall is configured
+ *  as an address range.
+ *
+ *  The start and end addresses are specified at 64B sector granularity, so
+ *  the 6 LSBs are don't cares.
+ *  If the start address is equal to the end address, then one sector is IP
+ *  protected. If the end address is equal to the start address + 1, then two
+ *  sectors are protected, and so on. If the end address is less than the start
+ *  address, the no sectors are IP protected. The hardware does not perform any
+ *  checks on the addresses.
+ *
+ *  @note This bit can be written only before INITDONE. At INITDONE, this
+ *        configuration gets locked and stays locked until the next BOOTRST.
+ *
+ *  @param[in] endAddr  The end address of the IP Protect firewall
+ */
+__STATIC_INLINE void DL_SYSCTL_setIPProtectFirewallAddrEnd(uint32_t endAddr)
+{
+    SYSCTL->SECCFG.FIPPROTMAINSTART =
+        (endAddr & SYSCTL_FIPPROTMAINEND_ADDR_MASK);
+}
+
+/**
+ *  @brief  Get the end address of the IP Protect Firewall
+ *
+ *  @return  The end address of the IP Protect Firewall
+ */
+__STATIC_INLINE uint32_t DL_SYSCTL_getIPProtectFirewallAddrEnd(void)
+{
+    return (SYSCTL->SECCFG.FIPPROTMAINSTART);
+}
+
+/**
+ *  @brief  Enable the policy to allow flash bank swapping
+ *
+ *  The bank swap policy needs to be configured ahead of any bank swapping or
+ *  firewall configurations. In dual/quad-bank devices, this policy can be set
+ *  to either
+ *      - CSC allows bank swapping
+ *      - CSC does not allow bank swapping
+ *
+ *  By default, bank swapping is enabled to ensure a high security state if the
+ *  system boot execution was glitched. Defaulting the system as allowing bank
+ *  swapping ensures that firewall protections get mirrored to both flash banks.
+ *  Additionally, when bank swapping is enabled, SYSCTL enforces write-excute
+ *  mutual exclusion across the two banks (or bank-pairs).
+ *
+ *  @note This is a write-once bit. This bit can only be written to before
+ *        INITDONE. At INITDONE, this bit becomes a read-only bit until next
+ *        BOOTRST.
+ */
+__STATIC_INLINE void DL_SYSCTL_enableFlashBankSwap(void)
+{
+    SYSCTL->SECCFG.FLBANKSWPPOLICY &= (~(SYSCTL_FLBANKSWPPOLICY_DISABLE_MASK) |
+                                       SYSCTL_FLBANKSWPPOLICY_KEY_VALUE);
+}
+
+/**
+ *  @brief  Disable the policy to allow flash bank swapping
+ *
+ *  The bank swap policy needs to be configured ahead of any bank swapping or
+ *  firewall configurations. In dual/quad-bank devices, this policy can be set
+ *  to either
+ *      - CSC allows bank swapping
+ *      - CSC does not allow bank swapping
+ *
+ *  By default, bank swapping is enabled to ensure a high security state if the
+ *  system boot execution was glitched. Defaulting the system as allowing bank
+ *  swapping ensures that firewall protections get mirrored to both flash banks.
+ *  Additionally, when bank swapping is enabled, SYSCTL enforces write-excute
+ *  mutual exclusion across the two banks (or bank-pairs).
+ *
+ *  @note This is a write-once bit. This bit can only be written to before
+ *        INITDONE. At INITDONE, this bit becomes a read-only bit until next
+ *        BOOTRST.
+ */
+__STATIC_INLINE void DL_SYSCTL_disableFlashBankSwap(void)
+{
+    SYSCTL->SECCFG.FLBANKSWPPOLICY = (SYSCTL_FLBANKSWPPOLICY_DISABLE_TRUE |
+                                      SYSCTL_FLBANKSWPPOLICY_KEY_VALUE);
+}
+
+/**
+ *  @brief      Perform bank swap and execute from the Upper Flash Bank
+ *
+ *  The upper physical bank maps to logical 0x0, and gets RX permission.
+ *  The lower physical bank gets RW permission.
+ *
+ *  @note This bit can only be written to before INITDONE. At INITDONE, this bit
+ *  becomes a read-only bit until next BOOTRST.
+ *
+ *  @pre  DL_SYSCTL_enableFlashBankSwap
+ */
+__STATIC_INLINE void DL_SYSCTL_executeFromUpperFlashBank(void)
+{
+    SYSCTL->SECCFG.FLBANKSWP |=
+        (SYSCTL_FLBANKSWP_USEUPPER_ENABLE | SYSCTL_FLBANKSWP_KEY_VALUE);
+}
+
+/**
+ *  @brief      Perform bank swap and execute from the Lower Flash Bank
+ *
+ *  The lower physical bank maps to logical 0x0, and gets RX permission.
+ *  The upper physical bank gets RW permission.
+ *
+ *  @note This bit can only be written to before INITDONE. At INITDONE, this bit
+ *  becomes a read-only bit until next BOOTRST.
+ *
+ *  @pre  DL_SYSCTL_enableFlashBankSwap
+ */
+__STATIC_INLINE void DL_SYSCTL_executeFromLowerFlashBank(void)
+{
+    SYSCTL->SECCFG.FLBANKSWP &=
+        (~(SYSCTL_FLBANKSWP_USEUPPER_MASK) | SYSCTL_FLBANKSWP_KEY_VALUE);
+}
+
+/**
+ *  @brief      Enable Read Execute (RX) Protect Firewall
+ *
+ *  Enables the Read Execute Protect Firewall before INITDONE.
+ *
+ *  @note This bit can be written only before INITDONE. At INITDONE, this
+ *        configuration gets locked and stays locked until the next BOOTRST
+ */
+__STATIC_INLINE void DL_SYSCTL_enableReadExecuteProtectFirewall(void)
+{
+    SYSCTL->SECCFG.FWENABLE |=
+        (SYSCTL_FWENABLE_FLRXPROT_ENABLE | SYSCTL_FWENABLE_KEY_VALUE);
+}
+
+/**
+ *  @brief      Enable IP Protect Firewall
+ *
+ *  Enables the IP Protect Firewall before INITDONE. After INITDONE,
+ *  this configuration gets locked until the next BOOTRST.
+ *
+ *  @note This bit can be written only before INITDONE. At INITDONE, this
+ *        configuration gets locked and stays locked until the next BOOTRST
+ */
+__STATIC_INLINE void DL_SYSCTL_enableIPProtectFirewall(void)
+{
+    SYSCTL->SECCFG.FWENABLE |=
+        (SYSCTL_SECSTATUS_FLIPPROT_ENABLED | SYSCTL_FWENABLE_KEY_VALUE);
+}
+
+/**
+ *  @brief      Enable SRAM Boundary Lock
+ *
+ *  When SRAM Boundary Lock is enabled, the SRAMBOUNDARY register is only
+ *  writeable only until INITDONE. After INITDONE, the SRAMBOUNDARY register
+ *  cannot be written.
+ *
+ *  When disabled, the SRAMBOUNDARY register is writeable throughout the
+ *  application, even after INITDONE.
+ *
+ *  @note This bit can be written only before INITDONE. At INITDONE, this
+ *        configuration gets locked and stays locked until the next BOOTRST
+ *
+ *  @sa DL_SYSCTL_setSRAMBoundaryAddress
+ */
+__STATIC_INLINE void DL_SYSCTL_enableSRAMBoundaryLock(void)
+{
+    SYSCTL->SECCFG.FWENABLE |=
+        (SYSCTL_FWENABLE_SRAMBOUNDARYLOCK_ENABLE | SYSCTL_FWENABLE_KEY_VALUE);
+}
+
+/**
+ *  @brief  Checks if INITDONE has been issued by the CSC
+ *
+ *  @return Whether INITDONE has been issued or not
+ *
+ *  @retval  true  If INITDONE has been issued
+ *  @retval  false If INITDONE has not been issued
+ */
+__STATIC_INLINE bool DL_SYSCTL_isINITDONEIssued(void)
+{
+    return ((SYSCTL->SECCFG.SECSTATUS & SYSCTL_SECSTATUS_INITDONE_YES) ==
+            SYSCTL_SECSTATUS_INITDONE_YES);
+}
+
+/**
+ *  @brief  Checks if Customer Startup Code (CSC) exists in system
+ *
+ *  @return Whether CSC exists in system
+ *
+ *  @retval  true  If CSC exists in system
+ *  @retval  false If CSC does not exist in system
+ */
+__STATIC_INLINE bool DL_SYSCTL_ifCSCExists(void)
+{
+    return ((SYSCTL->SECCFG.SECSTATUS & SYSCTL_SECSTATUS_CSCEXISTS_YES) ==
+            SYSCTL_SECSTATUS_CSCEXISTS_YES);
+}
+
+/**
+ *  @brief  Checks if Read Execute (RX) Protect Firewall is enabled
+ *
+ *  @return Whether Read Execute Protect Firewall is enabled
+ *
+ *  @retval  true  If Read Execute Protect Firewall is enabled
+ *  @retval  false If Read Execute Protect Firewall is not enabled
+ */
+__STATIC_INLINE bool DL_SYSCTL_isReadExecuteProtectFirewallEnabled(void)
+{
+    return ((SYSCTL->SECCFG.SECSTATUS & SYSCTL_SECSTATUS_FLRXPROT_ENABLED) ==
+            SYSCTL_SECSTATUS_FLRXPROT_ENABLED);
+}
+
+/**
+ *  @brief  Checks if IP Protect Firewall is enabled
+ *
+ *  @return Whether IP Protect Firewall is enabled
+ *
+ *  @retval  true  If IP Protect Firewall is enabled
+ *  @retval  false If IP Protect Firewall is not enabled
+ */
+__STATIC_INLINE bool DL_SYSCTL_isIPProtectFirewallEnabled(void)
+{
+    return ((SYSCTL->SECCFG.SECSTATUS & SYSCTL_SECSTATUS_FLIPPROT_ENABLED) ==
+            SYSCTL_SECSTATUS_FLIPPROT_ENABLED);
+}
+
+/**
+ *  @brief  Checks if SRAM Boundary Lock is enabled
+ *
+ *  @return Whether SRAM Boundary Lock is enabled
+ *
+ *  @retval  true  If SRAM Boundary Lock is enabled
+ *  @retval  false If SRAM Boundary Lock is not enabled
+ */
+__STATIC_INLINE bool DL_SYSCTL_isSRAMBoundaryLocked(void)
+{
+    return ((SYSCTL->SECCFG.SECSTATUS &
+                SYSCTL_SECSTATUS_SRAMBOUNDARYLOCK_ENABLED) ==
+            SYSCTL_SECSTATUS_SRAMBOUNDARYLOCK_ENABLED);
+}
+
+/**
+ *  @brief  Checks if Flash Bank swapping is enabled
+ *
+ *  @return Whether Flash Bank swap is enabled
+ *
+ *  @retval  true  If Flash Bank swap is enabled
+ *  @retval  false If Flash Bank swap is not enabled
+ */
+__STATIC_INLINE bool DL_SYSCTL_isFlashBankSwapEnabled(void)
+{
+    return ((SYSCTL->SECCFG.SECSTATUS &
+                SYSCTL_SECSTATUS_FLBANKSWPPOLICY_ENABLED) ==
+            SYSCTL_SECSTATUS_FLBANKSWPPOLICY_ENABLED);
+}
+
+/**
+ *  @brief  Checks if executing from upper flash bank
+ *
+ *  @return Whether executing from upper flash bank
+ *
+ *  @retval  true  If executing from upper flash bank
+ *  @retval  false If not executing from upper flash bank
+ */
+__STATIC_INLINE bool DL_SYSCTL_isExecuteFromUpperFlashBank(void)
+{
+    return ((SYSCTL->SECCFG.SECSTATUS & SYSCTL_SECSTATUS_FLBANKSWP_MASK) ==
+            SYSCTL_SECSTATUS_FLBANKSWP_MASK);
+}
+
+/**
+ *  @brief  Checks if executing from lower flash bank
+ *
+ *  @return Whether executing from lower flash bank
+ *
+ *  @retval  true  If executing from lower flash bank
+ *  @retval  false If not executing from lower flash bank
+ */
+__STATIC_INLINE bool DL_SYSCTL_isExecuteFromLowerFlashBank(void)
+{
+    return ((SYSCTL->SECCFG.SECSTATUS & SYSCTL_SECSTATUS_FLBANKSWP_MASK) !=
+            SYSCTL_SECSTATUS_FLBANKSWP_MASK);
+}
+
+/**
+ *  @brief  Indicate that INIT is done
+ *
+ *  After INITDONE is issued, the security configuration is locked and enforced.
+ *  A SYSRST will occur, restarting startup code execution, and the main
+ *  application is launched.
+ *
+ *  There is no hardware support to enforce a timeout if INITDONE is not issued
+ *  in a reasonable period of time. It is recommended that the CSC use a
+ *  watchdog to ensure that INITDONE is issued in a timely manner.
+ */
+__STATIC_INLINE void DL_SYSCTL_issueINITDONE(void)
+{
+    SYSCTL->SECCFG.INITDONE |=
+        (SYSCTL_INITDONE_PASS_TRUE | SYSCTL_INITDONE_KEY_VALUE);
+}
+
+/**
+ *  @brief  Enables super capacitor function
+ *
+ *  Allows battery backup system to be powered by a super capacitor
+ */
+__STATIC_INLINE void DL_SYSCTL_enableSuperCapacitor(void)
+{
+    SYSCTL->SOCLOCK.SYSTEMCFG |= SYSCTL_SYSTEMCFG_SUPERCAPEN_TRUE;
+}
+
+/**
+ *  @brief  Disables super capacitor function
+ *
+ *  Prevents battery backup system from being powered by a super capacitor
+ */
+__STATIC_INLINE void DL_SYSCTL_disableSuperCapacitor(void)
+{
+    SYSCTL->SOCLOCK.SYSTEMCFG &= ~(SYSCTL_SYSTEMCFG_SUPERCAPEN_TRUE);
+}
+
+/**
+ *  @brief  Checks if super capacitor function is enabled
+ *
+ *  @return returns the state of the super capacitor bit
+ *
+ *  @retval  true  The super capacitor function is enabled
+ *  @retval  false The super capacitor function is disabled
+ */
+__STATIC_INLINE bool DL_SYSCTL_isSuperCapacitorEnabled(void)
+{
+    return ((SYSCTL->SOCLOCK.SYSTEMCFG & SYSCTL_SYSTEMCFG_SUPERCAPEN_MASK) ==
+            SYSCTL_SYSTEMCFG_SUPERCAPEN_TRUE);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ti_dl_m0p_dl_sysctl_sysctl__include */
+/** @}*/

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,2 +1,4 @@
 build:
   cmake: .
+  settings:
+    dts_root: .


### PR DESCRIPTION
Added MSPM0 DriverLib and header files to be used for MSPM0 devices. 
Also includes mspm0 pinctrl dtsi file to add support for LP_MSPM0G3507.