### PR TITLE
Add SOC_CC2652{R,P}7 to DeviceFamily if-tree

### DIFF
--- a/simplelink/CMakeLists.txt
+++ b/simplelink/CMakeLists.txt
@@ -66,6 +66,8 @@ elseif(CONFIG_HAS_CC13X2_CC26X2_SDK OR CONFIG_HAS_CC13X2X7_CC26X2X7_SDK)
     zephyr_compile_definitions(DeviceFamily_CC13X2X7 ${COMPILER})
   elseif(CONFIG_SOC_CC2652R OR CONFIG_SOC_CC2652P)
     zephyr_compile_definitions(DeviceFamily_CC26X2 ${COMPILER})
+  elseif(CONFIG_SOC_CC2652R7 OR CONFIG_SOC_CC2652P7)
+    zephyr_compile_definitions(DeviceFamily_CC26X2X7 ${COMPILER})
   endif()
 
   zephyr_include_directories(

--- a/simplelink/source/ti/devices/DeviceFamily.h
+++ b/simplelink/source/ti/devices/DeviceFamily.h
@@ -121,6 +121,11 @@ extern "C" {
     #define DeviceFamily_DIRECTORY      cc13x2_cc26x2
     #define DeviceFamily_PARENT         DeviceFamily_PARENT_CC13X2_CC26X2
 
+#elif defined(DeviceFamily_CC26X2X7)
+    #define DeviceFamily_ID             DeviceFamily_ID_CC26X2
+    #define DeviceFamily_DIRECTORY      cc13x2x7_cc26x2x7
+    #define DeviceFamily_PARENT         DeviceFamily_PARENT_CC13X2_CC26X2
+
 #elif defined(DeviceFamily_CC3200)
     #define DeviceFamily_ID             DeviceFamily_ID_CC3200
     #define DeviceFamily_DIRECTORY      cc32xx
@@ -187,6 +192,7 @@ extern "C" {
 #if (defined(DeviceFamily_CC13X0) + defined(DeviceFamily_CC13X2)        \
     + defined(DeviceFamily_CC26X0) + defined(DeviceFamily_CC26X0R2)     \
     + defined(DeviceFamily_CC26X2)                                      \
+    + defined(DeviceFamily_CC13X2X7) + defined(DeviceFamily_CC26X2X7)   \
     + defined(DeviceFamily_CC3200) + defined(DeviceFamily_CC3220)       \
     + defined(DeviceFamily_MSP432P401x) + defined(DeviceFamily_MSP432P4x1xI) \
     + defined(DeviceFamily_MSP432P4x1xT) + defined(DeviceFamily_MSP432E401Y) \


### PR DESCRIPTION
The "DeviceFamily" defines are not generated for the CC26x2x7 family of parts.

Added the CMakeLists.txt, etc definitions in the pattern of the CC13x2x7 family.

Also add DeviceFamily_CC13X2X7 to DeviceFamily multiple select macro.