### PR TITLE
simplelink: ti: devices: Add ADC support

### DIFF
--- a/simplelink/source/ti/devices/cc13x2x7_cc26x2x7/CMakeLists.txt
+++ b/simplelink/source/ti/devices/cc13x2x7_cc26x2x7/CMakeLists.txt
@@ -45,3 +45,5 @@ zephyr_library_sources_ifdef(CONFIG_BLE_CC13XX_CC26XX driverlib/rfc.c)
 
 # Required for on-chip flash support
 zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_CC13XX_CC26XX driverlib/flash.c)
+
+zephyr_library_sources_ifdef(CONFIG_ADC_CC13XX_CC26XX driverlib/aux_adc.c)


### PR DESCRIPTION
- `AUXADCEnableSync` does not seem to be present in ROM and thus we need to add this file.
- Tested on beagleconnect freedom