### PR TITLE
Fix Implemented: Conditional MSPM0 Directory Inclusion

### DIFF
--- a/mspm0/CMakeLists.txt
+++ b/mspm0/CMakeLists.txt
@@ -1,6 +1,5 @@
-add_subdirectory(source/ti/devices/msp)
-
 if(CONFIG_HAS_MSPM0_SDK)
+  add_subdirectory(source/ti/devices/msp)
   zephyr_include_directories(
 	.
 	source


### PR DESCRIPTION
Currently, in `modules/hal/ti/mspm0/CMakeLists.txt`, the line `add_subdirectory(source/ti/devices/msp)` is placed outside of the `CONFIG_HAS_MSPM0_SDK` conditional block. This causes three key problems:

1. Compilation errors when building for non-MSPM0 devices because the build system incorrectly includes MSPM0-specific files
2. Unnecessary slowdown of the build process due to inclusion of irrelevant directories
3. Potential side effects from unintended header inclusions

This PR moves the `add_subdirectory(source/ti/devices/msp)` call inside the `if(CONFIG_HAS_MSPM0_SDK)` conditional block, ensuring MSPM0 files are only included when actually needed.

Issue fix: https://github.com/zephyrproject-rtos/zephyr/issues/102504