### PR TITLE
simplelink: cc13x2/cc26x2: link Bluetooth 5 CPE patches for BLE builds

### DIFF
--- a/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
+++ b/simplelink/source/ti/devices/cc13x2_cc26x2/CMakeLists.txt
@@ -39,7 +39,9 @@ zephyr_library_sources_ifdef(CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ driverlib/r
 
 # Required for BLE support
 zephyr_library_sources_ifdef(CONFIG_BLE_CC13XX_CC26XX
-  rf_patches/rf_patch_cpe_multi_protocol.c)
+  rf_patches/rf_patch_cpe_bt5.c
+  rf_patches/rf_patch_cpe_multi_protocol.c
+  rf_patches/rf_patch_cpe_multi_bt5_coex.c)
 # Required for RFCDoorbellSendTo which is not in ROM
 zephyr_library_sources_ifdef(CONFIG_BLE_CC13XX_CC26XX driverlib/rfc.c)
 

--- a/simplelink/source/ti/devices/cc13x2x7_cc26x2x7/CMakeLists.txt
+++ b/simplelink/source/ti/devices/cc13x2x7_cc26x2x7/CMakeLists.txt
@@ -39,7 +39,9 @@ zephyr_library_sources_ifdef(CONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ driverlib/r
 
 # Required for BLE support
 zephyr_library_sources_ifdef(CONFIG_BLE_CC13XX_CC26XX
-  rf_patches/rf_patch_cpe_multi_protocol.c)
+  rf_patches/rf_patch_cpe_bt5.c
+  rf_patches/rf_patch_cpe_multi_protocol.c
+  rf_patches/rf_patch_cpe_multi_bt5_coex.c)
 # Required for RFCDoorbellSendTo which is not in ROM
 zephyr_library_sources_ifdef(CONFIG_BLE_CC13XX_CC26XX driverlib/rfc.c)
 


### PR DESCRIPTION
`CONFIG_BLE_CC13XX_CC26XX` links only `rf_patch_cpe_multi_protocol.c` today. Bluetooth 5 controller features on CC13x2/CC26x2 (and the x7 variants) — 2M/Coded PHY, extended advertising — require the BT5 CPE patches already shipped in the SDK tree: `rf_patch_cpe_bt5.c` and `rf_patch_cpe_multi_bt5_coex.c`. This adds them to the same gated source list in both device trees.

The patch objects are const arrays referenced only when the application's RF setup command selects them; unreferenced objects are dropped at link time, so existing BLE and non-BLE applications see no size or behavior change.

Exercised extensively on CC2652R7 (Zephyr software link-layer port, PTS-tested).