### PR TITLE
Enable "west blobs" fetching for TI foundational security firmware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore binary blob files
+zephyr/blobs/ti-sysfw/

--- a/zephyr/blobs/LICENSE.ti
+++ b/zephyr/blobs/LICENSE.ti
@@ -1,0 +1,61 @@
+Copyright (C) 2026 Texas Instruments Incorporated
+
+All rights reserved not granted herein.
+
+Limited License.
+
+Texas Instruments Incorporated grants a world-wide, royalty-free, non-exclusive
+license under copyrights and patents it now or hereafter owns or controls to
+make, have made, use, import, offer to sell and sell ("Utilize") this software
+subject to the terms herein. With respect to the foregoing patent license, such
+license is granted solely to the extent that any such patent is necessary to
+Utilize the software alone. The patent license shall not apply to any
+combinations which include this software, other than combinations with devices
+manufactured by or for TI (“TI Devices”). No hardware patent is licensed
+hereunder.
+
+Redistributions must preserve existing copyright notices and reproduce this
+license (including the above copyright notice and the disclaimer and
+(if applicable) source code license limitations below) in the documentation
+and/or other materials provided with the distribution
+
+Redistribution and use in binary form, without modification, are permitted
+provided that the following conditions are met:
+
+	* No reverse engineering, decompilation, or disassembly of this
+	  software is permitted with respect to any software provided in binary
+	  form.
+
+	* any redistribution and use are licensed by TI for use only with TI
+	  Devices.
+
+	* Nothing shall obligate TI to provide you with source code for the
+	  software licensed and provided to you in object code.
+
+If software source code is provided to you, modification and redistribution of
+the source code are permitted provided that the following conditions are met:
+
+	* any redistribution and use of the source code, including any
+	  resulting derivative works, are licensed by TI for use only with TI
+	  Devices.
+
+	* any redistribution and use of any object code compiled from the
+	  source code and any resulting derivative works, are licensed by TI
+	  for use only with TI Devices.
+
+Neither the name of Texas Instruments Incorporated nor the names of its
+suppliers may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+DISCLAIMER.
+
+THIS SOFTWARE IS PROVIDED BY TI AND TI’S LICENSORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL TI AND TI’S LICENSORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,4 +1,23 @@
+name: hal_ti
 build:
   cmake: .
   settings:
     dts_root: .
+
+blobs:
+  # TIFS (TI Foundational Security) firmware for AM62Lx SoC
+  - path: ti-sysfw/ti-fs-firmware-am62lx-hs-enc.bin
+    sha256: a0f950de0258ee2dd1b6f4b48a6cc6a92df53bb19cea9f89cdde4266e89a060b
+    type: img
+    version: '12.00.00.07'
+    license-path: zephyr/blobs/LICENSE.ti
+    url: https://github.com/TexasInstruments/ti-linux-firmware/raw/12.00.00.07/ti-sysfw/ti-fs-firmware-am62lx-hs-enc.bin
+    description: "TIFS (TI Foundational Security) firmware for AM62Lx SoC"
+
+  - path: ti-sysfw/ti-fs-firmware-am62lx-hs-cert.bin
+    sha256: 114389460bb1c087c52e8d0709080b7b99d5c7da7e81d33d623de49f35c7375b
+    type: img
+    version: '12.00.00.07'
+    license-path: zephyr/blobs/LICENSE.ti
+    url: https://github.com/TexasInstruments/ti-linux-firmware/raw/12.00.00.07/ti-sysfw/ti-fs-firmware-am62lx-hs-cert.bin
+    description: "TIFS inner certificate for AM62Lx SoC"


### PR DESCRIPTION
This PR adds Zephyr blob support for the AM62Lx TIFS (TI Foundational Security) firmware binaries to the TI HAL module.

The below PR adds the support to generate tiboot3 and tispl images for AM62lx SoC in zephyr. Both these images are ROM bootable images that include TI foundational security firmware. 
This enables fetching those firmware through west blobs.

[https://github.com/zephyrproject-rtos/zephyr/pull/106763](url)