### PR TITLE
dts: ti: mspm0: Enable input for CAN RX pins

### DIFF
--- a/dts/ti/mspm0/g/mspm0g1x0x_g3x0x-pinctrl.dtsi
+++ b/dts/ti/mspm0/g/mspm0g1x0x_g3x0x-pinctrl.dtsi
@@ -1111,6 +1111,7 @@
 
 			/omit-if-no-ref/ canfd0_canrx_pa13: canfd0_canrx_pa13 {
 				pinmux = <MSP_PINMUX(35, MSPM0_PIN_FUNCTION_6)>;
+				input-enable;
 			};
 
 			/omit-if-no-ref/ tima0_ccp3_cmpl_pa13: tima0_ccp3_cmpl_pa13 {
@@ -1833,6 +1834,7 @@
 
 			/omit-if-no-ref/ canfd0_canrx_pa27: canfd0_canrx_pa27 {
 				pinmux = <MSP_PINMUX(60, MSPM0_PIN_FUNCTION_6)>;
+				input-enable;
 			};
 
 			/omit-if-no-ref/ timg7_ccp1_pa27: timg7_ccp1_pa27 {


### PR DESCRIPTION
Added input-enable property to all CAN RX pinmux entries across the MSPM0G1x0x_G3x0x pinctrl file to ensure proper input functionality for CAN RX on supported pins.