### PR TITLE
net: slnetsock: do not require posix to define SlNetSock_Timeval_t

### DIFF
--- a/simplelink/source/ti/net/slnetsock.h
+++ b/simplelink/source/ti/net/slnetsock.h
@@ -191,15 +191,6 @@ interface.  Some are mandatory, others are optional (but recommended).
 #define __SL_NET_SOCK_H__
 
 #include <stdint.h>
-/*
- * Commented out to prevent zsock_timeval from being redefined
- * Can remove this if support for CONFIG_NET_SOCKETS_POSIX_NAMES
- * is dropped someday
- */
-#if !(defined(CONFIG_NET_SOCKETS_POSIX_NAMES) || defined(CONFIG_POSIX_CLOCK) \
-    || defined(CONFIG_POSIX_API))
-#include <sys/time.h>
-#endif
 
 #ifdef    __cplusplus
 extern "C" {
@@ -646,7 +637,10 @@ typedef struct SlNetSock_linger_t
                 to be equivalent to the POSIX-defined <tt>struct
                 timeval</tt> data type.
 */
-typedef struct timeval SlNetSock_Timeval_t;
+typedef struct {
+    long tv_sec;
+    long tv_usec;
+} SlNetSock_Timeval_t;
 
 /*!
     \brief The SlNetSocklen_t is used for declaring the socket length parameter


### PR DESCRIPTION
Previously, the header `<ti/net/slnetsock.h>` was forward-declaring a typed struct depending on deprecated and nonexistent Kconfig options. This caused a compile error when building `sample.net.sockets.http_get.offload.simplelink` because struct timeval was not defined in a non-standard header.

https://github.com/zephyrproject-rtos/zephyr/actions/runs/17698392922/job/50300874059?pr=95939

Since the offload driver must exist whether or not the applciation has enabled POSIX, and struct timeval is POSIX, simply define the SlNetSock_Timeval_t typed structure whether or not POSIX is enabled using ANSI/ISO C types.

In this case, `long` was chosen to match the wordsize of whatever architecture is being built.