### PR TITLE
mspm0: ti: driverlib: dl_timer: fix uninitialized variables

### DIFF
--- a/mspm0/source/ti/driverlib/dl_timer.c
+++ b/mspm0/source/ti/driverlib/dl_timer.c
@@ -109,7 +109,7 @@ void DL_Timer_initTimerMode(
 void DL_Timer_initCaptureMode(
     GPTIMER_Regs *gptimer, const DL_Timer_CaptureConfig *config)
 {
-    Timer_Input_Chan_Config captConfig;
+    Timer_Input_Chan_Config captConfig = {0};
 
     DL_Timer_getInChanConfig(config->inputChan, &captConfig);
 
@@ -318,7 +318,7 @@ void DL_Timer_initCaptureCombinedMode(
 void DL_Timer_initCompareMode(
     GPTIMER_Regs *gptimer, const DL_Timer_CompareConfig *config)
 {
-    Timer_Input_Chan_Config inChanConfig;
+    Timer_Input_Chan_Config inChanConfig = {0};
 
     DL_Timer_getInChanConfig(config->inputChan, &inChanConfig);
 


### PR DESCRIPTION
Fix warnings about uninitialized variables `captConfig` and `inChanConfig` in the dl_timer.c file by explicitly initializing the structs to zero.